### PR TITLE
Commit no longer performed on bumpversion

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [bumpversion]
 current_version = 0.10.6-beta
-commit = True
+commit = False
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+).(?P<patch>\d+)(\-(?P<release>[a-z]+))?
 serialize =


### PR DESCRIPTION
<!--Please ensure the PR fulfills the follwing requirements-->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated **UNNECESSARY**

### After merging to master and before closing the branch:
- [ ] bumpversion (minor / major / patch) has been called on `master` branch
- [ ] Tags have been pushed

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
When `bumpversion` is called, `bumpversion` no longer performs a commit automatically. After bumping the version, a commit must be made manually (e.g. `git commit -m "bumped version 0.10.x to 0.11.x"`)

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
No.

* **Other information**:
Pre-commit hooks that are run at the same time that bumpversion is run creates a synchronous call of commands and causes some of the hooks to fail. By preventing pre-commit hooks from running due to bumpversion being called, this should solve the issue. 

<!--* When merging, please put `fixes #{issue number}` in your comment to auto-close the issue that your PR addresses. Thanks!-->
This PR fixes #xyz
