### PR TITLE
Allowing failures on Python3.4 and Python3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,11 @@ matrix:
         - TOXENV=flake8
       python: 3.6
     - env:
+        - TOXENV=py37
+      python: 3.7
+      sudo: required
+      dist: xenial
+    - env:
         - TOXENV=py36
       python: 3.6
     - env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 
 language: python
 sudo: false
-
+env:
 matrix:
   include:
 #    - env: TOXENV=py37
@@ -27,6 +27,10 @@ matrix:
     - env:
         - TOXENV=py27
       python: 2.7
+  allow_failures:
+    - env:
+        - TOXENV=py34
+      python: 3.4
 
 # Command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,9 @@
 
 language: python
 sudo: false
-env:
+
 matrix:
   include:
-#    - env: TOXENV=py37
-#      python: 3.7
-#      sudo: required
-#      dist: xenial
     - env:
         - TOXENV=docs
       python: 3.6
@@ -28,6 +24,11 @@ matrix:
         - TOXENV=py27
       python: 2.7
   allow_failures:
+    - env:
+        - TOXENV=py37
+      python: 3.7
+      sudo: required
+      dist: xenial
     - env:
         - TOXENV=py34
       python: 3.4

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py27, py34, py35, py36, flake8, docs
 
 [travis]
 python =
-;    3.7: py37
+    3.7: py37
     3.6: py36
     3.5: py35
     3.4: py34

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
-envlist = py27, py34, py35, py36, flake8, docs
-; envlist = py27, py34, py35, py36, py37, flake8
+envlist = py27, py34, py35, py36, py37, flake8, docs
 
 [travis]
 python =


### PR DESCRIPTION
Adding this in as a potential option to ease backwards compatibility. Failed py34 tests will not trigger a failed build but if they continue to work, great! 