### PR TITLE
Support for multivariate indicators

### DIFF
--- a/tests/test_temperature.py
+++ b/tests/test_temperature.py
@@ -51,7 +51,7 @@ class TestFrostDays:
 
         fd1 = (x1[x1 < thresh]).size
         # fd2 = (x2[x2 < thresh]).size
-
+        
         assert (np.allclose(fd1, fd.values[0, 0, 0]))
         # assert (np.allclose(fd1, fds.values[0, 0, 0]))
         assert (np.isnan(fd.values[0, 1, 0]))

--- a/tests/test_temperature.py
+++ b/tests/test_temperature.py
@@ -51,7 +51,7 @@ class TestFrostDays:
 
         fd1 = (x1[x1 < thresh]).size
         # fd2 = (x2[x2 < thresh]).size
-        
+
         assert (np.allclose(fd1, fd.values[0, 0, 0]))
         # assert (np.allclose(fd1, fds.values[0, 0, 0]))
         assert (np.isnan(fd.values[0, 1, 0]))
@@ -100,18 +100,18 @@ class TestHeatWaveFrequency:
 
         # some hw
         hwf = temp.heat_wave_frequency(tn, tx, thresh_tasmin=22,
-                                      thresh_tasmax=30)
+                                       thresh_tasmax=30)
         np.testing.assert_allclose(hwf.values[:1], 2)
 
         hwf = temp.heat_wave_frequency(tn, tx, thresh_tasmin=22,
-                                      thresh_tasmax=30, window=4)
+                                       thresh_tasmax=30, window=4)
         np.testing.assert_allclose(hwf.values[:1], 1)
 
         # one long hw
         hwf = temp.heat_wave_frequency(tn, tx, thresh_tasmin=10,
-                                      thresh_tasmax=10)
+                                       thresh_tasmax=10)
         np.testing.assert_allclose(hwf.values[:1], 1)
         # no hw
         hwf = temp.heat_wave_frequency(tn, tx, thresh_tasmin=40,
-                                      thresh_tasmax=40)
+                                       thresh_tasmax=40)
         np.testing.assert_allclose(hwf.values[:1], 0)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -24,7 +24,7 @@ import pandas as pd
 import pytest
 import xarray as xr
 
-from xclim.utils import daily_downsampler, UnivariateIndicator, format_kwargs, parse_doc
+from xclim.utils import daily_downsampler, Indicator, format_kwargs, parse_doc
 from xclim.testing.common import tas_series, pr_series
 from xclim import indices as ind
 
@@ -115,7 +115,7 @@ class TestDailyDownsampler:
             assert (np.allclose(x2.values, target))
 
 
-class UniIndTemp(UnivariateIndicator):
+class UniIndTemp(Indicator):
     identifier = 'tmin'
     units = 'K'
     required_units = 'K'
@@ -128,10 +128,11 @@ class UniIndTemp(UnivariateIndicator):
         return da.resample(time=freq).mean()
 
 
-class UniIndPr(UnivariateIndicator):
+class UniIndPr(Indicator):
     identifier = 'prmax'
     units = 'kg m-2 s-1'
     required_units = 'kg m-2 s-1'
+    context = 'hydro'
 
     @staticmethod
     def compute(da, freq):
@@ -151,7 +152,7 @@ class TestUnivariateIndicator:
         ind = UniIndTemp()
         txk = ind(a, freq='YS')
 
-        ind.required_units = 'degC'
+        ind.required_units = ('degC',)
         ind.units = 'degC'
         txc = ind(a, freq='YS')
 
@@ -162,7 +163,7 @@ class TestUnivariateIndicator:
         ind = UniIndPr()
         txk = ind(a, freq='YS')
 
-        ind.required_units = 'mm/day'
+        ind.required_units = ('mm/day',)
         ind.units = 'mm'
         txm = ind(a, freq='YS')
 
