### PR TITLE
Consecutive dry days

### DIFF
--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -27,6 +27,7 @@ import pytest
 import xarray as xr
 
 import xclim.indices as xci
+from xclim.testing.common import pr_series
 
 xr.set_options(enable_cftimeindex=True)
 
@@ -162,6 +163,23 @@ class TestCoolingDegreeDays:
         assert cdd.long_name == 'cooling degree days'
         assert cdd.units == 'K*day'
         assert cdd.description
+
+
+class TestMaximumConsecutiveDryDays:
+
+    def test_simple(self, pr_series):
+        a = np.zeros(365) + 10
+        a[5:15] = 0
+        pr = pr_series(a)
+        out = xci.maximum_consecutive_dry_days(pr, freq='M')
+        assert out[0] == 10
+
+    def test_run_start_at_0(self, pr_series):
+        a = np.zeros(365) + 10
+        a[:10] = 0
+        pr = pr_series(a)
+        out = xci.maximum_consecutive_dry_days(pr, freq='M')
+        assert out[0] == 10
 
 
 class TestPrcpTotal:

--- a/tests/test_run_length.py
+++ b/tests/test_run_length.py
@@ -1,0 +1,54 @@
+from xclim import run_length as rl
+import xarray as xr
+import pandas as pd
+import numpy as np
+
+class TestLongestRun:
+    def test_simple(self):
+        values = np.zeros(365)
+        time = pd.date_range('7/1/2000', periods=len(values), freq=pd.DateOffset(days=1))
+        values[1:11] = 1
+        da = xr.DataArray(values, coords={'time': time}, dims='time')
+
+        l = rl.xr_longest_run(da != 0, 'M')
+        assert l[0] == 10
+        np.testing.assert_array_equal(l[1:], 0)
+
+    def test_start_at_0(self):
+        values = np.zeros(365)
+        time = pd.date_range('7/1/2000', periods=len(values), freq=pd.DateOffset(days=1))
+        values[0:10] = 1
+        da = xr.DataArray(values, coords={'time': time}, dims='time')
+
+        l = rl.xr_longest_run(da != 0, 'M')
+        assert l[0] == 10
+        np.testing.assert_array_equal(l[1:], 0)
+
+    def test_end_start_at_0(self):
+        values = np.zeros(365)
+        time = pd.date_range('7/1/2000', periods=len(values), freq=pd.DateOffset(days=1))
+        values[-10:] = 1
+        da = xr.DataArray(values, coords={'time': time}, dims='time')
+
+        l = rl.xr_longest_run(da != 0, 'M')
+        assert l[-1] == 10
+        np.testing.assert_array_equal(l[:-1], 0)
+
+    def test_all_true(self):
+        values = np.ones(365)
+        time = pd.date_range('7/1/2000', periods=len(values), freq=pd.DateOffset(days=1))
+        da = xr.DataArray(values, coords={'time': time}, dims='time')
+
+        l = rl.xr_longest_run(da != 0, 'M')
+        np.testing.assert_array_equal(l, da.resample(time='M').count(dim='time'))
+
+    def test_almost_all_true(self):
+        values = np.ones(365)
+        values[35] = 0
+        time = pd.date_range('7/1/2000', periods=len(values), freq=pd.DateOffset(days=1))
+        da = xr.DataArray(values, coords={'time': time}, dims='time')
+
+        l = rl.xr_longest_run(da != 0, 'M')
+        n = da.resample(time='M').count(dim='time')
+        np.testing.assert_array_equal(l[0], n[0])
+        np.testing.assert_array_equal(l[1], 26)

--- a/tests/test_run_length.py
+++ b/tests/test_run_length.py
@@ -1,54 +1,66 @@
 from xclim import run_length as rl
+
 import xarray as xr
 import pandas as pd
 import numpy as np
+
+
+class TestRLE:
+    def test_dataarray(self):
+        values = np.zeros(365)
+        time = pd.date_range('7/1/2000', periods=len(values), freq=pd.DateOffset(days=1))
+        values[1:11] = 1
+        da = xr.DataArray(values, coords={'time': time}, dims='time')
+
+        v, l, p = rl.rle(da != 0)
+
 
 class TestLongestRun:
     def test_simple(self):
         values = np.zeros(365)
         time = pd.date_range('7/1/2000', periods=len(values), freq=pd.DateOffset(days=1))
         values[1:11] = 1
-        da = xr.DataArray(values, coords={'time': time}, dims='time')
+        da = xr.DataArray(values != 0, coords={'time': time}, dims='time')
 
