### PR TITLE
fix-286

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,7 +6,7 @@ History
 ------------------------
 * Added type hinting to call signatures of many functions for more explicit type-checking
 * Now supporting explicit builds for Windows OS via Travis CI
-
+* Fixed bug in subset.subset_bbox that could add unwanted coordinates/dims to some variables when applied to an entire dataset
 
 0.10.x-beta (2019-06-18)
 ------------------------

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ requirements = [
     "scipy>=1.2",
     "numpy>=1.15",
     "pandas>=0.23",
-    "cftime==1.0.3.4",
+    "cftime~=1.0.3.4",
     "netCDF4>=1.4",
     "dask[complete]",
     "bottleneck>=1.2.1",

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ requirements = [
     "scipy>=1.2",
     "numpy>=1.15",
     "pandas>=0.23",
-    "cftime>=1.0.3",
+    "cftime==1.0.3.4",
     "netCDF4>=1.4",
     "dask[complete]",
     "bottleneck>=1.2.1",

--- a/tests/test_subset.py
+++ b/tests/test_subset.py
@@ -343,6 +343,20 @@ class TestSubsetBbox:
         assert np.all(out.lat.values[mask1.values] >= np.min(self.lat))
         assert np.all(out.lat.values[mask1.values] <= np.max(self.lat))
 
+    def test_irregular_datset(self):
+        da = xr.open_dataset(self.nc_2dlonlat)
+        out = subset.subset_bbox(da, lon_bnds=self.lon, lat_bnds=self.lat)
+        vars = list(da.data_vars)
+        vars.pop(vars.index("tasmax"))
+        # only tasmax should be subsetted/masked others should remain untouched
+        for v in vars:
+            assert out[v].dims == da[v].dims
+            np.testing.assert_array_equal(out[v], da[v])
+
+        # ensure results are equal to previous test on DataArray only
+        out1 = subset.subset_bbox(da.tasmax, lon_bnds=self.lon, lat_bnds=self.lat)
+        np.testing.assert_array_equal(out1, out.tasmax)
+
     # test datasets with descending coords
     def test_inverted_coords(self):
         lon = np.linspace(-90, -60, 200)

--- a/tests/test_subset.py
+++ b/tests/test_subset.py
@@ -346,10 +346,10 @@ class TestSubsetBbox:
     def test_irregular_datset(self):
         da = xr.open_dataset(self.nc_2dlonlat)
         out = subset.subset_bbox(da, lon_bnds=self.lon, lat_bnds=self.lat)
-        vars = list(da.data_vars)
-        vars.pop(vars.index("tasmax"))
+        variables = list(da.data_vars)
+        variables.pop(variables.index("tasmax"))
         # only tasmax should be subsetted/masked others should remain untouched
-        for v in vars:
+        for v in variables:
             assert out[v].dims == da[v].dims
             np.testing.assert_array_equal(out[v], da[v])
 

--- a/xclim/subset.py
+++ b/xclim/subset.py
@@ -247,9 +247,7 @@ def subset_bbox(
             # If da is a xr.DataSet Mask only variables that have the
             # same 2d coordinates as da.lat (or da.lon)
             for var in da.data_vars:
-                if [d for d in da[var].dims if d in list(da.lat.dims)] == list(
-                    da.lat.dims
-                ):
+                if set(da.lat.dims).issubset(da[var].dims):
                     da[var] = da[var].where(lon_cond & lat_cond, drop=True)
         else:
 

--- a/xclim/subset.py
+++ b/xclim/subset.py
@@ -243,7 +243,17 @@ def subset_bbox(
             lon_cond = in_bounds(lon_b, da.lon)
 
         # Mask coordinates outside the bounding box
-        da = da.where(lon_cond & lat_cond, drop=True)
+        if isinstance(da, xarray.Dataset):
+            # If da is a xr.DataSet Mask only variables that have the
+            # same 2d coordinates as da.lat (or da.lon)
+            for var in da.data_vars:
+                if [d for d in da[var].dims if d in list(da.lat.dims)] == list(
+                    da.lat.dims
+                ):
+                    da[var] = da[var].where(lon_cond & lat_cond, drop=True)
+        else:
+
+            da = da.where(lon_cond & lat_cond, drop=True)
 
     else:
         raise (


### PR DESCRIPTION
fix bug that adds unwanted dims to variables using curvlinear subset_bbox when applied to a xr.DataSet

<!--Please ensure the PR fulfills the follwing requirements-->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated

### After merging to master and before closing the branch:
- [ ] bumpversion (minor / major / patch) has been called on `master` branch
- [ ] Tags have been pushed

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
Bug fix - subset_bbox can add unwanted coordinates/dims to variables when applied to an entire dataset   #286 

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
No

* **Other information**:

<!--* When merging, please put `fixes #{issue number}` in your comment to auto-close the issue that your PR addresses. Thanks!-->
This PR fixes #xyz
