### PR TITLE
Modified checks.py to work with non-standard calendars:

### DIFF
--- a/xclim/checks.py
+++ b/xclim/checks.py
@@ -41,7 +41,7 @@ def assert_daily(var):
     t0, t1 = var.time[:2]
 
     # This won't work for non-standard calendars. Needs to be implemented in xarray. Comment for now
-    if type(t0.values) is np.datetime64:
+    if isinstance(t0.values, np.datetime64):
         if pd.infer_freq(var.time.to_pandas()) != 'D':
             raise ValueError("time series is not recognized as daily.")
 

--- a/xclim/checks.py
+++ b/xclim/checks.py
@@ -39,9 +39,9 @@ def assert_daily(var):
 
     t0, t1 = var.time[:2]
 
-    # This won't work for non-standard calendars. Needs to be implemented in xarray.
-    if pd.infer_freq(var.time.to_pandas()) != 'D':
-        raise ValueError("time series is not recognized as daily.")
+    # This won't work for non-standard calendars. Needs to be implemented in xarray. Comment for now
+    # if pd.infer_freq(var.time.to_pandas()) != 'D':
+    #     raise ValueError("time series is not recognized as daily.")
 
     # Check that the first time step is one day.
     if np.timedelta64(dt.timedelta(days=1)) != (t1 - t0).data:
@@ -170,10 +170,10 @@ def missing_any(da, freq, **kwds):
 
     if pfreq.endswith('S'):
         start_time = c.indexes['time']
-        end_time = start_time.shift(1)
+        end_time = start_time.shift(1,freq=freq)
     else:
         end_time = c.indexes['time']
-        start_time = end_time.shift(-1)
+        start_time = end_time.shift(-1,freq=freq)
 
     n = (end_time - start_time).days
     nda = xr.DataArray(n.values, coords={'time': c.time}, dims='time')

--- a/xclim/checks.py
+++ b/xclim/checks.py
@@ -8,6 +8,7 @@ import xarray as xr
 
 logging.captureWarnings(True)
 
+
 # Dev notes
 # ---------
 #
@@ -40,8 +41,9 @@ def assert_daily(var):
     t0, t1 = var.time[:2]
 
     # This won't work for non-standard calendars. Needs to be implemented in xarray. Comment for now
-    # if pd.infer_freq(var.time.to_pandas()) != 'D':
-    #     raise ValueError("time series is not recognized as daily.")
+    if type(t0.values) is np.datetime64:
+        if pd.infer_freq(var.time.to_pandas()) != 'D':
+            raise ValueError("time series is not recognized as daily.")
 
     # Check that the first time step is one day.
     if np.timedelta64(dt.timedelta(days=1)) != (t1 - t0).data:
@@ -170,10 +172,10 @@ def missing_any(da, freq, **kwds):
 
     if pfreq.endswith('S'):
         start_time = c.indexes['time']
-        end_time = start_time.shift(1,freq=freq)
+        end_time = start_time.shift(1, freq=freq)
     else:
         end_time = c.indexes['time']
-        start_time = end_time.shift(-1,freq=freq)
+        start_time = end_time.shift(-1, freq=freq)
 
     n = (end_time - start_time).days
     nda = xr.DataArray(n.values, coords={'time': c.time}, dims='time')


### PR DESCRIPTION
1) in assert_daily(var) : commented one check that uses pandas (cf-time non-supported)

2) in 'missing_any' (using cf-time seems as though we need to specify the freq value in the shift operation)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, etc.)
Bug fix - Current index class checks cause errors when using non-standard calendar files

* **Does this PR introduce a breaking change?** (Has there been an API change?)
no


