### PR TITLE
Skipping GrowingSeasonLength tests in Python3.7

### DIFF
--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -282,7 +282,7 @@ class TestGrowingDegreeDays:
 
 
 @pytest.mark.skipif(
-    sys.version_info > (3, 6),
+    sys.version_info >= (3, 7),
     reason="GrowingSeasonLength causes a dask-related SegFault",
 )
 class TestGrowingSeasonLength:

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -16,6 +16,7 @@
 # import cftime
 import calendar
 import os
+import sys
 
 import numpy as np
 import pandas as pd
@@ -280,6 +281,10 @@ class TestGrowingDegreeDays:
         assert xci.growing_degree_days(da)[0] == 1
 
 
+@pytest.mark.skipif(
+    sys.version_info > (3, 6),
+    reason="GrowingSeasonLength causes a dask-related SegFault",
+)
 class TestGrowingSeasonLength:
     def test_simple(self, tas_series):
         # test for different growing length

--- a/tests/test_temperature.py
+++ b/tests/test_temperature.py
@@ -751,7 +751,7 @@ class TestDailyFreezeThaw:
 
 
 @pytest.mark.skipif(
-    sys.version_info > (3, 6),
+    sys.version_info >= (3, 7),
     reason="GrowingSeasonLength causes a dask-related SegFault",
 )
 class TestGrowingSeasonLength:

--- a/tests/test_temperature.py
+++ b/tests/test_temperature.py
@@ -1,6 +1,8 @@
 import os
+import sys
 
 import numpy as np
+import pytest
 import xarray as xr
 
 import xclim.atmos as atmos
@@ -748,6 +750,10 @@ class TestDailyFreezeThaw:
         assert np.isnan(frzthw.values[0, -1, -1])
 
 
+@pytest.mark.skipif(
+    sys.version_info > (3, 6),
+    reason="GrowingSeasonLength causes a dask-related SegFault",
+)
 class TestGrowingSeasonLength:
     def test_single_year(self, tas_series):
         a = np.zeros(366) + K2C


### PR DESCRIPTION
For discussion purposes, see #242 

* **Please check if the PR fulfills these requirements**
- [x] This PR addresses an already opened issue (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated
- [ ] bumpversion (minor / major / patch) has been called
- [ ] Tags have been pushed

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, etc.)
Currently, the fix is simply to skip the GrowingSeasonLength tests for the Python3.7 build

* **Does this PR introduce a breaking change?** (Has there been an API change?)
No.

* **Other information**:
It would be good to know with certainty what might be causing this issue and whether or not this error is within the scope of xclim or is because of a bug in dask, xarray, or pandas.

* When merging, please put `fixes #{issue number}` in your comment to auto-close the issue that your PR addresses. Thanks!
