### PR TITLE
Broadcast memory management

### DIFF
--- a/xclim/indices.py
+++ b/xclim/indices.py
@@ -701,7 +701,7 @@ def growing_season_length(tas, thresh=5.0, window=6, freq='YS'):
     def compute_gsl(c):
         nt = c.time.size
         i = xr.DataArray(np.arange(nt), dims='time')
-        i = i.chunk({'time':1})
+        i = i.chunk({'time': 1})
 
         ind = xr.broadcast(i, c)[0]
         ind = ind.chunk(c.chunks)

--- a/xclim/indices.py
+++ b/xclim/indices.py
@@ -700,20 +700,13 @@ def growing_season_length(tas, thresh=5.0, window=6, freq='YS'):
 
     def compute_gsl(c):
         nt = c.time.size
-        i = xr.DataArray(np.arange(nt), dims='time')
-        i = i.chunk({'time': 1})
-
-        ind = xr.broadcast(i, c)[0]
-        ind = ind.chunk(c.chunks)
-
+        i = xr.DataArray(np.arange(nt), dims='time').chunk({'time': 1})
+        ind = xr.broadcast(i, c)[0].chunk(c.chunks)
         i1 = ind.where(c == window).min(dim='time')
         i1 = xr.where(np.isnan(i1), nt, i1)
-
         i11 = i1.reindex_like(c, method='ffill')
-
         i2 = ind.where((c == 0) & (ind > i11)).where(c.time.dt.month >= 7)
         i2 = xr.where(np.isnan(i2), nt, i2)
-
         d = (i2 - i1).min(dim='time')
         return d
 

--- a/xclim/indices.py
+++ b/xclim/indices.py
@@ -696,12 +696,15 @@ def growing_season_length(tas, thresh=5.0, window=6, freq='YS'):
 
     # compute growth season length on resampled data
 
-    c = ((tas > thresh + K2C) * 1).rolling(time=window).sum()
+    c = ((tas > thresh + K2C) * 1).rolling(time=window).sum().chunk(tas.chunks)
 
     def compute_gsl(c):
         nt = c.time.size
         i = xr.DataArray(np.arange(nt), dims='time')
+        i = i.chunk({'time':1})
+
         ind = xr.broadcast(i, c)[0]
+        ind = ind.chunk(c.chunks)
 
         i1 = ind.where(c == window).min(dim='time')
         i1 = xr.where(np.isnan(i1), nt, i1)

--- a/xclim/run_length.py
+++ b/xclim/run_length.py
@@ -11,12 +11,9 @@ logging.captureWarnings(True)
 
 def rle(da, dim='time', max_chunk=1000000):
     n = len(da[dim])
-    i = xr.DataArray(np.arange(da[dim].size), dims=dim)
-    i = i.chunk({'time': 1})
-    ind = xr.broadcast(i, da)[0]
-    ind = ind.chunk(da.chunks)
+    i = xr.DataArray(np.arange(da[dim].size), dims=dim).chunk({'time': 1})
+    ind = xr.broadcast(i, da)[0].chunk(da.chunks)
     b = ind.where(~da)  # find indexes where false
-
     end1 = da.where(b[dim] == b[dim][-1], drop=True) * 0 + n  # add additional end value index (deal with end cases)
     start1 = da.where(b[dim] == b[dim][0], drop=True) * 0 - 1  # add additional start index (deal with end cases)
     b = xr.concat([start1, b, end1], dim)
@@ -134,10 +131,8 @@ def first_run(da, window, dim='time'):
         da['time'] = da[dim]
         da.swap_dims({dim: 'time'})
     da = da.astype('int')
-    i = xr.DataArray(np.arange(da[dim].size), dims=dim)
-    i = i.chunk({'time': 1})
-    ind = xr.broadcast(i, da)[0]
-    ind = ind.chunk(da.chunks)
+    i = xr.DataArray(np.arange(da[dim].size), dims=dim).chunk({'time': 1})
+    ind = xr.broadcast(i, da)[0].chunk(da.chunks)
     wind_sum = da.rolling(time=window).sum()
     out = ind.where(wind_sum >= window).min(dim=dim) - (
         window - 1)  # remove window -1 as rolling result index is last element of the moving window

--- a/xclim/run_length.py
+++ b/xclim/run_length.py
@@ -12,7 +12,9 @@ logging.captureWarnings(True)
 def rle(da, dim='time', max_chunk=1000000):
     n = len(da[dim])
     i = xr.DataArray(np.arange(da[dim].size), dims=dim)
+    i = i.chunk({'time': 1})
     ind = xr.broadcast(i, da)[0]
+    ind = ind.chunk(da.chunks)
     b = ind.where(~da)  # find indexes where false
 
     end1 = da.where(b[dim] == b[dim][-1], drop=True) * 0 + n  # add additional end value index (deal with end cases)
@@ -133,7 +135,9 @@ def first_run(da, window, dim='time'):
         da.swap_dims({dim: 'time'})
     da = da.astype('int')
     i = xr.DataArray(np.arange(da[dim].size), dims=dim)
+    i = i.chunk({'time': 1})
     ind = xr.broadcast(i, da)[0]
+    ind = ind.chunk(da.chunks)
     wind_sum = da.rolling(time=window).sum()
     out = ind.where(wind_sum >= window).min(dim=dim) - (
         window - 1)  # remove window -1 as rolling result index is last element of the moving window


### PR DESCRIPTION
xr.broadcast() calls in run_length.py and growing_season_length can create very large arrays in memory when working with mf_datasets or very large .nc data variables.  This fix makes sure that broadcast arrays are dask / chunked in memory... When appropraite the chunking is copied from the input dataarray 
