### PR TITLE
Added a temperature threshold for freezethaw cycle events

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,7 +2,7 @@
 * Python version:
 * Operating System:
 
-### Description 
+### Description
 <!--Describe what you were trying to get done.
 Tell us what happened, what went wrong, and what you expected to happen.-->
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,4 +22,3 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-

--- a/docs/itable.py
+++ b/docs/itable.py
@@ -19,13 +19,17 @@ def _get_indicators(modules):
 def _indicator_table():
     """Return a sequence of dicts storing metadata about all available indices."""
     from xclim import atmos
-    import inspect2
+    import inspect
 
     inds = _get_indicators([atmos])
     table = []
     for ind in inds:
         # Apply default values
-        args = {name: p.default for (name, p) in ind._sig.parameters.items() if p.default != inspect2._empty}
+        args = {
+            name: p.default
+            for (name, p) in ind._sig.parameters.items()
+            if p.default != inspect._empty
+        }
         table.append(ind.json(args))
     return table
 

--- a/docs/itable.rst
+++ b/docs/itable.rst
@@ -33,6 +33,3 @@ Table of indicators
       background-color: #dddddd;
     }
    </style>
-
-
-

--- a/docs/rstjinja.py
+++ b/docs/rstjinja.py
@@ -3,14 +3,12 @@ def rstjinja(app, docname, source):
     Render our pages as a jinja template for fancy templating goodness.
     """
     # Make sure we're outputting HTML
-    if app.builder.format != 'html':
+    if app.builder.format != "html":
         return
     src = source[0]
-    rendered = app.builder.templates.render_string(
-        src, app.config.html_context
-    )
+    rendered = app.builder.templates.render_string(src, app.config.html_context)
     source[0] = rendered
-    
+
 
 def setup(app):
     app.connect("source-read", rstjinja)

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ ignore =
 	F401
 	F403
 	W503
+    W504
 
 [aliases]
 test = pytest

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -116,9 +116,9 @@ class TestColdSpellDurationIndex:
         i = 3650
         A = 10.0
         tn = (
-            np.zeros(i) +
-            A * np.sin(np.arange(i) / 365.0 * 2 * np.pi) +
-            0.1 * np.random.rand(i)
+            np.zeros(i)
+            + A * np.sin(np.arange(i) / 365.0 * 2 * np.pi)
+            + 0.1 * np.random.rand(i)
         )
         tn[10:20] -= 2
         tn = tasmin_series(tn)
@@ -282,13 +282,13 @@ class TestFreshetStart:
         w = 5
 
         i = 10
-        tg[i: i + w - 1] += 6  # too short
+        tg[i : i + w - 1] += 6  # too short
 
         i = 20
-        tg[i: i + w] += 6  # ok
+        tg[i : i + w] += 6  # ok
 
         i = 30
-        tg[i: i + w + 1] += 6  # Second valid condition, should be ignored.
+        tg[i : i + w + 1] += 6  # Second valid condition, should be ignored.
 
         tg = tas_series(tg + K2C, start="1/1/2000")
         out = xci.freshet_start(tg, window=w)
@@ -889,9 +889,9 @@ class TestWarmSpellDurationIndex:
         i = 3650
         A = 10.0
         tx = (
-            np.zeros(i) +
-            A * np.sin(np.arange(i) / 365.0 * 2 * np.pi) +
-            0.1 * np.random.rand(i)
+            np.zeros(i)
+            + A * np.sin(np.arange(i) / 365.0 * 2 * np.pi)
+            + 0.1 * np.random.rand(i)
         )
         tx[10:20] += 2
         tx = tasmax_series(tx)

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -220,11 +220,11 @@ class TestDailyFreezeThawCycles:
 
         mn = tasmin_series(mn + K2C)
         mx = tasmax_series(mx + K2C)
-        out = xci.daily_freezethaw_cycles(mx, mn, thresh="0 degC", freq="M")
+        out = xci.daily_freezethaw_cycles(mx, mn, freq="M")
         np.testing.assert_array_equal(out[:2], [5, 1])
         np.testing.assert_array_equal(out[2:], 0)
 
-    def test_negative_one(self, tasmin_series, tasmax_series):
+    def test_zeroed_thresholds(self, tasmin_series, tasmax_series):
         mn = np.zeros(365)
         mx = np.zeros(365)
 
@@ -238,8 +238,10 @@ class TestDailyFreezeThawCycles:
 
         mn = tasmin_series(mn + K2C)
         mx = tasmax_series(mx + K2C)
-        out = xci.daily_freezethaw_cycles(mx, mn, thresh="-1 degC", freq="M")
-        np.testing.assert_array_equal(out[:2], [0, 0])
+        out = xci.daily_freezethaw_cycles(
+            mx, mn, thresh_tasmax="0 degC", thresh_tasmin="0 degC", freq="M"
+        )
+        np.testing.assert_array_equal(out[:2], [5, 1])
         np.testing.assert_array_equal(out[2:], 0)
 
 

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -116,9 +116,9 @@ class TestColdSpellDurationIndex:
         i = 3650
         A = 10.0
         tn = (
-            np.zeros(i)
-            + A * np.sin(np.arange(i) / 365.0 * 2 * np.pi)
-            + 0.1 * np.random.rand(i)
+            np.zeros(i) +
+            A * np.sin(np.arange(i) / 365.0 * 2 * np.pi) +
+            0.1 * np.random.rand(i)
         )
         tn[10:20] -= 2
         tn = tasmin_series(tn)
@@ -220,8 +220,26 @@ class TestDailyFreezeThawCycles:
 
         mn = tasmin_series(mn + K2C)
         mx = tasmax_series(mx + K2C)
-        out = xci.daily_freezethaw_cycles(mx, mn, "M")
+        out = xci.daily_freezethaw_cycles(mx, mn, thresh="0 degC", freq="M")
         np.testing.assert_array_equal(out[:2], [5, 1])
+        np.testing.assert_array_equal(out[2:], 0)
+
+    def test_negative_one(self, tasmin_series, tasmax_series):
+        mn = np.zeros(365)
+        mx = np.zeros(365)
+
+        # 5 days in 1st month
+        mn[10:20] -= 1
+        mx[10:15] += 1
+
+        # 1 day in 2nd month
+        mn[40:44] += [1, 1, -1, -1]
+        mx[40:44] += [1, -1, 1, -1]
+
+        mn = tasmin_series(mn + K2C)
+        mx = tasmax_series(mx + K2C)
+        out = xci.daily_freezethaw_cycles(mx, mn, thresh="-1 degC", freq="M")
+        np.testing.assert_array_equal(out[:2], [0, 0])
         np.testing.assert_array_equal(out[2:], 0)
 
 
@@ -264,13 +282,13 @@ class TestFreshetStart:
         w = 5
 
         i = 10
-        tg[i : i + w - 1] += 6  # too short
+        tg[i: i + w - 1] += 6  # too short
 
         i = 20
-        tg[i : i + w] += 6  # ok
+        tg[i: i + w] += 6  # ok
 
         i = 30
-        tg[i : i + w + 1] += 6  # Second valid condition, should be ignored.
+        tg[i: i + w + 1] += 6  # Second valid condition, should be ignored.
 
         tg = tas_series(tg + K2C, start="1/1/2000")
         out = xci.freshet_start(tg, window=w)
@@ -871,9 +889,9 @@ class TestWarmSpellDurationIndex:
         i = 3650
         A = 10.0
         tx = (
-            np.zeros(i)
-            + A * np.sin(np.arange(i) / 365.0 * 2 * np.pi)
-            + 0.1 * np.random.rand(i)
+            np.zeros(i) +
+            A * np.sin(np.arange(i) / 365.0 * 2 * np.pi) +
+            0.1 * np.random.rand(i)
         )
         tx[10:20] += 2
         tx = tasmax_series(tx)

--- a/tests/test_run_length.py
+++ b/tests/test_run_length.py
@@ -59,7 +59,7 @@ class TestLongestRun:
 
         # n-dim version versus ufunc
         da3d = xr.open_dataset(self.nc_pr).pr[:, 40:50, 50:68] * 0
-        da3d[0:10, ] = da3d[0:10, ] + 1
+        da3d[0:10,] = da3d[0:10,] + 1
         da3d = da3d == 1
         lt_orig = da3d.resample(time="M").apply(rl.longest_run_ufunc)
         # override 'auto' usage of ufunc for small number of gridpoints
@@ -82,7 +82,7 @@ class TestLongestRun:
 
         # n-dim version versus ufunc
         da3d = xr.open_dataset(self.nc_pr).pr[:, 40:50, 50:68] * 0
-        da3d[-10:, ] = da3d[-10:, ] + 1
+        da3d[-10:,] = da3d[-10:,] + 1
         da3d = da3d == 1
         lt_orig = da3d.resample(time="M").apply(rl.longest_run_ufunc)
         lt_Ndim = da3d.resample(time="M").apply(
@@ -124,7 +124,7 @@ class TestLongestRun:
 
         # n-dim version versus ufunc
         da3d = xr.open_dataset(self.nc_pr).pr[:, 40:50, 50:68] * 0 + 1
-        da3d[35, ] = da3d[35, ] + 1
+        da3d[35,] = da3d[35,] + 1
         da3d = da3d == 1
         lt_orig = da3d.resample(time="M").apply(rl.longest_run_ufunc)
         lt_Ndim = da3d.resample(time="M").apply(

--- a/tests/test_run_length.py
+++ b/tests/test_run_length.py
@@ -59,7 +59,7 @@ class TestLongestRun:
 
         # n-dim version versus ufunc
         da3d = xr.open_dataset(self.nc_pr).pr[:, 40:50, 50:68] * 0
-        da3d[0:10,] = da3d[0:10,] + 1
+        da3d[0:10, ] = da3d[0:10, ] + 1
         da3d = da3d == 1
         lt_orig = da3d.resample(time="M").apply(rl.longest_run_ufunc)
         # override 'auto' usage of ufunc for small number of gridpoints
@@ -82,7 +82,7 @@ class TestLongestRun:
 
         # n-dim version versus ufunc
         da3d = xr.open_dataset(self.nc_pr).pr[:, 40:50, 50:68] * 0
-        da3d[-10:,] = da3d[-10:,] + 1
+        da3d[-10:, ] = da3d[-10:, ] + 1
         da3d = da3d == 1
         lt_orig = da3d.resample(time="M").apply(rl.longest_run_ufunc)
         lt_Ndim = da3d.resample(time="M").apply(
@@ -124,7 +124,7 @@ class TestLongestRun:
 
         # n-dim version versus ufunc
         da3d = xr.open_dataset(self.nc_pr).pr[:, 40:50, 50:68] * 0 + 1
-        da3d[35,] = da3d[35,] + 1
+        da3d[35, ] = da3d[35, ] + 1
         da3d = da3d == 1
         lt_orig = da3d.resample(time="M").apply(rl.longest_run_ufunc)
         lt_Ndim = da3d.resample(time="M").apply(

--- a/tests/test_temperature.py
+++ b/tests/test_temperature.py
@@ -706,14 +706,12 @@ class TestDailyFreezeThaw:
         # put a nan somewhere
         tasmin.values[180, 1, 0] = np.nan
 
-        frzthw = atmos.daily_freezethaw_cycles(
-            tasmax, tasmin, thresh="0 degC", freq="YS"
-        )
+        frzthw = atmos.daily_freezethaw_cycles(tasmax, tasmin, freq="YS")
 
         min1 = tasmin.values[:, 0, 0]
         max1 = tasmax.values[:, 0, 0]
 
-        frzthw1 = ((min1 < K2C) * (max1 > K2C) * 1.0).sum()
+        frzthw1 = ((min1 < K2C - 1) * (max1 > K2C) * 1.0).sum()
 
         assert np.allclose(frzthw1, frzthw.values[0, 0, 0])
 
@@ -732,13 +730,13 @@ class TestDailyFreezeThaw:
         tasmin.values[180, 1, 0] = np.nan
 
         frzthw = atmos.daily_freezethaw_cycles(
-            tasmax, tasmin, thresh="0 degC", freq="YS"
+            tasmax, tasmin, thresh_tasmax="0 degC", thresh_tasmin="-1 degC", freq="YS"
         )
 
         min1 = tasmin.values[:, 0, 0]
         max1 = tasmax.values[:, 0, 0]
 
-        frzthw1 = ((min1 < 0) * (max1 > 0) * 1.0).sum()
+        frzthw1 = ((min1 < -1) * (max1 > 0) * 1.0).sum()
 
         assert np.allclose(frzthw1, frzthw.values[0, 0, 0])
 

--- a/tests/test_temperature.py
+++ b/tests/test_temperature.py
@@ -706,7 +706,9 @@ class TestDailyFreezeThaw:
         # put a nan somewhere
         tasmin.values[180, 1, 0] = np.nan
 
-        frzthw = atmos.daily_freezethaw_cycles(tasmax, tasmin, freq="YS")
+        frzthw = atmos.daily_freezethaw_cycles(
+            tasmax, tasmin, thresh="0 degC", freq="YS"
+        )
 
         min1 = tasmin.values[:, 0, 0]
         max1 = tasmax.values[:, 0, 0]
@@ -729,7 +731,9 @@ class TestDailyFreezeThaw:
         # put a nan somewhere
         tasmin.values[180, 1, 0] = np.nan
 
-        frzthw = atmos.daily_freezethaw_cycles(tasmax, tasmin, freq="YS")
+        frzthw = atmos.daily_freezethaw_cycles(
+            tasmax, tasmin, thresh="0 degC", freq="YS"
+        )
 
         min1 = tasmin.values[:, 0, 0]
         max1 = tasmax.values[:, 0, 0]

--- a/xclim/atmos/__init__.py
+++ b/xclim/atmos/__init__.py
@@ -10,5 +10,5 @@ The concept followed here is to define Indicator subclasses for each input varia
 for each indicator.
 
 """
