### PR TITLE
Fix runlength backfill bug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+git+git://github.com/Ouranosinc/xarray@master
 .

--- a/setup.py
+++ b/setup.py
@@ -18,15 +18,16 @@ requirements = [
     'scipy>=1.2',
     'cftime>=1.0.3',
     'netCDF4>=1.4',
-    'dask>=0.18',
+    'dask[complete]',
     'bottleneck>=1.2.1',
-    'xarray',
+    # 'xarray',
     'pint>=0.8',
     'inspect2>=0.1',
     'unittest2>=1.1',
     'six>=1.11',
-    'boltons>=18.0'
+    'boltons>=18.0',
 ]
+
 setup_requirements = ['pytest-runner', ]
 
 test_requirements = ['pytest', 'tox', ]

--- a/xclim/indices.py
+++ b/xclim/indices.py
@@ -121,7 +121,7 @@ def base_flow_index(q, freq='YS'):
       Base flow index.
     """
 
-    m7 = q.rolling(time=7, center=True).mean(dim='time').resample(time=freq)
+    m7 = q.rolling(time=7, center=True).mean().resample(time=freq)
     mq = q.resample(time=freq)
 
     m7m = m7.min(dim='time')
@@ -669,7 +669,7 @@ def growing_season_length(tas, thresh=5.0, window=6, freq='YS'):
     i = xr.DataArray(np.arange(tas.time.size), dims='time')
     ind = xr.broadcast(i, tas)[0]
 
-    c = ((tas > thresh + K2C) * 1).rolling(time=window).sum(dim='time')
+    c = ((tas > thresh + K2C) * 1).rolling(time=window).sum()
     i1 = ind.where(c == window).resample(time=freq).min(dim='time')
 
     # Resample sets the time to T00:00.
@@ -991,8 +991,8 @@ def max_n_day_precipitation_amount(pr, window=1, freq='YS'):
     """
 
     # rolling sum of the values
-    arr = pr.rolling(time=window, center=False).sum(dim='time')
-    return arr.resample(time=freq).max(dim='time')
+    arr = pr.rolling(time=window, center=False).sum()
+    return arr.resample(time=freq).max()
 
 
 def max_1day_precipitation_amount(pr, freq='YS'):

--- a/xclim/indices.py
+++ b/xclim/indices.py
@@ -921,8 +921,8 @@ def liquid_precip_ratio(pr, prsn=None, tas=None, freq='QS-DEC'):
     if prsn is None:
         prsn = pr.where(tas < K2C, 0)
 
-    tot = pr.resample(time=freq).sum()
-    rain = tot - prsn.resample(time=freq).sum()
+    tot = pr.resample(time=freq).sum(dim='time')
+    rain = tot - prsn.resample(time=freq).sum(dim='time')
     ratio = rain / tot
     return ratio
 
@@ -992,7 +992,7 @@ def max_n_day_precipitation_amount(pr, window=1, freq='YS'):
 
     # rolling sum of the values
     arr = pr.rolling(time=window, center=False).sum()
-    return arr.resample(time=freq).max()
+    return arr.resample(time=freq).max(dim='time')
 
 
 def max_1day_precipitation_amount(pr, freq='YS'):

--- a/xclim/run_length.py
+++ b/xclim/run_length.py
@@ -5,10 +5,11 @@ import numpy as np
 import xarray as xr
 import logging
 from warnings import warn
+
 logging.captureWarnings(True)
 
 
-def rle(da, dim='time',max_chunk=1000000):
+def rle(da, dim='time', max_chunk=1000000):
     n = len(da[dim])
     i = xr.DataArray(np.arange(da[dim].size), dims=dim)
     ind = xr.broadcast(i, da)[0]
@@ -24,9 +25,9 @@ def rle(da, dim='time',max_chunk=1000000):
     chunk_dim = b[dim].size
     # divide extra dims into equal size
     # Note : even if calculated chunksize > dim.size result will have chunk==dim.size
