### PR TITLE
Remove six and Python2/3 compatibility libraries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,12 +38,10 @@ matrix:
       python: 3.6
     - env: TOXENV=py35
       python: 3.5
-    - env: TOXENV=py27
-      python: 2.7
   allow_failures:
     - env: TOXENV=py38-dev
     - env: TOXENV=py37
-    - env: TOXENV=py27
+
 
 install:
     - sudo -H pip install --upgrade pip

--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,6 @@ requirements = [
     'pyproj>=1.9.5.1',
     'pint>=0.8',
     'boltons>=18.0',
-    'inspect2',
-    'unittest2',
-    'six',
 ]
 
 setup_requirements = ['pytest-runner', ]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -246,7 +246,7 @@ class TestIndicator:
         cls(compute=indices.wetdays)(da)
 
     def test_signature(self):
-        from inspect2 import signature
+        from inspect import signature
         ind = UniIndTemp()
         assert signature(ind.compute) == signature(ind.__call__)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36, py37, py38-dev, flake8, docs
+envlist = py35, py36, py37, py38-dev, flake8, docs
 
 [travis]
 python =
@@ -7,7 +7,6 @@ python =
     3.7: py37
     3.6: py36
     3.5: py35
-    2.7: py27
     3.6: flake8
     3.6: docs
 

--- a/xclim/utils.py
+++ b/xclim/utils.py
@@ -747,7 +747,7 @@ class Indicator(object):
             for k, v in args.items():
                 if isinstance(v, str) and v in self._attrs_mapping.get(key, {}).keys():
                     mba[k] = '{{{}}}'.format(v)
-                if isinstance(v, dict):
+                elif isinstance(v, dict):
                     if v:
                         dk, dv = v.copy().popitem()
                         if dk == 'month':

--- a/xclim/utils.py
+++ b/xclim/utils.py
@@ -15,7 +15,6 @@ from inspect import signature
 
 import numpy as np
 import pint
-import six
 import xarray as xr
 from boltons.funcutils import wraps
 
@@ -722,8 +721,8 @@ class Indicator(object):
         out['parameters'] = str({key: {'default': p.default if p.default != p.empty else None, 'desc': ''}
                                  for (key, p) in self._sig.parameters.items()})
 
-        if six.PY2:
-            out = walk_map(out, lambda x: x.decode('utf8') if isinstance(x, six.string_types) else x)
+        # if six.PY2:
+        #     out = walk_map(out, lambda x: x.decode('utf8') if isinstance(x, six.string_types) else x)
 
         return out
 
@@ -746,9 +745,9 @@ class Indicator(object):
             mba = {'indexer': 'annual'}
             # Add formatting {} around values to be able to replace them with _attrs_mapping using format.
             for k, v in args.items():
-                if isinstance(v, six.string_types) and v in self._attrs_mapping.get(key, {}).keys():
+                if isinstance(v, str) and v in self._attrs_mapping.get(key, {}).keys():
                     mba[k] = '{{{}}}'.format(v)
-                elif isinstance(v, dict):
+                if isinstance(v, dict):
                     if v:
                         dk, dv = v.copy().popitem()
                         if dk == 'month':
@@ -835,7 +834,7 @@ def format_kwargs(attrs, params):
         mba = {}
         # Add formatting {} around values to be able to replace them with _attrs_mapping using format.
         for k, v in params.items():
-            if isinstance(v, six.string_types) and v in attrs_mapping.get(key, {}).keys():
+            if isinstance(v, str) and v in attrs_mapping.get(key, {}).keys():
                 mba[k] = '{' + v + '}'
             else:
                 mba[k] = v


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] This PR addresses an already opened issue (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, etc.)
This removes the Python2 compatibility utilities. 

* **Does this PR introduce a breaking change?** (Has there been an API change?)
This kills Python2, once and for all.

* **Other information**:
This change is necessary as many of the 2/3 compatible libraries that are needed to run some tests are preventing xclim from being ported to Anaconda. The Python2 build has not been failing for several months as xarray no longer supports Python < 3.5 since their 0.11.2 release.

* When merging, please put `fixes #{issue number}` in your comment to auto-close the issue that your PR addresses. Thanks!