-from ._temperature import *
 from ._precip import *
+from ._temperature import *

--- a/xclim/atmos/_temperature.py
+++ b/xclim/atmos/_temperature.py
@@ -306,7 +306,7 @@ daily_freezethaw_cycles = TasminTasmax(
     standard_name="daily_freezethaw_cycles",
     long_name="daily freezethaw cycles",
     description="{freq} number of days with a diurnal freeze-thaw cycle "
-    ": Tmax > 0℃ and Tmin < 0℃.",
+    ": Tmax > 0℃ and Tmin <= -1℃.",
     cell_methods="",
     compute=indices.daily_freezethaw_cycles,
 )

--- a/xclim/atmos/_temperature.py
+++ b/xclim/atmos/_temperature.py
@@ -306,7 +306,7 @@ daily_freezethaw_cycles = TasminTasmax(
     standard_name="daily_freezethaw_cycles",
     long_name="daily freezethaw cycles",
     description="{freq} number of days with a diurnal freeze-thaw cycle "
-    ": Tmax > 0℃ and Tmin <= -1℃.",
+    ": Tmax > {thresh_tasmax} and Tmin <= {thresh_tasmin}.",
     cell_methods="",
     compute=indices.daily_freezethaw_cycles,
 )

--- a/xclim/indices/__init__.py
+++ b/xclim/indices/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 """
 Indices library
 ===============
@@ -68,9 +67,9 @@ Indice descriptions
 .. _`NumPy`: https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard
 """
 
