### PR TITLE
Replace resample method by daily_downsampler

### DIFF
--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -67,11 +67,12 @@ class Test_max_1day_precipitation_amount():
         assert rx1day.time.dt.year == 2000
         assert len(rx1day) == 1
 
-    def non_standard_calendar(self):
+    @pytest.mark.skip
+    def test_non_standard_calendar(self):
         n = 360
         times = xr.cftime_range('2000-01-01', periods=n, freq='D', calendar='360_day')
         da = xarray.DataArray(range(n), [('time', times)])
-        out = xci.max_1day_precipitation_amount(a, freq='M')
+        out = xci.max_1day_precipitation_amount(da, freq='M')
         np.testing.assert_array_equal(out.data, da[29::30])
 
 

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -67,6 +67,13 @@ class Test_max_1day_precipitation_amount():
         assert rx1day.time.dt.year == 2000
         assert len(rx1day) == 1
 
+    def non_standard_calendar(self):
+        n = 360
+        times = xr.cftime_range('2000-01-01', periods=n, freq='D', calendar='360_day')
+        da = xarray.DataArray(range(n), [('time', times)])
+        out = xci.max_1day_precipitation_amount(a, freq='M')
+        np.testing.assert_array_equal(out.data, da[29::30])
+
 
 class Test_consecutive_frost_days():
     def time_series(self, values):

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -71,7 +71,7 @@ class Test_max_1day_precipitation_amount():
     def test_non_standard_calendar(self):
         n = 360
         times = xr.cftime_range('2000-01-01', periods=n, freq='D', calendar='360_day')
-        da = xarray.DataArray(range(n), [('time', times)])
+        da = xr.DataArray(range(n), [('time', times)])
         out = xci.max_1day_precipitation_amount(da, freq='M')
         np.testing.assert_array_equal(out.data, da[29::30])
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -40,13 +40,13 @@ class Test_daily_downsampler():
 
         for freq in 'YS MS QS-DEC'.split():
             resampler = da_std.resample(time=freq)
-            grouper = daily_downsampler(da_std, freq=freq)
+            grouper = daily_downsampler(da_std, time=freq)
 
             x1 = resampler.mean()
             x2 = grouper.mean()
 
             # add time coords to x2 and change dimension tags to time
-            time1 = daily_downsampler(da_std.time, freq=freq).first()
+            time1 = daily_downsampler(da_std.time, time=freq).first()
             x2.coords['time'] = ('tags', time1.values)
             x2 = x2.swap_dims({'tags': 'time'})
             x2 = x2.sortby('time')
@@ -67,13 +67,13 @@ class Test_daily_downsampler():
 
         for freq in 'YS MS QS-DEC'.split():
             resampler = da_std.resample(time=freq)
-            grouper = daily_downsampler(da_365, freq=freq)
+            grouper = daily_downsampler(da_365, time=freq)
 
             x1 = resampler.mean()
             x2 = grouper.mean()
 
             # add time coords to x2 and change dimension tags to time
-            time1 = daily_downsampler(da_365.time, freq=freq).first()
+            time1 = daily_downsampler(da_365.time, time=freq).first()
             x2.coords['time'] = ('tags', time1.values)
             x2 = x2.swap_dims({'tags': 'time'})
             x2 = x2.sortby('time')
@@ -91,12 +91,12 @@ class Test_daily_downsampler():
         da_360 = xr.DataArray(np.arange(1, time_360.size + 1), coords=[time_360], dims='time', name='data')
 
         for freq in 'YS MS QS-DEC'.split():
-            grouper = daily_downsampler(da_360, freq=freq)
+            grouper = daily_downsampler(da_360, time=freq)
 
             x2 = grouper.mean()
 
             # add time coords to x2 and change dimension tags to time
-            time1 = daily_downsampler(da_360.time, freq=freq).first()
+            time1 = daily_downsampler(da_360.time, time=freq).first()
             x2.coords['time'] = ('tags', time1.values)
             x2 = x2.swap_dims({'tags': 'time'})
             x2 = x2.sortby('time')

