### PR TITLE
Options for precipitation_accumulation to compute solid and/or liquide phases

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -11,6 +11,7 @@ Co-Developers
 -------------
 
 * Sébastien Biner <biner.sebastien@ouranos.ca> `@sbiner <https://github.com/sbiner>`_
+* Pascal Bourgault <bourgault.pascal@ouranos.ca> `@aulemahal <https://github.com/aulemahal>`_
 * David Huard <huard.david@ouranos.ca> `@huard <https://github.com/huard>`_
 * Philippe Roy <roy.philippe@ouranos.ca> `@Balinus <https://github.com/Balinus>`_
 * Trevor James Smith <smith.trevorj@ouranos.ca> `@Zeitsperre <https://github.com/Zeitsperre>`_

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@ History
 * Now supporting explicit builds for Windows OS via Travis CI
 * Fix failing test with Python 3.7
 * Fixed bug in subset.subset_bbox that could add unwanted coordinates/dims to some variables when applied to an entire dataset
+* Enhancement to precip_accumulation() to allow estimated amounts solid (or liquid) phase precipitation
 
 0.10.x-beta (2019-06-18)
 ------------------------

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -553,6 +553,21 @@ class TestPrecipAccumulation:
         ]
         np.testing.assert_allclose(out_std.values, target)
 
+    def test_mixed_phases(self, pr_series, tas_series):
+        pr = np.zeros(100)
+        pr[5:15] = 1
+        pr = pr_series(pr)
+
+        tas = np.ones(100) * 280
+        tas[5:10] = 270
+        tas = tas_series(tas)
+
+        outsn = xci.precip_accumulation(pr, tas=tas, phase="solid", freq="M")
+        outrn = xci.precip_accumulation(pr, tas=tas, phase="liquid", freq="M")
+
+        np.testing.assert_array_equal(outsn[0], 5 * 3600 * 24)
+        np.testing.assert_array_equal(outrn[0], 5 * 3600 * 24)
+
 
 class TestRainOnFrozenGround:
     def test_simple(self, tas_series, pr_series):

--- a/tests/test_precip.py
+++ b/tests/test_precip.py
@@ -113,8 +113,8 @@ class TestPrecipAccumulation:
         tasmin = xr.open_dataset(self.nc_tasmin).tasmin  # K
 
         out_tot = atmos.precip_accumulation(pr, freq="MS")
-        out_sol = atmos.precip_accumulation(pr, tas=tasmin, phase="solid", freq="MS")
-        out_liq = atmos.precip_accumulation(pr, tas=tasmin, phase="liquid", freq="MS")
+        out_sol = atmos.solid_precip_accumulation(pr, tas=tasmin, freq="MS")
+        out_liq = atmos.liquid_precip_accumulation(pr, tas=tasmin, freq="MS")
 
         np.testing.assert_array_almost_equal(out_liq + out_sol, out_tot, 4)
 

--- a/tests/test_precip.py
+++ b/tests/test_precip.py
@@ -71,12 +71,15 @@ class TestRainOnFrozenGround:
 
 class TestPrecipAccumulation:
     # TODO: replace by fixture
-    nc_file = os.path.join(TESTS_DATA, "NRCANdaily", "nrcan_canada_daily_pr_1990.nc")
+    nc_pr = os.path.join(TESTS_DATA, "NRCANdaily", "nrcan_canada_daily_pr_1990.nc")
+    nc_tasmin = os.path.join(
+        TESTS_DATA, "NRCANdaily", "nrcan_canada_daily_tasmin_1990.nc"
+    )
 
     def test_3d_data_with_nans(self):
         # test with 3d data
-        pr = xr.open_dataset(self.nc_file).pr  # mm/s
-        prMM = xr.open_dataset(self.nc_file).pr
+        pr = xr.open_dataset(self.nc_pr).pr  # mm/s
+        prMM = xr.open_dataset(self.nc_pr).pr
         prMM *= 86400
         prMM.attrs["units"] = "mm/day"
         # put a nan somewhere
