### PR TITLE
no need for port forwarding for both jupyter notebook and dask dashboard

### DIFF
--- a/docs/notebooks/xclim_training/XCLIM Demo - Ensembles.ipynb
+++ b/docs/notebooks/xclim_training/XCLIM Demo - Ensembles.ipynb
@@ -79,7 +79,7 @@
    ],
    "source": [
     "# start client\n",
-    "client=Client(n_workers=2, threads_per_worker=10, dashboard_address=8788, memory_limit='10GB')\n",
+    "client=Client(n_workers=2, threads_per_worker=10, dashboard_address=8788, ip='0.0.0.0', memory_limit='10GB')\n",
     "client"
    ]
   },

--- a/docs/notebooks/xclim_training/XCLIM_calculate_index-Exemple.ipynb
+++ b/docs/notebooks/xclim_training/XCLIM_calculate_index-Exemple.ipynb
@@ -103,7 +103,7 @@
    ],
    "source": [
     "from distributed import Client\n",
-    "client=Client(n_workers=2, threads_per_worker=10, dashboard_address=8788, memory_limit='6GB') \n",
+    "client=Client(n_workers=2, threads_per_worker=10, dashboard_address=8788, ip='0.0.0.0', memory_limit='6GB') \n",
     "#client=Client(n_workers=1)\n",
     "client"
    ]

--- a/docs/notebooks/xclim_training/readme.ipynb
+++ b/docs/notebooks/xclim_training/readme.ipynb
@@ -17,7 +17,7 @@
     "2. Charger le module `Anaconda`\n",
     "3. Ouvrir l'environnement `python36`\n",
     "4. Lancer un serveur de notebook jupyter avec le port désigné (8888 dans l'exemple) : voir liste ci-dessous pour le port à utiliser\n",
-    "5. Copier l'URL commençant par http://localhost:\n",
+    "5. Copier l'URL commençant par http://doris ou neree:\n",
     "\n",
     "### Liste de ports par poste de travail pour la formation\n",
     "1. Poste 1 : JP=8890 ; DP=8790\n",
@@ -55,7 +55,7 @@
     "$ module load Anaconda\n",
     "$ export OMP_NUM_THREADS=4\n",
     "$ source activate python36\n",
-    "$ jupyter notebook --no-browser --port {JP}    "
+    "$ jupyter notebook --no-browser --port {JP} --ip 0.0.0.0   "
    ]
   },
   {
@@ -64,17 +64,7 @@
    "source": [
     "## Sur votre machine\n",
     "\n",
-    "1. Créer un tunnel entre le serveur et votre laptop (un port pour le notebook {JP} et un port pour le dashboard {DP} \n",
-    "2. Accéder à Jupyter dans un navigateur via l'URL  http://localhost:{JP}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "$ ssh -N -L{JP}:localhost:{JP} -L{DP}:localhost:{DP} user@server"
+    "1. Accéder à Jupyter dans un navigateur via l'URL affiché par la commande `jupyter notebook` précédent http://doris ou neree:{JP}"
    ]
   },
   {
@@ -83,8 +73,7 @@
    "source": [
     "## À la fin de la formation\n",
     "\n",
-    "1. Fermer Jupyter sur le serveur (CTRL-C)\n",
-    "2. Fermer le tunnel sur votre machine"
+    "1. Fermer Jupyter sur le serveur (CTRL-C)\n"
    ]
   },
   {


### PR DESCRIPTION
Jupyter notebook and the dask dashboard will bind directly to the public IP of doris or neree.  See URL used in screenshot below, note also the URL of the dask dashboard.

![no-port-forwarding](https://user-images.githubusercontent.com/11966697/57706408-ad097a80-7633-11e9-90e3-cc9f407d409f.png)


User will directly use the hostname and IP address of doris and neree.

* **Please check if the PR fulfills these requirements**
- [ ] This PR addresses an already opened issue (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)



* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, etc.)


* **Does this PR introduce a breaking change?** (Has there been an API change?)


* **Other information**:


* When merging, please put `fixes #{issue number}` in your comment to auto-close the issue that your PR addresses. Thanks!
