### PR TITLE
Versioning

### DIFF
--- a/.github/CONTRIBUTING.rst
+++ b/.github/CONTRIBUTING.rst
@@ -102,7 +102,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.7, 3.4, 3.5 and 3.6, and for PyPy. Check
+3. The pull request should work for Python 2.7, 3.4, 3.5, 3.6, 3.7, and for PyPy. Check
    https://travis-ci.org/Ouranosinc/xclim/pull_requests
    and make sure that the tests pass for all supported Python versions.
 
@@ -114,6 +114,22 @@ To run a subset of tests::
 $ py.test tests.test_xclim
 
 
+Versioning
+----------
+
+In order to update and release the library to PyPi, it's good to use a semantic versioning scheme.
+The method we use is as such::
+
+  major.minor-release
+
+**Major** releases denote major changes resulting in a stable API;
+
+**Minor** is to be used when adding a module or set of components;
+
+**Release** is a keyword used to specify the degree of production readiness (`alpha`, `beta` [, and optionally, `gamma`])
+
+  An increment to the Major or Minor will reset the Release to `alpha`. When a build is promoted above `beta` (ie: release-ready), it's a good idea to push this version towards PyPi.
+
 Deploying
 ---------
 
@@ -121,7 +137,7 @@ A reminder for the maintainers on how to deploy.
 Make sure all your changes are committed (including an entry in HISTORY.rst).
 Then run::
 
-$ bumpversion patch # possible: major / minor / patch
+$ bumpversion minor # possible options: major / minor / release
 $ git push
 $ git push --tags
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,18 +1,18 @@
 [bumpversion]
-current_version = 0.1-alpha
+current_version = 0.2-alpha
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)(\-(?P<release>[a-z]+))?
-serialize =
-        {major}.{minor}-{release}
-        {major}.{minor}
+serialize = 
+	{major}.{minor}-{release}
+	{major}.{minor}
 
 [bumpversion:part:release]
 optional_value = gamma
-values =
-        alpha
-        beta
-        gamma
+values = 
+	alpha
+	beta
+	gamma
 
 [bumpversion:file:setup.py]
 search = version='{current_version}'
@@ -29,7 +29,6 @@ universal = 1
 exclude = docs
 
 [aliases]
-# Define setup.py command aliases here
 test = pytest
 
 [tool:pytest]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2-alpha
+current_version = 0.1
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)(\-(?P<release>[a-z]+))?

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,18 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = 0.1-alpha
 commit = True
 tag = True
+parse = (?P<major>\d+)\.(?P<minor>\d+)(\-(?P<release>[a-z]+))?
+serialize =
+        {major}.{minor}-{release}
+        {major}.{minor}
+
+[bumpversion:part:release]
+optional_value = gamma
+values =
+        alpha
+        beta
+        gamma
 
 [bumpversion:file:setup.py]
 search = version='{current_version}'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1
+current_version = 0.1-alpha
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)(\-(?P<release>[a-z]+))?

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/Ouranosinc/xclim',
-    version='0.2-alpha',
+    version='0.1',
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/Ouranosinc/xclim',
-    version='0.1-alpha',
+    version='0.2-alpha',
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/Ouranosinc/xclim',
-    version='0.1',
+    version='0.1-alpha',
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/Ouranosinc/xclim',
-    version='0.1.0.dev',
+    version='0.1-alpha',
     zip_safe=False,
 )

--- a/xclim/__init__.py
+++ b/xclim/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Travis Logan"""
 __email__ = 'logan.travis@ouranos.ca'
-__version__ = '0.1'
+__version__ = '0.1-alpha'
 
 
 from .checks import *

--- a/xclim/__init__.py
+++ b/xclim/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Travis Logan"""
 __email__ = 'logan.travis@ouranos.ca'
-__version__ = '0.1-alpha'
+__version__ = '0.2-alpha'
 
 
 from .checks import *

--- a/xclim/__init__.py
+++ b/xclim/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Travis Logan"""
 __email__ = 'logan.travis@ouranos.ca'
-__version__ = '0.2-alpha'
+__version__ = '0.1'
 
 
 from .checks import *

--- a/xclim/__init__.py
+++ b/xclim/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Travis Logan"""
 __email__ = 'logan.travis@ouranos.ca'
-__version__ = '0.1.0.dev'
+__version__ = '0.1-alpha'
 
 
 from .checks import *


### PR DESCRIPTION
For rationale, see #6 

I've put together a slightly modified bumpversion that uses the convention:

- `major.minor-release`, e.g. `1.3-beta`

Whenever a module or a large set of calculations is added, using "bumpversion" we should increment the minor by doing the following in a terminal: `$ bumpversion minor`. This will increment the `minor` number and reset the release to `alpha`.

Whenever a series of tests or stability fixes or optimizations to the current set of algorithms is produced, it's good practice to bump the release (ie: `$ bumpversion release`). This will increase from `alpha` to `beta`, and from `beta` to none  (`1.3-beta` --> `1.3`). This version can then be put on PyPi.

When we have a production-ready version of xclim, we can perform a `$ bumpversion major`.

The reason for this is to better know when to push things towards PyPi. A more mature/tested version should be made easily installable via pip, while versions that are in really active development (ie: `alpha` and `beta`) are best left on GitHub. This also makes it easier to continue work on one minor version to bring up its stability and potentially place it online before being merged into the master or more development versions.