### PR TITLE
implement missing_any_fill function 

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -6,3 +6,9 @@ To use xclim in a project::
 
     import xclim
 
+
+
+Resampling frequencies
+----------------------
+
+Use `Q-NOV` to resample into climatological seasons (DJF, MAM, JJA, SON).

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -5,6 +5,7 @@ import xarray as xr
 from xclim.indices import tg_mean
 from xclim import checks
 
+
 def test_assert_daily():
     n = 365  # one day short of a full year
     times = pd.date_range('2000-01-01', freq='1D', periods=n)
@@ -33,24 +34,17 @@ def test_assert_daily():
 
 
 def test_missing_any_fill():
-    n = 36  # one day short of a full year
-    times = pd.date_range('2000-01-01', freq='1D', periods=n)
+    n = 66
+    times = pd.date_range('2001-12-30', freq='1D', periods=n)
     da = xr.DataArray(np.arange(n), [('time', times)])
-
     miss = checks.missing_any_fill(da, 'MS')
-    assert not miss[0]
-    assert miss[1]
+    np.testing.assert_array_equal(miss, [True, False, False, True])
 
-    n = 378  # one day short of a full year
-    times = pd.date_range('2000-01-01', freq='1D', periods=n)
+    n = 378
+    times = pd.date_range('2001-12-31', freq='1D', periods=n)
     da = xr.DataArray(np.arange(n), [('time', times)])
-
     miss = checks.missing_any_fill(da, 'YS')
-    assert not miss[0]
-    assert miss[1]
+    np.testing.assert_array_equal(miss, [True, False, True])
 
-    miss = checks.missing_any_fill(da, 'QS-DEC')
-    assert miss[0]
-    # assert not miss[1] This should be True. There is probably a bug in xarray or pandas.
-
-
+    miss = checks.missing_any_fill(da, 'Q-NOV')
+    np.testing.assert_array_equal(miss, [True, False, False, False, True])

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -3,7 +3,7 @@ import pandas as pd
 import pytest
 import xarray as xr
 from xclim.indices import tg_mean
-
+from xclim import checks
 
 def test_assert_daily():
     n = 365  # one day short of a full year
@@ -30,3 +30,23 @@ def test_assert_daily():
         times = times.append(pd.date_range('2000-12-29', freq='1D', periods=n))
         da = xr.DataArray(np.arange(2*n), [('time', times)])
         tg_mean(da)
+
+
+def test_missing_any_fill():
+    n = 36  # one day short of a full year
+    times = pd.date_range('2000-01-01', freq='1D', periods=n)
+    da = xr.DataArray(np.arange(n), [('time', times)])
+
+    miss = checks.missing_any_fill(da, 'MS')
+    assert not miss[0]
+    assert miss[1]
+
+    n = 378  # one day short of a full year
+    times = pd.date_range('2000-01-01', freq='1D', periods=n)
+    da = xr.DataArray(np.arange(n), [('time', times)])
+
+    miss = checks.missing_any_fill(da, 'YS')
+    assert not miss[0]
+    assert miss[1]
+
+

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -49,4 +49,8 @@ def test_missing_any_fill():
     assert not miss[0]
     assert miss[1]
 
+    miss = checks.missing_any_fill(da, 'QS-DEC')
+    assert miss[0]
+    # assert not miss[1] This should be True. There is probably a bug in xarray or pandas.
+
 

--- a/xclim/checks.py
+++ b/xclim/checks.py
@@ -4,7 +4,7 @@ from warnings import warn
 
 import numpy as np
 import pandas as pd
-import xarray as xr
+
 
 # Dev notes
 # ---------
@@ -151,6 +151,7 @@ def convert_temp(da, required_units='K'):
     else:
         raise AttributeError(da.units)
 
+
 def missing_any_fill(da, freq):
     """Return a boolean DataArray indicating whether there are missing days in the resampled array.
 
@@ -168,14 +169,5 @@ def missing_any_fill(da, freq):
     """
     c = da.notnull().resample(time=freq).sum(dim='time')
     p = c.indexes['time'].to_period()
-    if 'M' in freq:
-        m = c.values != p.days_in_month
-    elif 'Y' in freq:
-        m = c.values != p.day_of_year
-    else:
-        raise NotImplementedError
-
-    return xr.DataArray(m, coords=c.coords, dims='time')
-
-
-
+    n = (p.end_time - p.start_time).days + 1
+    return c != n


### PR DESCRIPTION
Compare number of days that are not null with the expected number of days per period. 

For it to work with non-standard calendars, we'll have to implement CFPeriodIndex as well... 