-    if ndims>1:
-        chunksize_ex_dims = np.round(np.power( max_chunk / chunk_dim, 1/(ndims-1)))
-    chunks ={}
+    if ndims > 1:
+        chunksize_ex_dims = np.round(np.power(max_chunk / chunk_dim, 1 / (ndims - 1)))
+    chunks = {}
     chunks[dim] = -1
     for dd in b.dims:
         if dd != dim:

--- a/xclim/run_length.py
+++ b/xclim/run_length.py
@@ -17,8 +17,9 @@ def rle(da, dim='time'):
     end1 = da.where(b[dim] == b[dim][-1], drop=True) * 0 + n  # add additional end value index (deal with end cases)
     start1 = da.where(b[dim] == b[dim][0], drop=True) * 0 - 1  # add additional start index (deal with end cases)
     b = xr.concat([start1, b, end1], dim)
-    z = b.bfill(dim=dim)
-    z = z.where(~np.isnan(z), n)  # backfill not filling last sequence from end1?
+    b = b.chunk({dim:30})
+    z = b.bfill(dim=dim) # backfill nans
+    z = z.ffill(dim=dim) #forwardfill to double check
     d = z.diff(dim=dim) - 1
     d = d.where(d >= 0)
     return d

--- a/xclim/run_length.py
+++ b/xclim/run_length.py
@@ -24,7 +24,8 @@ def rle(da, dim='time',max_chunk=1000000):
     chunk_dim = b[dim].size
     # divide extra dims into equal size
     # Note : even if calculated chunksize > dim.size result will have chunk==dim.size
-    chunksize_ex_dims = np.round(np.power( max_chunk / chunk_dim, 1/(ndims-1)))
+    if ndims>1:
+        chunksize_ex_dims = np.round(np.power( max_chunk / chunk_dim, 1/(ndims-1)))
     chunks ={}
     chunks[dim] = -1
     for dd in b.dims:

--- a/xclim/run_length.py
+++ b/xclim/run_length.py
@@ -8,7 +8,7 @@ from warnings import warn
 logging.captureWarnings(True)
 
 
-def rle(da, dim='time'):
+def rle(da, dim='time',max_chunk=1000000):
     n = len(da[dim])
     i = xr.DataArray(np.arange(da[dim].size), dims=dim)
     ind = xr.broadcast(i, da)[0]
@@ -17,9 +17,24 @@ def rle(da, dim='time'):
     end1 = da.where(b[dim] == b[dim][-1], drop=True) * 0 + n  # add additional end value index (deal with end cases)
     start1 = da.where(b[dim] == b[dim][0], drop=True) * 0 - 1  # add additional start index (deal with end cases)
     b = xr.concat([start1, b, end1], dim)
-    b = b.chunk({dim:30})
-    z = b.bfill(dim=dim) # backfill nans
-    z = z.ffill(dim=dim) #forwardfill to double check
+
+    # Ensure bfill operates on entire (unchunked) time dimension
+    # Determine appropraite chunk size for other dims - do not exceed 'max_chunk' total size per chunk (default 1000000)
+    ndims = len(b.shape)
+    chunk_dim = b[dim].size
+    # divide extra dims into equal size
+    # Note : even if calculated chunksize > dim.size result will have chunk==dim.size
+    chunksize_ex_dims = np.round(np.power( max_chunk / chunk_dim, 1/(ndims-1)))
+    chunks ={}
+    chunks[dim] = -1
+    for dd in b.dims:
+        if dd != dim:
+            chunks[dd] = chunksize_ex_dims
+    b = b.chunk(chunks)
+
+    # back fill nans with first position after
+    z = b.bfill(dim=dim)
+    # calculate lengths
     d = z.diff(dim=dim) - 1
     d = d.where(d >= 0)
     return d


### PR DESCRIPTION
I found some strange behavior from da.bfill() not catching nans in the run_length calculation.  Seems to be only when the data is a dask array with chunk=1 for time.  Changing the chunking seems to fix the issue. Have also added a subsequent .ffill to make sure that all nans are caught.


Also changed 'rolling' calls which now throw errors if we specify the dimension