+from ._multivariate import *
 from ._simple import *
 from ._threshold import *
-from ._multivariate import *
 
 # TODO: Define a unit conversion system for temperature [K, C, F] and precipitation [mm h-1, Kg m-2 s-1] metrics
 # TODO: Move utility functions to another file.

--- a/xclim/indices/_multivariate.py
+++ b/xclim/indices/_multivariate.py
@@ -154,9 +154,15 @@ def cold_and_dry_days(tas, tgin25, pr, wet25, freq="YS"):
 
 
 @declare_units(
-    "days", tasmax="[temperature]", tasmin="[temperature]", thresh="[temperature]"
+    "days",
+    tasmax="[temperature]",
+    tasmin="[temperature]",
+    thresh_tasmax="[temperature]",
+    thresh_tasmin="[temperature]",
 )
-def daily_freezethaw_cycles(tasmax, tasmin, thresh="0 degC", freq="YS"):
+def daily_freezethaw_cycles(
+    tasmax, tasmin, thresh_tasmax="0 degC", thresh_tasmin="-1 degC", freq="YS"
+):
     r"""Number of days with a diurnal freeze-thaw cycle
 
     The number of days where Tmax > 0℃ and Tmin < 0℃.
@@ -167,8 +173,10 @@ def daily_freezethaw_cycles(tasmax, tasmin, thresh="0 degC", freq="YS"):
       Maximum daily temperature [℃] or [K]
     tasmin : xarray.DataArray
       Minimum daily temperature values [℃] or [K]
-    thresh : str
-      The temperature threshold needed to trigger a freeze-thaw event [℃] or [K]. Default : '0 degC'
+    thresh_tasmax : str
+      The temperature threshold needed to trigger a thaw event [℃] or [K]. Default : '0 degC'
+    thresh_tasmin : str
+      The temperature threshold needed to trigger a freeze event [℃] or [K]. Default : '-1 degC'
     freq : str
       Resampling frequency
 
@@ -189,9 +197,12 @@ def daily_freezethaw_cycles(tasmax, tasmin, thresh="0 degC", freq="YS"):
 
     where :math:`[P]` is 1 if :math:`P` is true, and 0 if false.
     """