@@ -103,6 +106,21 @@ class TestPrecipAccumulation:
         assert np.isnan(out1.values[0, 1, 0])
 
         assert np.isnan(out1.values[0, -1, -1])
+
+    def test_with_different_phases(self):
+        # test with different phases
+        pr = xr.open_dataset(self.nc_pr).pr  # mm/s
+        tasmin = xr.open_dataset(self.nc_tasmin).tasmin  # K
+
+        out_tot = atmos.precip_accumulation(pr, freq="MS")
+        out_sol = atmos.precip_accumulation(pr, tas=tasmin, phase="solid", freq="MS")
+        out_liq = atmos.precip_accumulation(pr, tas=tasmin, phase="liquid", freq="MS")
+
+        np.testing.assert_array_almost_equal(out_liq + out_sol, out_tot, 4)
+
+        assert "solid" in out_sol.long_name
+        assert "liquid" in out_liq.long_name
+        assert out_sol.standard_name == "lwe_thickness_of_snowfall_amount"
 
 
 class TestWetDays:

--- a/xclim/atmos/_precip.py
+++ b/xclim/atmos/_precip.py
@@ -107,9 +107,9 @@ daily_pr_intensity = Pr(
 precip_accumulation = Pr(
     identifier="prcptot",
     units="mm",
-    standard_name="lwe_thickness_of_precipitation_amount",
-    long_name="Total{phase:>1}precipitation",
-    description="{freq} total{phase:>1}precipitation.",
+    standard_name=lambda **kw: "lwe_thickness_of_snowfall_amount" if kw['phase'] == 'solid' else "lwe_thickness_of_precipitation_amount",
+    long_name=lambda **kw: "Total {} precipitation".format(kw['phase']) if kw['phase'] != 'both' else "Total precipitation",
+    description=lambda **kw: "{freq} " + ("total {} precipitation".format(kw['phase']) if kw['phase'] != 'both' else "total precipitation"),
     cell_methods="time: sum within days time: sum over days",
     compute=indices.precip_accumulation,
 )

--- a/xclim/atmos/_precip.py
+++ b/xclim/atmos/_precip.py
@@ -110,12 +110,14 @@ precip_accumulation = Pr(
     standard_name=lambda **kw: "lwe_thickness_of_snowfall_amount"
     if kw["phase"] == "solid"
     else "lwe_thickness_of_precipitation_amount",
-    long_name=lambda **kw: "Total {} precipitation".format(kw["phase"])
-    if kw["phase"] != "both"
-    else "Total precipitation",
+    long_name=lambda **kw: "Total {} precipitation".format(kw["phase"]).replace(
+        "both ", ""
+    ),
     description=lambda **kw: "{freq} "
     + (
-        "total {} precipitation".format(kw["phase"])
+        "total {} precipitation, estimated as precipitation when T {} 0".format(
+            kw["phase"], "<" if kw["phase"] == "solid" else ">="
+        )
         if kw["phase"] != "both"
         else "total precipitation"
     ),

--- a/xclim/atmos/_precip.py
+++ b/xclim/atmos/_precip.py
@@ -108,8 +108,8 @@ precip_accumulation = Pr(
     identifier="prcptot",
     units="mm",
     standard_name="lwe_thickness_of_precipitation_amount",
-    long_name="Total precipitation",
-    description="{freq} total precipitation.",
+    long_name="Total{phase:>1}precipitation",
+    description="{freq} total{phase:>1}precipitation.",
     cell_methods="time: sum within days time: sum over days",
     compute=indices.precip_accumulation,
 )

--- a/xclim/atmos/_precip.py
+++ b/xclim/atmos/_precip.py
@@ -115,7 +115,7 @@ precip_accumulation = Pr(
     ),
     description=lambda **kw: "{freq} "
     + (
-        "total {} precipitation, estimated as precipitation when T {} 0".format(
+        "total {} precipitation, estimated as precipitation when daily average temperature {} 0°C".format(
             kw["phase"], "<" if kw["phase"] == "solid" else ">="
         )
         if kw["phase"] != "both"

--- a/xclim/atmos/_precip.py
+++ b/xclim/atmos/_precip.py
@@ -107,9 +107,18 @@ daily_pr_intensity = Pr(
 precip_accumulation = Pr(
     identifier="prcptot",
     units="mm",
-    standard_name=lambda **kw: "lwe_thickness_of_snowfall_amount" if kw['phase'] == 'solid' else "lwe_thickness_of_precipitation_amount",
-    long_name=lambda **kw: "Total {} precipitation".format(kw['phase']) if kw['phase'] != 'both' else "Total precipitation",
-    description=lambda **kw: "{freq} " + ("total {} precipitation".format(kw['phase']) if kw['phase'] != 'both' else "total precipitation"),
+    standard_name=lambda **kw: "lwe_thickness_of_snowfall_amount"
+    if kw["phase"] == "solid"
+    else "lwe_thickness_of_precipitation_amount",
+    long_name=lambda **kw: "Total {} precipitation".format(kw["phase"])
+    if kw["phase"] != "both"
+    else "Total precipitation",
+    description=lambda **kw: "{freq} "
+    + (
+        "total {} precipitation".format(kw["phase"])
+        if kw["phase"] != "both"
+        else "total precipitation"
+    ),
     cell_methods="time: sum within days time: sum over days",
     compute=indices.precip_accumulation,
 )

--- a/xclim/atmos/_precip.py
+++ b/xclim/atmos/_precip.py
@@ -2,6 +2,7 @@
 from xclim import indices
 from xclim.utils import Indicator
 from xclim.utils import Indicator2D
+from xclim.utils import wrapped_partial
 
 __all__ = [
     "rain_on_frozen_ground_days",
@@ -12,6 +13,8 @@ __all__ = [
     "maximum_consecutive_wet_days",
     "daily_pr_intensity",
     "precip_accumulation",
+    "liquid_precip_accumulation",
+    "solid_precip_accumulation",
 ]
 
 
@@ -107,20 +110,32 @@ daily_pr_intensity = Pr(
 precip_accumulation = Pr(
     identifier="prcptot",
     units="mm",
-    standard_name=lambda **kw: "lwe_thickness_of_snowfall_amount"
-    if kw["phase"] == "solid"
-    else "lwe_thickness_of_precipitation_amount",
-    long_name=lambda **kw: "Total {} precipitation".format(kw["phase"]).replace(
-        "both ", ""
-    ),
-    description=lambda **kw: "{freq} "
-    + (
-        "total {} precipitation, estimated as precipitation when daily average temperature {} 0°C".format(
-            kw["phase"], "<" if kw["phase"] == "solid" else ">="
-        )
-        if kw["phase"] != "both"
-        else "total precipitation"
-    ),
+    standard_name="lwe_thickness_of_precipitation_amount",
+    long_name="Total precipitation",
+    description="{freq} total precipitation",
     cell_methods="time: sum within days time: sum over days",
-    compute=indices.precip_accumulation,
+    _partial=True,
+    compute=wrapped_partial(indices.precip_accumulation, phase=None),
+)
+
+liquid_precip_accumulation = Pr(
+    identifier="liquidprcptot",
+    units="mm",
+    standard_name="lwe_thickness_of_liquid_precipitation_amount",
+    long_name="Total liquid precipitation",
+    description="{freq} total liquid precipitation, estimated as precipitation when daily average temperature >= 0°C",
+    cell_methods="time: sum within days time: sum over days",
+    _partial=True,
+    compute=wrapped_partial(indices.precip_accumulation, phase="liquid"),
+)
+
+solid_precip_accumulation = Pr(
+    identifier="solidprcptot",
+    units="mm",
+    standard_name="lwe_thickness_of_snowfall_amount",
+    long_name="Total solid precipitation",
+    description="{freq} total solid precipitation, estimated as precipitation when daily average temperature < 0°C",
+    cell_methods="time: sum within days time: sum over days",
+    _partial=True,
+    compute=wrapped_partial(indices.precip_accumulation, phase="solid"),
 )

--- a/xclim/indices/_multivariate.py
+++ b/xclim/indices/_multivariate.py
@@ -543,7 +543,7 @@ def liquid_precip_ratio(
 def precip_accumulation(
     pr: xr.DataArray,
     tas: xr.DataArray = None,
-    phase: str = "both",
+    phase: Optional[str] = None,
     freq: Optional[str] = None,
 ) -> xr.DataArray:
     r"""Accumulated total (liquid and/or solid) precipitation.
@@ -590,12 +590,9 @@ def precip_accumulation(
     """
     freq = freq or "YS"
 
-    if phase != "both":
-        tu = units.parse_units(tas.attrs["units"].replace("-", "**-"))
-        fu = "degC"
-        frz = 0
-        if fu != tu:
-            frz = units.convert(frz, fu, tu)
+    if phase in ["liquid", "solid"]:
+        frz = utils.convert_units_to("0 degC", tas)
+
         if phase == "liquid":
             pr = pr.where(tas >= frz, 0)
         elif phase == "solid":

--- a/xclim/indices/_multivariate.py
+++ b/xclim/indices/_multivariate.py
@@ -35,6 +35,7 @@ __all__ = [
     "heat_wave_frequency",
     "heat_wave_max_length",
     "liquid_precip_ratio",
+    "precip_accumulation",
     "rain_on_frozen_ground_days",
     "tg90p",
     "tg10p",
@@ -536,6 +537,72 @@ def liquid_precip_ratio(
     rain = tot - prsn.resample(time=freq).sum(dim="time")
     ratio = rain / tot
     return ratio
+
+
+@declare_units("mm", pr="[precipitation]", tas="[temperature]")
+def precip_accumulation(
+    pr: xr.DataArray,
+    tas: xr.DataArray = None,
+    phase: str = "",
+    freq: Optional[str] = None,
+) -> xr.DataArray:
+    r"""Accumulated total (liquid and/or solid) precipitation.
+
+    Resample the original daily mean precipitation flux and accumulate over each period.
+    If the daily mean temperature is provided, the phase keyword can be used to only sum precipitation of a certain phase.
+    When the mean temperature is over 0 degC, precipitatio is assumed to be liquid rain and snow otherwise.
+
+    Parameters
+    ----------
+    pr : xr.DataArray
+      Mean daily precipitation flux [Kg m-2 s-1] or [mm].
+    tas : xr.DataArray, optional
+      Mean daily temperature [℃] or [K]
+    phase : str, optional,
+      Which phase to consider, "liquid" or "solid", if None (default), both are considered.
+    freq : str, optional
+      Resampling frequency as defined in
+      http://pandas.pydata.org/pandas-docs/stable/timeseries.html#resampling. Defaults to "YS"
+
+    Returns
+    -------
+    xr.DataArray
+      The total daily precipitation at the given time frequency for the given phase.
+
+    Notes
+    -----
+    Let :math:`PR_i` be the mean daily precipitation of day :math:`i`, then for a period :math:`j` starting at
+    day :math:`a` and finishing on day :math:`b`:
+
+    .. math::
+
+       PR_{ij} = \sum_{i=a}^{b} PR_i
+
+    If `phase` is "liquid", only times where the daily mean temperature :math:`T_i` is above or equal to 0 °C are considered, inversely for "solid".
+
+    Examples
+    --------
+    The following would compute for each grid cell of file `pr_day.nc` the total
+    precipitation at the seasonal frequency, ie DJF, MAM, JJA, SON, DJF, etc.:
+
+    >>> pr_day = xr.open_dataset('pr_day.nc').pr
+    >>> prcp_tot_seasonal = precip_accumulation(pr_day, freq="QS-DEC")
+    """
+    freq = freq or "YS"
+
+    if phase:
+        tu = units.parse_units(tas.attrs["units"].replace("-", "**-"))
+        fu = "degC"
+        frz = 0
+        if fu != tu:
+            frz = units.convert(frz, fu, tu)
+        if phase == "liquid":
+            pr = pr.where(tas >= frz, 0)
+        elif phase == "solid":
+            pr = pr.where(tas < frz, 0)
+
+    out = pr.resample(time=freq).sum(dim="time", keep_attrs=True)
+    return utils.pint_multiply(out, 1 * units.day, "mm")
 
 
 @declare_units(

--- a/xclim/indices/_multivariate.py
+++ b/xclim/indices/_multivariate.py
@@ -543,7 +543,7 @@ def liquid_precip_ratio(
 def precip_accumulation(
     pr: xr.DataArray,
     tas: xr.DataArray = None,
-    phase: str = "",
+    phase: str = "both",
     freq: Optional[str] = None,
 ) -> xr.DataArray:
     r"""Accumulated total (liquid and/or solid) precipitation.
@@ -590,7 +590,7 @@ def precip_accumulation(
     """
     freq = freq or "YS"
 
-    if phase:
+    if phase != "both":
         tu = units.parse_units(tas.attrs["units"].replace("-", "**-"))
         fu = "degC"
         frz = 0

--- a/xclim/indices/_simple.py
+++ b/xclim/indices/_simple.py
@@ -36,7 +36,6 @@ __all__ = [
     "ice_days",
     "max_1day_precipitation_amount",
     "max_n_day_precipitation_amount",
-    "precip_accumulation",
 ]
 
 
@@ -564,45 +563,4 @@ def max_n_day_precipitation_amount(pr, window=1, freq="YS"):
 
     out.attrs["units"] = pr.units
     # Adjust values and units to make sure they are daily
-    return utils.pint_multiply(out, 1 * units.day, "mm")
-
-
-@declare_units("mm", pr="[precipitation]")
-def precip_accumulation(pr, freq="YS"):
-    r"""Accumulated total (liquid + solid) precipitation.
-
-    Resample the original daily mean precipitation flux and accumulate over each period.
-
-    Parameters
-    ----------
-    pr : xarray.DataArray
-      Mean daily precipitation flux [Kg m-2 s-1] or [mm].
-    freq : str, optional
-      Resampling frequency as defined in
-      http://pandas.pydata.org/pandas-docs/stable/timeseries.html#resampling.
-
-    Returns
-    -------
-    xarray.DataArray
-      The total daily precipitation at the given time frequency.
-
-    Notes
-    -----
-    Let :math:`PR_i` be the mean daily precipitation of day :math:`i`, then for a period :math:`j` starting at
-    day :math:`a` and finishing on day :math:`b`:
-
-    .. math::
-
-       PR_{ij} = \sum_{i=a}^{b} PR_i
-
-    Examples
-    --------
-    The following would compute for each grid cell of file `pr_day.nc` the total
-    precipitation at the seasonal frequency, ie DJF, MAM, JJA, SON, DJF, etc.:
-
-    >>> pr_day = xr.open_dataset('pr_day.nc').pr
-    >>> prcp_tot_seasonal = precip_accumulation(pr_day, freq="QS-DEC")
-    """
-
-    out = pr.resample(time=freq).sum(dim="time", keep_attrs=True)
     return utils.pint_multiply(out, 1 * units.day, "mm")

--- a/xclim/utils.py
+++ b/xclim/utils.py
@@ -923,6 +923,9 @@ class Indicator:
                 else:
                     mba[k] = v
 
+            if callable(val):
+                val = val(**mba)
+
             out[key] = val.format(**mba).format(**self._attrs_mapping.get(key, {}))
 
         return out


### PR DESCRIPTION
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated

### After merging to master and before closing the branch:
- [ ] bumpversion (minor / major / patch) has been called on `master` branch
- [ ] Tags have been pushed

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
Moves "precipitation_accumulation" to the `_multivariate.py` file. Adds two optional arguments to pass the mean temperature and phase selection. If `phase` is `solid`, only time steps where T < 0°C are summed. If it is `liquid`, time steps with T >= 0°C are summed. If it is not provided, goes back to the usual behaviour, summing everything.

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
Nope

* **Other information**:
Tests have been added.
 `xclim.atmos.precip_accumulation` has been modified so the attributes reflect the change, however, I have not yet found a way to modify the given standard name. (There is an ambiguity if `phase` is "liquid" and it should be different for "solid".