@@ -179,11 +180,11 @@ class TestUnivariateIndicator:
 
     def test_factory(self, pr_series):
         attrs = dict(identifier='test', units='days', required_units='mm/day', long_name='long name',
-                     standard_name='standard name',
+                     standard_name='standard name', context='hydro'
                      )
-        cls = UnivariateIndicator.factory(attrs)
+        cls = Indicator.factory(attrs)
 
-        assert issubclass(cls, UnivariateIndicator)
+        assert issubclass(cls, Indicator)
         da = pr_series(np.arange(365))
         cls(compute=ind.wet_days)(da)
 

--- a/xclim/precip.py
+++ b/xclim/precip.py
@@ -1,9 +1,10 @@
 from . import indices as _ind
-from .utils import UnivariateIndicator
+from .utils import Indicator
 
 
-class Pr(UnivariateIndicator):
+class Pr(Indicator):
     required_units = 'mm'
+    context = 'hydro'
 
 
 r1max = Pr(identifier='r1max',

--- a/xclim/streamflow.py
+++ b/xclim/streamflow.py
@@ -1,9 +1,9 @@
 from . import checks
 from . import indices as _ind
-from .utils import UnivariateIndicator
+from .utils import Indicator
 
 
-class BaseFlowIndex(UnivariateIndicator):
+class BaseFlowIndex(Indicator):
     identifier = 'tx_max'
     units = 'm3 s-1'
     required_units = 'K'

--- a/xclim/temperature.py
+++ b/xclim/temperature.py
@@ -47,16 +47,18 @@ class Tasmax(Indicator):
         checks.check_valid(da, 'cell_methods', 'time: maximum within days')
         checks.check_valid(da, 'standard_name', 'air_temperature')
 
+
 class TasminTasmax(BivariateIndicator):
     required_units = ('K', 'K')
-    
+
     def cfprobe(self, dan, dax):
         for da in (dan, dax):
             checks.check_valid(da, 'cell_methods', 'time: maximum within days')
             checks.check_valid(da, 'standard_name', 'air_temperature')
 
+
 heat_wave_frequency = TasminTasmax(identifier='heat_wave_frequency',
-                                   units='', 
+                                   units='',
                                    long_name='Number of heat wave events',
                                    standard_name='events',
                                    description="Number of spells meeting criteria for health impacting heat wave.",

--- a/xclim/temperature.py
+++ b/xclim/temperature.py
@@ -14,7 +14,7 @@ for each indicator.
 
 from . import checks
 from . import indices as _ind
-from .utils import UnivariateIndicator
+from .utils import UnivariateIndicator, BivariateIndicator
 
 # TODO: Should we reference the standard vocabulary we're using ?
 # E.g. http://vocab.nerc.ac.uk/collection/P07/current/BHMHISG2/
@@ -46,6 +46,21 @@ class Tasmax(UnivariateIndicator):
         checks.check_valid(da, 'cell_methods', 'time: maximum within days')
         checks.check_valid(da, 'standard_name', 'air_temperature')
 
+class TasminTasmax(BivariateIndicator):
+    required_units = ('K', 'K')
+    
+    def cfprobe(self, dan, dax):
+        for da in (dan, dax):
+            checks.check_valid(da, 'cell_methods', 'time: maximum within days')
+            checks.check_valid(da, 'standard_name', 'air_temperature')
+
+heat_wave_frequency = TasminTasmax(identifier='heat_wave_frequency',
+                                   units='', 
+                                   long_name='Number of heat wave events',
+                                   standard_name='events',
+                                   description="Number of spells meeting criteria for health impacting heat wave.",
+                                   keywords="health,",
+                                   compute=_ind.heat_wave_frequency)
 
 tmmean = Tas(identifier='tmmean',
              units='K',

--- a/xclim/temperature.py
+++ b/xclim/temperature.py
@@ -7,20 +7,21 @@ While the `indices` module stores the computing functions, this module defines I
 include a number of functionalities, such as input validation, unit conversion, output meta-data handling,
 and missing value masking.
 
-The concept followed here is to define UnivariateIndicator subclasses for each input variable, then create instances
+The concept followed here is to define Indicator subclasses for each input variable, then create instances
 for each indicator.
 
 """
 
 from . import checks
 from . import indices as _ind
-from .utils import UnivariateIndicator, BivariateIndicator
+from .utils import Indicator
 
+Indicator = BivariateIndicator = Indicator
 # TODO: Should we reference the standard vocabulary we're using ?
 # E.g. http://vocab.nerc.ac.uk/collection/P07/current/BHMHISG2/
 
 
-class Tas(UnivariateIndicator):
+class Tas(Indicator):
     """Class for univariate indices using mean daily temperature as the input."""
     required_units = 'K'
 
@@ -29,7 +30,7 @@ class Tas(UnivariateIndicator):
         checks.check_valid(da, 'standard_name', 'air_temperature')
 
 
-class Tasmin(UnivariateIndicator):
+class Tasmin(Indicator):
     """Class for univariate indices using min daily temperature as the input."""
     required_units = 'K'
 
@@ -38,7 +39,7 @@ class Tasmin(UnivariateIndicator):
         checks.check_valid(da, 'standard_name', 'air_temperature')
 
 
-class Tasmax(UnivariateIndicator):
+class Tasmax(Indicator):
     """Class for univariate indices using max daily temperature as the input."""
     required_units = 'K'
 

--- a/xclim/utils.py
+++ b/xclim/utils.py
@@ -62,7 +62,7 @@ def percentile_doy(arr, window=5, per=.1):
 
 def get_daily_events(da, da_value, operator):
     r"""
-    function that returns a 0/1 mask when a condtion is True or False
+    function that returns a 0/1 mask when a condition is True or False
 
     the function returns 1 where operator(da, da_value) is True
                          0 where operator(da, da_value) is False
@@ -154,11 +154,11 @@ def daily_downsampler(da, freq='YS'):
     return buffer.groupby('tags')
 
 
-class UnivariateIndicator(object):
-    r"""Univariate indicator
+class Indicator(object):
+    r"""Indicator class
 
     This class needs to be subclassed by individual indicator classes defining metadata information, compute and
-    missing functions.
+    missing functions. It can handle indicators with any number of forcing fields.
 
     """
     # Unique ID for registry. May use tags {<tag>} that will be formatted at runtime.
@@ -169,11 +169,14 @@ class UnivariateIndicator(object):
     long_name = ''  # Scraped from compute.__doc.__.
     units = ''  # Representative units of the physical quantity.
     cell_methods = ''  # List of blank-separated words of the form "name: method"
-    description = ''  # The description is meant to clarify the qualifiers of the fundamental quantities such a which
+    description = ''  # The description is meant to clarify the qualifiers of the fundamental quantities, such as which
     #   surface a quantity is defined on or what the flux sign conventions are.
 
     # The units expected by the function. Used to convert input units to the required_units.
     required_units = ''
+
+    # The `pint` unit context. Use 'hydro' to allow conversion from kg m-2 s-1 to mm/day.
+    context = None
 
     # Additional information made available to third party libraries.
     title = ''  # Scraped from compute.__doc.__
@@ -198,9 +201,9 @@ class UnivariateIndicator(object):
 
         # Infer number of variables from `required_units`.
         if isinstance(self.required_units, six.string_types):
-            self._nvar = 1
-        else:
-            self._nvar = len(self.required_units)
+            self.required_units = (self.required_units,)
+
+        self._nvar = len(self.required_units)
 
         # Extract information from the `compute` function.
         # The signature
@@ -223,27 +226,29 @@ class UnivariateIndicator(object):
         ba = self._sig.bind(*args, **kwds)
         ba.apply_defaults()
 
-        # Assume the first argument is always the DataArray.
-        da = ba.arguments.pop(self._parameters[0])
+        # Assume the two first arguments are always the DataArray.
+        das = tuple((ba.arguments.pop(self._parameters[i]) for i in range(self._nvar)))
 
         # Pre-computation validation checks
-        self.validate(da)
-        self.cfprobe(da)
+        for da in das:
+            self.validate(da)
+        self.cfprobe(*das)
 
         # Convert units if necessary
-        da = self.convert_units(da)
+        das = tuple((self.convert_units(da, ru, self.context) for (da, ru) in zip(das, self.required_units)))
 
         # Compute the indicator values, ignoring NaNs.
-        out = self.compute(da, **ba.arguments)
+        out = self.compute(*das, **ba.arguments)
 
         # Set metadata attributes to the output according to class attributes.
         self.decorate(out, ba.arguments)
 
         # Bind call arguments to the `missing` function, whose signature might be different from `compute`.
-        mba = signature(self.missing).bind(da, **ba.arguments)
+        mba = signature(self.missing).bind(*das, **ba.arguments)
 
         # Mask results that do not meet criteria defined by the `missing` method.
-        ma_out = out.where(~self.missing(**mba.arguments))
+        mask = self.missing(*mba.args, **mba.kwargs)
+        ma_out = out.where(~mask)
 
         return ma_out.rename(self.identifier.format(ba.arguments))
 
@@ -271,22 +276,26 @@ class UnivariateIndicator(object):
 
         return out
 
-    def cfprobe(self, da):
+    def cfprobe(self, *das):
         """Check input data compliance to expectations.
         Warn of potential issues."""
         pass
 
     @abc.abstractmethod
-    def compute(da, freq='Y', *args, **kwds):
+    def compute(*args, **kwds):
         """The function computing the indicator."""
 
-    def convert_units(self, da):
-        """Return DataArray with correct units, defined by `self.required_units`."""
+    @staticmethod
+    def convert_units(da, req_units, context=None):
+        """Return DataArray converted to unit."""
         fu = units.parse_units(da.attrs['units'].replace('-', '**-'))
-        tu = units.parse_units(self.required_units.replace('-', '**-'))
+        tu = units.parse_units(req_units.replace('-', '**-'))
         if fu != tu:
             b = da.copy()
-            b.values = (da.values * fu).to(tu, 'hydro')
+            if context:
+                b.values = (da.values * fu).to(tu, context)
+            else:
+                b.values = (da.values * fu).to(tu)
             return b
 
         return da
@@ -314,9 +323,13 @@ class UnivariateIndicator(object):
         da.attrs.update(attrs)
 
     @staticmethod
-    def missing(da, freq='Y', *args, **kwds):
+    def missing(*args, **kwds):
         """Return whether an output is considered missing or not."""
-        return checks.missing_any(da, freq)
+        from functools import reduce
+
+        freq = kwds.get('freq')
+        miss = (checks.missing_any(da, freq) for da in args)
+        return reduce(xr.ufuncs.logical_or, miss)
 
     def validate(self, da):
         """Validate input data requirements.
@@ -328,70 +341,6 @@ class UnivariateIndicator(object):
         """Create a subclass from the attributes dictionary."""
         name = attrs['identifier'].capitalize()
         return type(name, (cls,), attrs)
-
-
-class BivariateIndicator(UnivariateIndicator):
-    required_units = ('', '')
-
-    def __call__(self, *args, **kwds):
-        # Bind call arguments. We need to use the class signature, not the instance, otherwise it removes the first
-        # argument.
-        ba = self._sig.bind(*args, **kwds)
-        ba.apply_defaults()
-
-        # Assume the two first arguments are always the DataArray.
-        das = tuple((ba.arguments.pop(self._parameters[i]) for i in range(self._nvar)))
-
-        # Pre-computation validation checks
-        for da in das:
-            self.validate(da)
-        self.cfprobe(*das)
-
-        # Convert units if necessary
-        das = tuple((self.convert_units(da, ru) for (da, ru) in zip(das, self.required_units)))
-
-        # Compute the indicator values, ignoring NaNs.
-        out = self.compute(*das, **ba.arguments)
-
-        # Set metadata attributes to the output according to class attributes.
-        self.decorate(out, ba.arguments)
-
-        # Bind call arguments to the `missing` function, whose signature might be different from `compute`.
-        mba = signature(self.missing).bind(*das, **ba.arguments)
-
-        # Mask results that do not meet criteria defined by the `missing` method.
-        mask = self.missing(**mba.arguments)
-        ma_out = out.where(~mask)
-
-        return ma_out.rename(self.identifier.format(ba.arguments))
-
-    def cfprobe(self, *das):
-        """Check input data compliance to expectations.
-        Warn of potential issues."""
-        pass
-
-    @abc.abstractmethod
-    def compute(da1, da2, freq='Y', *args, **kwds):
-        """The function computing the indicator."""
-
-    @staticmethod
-    def convert_units(da, req_units):
-        """Return DataArray converted to unit."""
-        fu = units.parse_units(da.attrs['units'].replace('-', '**-'))
-        tu = units.parse_units(req_units.replace('-', '**-'))
-        if fu != tu:
-            b = da.copy()
-            b.values = (da.values * fu).to(tu, 'hydro')
-            return b
-
-        return da
-
-    @staticmethod
-    def missing(da1, da2, freq='Y', *args, **kwds):
-        """Return whether an output is considered missing or not."""
-        m1 = checks.missing_any(da1, freq)
-        m2 = checks.missing_any(da2, freq)
-        return m1 + m2
 
 
 def parse_doc(obj):
@@ -420,16 +369,6 @@ def parse_doc(obj):
     return out
 
 
-def first_paragraph(txt):
-    r"""Return the first paragraph of a text
-
-    Parameters
-    ----------
-    txt : str
-    """
-    return txt.split('\n\n')[0]
-
-
 def format_kwargs(attrs, params):
     """Modify attribute with argument values.
 
@@ -455,34 +394,3 @@ def format_kwargs(attrs, params):
 
         attrs[key] = val.format(**mba).format(**attrs_mapping.get(key, {}))
 
-
-def with_attrs(**func_attrs):
-    r"""Set attributes in the decorated function at definition time,
-    and assign these attributes to the function output at the
-    execution time.
-
-    Note
-    ----
-    Assumes the output has an attrs dictionary attribute (e.g. xarray.DataArray).
-    """
-
-    def attr_decorator(fn):
-        # Use the docstring as the description attribute.
-        func_attrs['description'] = first_paragraph(fn.__doc__)
-
-        @wraps(fn)
-        def wrapper(*args, **kwargs):
-            out = fn(*args, **kwargs)
-            # Bind the arguments
-            ba = signature(fn).bind(*args, **kwargs)
-            format_kwargs(func_attrs, ba.arguments)
-            out.attrs.update(func_attrs)
-            return out
-
-        # Assign the attributes to the function itself
-        for attr, value in func_attrs.items():
-            setattr(wrapper, attr, value)
-
-        return wrapper
-
-    return attr_decorator

--- a/xclim/utils.py
+++ b/xclim/utils.py
@@ -7,7 +7,6 @@ xclim xarray.DataArray utilities module
 import numpy as np
 import xarray as xr
 import six
-from functools import wraps
 import pint
 from . import checks
 from inspect2 import signature
@@ -393,4 +392,3 @@ def format_kwargs(attrs, params):
                 mba[k] = v
 
         attrs[key] = val.format(**mba).format(**attrs_mapping.get(key, {}))
-


### PR DESCRIPTION
Converts UnivariateIndicator to Indicator, which can handle any number of driving variables. 

The logic is based on counting the number of required_units. If required_units is a string, then we assume the class is Univariate. If required_units is a tuple `('K', 'K')`, then we assume it's multivariate with n = len(required_units). 