-        l = rl.xr_longest_run(da != 0, 'M')
-        assert l[0] == 10
-        np.testing.assert_array_equal(l[1:], 0)
+        lt = da.resample(time='M').apply(rl.longest_run_ufunc)
+        assert lt[0] == 10
+        np.testing.assert_array_equal(lt[1:], 0)
 
     def test_start_at_0(self):
         values = np.zeros(365)
         time = pd.date_range('7/1/2000', periods=len(values), freq=pd.DateOffset(days=1))
         values[0:10] = 1
-        da = xr.DataArray(values, coords={'time': time}, dims='time')
+        da = xr.DataArray(values != 0, coords={'time': time}, dims='time')
 
-        l = rl.xr_longest_run(da != 0, 'M')
-        assert l[0] == 10
-        np.testing.assert_array_equal(l[1:], 0)
+        lt = da.resample(time='M').apply(rl.longest_run_ufunc)
+        assert lt[0] == 10
+        np.testing.assert_array_equal(lt[1:], 0)
 
     def test_end_start_at_0(self):
         values = np.zeros(365)
         time = pd.date_range('7/1/2000', periods=len(values), freq=pd.DateOffset(days=1))
         values[-10:] = 1
-        da = xr.DataArray(values, coords={'time': time}, dims='time')
+        da = xr.DataArray(values != 0, coords={'time': time}, dims='time')
 
-        l = rl.xr_longest_run(da != 0, 'M')
-        assert l[-1] == 10
-        np.testing.assert_array_equal(l[:-1], 0)
+        lt = da.resample(time='M').apply(rl.longest_run_ufunc)
+        assert lt[-1] == 10
+        np.testing.assert_array_equal(lt[:-1], 0)
 
     def test_all_true(self):
         values = np.ones(365)
         time = pd.date_range('7/1/2000', periods=len(values), freq=pd.DateOffset(days=1))
-        da = xr.DataArray(values, coords={'time': time}, dims='time')
+        da = xr.DataArray(values != 0, coords={'time': time}, dims='time')
 
-        l = rl.xr_longest_run(da != 0, 'M')
-        np.testing.assert_array_equal(l, da.resample(time='M').count(dim='time'))
+        lt = da.resample(time='M').apply(rl.longest_run_ufunc)
+        np.testing.assert_array_equal(lt, da.resample(time='M').count(dim='time'))
 
     def test_almost_all_true(self):
         values = np.ones(365)
         values[35] = 0
         time = pd.date_range('7/1/2000', periods=len(values), freq=pd.DateOffset(days=1))
-        da = xr.DataArray(values, coords={'time': time}, dims='time')
+        da = xr.DataArray(values != 0, coords={'time': time}, dims='time')
 
-        l = rl.xr_longest_run(da != 0, 'M')
+        lt = da.resample(time='M').apply(rl.longest_run_ufunc)
         n = da.resample(time='M').count(dim='time')
-        np.testing.assert_array_equal(l[0], n[0])
-        np.testing.assert_array_equal(l[1], 26)
+        np.testing.assert_array_equal(lt[0], n[0])
+        np.testing.assert_array_equal(lt[1], 26)

--- a/xclim/__init__.py
+++ b/xclim/__init__.py
@@ -95,7 +95,7 @@ def __build_icclim(mode='warn'):
                'ID': indices.ice_days,
                'HD17': indices.heating_degree_days,
                # 'CDD': indices.consecutive_dry_days,
-               'CWD': indices.consecutive_wet_days,
+               'CWD': indices.maximum_consecutive_wet_days,
                # 'PRCPTOT': indices.prec_total,
                # 'RR1': indices.wet_days,
                'DTR': indices.daily_temperature_range, }

--- a/xclim/run_length.py
+++ b/xclim/run_length.py
@@ -86,6 +86,8 @@ def longest_run(arr):
     return np.where(v, rl, 0).max()
 
 
+# DO NOT USE #
+# This function does not work for some corner cases.
 def xr_longest_run(da, freq):
     """Return the length of the longest run of true values along the time dimension.
 
@@ -114,7 +116,8 @@ def xr_longest_run(da, freq):
 
     # Find the longest run by period - but it does not work if all values are True.
     run = diff_ind.resample(time=freq).max(dim='time')
-    return run
+
+    # Replace periods where all values are true by the item count
     g = da.resample(time=freq)
     return run.where(~g.all(dim='time'), g.count(dim='time'))
 


### PR DESCRIPTION
The code previously used to find the maximum number of consecutive days where a condition is True was not very robust. It didn't work if all values during the period where True, or if the end and start of individual periods where True. 

What I ended up doing is creating a ufunc based on longest_run, and that seems to work fine. 
We should however benchmark it against Seb's function. 