-    frz = utils.convert_units_to(thresh, tasmax)
-    ft = (tasmin < frz) * (tasmax > frz) * 1
+    thaw_threshold = utils.convert_units_to(thresh_tasmax, tasmax)
+    freeze_threshold = utils.convert_units_to(thresh_tasmin, tasmin)
+
+    ft = (tasmin <= freeze_threshold) * (tasmax > thaw_threshold) * 1
     out = ft.resample(time=freq).sum(dim="time")
+
     return out
 
 

--- a/xclim/indices/_multivariate.py
+++ b/xclim/indices/_multivariate.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 
 import numpy as np
 import xarray as xr
@@ -161,7 +162,11 @@ def cold_and_dry_days(tas, tgin25, pr, wet25, freq="YS"):
     thresh_tasmin="[temperature]",
 )
 def daily_freezethaw_cycles(
-    tasmax, tasmin, thresh_tasmax="0 degC", thresh_tasmin="-1 degC", freq="YS"
+    tasmax,
+    tasmin,
+    thresh_tasmax="UNSET 0 degC",
+    thresh_tasmin="UNSET 0 degC",
+    freq="YS",
 ):
     r"""Number of days with a diurnal freeze-thaw cycle
 
@@ -197,6 +202,12 @@ def daily_freezethaw_cycles(
 
     where :math:`[P]` is 1 if :math:`P` is true, and 0 if false.
     """
