### PR TITLE
Fix 85

### DIFF
--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -128,7 +128,7 @@ class TestColdSpellDurationIndex:
         tn = tasmin_series(tn)
         tn10 = percentile_doy(tn, per=.1)
 
-        out = xci.cold_spell_duration_index(tn, tn10, 'YS')
+        out = xci.cold_spell_duration_index(tn, tn10, freq='YS')
         assert out[0] == 10
 
 
@@ -547,7 +547,7 @@ class TestWarmSpellDurationIndex:
         tx = tasmax_series(tx)
         tx90 = percentile_doy(tx, per=.9)
 
-        out = xci.warm_spell_duration_index(tx, tx90, 'YS')
+        out = xci.warm_spell_duration_index(tx, tx90, freq='YS')
         assert out[0] == 10
 
 

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -522,6 +522,34 @@ class TestWarmMinimumAndMaximumTemperatureFrequency:
         np.testing.assert_allclose(wmmtf.values, [10])
 
 
+class TestWarmSpellDurationIndex:
+    def test_simple(self, tasmax_series):
+        tx = np.zeros(365) + K2C
+        tx90 = 330.
+
+        tx[10:20] += tx90 + 1
+        tx = tasmax_series(tx)
+
+        out = xci.warm_spell_duration_index(tx, tx90, 'YS')
+        assert out[0] == 10
+
+    def test_hole(self, tasmax_series):
+        tx = np.zeros(365) + K2C
+        tx90 = 330.
+
+        tx[10:15] += tx90 + 1
+        tx[17:20] += tx90 + 1
+        tx = tasmax_series(tx)
+
+        out = xci.warm_spell_duration_index(tx, tx90, 'YS')
+        assert out[0] == 0
+
+    @pytest.mark.skip("not implemented")
+    def test_doy(self, tasmax_series):
+        """Compute doy tx90 then compute WSDI"""
+        raise NotImplementedError
+
+
 class TestWinterRainRatio:
     def test_simple(self, pr_series, tas_series):
         pr = np.ones(450)

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -28,6 +28,7 @@ import xarray as xr
 
 import xclim.indices as xci
 from xclim.testing.common import tas_series, tasmax_series, tasmin_series, pr_series
+from xclim.utils import percentile_doy
 
 xr.set_options(enable_cftimeindex=True)
 
@@ -125,7 +126,7 @@ class TestColdSpellDurationIndex:
         tn = np.zeros(i) + K2C + A * np.sin(np.arange(i)/365. * 2 * np.pi) + .1*np.random.rand(i)
         tn[10:20] -= 2
         tn = tasmin_series(tn)
-        tn10 = xci.percentile_doy(tn, per=.1)
+        tn10 = percentile_doy(tn, per=.1)
 
         out = xci.cold_spell_duration_index(tn, tn10, 'YS')
         assert out[0] == 10
@@ -272,8 +273,8 @@ class TestHeatWaveIndex:
 class TestHeatWaveFrequency:
 
     def test_1d(self, tasmax_series, tasmin_series):
