### PR TITLE
Pin Bottleneck to 1.2.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ requirements = [
     "cftime~=1.0.3.4",
     "netCDF4>=1.4",
     "dask[complete]",
-    "bottleneck>=1.2.1",
+    "bottleneck~=1.2.1",
     "xarray==0.13.0",
     "pyproj==2.4.1",
     "pint>=0.8",


### PR DESCRIPTION
<!--Please ensure the PR fulfills the follwing requirements-->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated

### After merging to master and before closing the branch:
- [ ] bumpversion (minor / major / patch) has been called on `master` branch
- [ ] Tags have been pushed

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
Pins Bottleneck at version 1.2.1

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
No.

* **Other information**:
Bottleneck 1.3 does not seem to install too cleanly in most Python versions and for most OSes. This pins the library at 1.2.1 until a better built version of that library is released. 

<!--* When merging, please put `fixes #{issue number}` in your comment to auto-close the issue that your PR addresses. Thanks!-->