+    if thresh_tasmax.startswith("UNSET ") or thresh_tasmin.startswith("UNSET"):
+        thresh_tasmax, thresh_tasmin = (
+            thresh_tasmax.replace("UNSET ", ""),
+            thresh_tasmin.replace("UNSET ", ""),
+        )
+
     thaw_threshold = utils.convert_units_to(thresh_tasmax, tasmax)
     freeze_threshold = utils.convert_units_to(thresh_tasmin, tasmin)
 

--- a/xclim/indices/_multivariate.py
+++ b/xclim/indices/_multivariate.py
@@ -170,7 +170,7 @@ def daily_freezethaw_cycles(
 ):
     r"""Number of days with a diurnal freeze-thaw cycle
 
-    The number of days where Tmax > 0℃ and Tmin < 0℃.
+    The number of days where Tmax > thresh_tasmax and Tmin <= thresh_tasmin.
 
     Parameters
     ----------
@@ -181,7 +181,7 @@ def daily_freezethaw_cycles(
     thresh_tasmax : str
       The temperature threshold needed to trigger a thaw event [℃] or [K]. Default : '0 degC'
     thresh_tasmin : str
-      The temperature threshold needed to trigger a freeze event [℃] or [K]. Default : '-1 degC'
+      The temperature threshold needed to trigger a freeze event [℃] or [K]. Default : '0 degC'
     freq : str
       Resampling frequency
 

--- a/xclim/indices/_multivariate.py
+++ b/xclim/indices/_multivariate.py
@@ -153,8 +153,10 @@ def cold_and_dry_days(tas, tgin25, pr, wet25, freq="YS"):
     # return c.resample(time=freq).sum(dim='time')
 
 
-@declare_units("days", tasmax="[temperature]", tasmin="[temperature]")
-def daily_freezethaw_cycles(tasmax, tasmin, freq="YS"):
+@declare_units(
+    "days", tasmax="[temperature]", tasmin="[temperature]", thresh="[temperature]"
+)
+def daily_freezethaw_cycles(tasmax, tasmin, thresh="0 degC", freq="YS"):
     r"""Number of days with a diurnal freeze-thaw cycle
 
     The number of days where Tmax > 0℃ and Tmin < 0℃.
