### PR TITLE
Removed redundant pr/push build behaviour

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ language: python
 
 matrix:
   include:
-    - env: TOXENV=py37
-      python: 3.7
-      sudo: required
-      dist: xenial
+#    - env: TOXENV=py37
+#      python: 3.7
+#      sudo: required
+#      dist: xenial
     - env: TOXENV=py36
       python: 3.6
     - env: TOXENV=py35
@@ -16,13 +16,6 @@ matrix:
       python: 3.4
     - env: TOXENV=py27
       python: 2.7
-
-#python:
-#    - 3.7
-#    - 3.6
-#    - 3.5
-#    - 3.4
-#    - 2.7
 
 # Command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: pip install -U tox-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,21 @@
 
 language: python
 python:
-  - 3.6
-  - 3.5
-  - 3.4
-  - 2.7
+    - 3.7
+    - 3.6
+    - 3.5
+    - 3.4
+    - 2.7
 
 # Command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: pip install -U tox-travis
 
 # Command to run tests, e.g. python setup.py test
 script: tox
+
+branches:
+  only:
+    - master
 
 # Assuming you have installed the travis-ci CLI tool, after you
 # create the Github repo and add it to Travis, run the

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,28 @@
 # Config file for automatic testing at travis-ci.org
 
 language: python
-python:
-    - 3.7
-    - 3.6
-    - 3.5
-    - 3.4
-    - 2.7
+
+matrix:
+  include:
+    - env: TOXENV=py37
+      python: 3.7
+      sudo: required
+      dist: xenial
+    - env: TOXENV=py36
+      python: 3.6
+    - env: TOXENV=py35
+      python: 3.5
+    - env: TOXENV=py34
+      python: 3.4
+    - env: TOXENV=py27
+      python: 2.7
+
+#python:
+#    - 3.7
+#    - 3.6
+#    - 3.5
+#    - 3.4
+#    - 2.7
 
 # Command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: pip install -U tox-travis

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
-envlist = py27, py34, py35, py36, flake8
+envlist = py27, py34, py35, py36, py37, flake8
 
 [travis]
 python =
+    3.7: py37
     3.6: py36
     3.5: py35
     3.4: py34

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 [tox]
-envlist = py27, py34, py35, py36, py37, flake8
+envlist = py27, py34, py35, py36, flake8
+; envlist = py27, py34, py35, py36, py37, flake8
 
 [travis]
 python =
-    3.7: py37
+;    3.7: py37
     3.6: py36
     3.5: py35
     3.4: py34


### PR DESCRIPTION
Currently, pushes to PRs triggers two synonymous builds. This setting only triggers builds for pushes to PRs XOR Master.

Also adding Python3.7 is a good idea in general.