### PR TITLE
Set up CI with Azure Pipelines

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,7 @@ root = true
 indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true
-insert_final_newline = true
+insert_final_newline = false
 charset = utf-8
 end_of_line = lf
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,7 @@ root = true
 indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true
-insert_final_newline = false
+insert_final_newline = true
 charset = utf-8
 end_of_line = lf
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: python
 
 sudo: false
 
-#branches:
-#  only:
-#    - master
-#    - ^v[0-9]+\.[0-9]+[\.]?[a-c-]?[0-9]?[\w-]+\b
+branches:
+  only:
+    - master
+    - ^v[0-9]+\.[0-9]+[\.]?[a-c-]?[0-9]?[\w-]+\b
 
 matrix:
   fast_finish: true

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -15,6 +15,7 @@ History
 * Modified create_ensembles() to allow creation of ensemble dataset without a time dimension as well as from xr.Datasets
 * Modified create ensembles() to pad input data with nans when time dimensions are unequal
 * Updated subset_gridpoint() and subset_bbox() to use .sel method if 'lon' and 'lat' dims are present.
+* Added Azure Pipelines to automatically build xclim in Microsoft Windows environments
 
 0.10-beta (2019-06-06)
 ----------------------

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,35 @@
+# Python package
+# Create and test a Python package on multiple Python versions.
+# Add steps that analyze code, save the dist with the build record, publish to a PyPI-compatible index, and more:
+# https://docs.microsoft.com/azure/devops/pipelines/languages/python
+
+trigger:
+- master
+
+pool:
+  vmImage: 'vs2017-win2016'
+strategy:
+  matrix:
+    Python35:
+      python.version: '3.5'
+    Python36:
+      python.version: '3.6'
+    Python37:
+      python.version: '3.7'
+
+steps:
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: '$(python.version)'
+  displayName: 'Use Python $(python.version)'
+
+- script: |
+    python -m pip install --upgrade pip
+    pip install -r requirements.txt
+  displayName: 'Install dependencies'
+
+- script: |
+    pip install pytest pytest-azurepipelines
+    pip install .
+    pytest tests
+  displayName: 'pytest'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@
 # Add steps that analyze code, save the dist with the build record, publish to a PyPI-compatible index, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/languages/python
 
-trigger:
+pr:
 - master
 
 pool:
@@ -16,6 +16,7 @@ strategy:
       python.version: '3.6'
     Python37:
       python.version: '3.7'
+  maxParallel: 3
 
 steps:
 - task: UsePythonVersion@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,11 +25,10 @@ steps:
 
 - script: |
     python -m pip install --upgrade pip
-    pip install -r requirements.txt
+    pip install -e .
   displayName: 'Install dependencies'
 
 - script: |
     pip install pytest pytest-azurepipelines
-    pip install .
     pytest tests
   displayName: 'pytest'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
-current_version = 0.10.6-beta
+current_version = 0.10.7-beta
 commit = False
-tag = True
+tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+).(?P<patch>\d+)(\-(?P<release>[a-z]+))?
 serialize =
 	{major}.{minor}.{patch}-{release}

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ URL = "https://github.com/Ouranosinc/xclim"
 AUTHOR = "Travis Logan"
 AUTHOR_EMAIL = "logan.travis@ouranos.ca"
 REQUIRES_PYTHON = ">=3.5.0"
-VERSION = "0.10.6-beta"
+VERSION = "0.10.7-beta"
 LICENSE = "Apache Software License 2.0"
 
 with open("README.rst") as readme_file:

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: Apache Software License",
         "Natural Language :: English",
+        "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",

--- a/xclim/__init__.py
+++ b/xclim/__init__.py
@@ -9,7 +9,7 @@ from xclim import indices
 
 __author__ = """Travis Logan"""
 __email__ = "logan.travis@ouranos.ca"
-__version__ = "0.10.6-beta"
+__version__ = "0.10.7-beta"
 
 
 def build_module(name, objs, doc="", source=None, mode="ignore"):


### PR DESCRIPTION
Test building of the xclim library with Azure Pipeline integration in order to ensure that Windows is supported. Similar to Travis CI, Azure Pipelines is a free CI service and supports builds using Windows Server 2016 as well as others. The current configuration only tests for build and unit tests (pytest) on a Windows VM.

This PR closes #252 