-        tn = tasmin_series([20, 23, 23, 23, 23, 22, 23, 23, 23, 23])
-        tx = tasmax_series([29, 31, 31, 31, 29, 31, 31, 31, 31, 31])
+        tn = tasmin_series([20, 23, 23, 23, 23, 22, 23, 23, 23, 23]) + K2C
+        tx = tasmax_series([29, 31, 31, 31, 29, 31, 31, 31, 31, 31]) + K2C
 
         # some hw
         hwf = xci.heat_wave_frequency(tn, tx, thresh_tasmin=22,
@@ -544,7 +545,7 @@ class TestWarmSpellDurationIndex:
         tx = np.zeros(i) + K2C + A * np.sin(np.arange(i)/365. * 2 * np.pi) + .1*np.random.rand(i)
         tx[10:20] += 2
         tx = tasmax_series(tx)
-        tx90 = xci.percentile_doy(tx, per=.9)
+        tx90 = percentile_doy(tx, per=.9)
 
         out = xci.warm_spell_duration_index(tx, tx90, 'YS')
         assert out[0] == 10

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -524,30 +524,16 @@ class TestWarmMinimumAndMaximumTemperatureFrequency:
 
 class TestWarmSpellDurationIndex:
     def test_simple(self, tasmax_series):
-        tx = np.zeros(365) + K2C
-        tx90 = 330.
 
-        tx[10:20] += tx90 + 1
+        i = 3650
+        A = 10.
+        tx = np.zeros(i) + K2C + A * np.sin(np.arange(i)/365. * 2 * np.pi) + .1*np.random.rand(i)
+        tx[10:20] += 2
         tx = tasmax_series(tx)
+        tx90 = xci.percentile_doy(tx, per=.9)
 
         out = xci.warm_spell_duration_index(tx, tx90, 'YS')
         assert out[0] == 10
-
-    def test_hole(self, tasmax_series):
-        tx = np.zeros(365) + K2C
-        tx90 = 330.
-
-        tx[10:15] += tx90 + 1
-        tx[17:20] += tx90 + 1
-        tx = tasmax_series(tx)
-
-        out = xci.warm_spell_duration_index(tx, tx90, 'YS')
-        assert out[0] == 0
-
-    @pytest.mark.skip("not implemented")
-    def test_doy(self, tasmax_series):
-        """Compute doy tx90 then compute WSDI"""
-        raise NotImplementedError
 
 
 class TestWinterRainRatio:

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -117,6 +117,20 @@ class TestMax1DayPrecipitationAmount:
         assert np.isnan(rx1day)
 
 
+class TestColdSpellDurationIndex:
+    def test_simple(self, tasmin_series):
+
+        i = 3650
+        A = 10.
+        tn = np.zeros(i) + K2C + A * np.sin(np.arange(i)/365. * 2 * np.pi) + .1*np.random.rand(i)
+        tn[10:20] -= 2
+        tn = tasmin_series(tn)
+        tn10 = xci.percentile_doy(tn, per=.1)
+
+        out = xci.cold_spell_duration_index(tn, tn10, 'YS')
+        assert out[0] == 10
+
+
 class TestColdSpellIndex:
     def test_simple(self, tas_series):
         a = np.zeros(365) + K2C

--- a/tests/test_run_length.py
+++ b/tests/test_run_length.py
@@ -74,3 +74,11 @@ class TestFirstRun:
         a[10:20] = 1
         i = rl.first_run(a, 5)
         assert 10 == i
+
+
+class TestWindowedRunEvents:
+    def test_simple(self):
+        a = np.zeros(50, bool)
+        a[4:7] = True
+        a[34:45] = True
+        assert rl.windowed_run_events(a, 3) == 2

--- a/xclim/indices.py
+++ b/xclim/indices.py
@@ -1265,7 +1265,7 @@ def warm_minimum_and_maximum_temperature_frequency(tasmin, tasmax, thresh_tasmin
     r"""Frequency days with hot maximum and minimum temperature
 
     Return the number of days with tasmin > thresh_tasmin
-                               and tasmax > thresh_tasamax per period
+                               and tasmax > thresh_tasmax per period
 
     Parameters
     ----------
@@ -1302,6 +1302,33 @@ def warm_night_frequency(tasmin, thresh=22, freq='YS'):
     """
     events = (tasmin > thresh) * 1
     return events.resample(time=freq).sum(dim='time')
+
+
+def warm_spell_duration_index(tasmax, tx90, freq='YS'):
+    """Warm spell duration index
+
+    Number of days with at least six consecutive days where the daily maximum temperature is above the 90th
+    percentile. The 90th percentile should be computed for a 5-day window centred on each calendar day in the
+    1961-1990 period.
+
+    Parameters
+    ----------
+    tasmax : xarray.DataArray
+      Maximum daily temperature [℃] or [K]
+    tx90 : float
+      90th percentile of daily maximum temperature [K]
+    freq : str, optional
+      Resampling frequency
+
+    Returns
+    xarray.DataArray
+      Count of days with at least six consecutive days with daily maximum temperature is above the 90th percentile [
+      days].
+
+    """
+    # TODO: This only works for a fixed tx90. Need to have it work with an array for each doy.
+    above = (tasmax > tx90)
+    return above.resample(time=freq).apply(rl.windowed_run_count_ufunc, window=6)
 
 
 def wet_days(pr, thresh=1.0, freq='YS'):

--- a/xclim/indices.py
+++ b/xclim/indices.py
@@ -63,7 +63,7 @@ def base_flow_index(q, freq='YS'):
     return m7m / mq.mean(dim='time')
 
 
-def cold_spell_duration_index(tasmin, tn10, freq='YS'):
+def cold_spell_duration_index(tasmin, tn10, window=6, freq='YS'):
     r"""Warm spell duration index
 
     Number of days with at least six consecutive days where the daily minimum temperature is below the 10th
@@ -106,7 +106,7 @@ def cold_spell_duration_index(tasmin, tn10, freq='YS'):
 
     below = (tasmin < thresh)
 
-    return below.resample(time=freq).apply(rl.windowed_run_count_ufunc, window=6)
+    return below.resample(time=freq).apply(rl.windowed_run_count_ufunc, window=window)
 
 
 def cold_spell_index(tas, thresh=-10, window=5, freq='AS-JUL'):
@@ -637,10 +637,23 @@ def heat_wave_frequency(tasmin, tasmax, thresh_tasmin=22.0, thresh_tasmax=30,
     xarray.DataArray
       Number of heatwave at the wanted frequency
 
+
+    Notes
+    -----
+    The thresholds of 22° and 25°C for night temperatures and 30° and 35°C for day temperatures were selected by
+    Health Canada professionals, following a temperature–mortality analysis. These absolute temperature thresholds
+    characterize the occurrence of hot weather events that can result in adverse health outcomes for Canadian
+    communities (Casati et al., 2013).
+
+    In Robinson (2001), the parameters would be `thresh_tasmin=27.22, thresh_tasmax=39.44, window=2` (81F, 103F).
+
     References
     ----------
-    In Robinson (2001), the parameters would be `thresh_tasmin=27.22, thresh_tasmax=39.44, window=2` (81F, 103F)
-    See Robinson, P.J., 2001: On the Definition of a Heat Wave. J. Appl. Meteor., 40, 762–775,
+    Casati, B., A. Yagouti, and D. Chaumont, 2013: Regional Climate Projections of Extreme Heat Events in Nine Pilot
+    Canadian Communities for Public Health Planning. J. Appl. Meteor. Climatol., 52, 2669–2698,
+    https://doi.org/10.1175/JAMC-D-12-0341.1
+
+    Robinson, P.J., 2001: On the Definition of a Heat Wave. J. Appl. Meteor., 40, 762–775,
     https://doi.org/10.1175/1520-0450(2001)040<0762:OTDOAH>2.0.CO;2
     """
 
@@ -1278,7 +1291,7 @@ def warm_night_frequency(tasmin, thresh=22, freq='YS'):
     return events.resample(time=freq).sum(dim='time')
 
 
-def warm_spell_duration_index(tasmax, tx90, freq='YS'):
+def warm_spell_duration_index(tasmax, tx90, window=6, freq='YS'):
     r"""Warm spell duration index
 
     Number of days with at least six consecutive days where the daily maximum temperature is above the 90th
@@ -1319,7 +1332,7 @@ def warm_spell_duration_index(tasmax, tx90, freq='YS'):
 
     above = (tasmax > thresh)
 
-    return above.resample(time=freq).apply(rl.windowed_run_count_ufunc, window=6)
+    return above.resample(time=freq).apply(rl.windowed_run_count_ufunc, window=window)
 
 
 def wet_days(pr, thresh=1.0, freq='YS'):

--- a/xclim/indices.py
+++ b/xclim/indices.py
@@ -1356,7 +1356,7 @@ def warm_minimum_and_maximum_temperature_frequency(tasmin, tasmax, thresh_tasmin
     r"""Frequency days with hot maximum and minimum temperature
 
     Returns the number of days with tasmin > thresh_tasmin
-                               and tasmax > thresh_tasamax per period
+                               and tasmax > thresh_tasmax per period
 
     Parameters
     ----------

--- a/xclim/indices.py
+++ b/xclim/indices.py
@@ -1326,8 +1326,18 @@ def warm_spell_duration_index(tasmax, tx90, freq='YS'):
       days].
 
     """
-    # TODO: This only works for a fixed tx90. Need to have it work with an array for each doy.
-    above = (tasmax > tx90)
+    if 'dayofyear' not in tx90.coords.keys():
+        raise AttributeError("tx90 should have dayofyear coordinates.")
+
+    # The day of year value of the tasmax series.
+    doy = tasmax.indexes['time'].dayofyear
+
+    # Create an array with the shape and coords of tasmax, but with values set to tx90 according to the doy index.
+    thresh = xr.full_like(tasmax, np.nan)
+    thresh.data = tx90.sel(dayofyear=doy)
+
+    above = (tasmax > thresh)
+
     return above.resample(time=freq).apply(rl.windowed_run_count_ufunc, window=6)
 
 


### PR DESCRIPTION
@sbiner regarde indices.warm_spell_duration_index et son test pour mon implémentation des percentiles. 
Ça ne supporte pas le shift de calendrier par défaut, donc encore à faire. 

Remove get_ev_length to solve our PEP8 complaint (function too complex). Replaced usage in heat_wave_frequency by run length. Added reference of usage. 