@@ -165,6 +167,8 @@ def daily_freezethaw_cycles(tasmax, tasmin, freq="YS"):
       Maximum daily temperature [℃] or [K]
     tasmin : xarray.DataArray
       Minimum daily temperature values [℃] or [K]
+    thresh : str
+      The temperature threshold needed to trigger a freeze-thaw event [℃] or [K]. Default : '0 degC'
     freq : str
       Resampling frequency
 
@@ -185,7 +189,7 @@ def daily_freezethaw_cycles(tasmax, tasmin, freq="YS"):
 
     where :math:`[P]` is 1 if :math:`P` is true, and 0 if false.
     """
-    frz = utils.convert_units_to("0 degC", tasmax)
+    frz = utils.convert_units_to(thresh, tasmax)
     ft = (tasmin < frz) * (tasmax > frz) * 1
     out = ft.resample(time=freq).sum(dim="time")
     return out

--- a/xclim/indices/_threshold.py
+++ b/xclim/indices/_threshold.py
@@ -40,7 +40,7 @@ __all__ = [
     "tropical_nights",
 ]
 
-
+# TODO: Add docstring for window
 @declare_units("days", tas="[temperature]", thresh="[temperature]")
 def cold_spell_days(tas, thresh="-10 degC", window=5, freq="AS-JUL"):
     r"""Cold spell days

--- a/xclim/utils.py
+++ b/xclim/utils.py
@@ -253,6 +253,16 @@ def _check_units(val, dim):
     if dim is None or val is None:
         return
 
+    if str(val).startswith("UNSET "):
+        from warnings import warn
+
+        warnings.warn(
+            "This index calculation will soon require user-specified thresholds.",
+            FutureWarning,
+            stacklevel=4,
+        )
+        val = str(val).replace("UNSET ", "")
+
     # TODO remove backwards compatibility of int/float thresholds after v1.0 release
     if isinstance(val, (int, float)):
         return

--- a/xclim/utils.py
+++ b/xclim/utils.py
@@ -917,7 +917,7 @@ def parse_doc(doc):
             out["title"], out["abstract"] = content
 
     for i in range(0, len(sections), 2):
-        header, content = sections[i: i + 2]
+        header, content = sections[i : i + 2]
 
         if header in ["Notes", "References"]:
             out[header.lower()] = content.replace("\n    ", "\n")

--- a/xclim/utils.py
+++ b/xclim/utils.py
@@ -917,7 +917,7 @@ def parse_doc(doc):
             out["title"], out["abstract"] = content
 
     for i in range(0, len(sections), 2):
-        header, content = sections[i : i + 2]
+        header, content = sections[i: i + 2]
 
         if header in ["Notes", "References"]:
             out[header.lower()] = content.replace("\n    ", "\n")


### PR DESCRIPTION
<!--Please ensure the PR fulfills the follwing requirements-->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated

### After merging to master and before closing the branch:
- [ ] bumpversion (minor / major / patch) has been called on `master` branch
- [ ] Tags have been pushed

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
A threshold is now implemented for freezethaw cycles 

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
Yes. With the exception of Atmos Indices, variables with thresholds will eventually require user-specified key=value pairs. This is now implemented fro daily_freezethaw_cycle calculations via the "UNSET " keyword prepended to the threshold. Calculations should eventually use this approach alongside other changes such as keyword call enforcement, e.g.:
```
def function(*,input=None, key1=word1, key2=word2):
    do stuff
```
* **Other information**:

<!--* When merging, please put `fixes #{issue number}` in your comment to auto-close the issue that your PR addresses. Thanks!-->
This PR fixes #265 