--- a/xclim/indices.py
+++ b/xclim/indices.py
@@ -517,7 +517,7 @@ def max_1day_precipitation_amount(da, freq='YS'):
 
     """
     return da.resample(time=freq).max(dim='time')
-    
+
 
 # @check_is_dataarray
 def prcp_tot(pr, freq='YS', units='kg m-2 s-1'):

--- a/xclim/indices.py
+++ b/xclim/indices.py
@@ -39,6 +39,7 @@ def with_attrs(**func_attrs):
     -----
     Assumes the output has an attrs dictionary attribute (e.g. xarray.DataArray).
     """
+    import types
 
     def attr_decorator(fn):
         # Use the docstring as the description attribute.
@@ -46,8 +47,22 @@ def with_attrs(**func_attrs):
 
         @wraps(fn)
         def wrapper(*args, **kwargs):
+            # This is a temporary fix to support non-standard calendars.
+            tmp_fix = False
+            for i, arg in enumerate(args):
+                if isinstance(arg.indexes['time'], xr.CFTimeIndex):
+                    args[i].resample = types.MethodType(dds, args[i])
+                    tmp_fix = True
+
             out = fn(*args, **kwargs)
             out.attrs.update(func_attrs)
+
+            if tmp_fix:
+                time1 = dds(args[0].time, time=kwargs['freq']).first()
+                out.coords['time'] = ('tags', time1.values)
+                out = out.swap_dims({'tags': 'time'})
+                out = out.sortby('time')
+
             return out
 
         # Assign the attributes to the function itself
@@ -472,6 +487,7 @@ def tn_min(tasmin, freq='YS'):
 
 # @check_daily_monotonic # TODO create daily timestep check
 # @convert_precip_units   # TODO create units checker / converter
+@with_attrs(long_name='maximum daily precipitation')
 def max_1day_precipitation_amount(da, freq='YS'):
     """Highest 1-day precipitation amount for a period (frequency).
 
@@ -500,24 +516,8 @@ def max_1day_precipitation_amount(da, freq='YS'):
     >>> rx1day = max_1day_precipitation_amount(pr, freq="YS")
 
     """
-
-    # resample the values
-    # arr = da.resample(time=freq,keep_attrs=True)
-    # Get max value for each period
-    # output1 = arr.max(dim='time')
-
-    # use custom resample function for now
-    grouper = dds(da, freq=freq)
-    output = grouper.max(dim='time', keep_attrs=True)
-
-    # add time coords to output and change dimension tags to time
-    time1 = dds(da.time, freq=freq).first()
-    output.coords['time'] = ('tags', time1.values)
-    output = output.swap_dims({'tags': 'time'})
-    output = output.sortby('time')
-
-    return output
-
+    return da.resample(time=freq).max(dim='time')
+    
 
 # @check_is_dataarray
 def prcp_tot(pr, freq='YS', units='kg m-2 s-1'):

--- a/xclim/utils.py
+++ b/xclim/utils.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 
-def daily_downsampler(da, freq='YS'):
+def daily_downsampler(da, **indexer):
     """
     :param da: xarray.DataArray
 
@@ -23,6 +23,9 @@ def daily_downsampler(da, freq='YS'):
 
 
     """
+    dim, freq = indexer.popitem()
+    if dim != 'time':
+        raise ValueError("Expected `time` dimension.")
 
     # generate tags from da.time and freq
     if isinstance(da.time.values[0], np.datetime64):


### PR DESCRIPTION
Partial fix for #30

To use, decorate index function with @with_attrs. This will check if the index is a CFTimeIndex instance, and if yes, will replace the standard resample method by daily_downsampler, which I've modified a little to copy resample's signature. 

Using this, we can use ``resample`` in our indicators. When xarray has support for non-standard calendar resampling, we can just remove that bit of code in the decorator. 

The code is barely tested, but it's all I can do at the moment... 