### PR TITLE
Fix function signatures and standardize all to xarray

### DIFF
--- a/xclim/indices/_multivariate.py
+++ b/xclim/indices/_multivariate.py
@@ -1,19 +1,14 @@
-import logging
-import warnings
 from typing import Optional
 
 import numpy as np
-import xarray as xr
+import xarray
 
 from xclim import run_length as rl
 from xclim import utils
 from xclim.utils import declare_units
 from xclim.utils import units
 
-# logging.basicConfig(level=logging.DEBUG)
-# logging.captureWarnings(True)
-
-xr.set_options(enable_cftimeindex=True)  # Set xarray to use cftimeindex
+xarray.set_options(enable_cftimeindex=True)  # Set xarray to use cftimeindex
 
 
 # Frequencies : YS: year start, QS-DEC: seasons starting in december, MS: month start
@@ -52,8 +47,8 @@ __all__ = [
 
 @declare_units("days", tasmin="[temperature]", tn10="[temperature]")
 def cold_spell_duration_index(
-    tasmin: xr.DataArray, tn10: float, window: int = 6, freq: Optional[str] = None
-) -> xr.DataArray:
+    tasmin: xarray.DataArray, tn10: float, window: int = 6, freq: str = "YS"
+) -> xarray.DataArray:
     r"""Cold spell duration index
 
     Number of days with at least six consecutive days where the daily minimum temperature is below the 10th
@@ -61,18 +56,18 @@ def cold_spell_duration_index(
 
     Parameters
     ----------
-    tasmin : xr.DataArray
+    tasmin : xarray.DataArray
       Minimum daily temperature.
     tn10 : float
       10th percentile of daily minimum temperature.
     window : int
       Minimum number of days with temperature below threshold to qualify as a cold spell. Default: 6.
-    freq : Optional[str]
+    freq : str
       Resampling frequency; Defaults to "YS".
 
     Returns
     -------
-    xr.DataArray
+    xarray.DataArray
       Count of days with at least six consecutive days where the daily minimum temperature is below the 10th
       percentile [days].
 
@@ -98,8 +93,6 @@ def cold_spell_duration_index(
     >>> tn10 = xcu.percentile_doy(historical_tasmin, per=.1)
     >>> cold_spell_duration_index(reference_tasmin, tn10)
     """
-    freq = freq or "YS"
-
     tn10 = utils.convert_units_to(tn10, tasmin)
 
     # Create time series out of doy values.
@@ -113,28 +106,28 @@ def cold_spell_duration_index(
 
 
 def cold_and_dry_days(
-    tas: xr.DataArray, tgin25, pr, wet25, freq: Optional[str] = None
-) -> xr.DataArray:
+    tas: xarray.DataArray, tgin25, pr, wet25, freq: str = "YS"
+) -> xarray.DataArray:
     r"""Cold and dry days.
 
     Returns the total number of days where "Cold" and "Dry" conditions coincide.
 
     Parameters
     ----------
-    tas : xr.DataArray
+    tas : xarray.DataArray
       Mean daily temperature values [℃] or [K]
-    tgin25 : xr.DataArray
+    tgin25 : xarray.DataArray
       First quartile of daily mean temperature computed by month.
-    pr : xr.DataArray
+    pr : xarray.DataArray
       Daily precipitation.
-    wet25 : xr.DataArray
+    wet25 : xarray.DataArray
       First quartile of daily total precipitation computed by month.
-    freq : Optional[str]
+    freq : str
       Resampling frequency; Defaults to "YS".
 
     Returns
     -------
-    xr.DataArray
+    xarray.DataArray
       The total number of days where cold and dry conditions coincide.
 
     Notes
@@ -146,10 +139,9 @@ def cold_and_dry_days(
     .. [cold_dry_days] Beniston, M. (2009). Trends in joint quantiles of temperature and precipitation in Europe
         since 1901 and projected for 2100. Geophysical Research Letters, 36(7). https://doi.org/10.1029/2008GL037119
     """
-
     raise NotImplementedError
     # There is an issue with the 1 mm threshold. It makes no sense to assume a day with < 1mm is not dry.
-    # freq = freq or "YS"
+    #
     # c1 = tas < utils.convert_units_to(tgin25, tas)
     # c2 = (pr > utils.convert_units_to('1 mm', pr)) * (pr < utils.convert_units_to(wet25, pr))
 
@@ -165,32 +157,32 @@ def cold_and_dry_days(
     thresh_tasmin="[temperature]",
 )
 def daily_freezethaw_cycles(
-    tasmax: xr.DataArray,
-    tasmin: xr.DataArray,
+    tasmax: xarray.DataArray,
+    tasmin: xarray.DataArray,
     thresh_tasmax: str = "UNSET 0 degC",
     thresh_tasmin: str = "UNSET 0 degC",
-    freq: Optional[str] = None,
-) -> xr.DataArray:
+    freq: str = "YS",
+) -> xarray.DataArray:
     r"""Number of days with a diurnal freeze-thaw cycle
 
     The number of days where Tmax > thresh_tasmax and Tmin <= thresh_tasmin.
 
     Parameters
     ----------
-    tasmax : xr.DataArray
+    tasmax : xarray.DataArray
       Maximum daily temperature [℃] or [K]
-    tasmin : xr.DataArray
+    tasmin : xarray.DataArray
       Minimum daily temperature values [℃] or [K]
     thresh_tasmax : str
       The temperature threshold needed to trigger a thaw event [℃] or [K]. Default : '0 degC'
     thresh_tasmin : str
       The temperature threshold needed to trigger a freeze event [℃] or [K]. Default : '0 degC'
-    freq : Optional[str]
+    freq : str
       Resampling frequency; Defaults to "YS".
 
     Returns
     -------
-    xr.DataArray
+    xarray.DataArray
       Number of days with a diurnal freeze-thaw cycle
 
     Notes
@@ -205,8 +197,6 @@ def daily_freezethaw_cycles(
 
     where :math:`[P]` is 1 if :math:`P` is true, and 0 if false.
     """
-    freq = freq or "YS"
-
     if thresh_tasmax.startswith("UNSET ") or thresh_tasmin.startswith("UNSET"):
         thresh_tasmax, thresh_tasmin = (
             thresh_tasmax.replace("UNSET ", ""),
@@ -223,7 +213,7 @@ def daily_freezethaw_cycles(
 
 
 @declare_units("K", tasmax="[temperature]", tasmin="[temperature]")
-def daily_temperature_range(tasmax, tasmin, freq: Optional[str] = None) -> xr.DataArray:
+def daily_temperature_range(tasmax, tasmin, freq: str = "YS") -> xarray.DataArray:
     r"""Mean of daily temperature range.
 
     The mean difference between the daily maximum temperature and the daily minimum temperature.
@@ -234,12 +224,12 @@ def daily_temperature_range(tasmax, tasmin, freq: Optional[str] = None) -> xr.Da
       Maximum daily temperature values [℃] or [K]
     tasmin : xarray.DataArray
       Minimum daily temperature values [℃] or [K]
-    freq : Optional[str]
+    freq : str
       Resampling frequency; Defaults to "YS".
 
     Returns
     -------
-    xr.DataArray
+    xarray.DataArray
       The average variation in daily temperature range for the given time period.
 
     Notes
@@ -251,7 +241,6 @@ def daily_temperature_range(tasmax, tasmin, freq: Optional[str] = None) -> xr.Da
 
         DTR_j = \frac{ \sum_{i=1}^I (TX_{ij} - TN_{ij}) }{I}
     """
-    freq = freq or "YS"
     dtr = tasmax - tasmin
     out = dtr.resample(time=freq).mean(dim="time", keep_attrs=True)
     out.attrs["units"] = tasmax.units
@@ -260,24 +249,24 @@ def daily_temperature_range(tasmax, tasmin, freq: Optional[str] = None) -> xr.Da
 
 @declare_units("K", tasmax="[temperature]", tasmin="[temperature]")
 def daily_temperature_range_variability(
-    tasmax: xr.DataArray, tasmin: xr.DataArray, freq: Optional[str] = None
-) -> xr.DataArray:
+    tasmax: xarray.DataArray, tasmin: xarray.DataArray, freq: str = "YS"
+) -> xarray.DataArray:
     r"""Mean absolute day-to-day variation in daily temperature range.
 
     Mean absolute day-to-day variation in daily temperature range.
 
     Parameters
     ----------
-    tasmax : xr.DataArray
+    tasmax : xarray.DataArray
       Maximum daily temperature values [℃] or [K]
-    tasmin : xr.DataArray
+    tasmin : xarray.DataArray
       Minimum daily temperature values [℃] or [K]
-    freq : Optional[str]
+    freq : str
       Resampling frequency; Defaults to "YS".
 
     Returns
     -------
-    xr.DataArray
+    xarray.DataArray
       The average day-to-day variation in daily temperature range for the given time period.
 
     Notes
@@ -290,7 +279,6 @@ def daily_temperature_range_variability(
 
        vDTR_j = \frac{ \sum_{i=2}^{I} |(TX_{ij}-TN_{ij})-(TX_{i-1,j}-TN_{i-1,j})| }{I}
     """
-
     vdtr = abs((tasmax - tasmin).diff(dim="time"))
     out = vdtr.resample(time=freq).mean(dim="time")
     out.attrs["units"] = tasmax.units
@@ -299,24 +287,24 @@ def daily_temperature_range_variability(
 
 @declare_units("K", tasmax="[temperature]", tasmin="[temperature]")
 def extreme_temperature_range(
-    tasmax: xr.DataArray, tasmin: xr.DataArray, freq: Optional[str] = None
-) -> xr.DataArray:
+    tasmax: xarray.DataArray, tasmin: xarray.DataArray, freq: str = "YS"
+) -> xarray.DataArray:
     r"""Extreme intra-period temperature range.
 
     The maximum of max temperature (TXx) minus the minimum of min temperature (TNn) for the given time period.
 
     Parameters
     ----------
-    tasmax : xr.DataArray
+    tasmax : xarray.DataArray
       Maximum daily temperature values [℃] or [K]
-    tasmin : xr.DataArray
+    tasmin : xarray.DataArray
       Minimum daily temperature values [℃] or [K]
     freq : Optional[str[
       Resampling frequency; Defaults to "YS".
 
     Returns
     -------
-    xr.DataArray
+    xarray.DataArray
       Extreme intra-period temperature range for the given time period.
 
     Notes
@@ -328,7 +316,6 @@ def extreme_temperature_range(
 
         ETR_j = max(TX_{ij}) - min(TN_{ij})
     """
-    freq = freq or "YS"
     tx_max = tasmax.resample(time=freq).max(dim="time")
     tn_min = tasmin.resample(time=freq).min(dim="time")
 
@@ -345,13 +332,13 @@ def extreme_temperature_range(
     thresh_tasmax="[temperature]",
 )
 def heat_wave_frequency(
-    tasmin: xr.DataArray,
-    tasmax: xr.DataArray,
+    tasmin: xarray.DataArray,
+    tasmax: xarray.DataArray,
     thresh_tasmin: str = "22.0 degC",
     thresh_tasmax: str = "30 degC",
     window: int = 3,
-    freq: Optional[str] = None,
-) -> xr.DataArray:
+    freq: str = "YS",
+) -> xarray.DataArray:
     # Dev note : we should decide if it is deg K or C
     r"""Heat wave frequency
 
@@ -362,9 +349,9 @@ def heat_wave_frequency(
     Parameters
     ----------
 
-    tasmin : xr.DataArray
+    tasmin : xarray.DataArray
       Minimum daily temperature [℃] or [K]
-    tasmax : xr.DataArray
+    tasmax : xarray.DataArray
       Maximum daily temperature [℃] or [K]
     thresh_tasmin : str
       The minimum temperature threshold needed to trigger a heatwave event [℃] or [K]. Default : '22 degC'
@@ -372,12 +359,12 @@ def heat_wave_frequency(
       The maximum temperature threshold needed to trigger a heatwave event [℃] or [K]. Default : '30 degC'
     window : int
       Minimum number of days with temperatures above thresholds to qualify as a heatwave.
-    freq : Optional[str]
+    freq : str
       Resampling frequency; Defaults to "YS".
 
     Returns
     -------
-    xr.DataArray
+    xarray.DataArray
       Number of heatwave at the wanted frequency
 
     Notes
@@ -398,7 +385,6 @@ def heat_wave_frequency(
     Robinson, P.J., 2001: On the Definition of a Heat Wave. J. Appl. Meteor., 40, 762–775,
     https://doi.org/10.1175/1520-0450(2001)040<0762:OTDOAH>2.0.CO;2
     """
-    freq = freq or "YS"
     thresh_tasmax = utils.convert_units_to(thresh_tasmax, tasmax)
     thresh_tasmin = utils.convert_units_to(thresh_tasmin, tasmin)
 
@@ -415,13 +401,13 @@ def heat_wave_frequency(
     thresh_tasmax="[temperature]",
 )
 def heat_wave_max_length(
-    tasmin: xr.DataArray,
-    tasmax: xr.DataArray,
+    tasmin: xarray.DataArray,
+    tasmax: xarray.DataArray,
     thresh_tasmin: str = "22.0 degC",
     thresh_tasmax: str = "30 degC",
     window: int = 3,
-    freq: Optional[str] = None,
-) -> xr.DataArray:
+    freq: str = "YS",
+) -> xarray.DataArray:
     # Dev note : we should decide if it is deg K or C
     r"""Heat wave max length
 
@@ -434,9 +420,9 @@ def heat_wave_max_length(
     Parameters
     ----------
 
-    tasmin : xr.DataArray
+    tasmin : xarray.DataArray
       Minimum daily temperature [℃] or [K]
-    tasmax : xr.DataArray
+    tasmax : xarray.DataArray
       Maximum daily temperature [℃] or [K]
     thresh_tasmin : str
       The minimum temperature threshold needed to trigger a heatwave event [℃] or [K]. Default : '22 degC'
@@ -444,12 +430,12 @@ def heat_wave_max_length(
       The maximum temperature threshold needed to trigger a heatwave event [℃] or [K]. Default : '30 degC'
     window : int
       Minimum number of days with temperatures above thresholds to qualify as a heatwave.
-    freq : Optional[str]
+    freq : str
       Resampling frequency; Defaults to "YS".
 
     Returns
     -------
-    xr.DataArray
+    xarray.DataArray
       Maximum length of heatwave at the wanted frequency
 
     Notes
@@ -470,7 +456,6 @@ def heat_wave_max_length(
     Robinson, P.J., 2001: On the Definition of a Heat Wave. J. Appl. Meteor., 40, 762–775,
     https://doi.org/10.1175/1520-0450(2001)040<0762:OTDOAH>2.0.CO;2
     """
-    freq = freq or "YS"
     thresh_tasmax = utils.convert_units_to(thresh_tasmax, tasmax)
     thresh_tasmin = utils.convert_units_to(thresh_tasmin, tasmin)
 
@@ -488,13 +473,13 @@ def heat_wave_max_length(
     thresh_tasmax="[temperature]",
 )
 def heat_wave_total_length(
-    tasmin: xr.DataArray,
-    tasmax: xr.DataArray,
+    tasmin: xarray.DataArray,
+    tasmax: xarray.DataArray,
     thresh_tasmin: str = "22.0 degC",
     thresh_tasmax: str = "30 degC",
     window: int = 3,
-    freq: Optional[str] = None,
-) -> xr.DataArray:
+    freq: str = "YS",
+) -> xarray.DataArray:
     # Dev note : we should decide if it is deg K or C
     r"""Heat wave total length
 
@@ -504,9 +489,9 @@ def heat_wave_total_length(
 
     Parameters
     ----------
-    tasmin : xr.DataArray
+    tasmin : xarray.DataArray
       Minimum daily temperature [℃] or [K]
-    tasmax : xr.DataArray
+    tasmax : xarray.DataArray
       Maximum daily temperature [℃] or [K]
     thresh_tasmin : str
       The minimum temperature threshold needed to trigger a heatwave event [℃] or [K]. Default : '22 degC'
@@ -514,19 +499,18 @@ def heat_wave_total_length(
       The maximum temperature threshold needed to trigger a heatwave event [℃] or [K]. Default : '30 degC'
     window : int
       Minimum number of days with temperatures above thresholds to qualify as a heatwave.
-    freq : Optional[str]
+    freq : str
       Resampling frequency; Defaults to "YS".
 
     Returns
     -------
-    xr.DataArray
+    xarray.DataArray
       Total length of heatwave at the wanted frequency
 
     Notes
     -----
     See notes and references of `heat_wave_max_length`
     """
-    freq = freq or "YS"
     thresh_tasmax = utils.convert_units_to(thresh_tasmax, tasmax)
     thresh_tasmin = utils.convert_units_to(thresh_tasmin, tasmin)
 
@@ -537,11 +521,11 @@ def heat_wave_total_length(
 
 @declare_units("", pr="[precipitation]", prsn="[precipitation]", tas="[temperature]")
 def liquid_precip_ratio(
-    pr: xr.DataArray,
-    prsn: xr.DataArray = None,
-    tas: xr.DataArray = None,
-    freq: Optional[str] = None,
-) -> xr.DataArray:
+    pr: xarray.DataArray,
+    prsn: xarray.DataArray = None,
+    tas: xarray.DataArray = None,
+    freq: str = "QS-DEC",
+) -> xarray.DataArray:
     r"""Ratio of rainfall to total precipitation
 
     The ratio of total liquid precipitation over the total precipitation. If solid precipitation is not provided,
@@ -549,18 +533,18 @@ def liquid_precip_ratio(
 
     Parameters
     ----------
-    pr : xr.DataArray
+    pr : xarray.DataArray
       Mean daily precipitation flux [Kg m-2 s-1] or [mm].
-    prsn : xr.DataArray
+    prsn : xarray.DataArray
       Mean daily solid precipitation flux [Kg m-2 s-1] or [mm].
-    tas : xr.DataArray
+    tas : xarray.DataArray
       Mean daily temperature [℃] or [K]
-    freq : Optional[str]
+    freq : str
       Resampling frequency; Defaults to "QS-DEC".
 
     Returns
     -------
-    xr.DataArray
+    xarray.DataArray
       Ratio of rainfall to total precipitation
 
     Notes
@@ -579,8 +563,6 @@ def liquid_precip_ratio(
     --------
     winter_rain_ratio
     """
-    freq = freq or "QS-DEC"
-
     if prsn is None:
         tu = units.parse_units(tas.attrs["units"].replace("-", "**-"))
         fu = "degC"
@@ -597,11 +579,11 @@ def liquid_precip_ratio(
 
 @declare_units("mm", pr="[precipitation]", tas="[temperature]")
 def precip_accumulation(
-    pr: xr.DataArray,
-    tas: xr.DataArray = None,
+    pr: xarray.DataArray,
+    tas: xarray.DataArray = None,
     phase: Optional[str] = None,
-    freq: Optional[str] = None,
-) -> xr.DataArray:
+    freq: str = "YS",
+) -> xarray.DataArray:
     r"""Accumulated total (liquid and/or solid) precipitation.
 
     Resample the original daily mean precipitation flux and accumulate over each period.
@@ -610,19 +592,19 @@ def precip_accumulation(
 
     Parameters
     ----------
-    pr : xr.DataArray
+    pr : xarray.DataArray
       Mean daily precipitation flux [Kg m-2 s-1] or [mm].
-    tas : xr.DataArray, optional
+    tas : xarray.DataArray, optional
       Mean daily temperature [℃] or [K]
     phase : str, optional,
       Which phase to consider, "liquid" or "solid", if None (default), both are considered.
-    freq : str, optional
+    freq : str
       Resampling frequency as defined in
       http://pandas.pydata.org/pandas-docs/stable/timeseries.html#resampling. Defaults to "YS"
 
     Returns
     -------
-    xr.DataArray
+    xarray.DataArray
       The total daily precipitation at the given time frequency for the given phase.
 
     Notes
@@ -644,7 +626,6 @@ def precip_accumulation(
     >>> pr_day = xr.open_dataset('pr_day.nc').pr
     >>> prcp_tot_seasonal = precip_accumulation(pr_day, freq="QS-DEC")
     """
-    freq = freq or "YS"
 
     if phase in ["liquid", "solid"]:
         frz = utils.convert_units_to("0 degC", tas)
@@ -662,11 +643,11 @@ def precip_accumulation(
     "days", pr="[precipitation]", tas="[temperature]", thresh="[precipitation]"
 )
 def rain_on_frozen_ground_days(
-    pr: xr.DataArray,
-    tas: xr.DataArray,
+    pr: xarray.DataArray,
+    tas: xarray.DataArray,
     thresh: str = "1 mm/d",
-    freq: Optional[str] = None,
-) -> xr.DataArray:
+    freq: str = "YS",
+) -> xarray.DataArray:
     """Number of rain on frozen ground events
 
     Number of days with rain above a threshold after a series of seven days below freezing temperature.
@@ -674,18 +655,18 @@ def rain_on_frozen_ground_days(
 
     Parameters
     ----------
-    pr : xr.DataArray
+    pr : xarray.DataArray
       Mean daily precipitation flux [Kg m-2 s-1] or [mm]
-    tas : xr.DataArray
+    tas : xarray.DataArray
       Mean daily temperature [℃] or [K]
     thresh : str
       Precipitation threshold to consider a day as a rain event. Default : '1 mm/d'
-    freq : Optional[str]
+    freq : str
       Resampling frequency; Defaults to "YS".
 
     Returns
     -------
-    xr.DataArray
+    xarray.DataArray
       The number of rain on frozen ground events per period [days]
 
     Notes
@@ -706,7 +687,6 @@ def rain_on_frozen_ground_days(
     is true for continuous periods where :math:`i ≥ 7`
 
     """
-    freq = freq or "YS"
     t = utils.convert_units_to(thresh, pr)
     frz = utils.convert_units_to("0 C", tas)
 
@@ -725,11 +705,11 @@ def rain_on_frozen_ground_days(
     "days", pr="[precipitation]", per="[precipitation]", thresh="[precipitation]"
 )
 def days_over_precip_thresh(
-    pr: xr.DataArray,
-    per: xr.DataArray,
+    pr: xarray.DataArray,
+    per: xarray.DataArray,
     thresh: str = "1 mm/day",
-    freq: Optional[str] = None,
-) -> xr.DataArray:
+    freq: str = "YS",
+) -> xarray.DataArray:
     r"""Number of wet days with daily precipitation over a given percentile.
 
     Number of days over period where the precipitation is above a threshold defining wet days and above a given
@@ -737,18 +717,18 @@ def days_over_precip_thresh(
 
     Parameters
     ----------
-    pr : xr.DataArray
+    pr : xarray.DataArray
       Mean daily precipitation flux [Kg m-2 s-1] or [mm/day]
-    per : xr.DataArray
+    per : xarray.DataArray
       Daily percentile of wet day precipitation flux [Kg m-2 s-1] or [mm/day].
     thresh : str
        Precipitation value over which a day is considered wet [Kg m-2 s-1] or [mm/day].
-    freq : Optional[str]
+    freq : str
       Resampling frequency; Defaults to "YS".
 
     Returns
     -------
-    xr.DataArray
+    xarray.DataArray
       Count of days with daily precipitation above the given percentile [days]
 
     Example
@@ -756,7 +736,6 @@ def days_over_precip_thresh(
     >>> p75 = historical_pr.quantile(.75, dim="time", keep_attrs=True)
     >>> r75p = days_over_precip_thresh(pr, p75)
     """
-    freq = freq or "YS"
     per = utils.convert_units_to(per, pr)
     thresh = utils.convert_units_to(thresh, pr)
 
@@ -775,11 +754,11 @@ def days_over_precip_thresh(
     "", pr="[precipitation]", per="[precipitation]", thresh="[precipitation]"
 )
 def fraction_over_precip_thresh(
-    pr: xr.DataArray,
-    per: xr.DataArray,
+    pr: xarray.DataArray,
+    per: xarray.DataArray,
     thresh: str = "1 mm/day",
-    freq: Optional[str] = None,
-) -> xr.DataArray:
+    freq: str = "YS",
+) -> xarray.DataArray:
     r"""Fraction of precipitation due to wet days with daily precipitation over a given percentile.
 
     Percentage of the total precipitation over period occurring in days where the precipitation is above a threshold
@@ -787,22 +766,21 @@ def fraction_over_precip_thresh(
 
     Parameters
     ----------
-    pr : xr.DataArray
+    pr : xarray.DataArray
       Mean daily precipitation flux [Kg m-2 s-1] or [mm/day].
-    per : xr.DataArray
+    per : xarray.DataArray
       Daily percentile of wet day precipitation flux [Kg m-2 s-1] or [mm/day].
     thresh : str
        Precipitation value over which a day is considered wet [Kg m-2 s-1] or [mm/day].
-    freq : Optional[str]
+    freq : str
       Resampling frequency; Defaults to "YS".
 
     Returns
     -------
-    xr.DataArray
+    xarray.DataArray
       Fraction of precipitation over threshold during wet days days.
 
     """
-    freq = freq or "YS"
     per = utils.convert_units_to(per, pr)
     thresh = utils.convert_units_to(thresh, pr)
 
@@ -822,24 +800,24 @@ def fraction_over_precip_thresh(
 
 @declare_units("days", tas="[temperature]", t90="[temperature]")
 def tg90p(
-    tas: xr.DataArray, t90: xr.DataArray, freq: Optional[str] = None
-) -> xr.DataArray:
+    tas: xarray.DataArray, t90: xarray.DataArray, freq: str = "YS"
+) -> xarray.DataArray:
     r"""Number of days with daily mean temperature over the 90th percentile.
 
     Number of days with daily mean temperature over the 90th percentile.
 
     Parameters
     ----------
-    tas : xr.DataArray
+    tas : xarray.DataArray
       Mean daily temperature [℃] or [K]
-    t90 : xr.DataArray
+    t90 : xarray.DataArray
       90th percentile of daily mean temperature [℃] or [K]
-    freq : Optional[str]
+    freq : str
       Resampling frequency; Defaults to "YS".
 
     Returns
     -------
-    xr.DataArray
+    xarray.DataArray
       Count of days with daily mean temperature below the 10th percentile [days]
 
     Notes
@@ -864,24 +842,24 @@ def tg90p(
 
 @declare_units("days", tas="[temperature]", t10="[temperature]")
 def tg10p(
-    tas: xr.DataArray, t10: xr.DataArray, freq: Optional[str] = None
-) -> xr.DataArray:
+    tas: xarray.DataArray, t10: xarray.DataArray, freq: str = "YS"
+) -> xarray.DataArray:
     r"""Number of days with daily mean temperature below the 10th percentile.
 
     Number of days with daily mean temperature below the 10th percentile.
 
     Parameters
     ----------
-    tas : xr.DataArray
+    tas : xarray.DataArray
       Mean daily temperature [℃] or [K]
-    t10 : xr.DataArray
+    t10 : xarray.DataArray
       10th percentile of daily mean temperature [℃] or [K]
-    freq : Optional[str]
+    freq : str
       Resampling frequency; Defaults to "YS".
 
     Returns
     -------
-    xr.DataArray
+    xarray.DataArray
       Count of days with daily mean temperature below the 10th percentile [days]
 
     Notes
@@ -893,7 +871,6 @@ def tg10p(
     >>> t10 = percentile_doy(historical_tas, per=0.1)
     >>> cold_days = tg10p(tas, t10)
     """
-    freq = freq or "YS"
     t10 = utils.convert_units_to(t10, tas)
 
     # Create time series out of doy values.
@@ -907,24 +884,24 @@ def tg10p(
 
 @declare_units("days", tasmin="[temperature]", t90="[temperature]")
 def tn90p(
-    tasmin: xr.DataArray, t90: xr.DataArray, freq: Optional[str] = None
-) -> xr.DataArray:
+    tasmin: xarray.DataArray, t90: xarray.DataArray, freq: str = "YS"
+) -> xarray.DataArray:
     r"""Number of days with daily minimum temperature over the 90th percentile.
 
     Number of days with daily minimum temperature over the 90th percentile.
 
     Parameters
     ----------
-    tasmin : xr.DataArray
+    tasmin : xarray.DataArray
       Minimum daily temperature [℃] or [K]
-    t90 : xr.DataArray
+    t90 : xarray.DataArray
       90th percentile of daily minimum temperature [℃] or [K]
-    freq : Optional[str]
+    freq : str
       Resampling frequency; Defaults to "YS".
 
     Returns
     -------
-    xr.DataArray
+    xarray.DataArray
       Count of days with daily minimum temperature below the 10th percentile [days]
 
     Notes
@@ -936,7 +913,6 @@ def tn90p(
     >>> t90 = percentile_doy(historical_tas, per=0.9)
     >>> hot_days = tg90p(tas, t90)
     """
-    freq = freq or "YS"
     t90 = utils.convert_units_to(t90, tasmin)
 
     # Create time series out of doy values.
@@ -950,8 +926,8 @@ def tn90p(
 
 @declare_units("days", tasmin="[temperature]", t10="[temperature]")
 def tn10p(
-    tasmin: xr.DataArray, t10: xr.DataArray, freq: Optional[str] = None
-) -> xr.DataArray:
+    tasmin: xarray.DataArray, t10: xarray.DataArray, freq: str = "YS"
+) -> xarray.DataArray:
     r"""Number of days with daily minimum temperature below the 10th percentile.
 
     Number of days with daily minimum temperature below the 10th percentile.
@@ -959,16 +935,16 @@ def tn10p(
     Parameters
     ----------
 
-    tasmin : xr.DataArray
+    tasmin : xarray.DataArray
       Mean daily temperature [℃] or [K]
-    t10 : xr.DataArray
+    t10 : xarray.DataArray
       10th percentile of daily minimum temperature [℃] or [K]
-    freq : Optional[str]
+    freq : str
       Resampling frequency; Defaults to "YS".
 
     Returns
     -------
-    xr.DataArray
+    xarray.DataArray
       Count of days with daily minimum temperature below the 10th percentile [days]
 
     Notes
@@ -980,7 +956,6 @@ def tn10p(
     >>> t10 = percentile_doy(historical_tas, per=0.1)
     >>> cold_days = tg10p(tas, t10)
     """
-    freq = freq or "YS"
     t10 = utils.convert_units_to(t10, tasmin)
 
     # Create time series out of doy values.
@@ -994,24 +969,24 @@ def tn10p(
 
 @declare_units("days", tasmax="[temperature]", t90="[temperature]")
 def tx90p(
-    tasmax: xr.DataArray, t90: xr.DataArray, freq: Optional[str] = None
-) -> xr.DataArray:
+    tasmax: xarray.DataArray, t90: xarray.DataArray, freq: str = "YS"
+) -> xarray.DataArray:
     r"""Number of days with daily maximum temperature over the 90th percentile.
 
     Number of days with daily maximum temperature over the 90th percentile.
 
     Parameters
     ----------
-    tasmax : xr.DataArray
+    tasmax : xarray.DataArray
       Maximum daily temperature [℃] or [K]
-    t90 : xr.DataArray
+    t90 : xarray.DataArray
       90th percentile of daily maximum temperature [℃] or [K]
-    freq : Optional[str]
+    freq : str
       Resampling frequency; Defaults to "YS".
 
     Returns
     -------
-    xr.DataArray
+    xarray.DataArray
       Count of days with daily maximum temperature below the 10th percentile [days]
 
     Notes
@@ -1023,7 +998,6 @@ def tx90p(
     >>> t90 = percentile_doy(historical_tas, per=0.9)
     >>> hot_days = tg90p(tas, t90)
     """
-    freq = freq or "YS"
     t90 = utils.convert_units_to(t90, tasmax)
 
     # Create time series out of doy values.
@@ -1037,24 +1011,24 @@ def tx90p(
 
 @declare_units("days", tasmax="[temperature]", t10="[temperature]")
 def tx10p(
-    tasmax: xr.DataArray, t10: xr.DataArray, freq: Optional[str] = None
-) -> xr.DataArray:
+    tasmax: xarray.DataArray, t10: xarray.DataArray, freq: str = "YS"
+) -> xarray.DataArray:
     r"""Number of days with daily maximum temperature below the 10th percentile.
 
     Number of days with daily maximum temperature below the 10th percentile.
 
     Parameters
     ----------
-    tasmax : xr.DataArray
+    tasmax : xarray.DataArray
       Maximum daily temperature [℃] or [K]
-    t10 : xr.DataArray
+    t10 : xarray.DataArray
       10th percentile of daily maximum temperature [℃] or [K]
-    freq : Optional[str]
+    freq : str
       Resampling frequency; Defaults to "YS".
 
     Returns
     -------
-    xr.DataArray
+    xarray.DataArray
       Count of days with daily maximum temperature below the 10th percentile [days]
 
     Notes
@@ -1066,7 +1040,6 @@ def tx10p(
     >>> t10 = percentile_doy(historical_tas, per=0.1)
     >>> cold_days = tg10p(tas, t10)
     """
-    freq = freq or "YS"
     t10 = utils.convert_units_to(t10, tasmax)
 
     # Create time series out of doy values.
@@ -1086,32 +1059,32 @@ def tx10p(
     thresh_tasmax="[temperature]",
 )
 def tx_tn_days_above(
-    tasmin: xr.DataArray,
-    tasmax: xr.DataArray,
+    tasmin: xarray.DataArray,
+    tasmax: xarray.DataArray,
     thresh_tasmin: str = "22 degC",
     thresh_tasmax: str = "30 degC",
-    freq: Optional[str] = "YS",
-) -> xr.DataArray:
+    freq: str = "YS",
+) -> xarray.DataArray:
     r"""Number of days with both hot maximum and minimum daily temperatures.
 
     The number of days per period with tasmin above a threshold and tasmax above another threshold.
 
     Parameters
     ----------
-    tasmin : xr.DataArray
+    tasmin : xarray.DataArray
       Minimum daily temperature [℃] or [K]
-    tasmax : xr.DataArray
+    tasmax : xarray.DataArray
       Maximum daily temperature [℃] or [K]
     thresh_tasmin : str
       Threshold temperature for tasmin on which to base evaluation [℃] or [K]. Default : '22 degC'
     thresh_tasmax : str
       Threshold temperature for tasmax on which to base evaluation [℃] or [K]. Default : '30 degC'
-    freq : Optional[str]
+    freq : str
       Resampling frequency; Defaults to "YS".
 
     Returns
     -------
-    xr.DataArray
+    xarray.DataArray
       the number of days with tasmin > thresh_tasmin and
       tasmax > thresh_tasamax per period
 
@@ -1134,7 +1107,7 @@ def tx_tn_days_above(
         TN_{ij} > TN_{thresh} [℃]
 
     """
-    freq = freq or "YS"
+
     thresh_tasmax = utils.convert_units_to(thresh_tasmax, tasmax)
     thresh_tasmin = utils.convert_units_to(thresh_tasmin, tasmin)
     events = ((tasmin > thresh_tasmin) & (tasmax > thresh_tasmax)) * 1
@@ -1143,8 +1116,8 @@ def tx_tn_days_above(
 
 @declare_units("days", tasmax="[temperature]", tx90="[temperature]")
 def warm_spell_duration_index(
-    tasmax: xr.DataArray, tx90: float, window: int = 6, freq: Optional[str] = None
-) -> xr.DataArray:
+    tasmax: xarray.DataArray, tx90: float, window: int = 6, freq: str = "YS"
+) -> xarray.DataArray:
     r"""Warm spell duration index
 
     Number of days with at least six consecutive days where the daily maximum temperature is above the 90th
@@ -1153,18 +1126,18 @@ def warm_spell_duration_index(
 
     Parameters
     ----------
-    tasmax : xr.DataArray
+    tasmax : xarray.DataArray
       Maximum daily temperature [℃] or [K]
     tx90 : float
       90th percentile of daily maximum temperature [℃] or [K]
     window : int
       Minimum number of days with temperature below threshold to qualify as a warm spell.
-    freq : Optional[str]
+    freq : str
       Resampling frequency; Defaults to "YS".
 
     Returns
     -------
-    xr.DataArray
+    xarray.DataArray
       Count of days with at least six consecutive days where the daily maximum temperature is above the 90th
       percentile [days].
 
@@ -1175,7 +1148,6 @@ def warm_spell_duration_index(
     precipitation, J. Geophys. Res., 111, D05109, doi: 10.1029/2005JD006290.
 
     """
-    freq = freq or "YS"
     # Create time series out of doy values.
     thresh = utils.resample_doy(tx90, tasmax)
 
@@ -1189,11 +1161,11 @@ def warm_spell_duration_index(
 @declare_units("", pr="[precipitation]", prsn="[precipitation]", tas="[temperature]")
 def winter_rain_ratio(
     *,
-    pr: xr.DataArray = None,
-    prsn: xr.DataArray = None,
-    tas: xr.DataArray = None,
-    freq: Optional[str] = None
-) -> xr.DataArray:
+    pr: xarray.DataArray = None,
+    prsn: xarray.DataArray = None,
+    tas: xarray.DataArray = None,
+    freq: str = "QS-DEC",
+) -> xarray.DataArray:
     """Ratio of rainfall to total precipitation during winter
 
     The ratio of total liquid precipitation over the total precipitation over the winter months (DJF. If solid
@@ -1201,21 +1173,20 @@ def winter_rain_ratio(
 
     Parameters
     ----------
-    pr : xr.DataArray
+    pr : xarray.DataArray
       Mean daily precipitation flux [Kg m-2 s-1] or [mm].
-    prsn : xr.DataArray
+    prsn : xarray.DataArray
       Mean daily solid precipitation flux [Kg m-2 s-1] or [mm].
-    tas : xr.DataArray
+    tas : xarray.DataArray
       Mean daily temperature [℃] or [K]
     freq : str
       Resampling frequency; Defaults to "QS-DEC".
 
     Returns
     -------
-    xr.DataArray
+    xarray.DataArray
       Ratio of rainfall to total precipitation during winter months (DJF)
     """
-    freq = freq or "QS-DEC"
     ratio = liquid_precip_ratio(pr, prsn, tas, freq=freq)
     winter = ratio.indexes["time"].month == 12
     return ratio[winter]

--- a/xclim/indices/_multivariate.py
+++ b/xclim/indices/_multivariate.py
@@ -622,7 +622,7 @@ def precip_accumulation(
     --------
     The following would compute for each grid cell of file `pr_day.nc` the total
     precipitation at the seasonal frequency, ie DJF, MAM, JJA, SON, DJF, etc.:
-
+    >>> import xarray as xr
     >>> pr_day = xr.open_dataset('pr_day.nc').pr
     >>> prcp_tot_seasonal = precip_accumulation(pr_day, freq="QS-DEC")
     """
@@ -733,8 +733,11 @@ def days_over_precip_thresh(
 
     Example
     -------
-    >>> p75 = historical_pr.quantile(.75, dim="time", keep_attrs=True)
-    >>> r75p = days_over_precip_thresh(pr, p75)
+    >>> import xarray as xr
+    >>> import xclim
+    >>> pr = xr.open_dataset("precipitation_data.nc").pr
+    >>> p75 = pr.quantile(.75, dim="time", keep_attrs=True)
+    >>> r75p = xclim.indices.days_over_precip_thresh(pr, p75)
     """
     per = utils.convert_units_to(per, pr)
     thresh = utils.convert_units_to(thresh, pr)
@@ -826,7 +829,10 @@ def tg90p(
 
     Example
     -------
-    >>> t90 = percentile_doy(historical_tas, per=0.9)
+    >>> import xarray as xr
+    >>> import xclim.utils
+    >>> tas = xr.open_dataset("temperature_data.nc").tas
+    >>> t90 = xclim.utils.percentile_doy(tas, per=0.9)
     >>> hot_days = tg90p(tas, t90)
     """
     t90 = utils.convert_units_to(t90, tas)
@@ -868,7 +874,10 @@ def tg10p(
 
     Example
     -------
-    >>> t10 = percentile_doy(historical_tas, per=0.1)
+    >>> import xarray as xr
+    >>> import xclim.utils
+    >>> tas = xr.open_dataset("temperature_data.nc").tas
+    >>> t10 = xclim.utils.percentile_doy(tas, per=0.1)
     >>> cold_days = tg10p(tas, t10)
     """
     t10 = utils.convert_units_to(t10, tas)
@@ -910,8 +919,11 @@ def tn90p(
 
     Example
     -------
-    >>> t90 = percentile_doy(historical_tas, per=0.9)
-    >>> hot_days = tg90p(tas, t90)
+    >>> import xarray as xr
+    >>> import xclim.utils
+    >>> tas = xr.open_dataset("temperature_data.nc").tas
+    >>> t90 = xclim.utils.percentile_doy(tas, per=0.9)
+    >>> hot_days = tn90p(tas, t90)
     """
     t90 = utils.convert_units_to(t90, tasmin)
 
@@ -953,7 +965,10 @@ def tn10p(
 
     Example
     -------
-    >>> t10 = percentile_doy(historical_tas, per=0.1)
+    >>> import xarray as xr
+    >>> import xclim.utils
+    >>> tas = xr.open_dataset("temperature_data.nc").tas
+    >>> t10 = xclim.utils.percentile_doy(tas, per=0.1)
     >>> cold_days = tg10p(tas, t10)
     """
     t10 = utils.convert_units_to(t10, tasmin)
@@ -995,7 +1010,10 @@ def tx90p(
 
     Example
     -------
-    >>> t90 = percentile_doy(historical_tas, per=0.9)
+    >>> import xarray as xr
+    >>> import xclim.utils
+    >>> tas = xr.open_dataset("temperature_data.nc").tas
+    >>> t90 = xclim.utils.percentile_doy(tas, per=0.9)
     >>> hot_days = tg90p(tas, t90)
     """
     t90 = utils.convert_units_to(t90, tasmax)
@@ -1037,7 +1055,10 @@ def tx10p(
 
     Example
     -------
-    >>> t10 = percentile_doy(historical_tas, per=0.1)
+    >>> import xarray as xr
+    >>> import xclim.utils
+    >>> tas = xr.open_dataset("temperature_data.nc").tas
+    >>> t10 = xclim.utils.percentile_doy(tas, per=0.1)
     >>> cold_days = tg10p(tas, t10)
     """
     t10 = utils.convert_units_to(t10, tasmax)
@@ -1164,7 +1185,7 @@ def winter_rain_ratio(
     pr: xarray.DataArray = None,
     prsn: xarray.DataArray = None,
     tas: xarray.DataArray = None,
-    freq: str = "QS-DEC",
+    freq: str = "QS-DEC"
 ) -> xarray.DataArray:
     """Ratio of rainfall to total precipitation during winter
 

--- a/xclim/indices/_simple.py
+++ b/xclim/indices/_simple.py
@@ -514,7 +514,7 @@ def max_1day_precipitation_amount(pr: xarray.DataArray, freq: str = "YS"):
     at an annual frequency:
     >>> import xarray as xr
     >>> pr = xr.open_dataset('pr.day.nc').pr
-    >>> rx1day = max_1day_precipitation_amount(pr, freq: str = "YS")
+    >>> rx1day = max_1day_precipitation_amount(pr, freq="YS")
     """
 
     out = pr.resample(time=freq).max(dim="time", keep_attrs=True)
@@ -549,7 +549,7 @@ def max_n_day_precipitation_amount(pr, window: int = 1, freq: str = "YS"):
     >>> import xarray as xr
     >>> da = xr.open_dataset('pr.day.nc').pr
     >>> window = 5
-    >>> output = max_n_day_precipitation_amount(da, window, freq: str = "YS")
+    >>> output = max_n_day_precipitation_amount(da, window, freq="YS")
     """
 
     # rolling sum of the values

--- a/xclim/indices/_simple.py
+++ b/xclim/indices/_simple.py
@@ -1,16 +1,11 @@
-import logging
-
-import xarray as xr
+import xarray
 
 from xclim import run_length as rl
 from xclim import utils
 from xclim.utils import declare_units
 from xclim.utils import units
 
-# logging.basicConfig(level=logging.DEBUG)
-# logging.captureWarnings(True)
-
-xr.set_options(enable_cftimeindex=True)  # Set xarray to use cftimeindex
+xarray.set_options(enable_cftimeindex=True)  # Set xarray to use cftimeindex
 
 
 # Frequencies : YS: year start, QS-DEC: seasons starting in december, MS: month start
@@ -40,7 +35,7 @@ __all__ = [
 
 
 @declare_units("[temperature]", tas="[temperature]")
-def tg_max(tas, freq="YS"):
+def tg_max(tas: xarray.DataArray, freq: str = "YS"):
     r"""Highest mean temperature.
 
     The maximum of daily mean temperature.
@@ -49,8 +44,8 @@ def tg_max(tas, freq="YS"):
     ----------
     tas : xarray.DataArray
       Mean daily temperature [℃] or [K]
-    freq : str, optional
-      Resampling frequency
+    freq : str
+      Resampling frequency; Defaults to "YS" (yearly).
 
     Returns
     -------
@@ -71,7 +66,7 @@ def tg_max(tas, freq="YS"):
 
 
 @declare_units("[temperature]", tas="[temperature]")
-def tg_mean(tas, freq="YS"):
+def tg_mean(tas: xarray.DataArray, freq: str = "YS"):
     r"""Mean of daily average temperature.
 
     Resample the original daily mean temperature series by taking the mean over each period.
@@ -80,8 +75,8 @@ def tg_mean(tas, freq="YS"):
     ----------
     tas : xarray.DataArray
       Mean daily temperature [℃] or [K]
-    freq : str, optional
-      Resampling frequency
+    freq : str
+      Resampling frequency; Defaults to "YS" (yearly).
 
     Returns
     -------
@@ -102,7 +97,7 @@ def tg_mean(tas, freq="YS"):
     --------
     The following would compute for each grid cell of file `tas.day.nc` the mean temperature
     at the seasonal frequency, ie DJF, MAM, JJA, SON, DJF, etc.:
-
+    >>> import xarray as xr
     >>> t = xr.open_dataset('tas.day.nc')
     >>> tg = tm_mean(t, freq="QS-DEC")
     """
@@ -112,7 +107,7 @@ def tg_mean(tas, freq="YS"):
 
 
 @declare_units("[temperature]", tas="[temperature]")
-def tg_min(tas, freq="YS"):
+def tg_min(tas: xarray.DataArray, freq: str = "YS"):
     r"""Lowest mean temperature
 
     Minimum of daily mean temperature.
@@ -121,8 +116,8 @@ def tg_min(tas, freq="YS"):
     ----------
     tas : xarray.DataArray
       Mean daily temperature [℃] or [K]
-    freq : str, optional
-      Resampling frequency
+    freq : str
+      Resampling frequency; Defaults to "YS" (yearly).
 
     Returns
     -------
@@ -143,7 +138,7 @@ def tg_min(tas, freq="YS"):
 
 
 @declare_units("[temperature]", tasmin="[temperature]")
-def tn_max(tasmin, freq="YS"):
+def tn_max(tasmin: xarray.DataArray, freq: str = "YS"):
     r"""Highest minimum temperature.
 
     The maximum of daily minimum temperature.
@@ -152,8 +147,8 @@ def tn_max(tasmin, freq="YS"):
     ----------
     tasmin : xarray.DataArray
       Minimum daily temperature [℃] or [K]
-    freq : str, optional
-      Resampling frequency
+    freq : str
+      Resampling frequency; Defaults to "YS" (yearly).
 
     Returns
     -------
@@ -174,7 +169,7 @@ def tn_max(tasmin, freq="YS"):
 
 
 @declare_units("[temperature]", tasmin="[temperature]")
-def tn_mean(tasmin, freq="YS"):
+def tn_mean(tasmin: xarray.DataArray, freq: str = "YS"):
     r"""Mean minimum temperature.
 
     Mean of daily minimum temperature.
@@ -183,8 +178,8 @@ def tn_mean(tasmin, freq="YS"):
     ----------
     tasmin : xarray.DataArray
       Minimum daily temperature [℃] or [K]
-    freq : str, optional
-      Resampling frequency
+    freq : str
+      Resampling frequency; Defaults to "YS" (yearly).
 
     Returns
     -------
@@ -206,7 +201,7 @@ def tn_mean(tasmin, freq="YS"):
 
 
 @declare_units("[temperature]", tasmin="[temperature]")
-def tn_min(tasmin, freq="YS"):
+def tn_min(tasmin: xarray.DataArray, freq: str = "YS"):
     r"""Lowest minimum temperature
 
     Minimum of daily minimum temperature.
@@ -215,8 +210,8 @@ def tn_min(tasmin, freq="YS"):
     ----------
     tasmin : xarray.DataArray
       Minimum daily temperature [℃] or [K]
-    freq : str, optional
-      Resampling frequency
+    freq : str
+      Resampling frequency; Defaults to "YS" (yearly).
 
     Returns
     -------
@@ -237,7 +232,7 @@ def tn_min(tasmin, freq="YS"):
 
 
 @declare_units("[temperature]", tasmax="[temperature]")
-def tx_max(tasmax, freq="YS"):
+def tx_max(tasmax: xarray.DataArray, freq: str = " YS"):
     r"""Highest max temperature
 
     The maximum value of daily maximum temperature.
@@ -246,8 +241,8 @@ def tx_max(tasmax, freq="YS"):
     ----------
     tasmax : xarray.DataArray
       Maximum daily temperature [℃] or [K]
-    freq : str, optional
-      Resampling frequency
+    freq : str
+      Resampling frequency; Defaults to "YS" (yearly).
 
     Returns
     -------
@@ -268,7 +263,7 @@ def tx_max(tasmax, freq="YS"):
 
 
 @declare_units("[temperature]", tasmax="[temperature]")
-def tx_mean(tasmax, freq="YS"):
+def tx_mean(tasmax: xarray.DataArray, freq: str = " YS"):
     r"""Mean max temperature
 
     The mean of daily maximum temperature.
@@ -277,8 +272,8 @@ def tx_mean(tasmax, freq="YS"):
     ----------
     tasmax : xarray.DataArray
       Maximum daily temperature [℃] or [K]
-    freq : str, optional
-      Resampling frequency
+    freq : str
+      Resampling frequency; Defaults to "YS" (yearly).
 
     Returns
     -------
@@ -300,7 +295,7 @@ def tx_mean(tasmax, freq="YS"):
 
 
 @declare_units("[temperature]", tasmax="[temperature]")
-def tx_min(tasmax, freq="YS"):
+def tx_min(tasmax: xarray.DataArray, freq: str = "YS"):
     r"""Lowest max temperature
 
     The minimum of daily maximum temperature.
@@ -309,8 +304,8 @@ def tx_min(tasmax, freq="YS"):
     ----------
     tasmax : xarray.DataArray
       Maximum daily temperature [℃] or [K]
-    freq : str, optional
-      Resampling frequency
+    freq : str
+      Resampling frequency; Defaults to "YS" (yearly).
 
     Returns
     -------
@@ -331,7 +326,7 @@ def tx_min(tasmax, freq="YS"):
 
 
 @declare_units("", q="[discharge]")
-def base_flow_index(q, freq="YS"):
+def base_flow_index(q: xarray.DataArray, freq: str = "YS"):
     r"""Base flow index
 
     Return the base flow index, defined as the minimum 7-day average flow divided by the mean flow.
@@ -340,8 +335,8 @@ def base_flow_index(q, freq="YS"):
     ----------
     q : xarray.DataArray
       Rate of river discharge [m³/s]
-    freq : str, optional
-      Resampling frequency
+    freq : str
+      Resampling frequency; Defaults to "YS" (yearly).
 
     Returns
     -------
@@ -374,7 +369,7 @@ def base_flow_index(q, freq="YS"):
 
 
 @declare_units("days", tasmin="[temperature]")
-def consecutive_frost_days(tasmin, freq="AS-JUL"):
+def consecutive_frost_days(tasmin: xarray.DataArray, freq="AS-JUL"):
     r"""Maximum number of consecutive frost days (Tmin < 0℃).
 
     Resample the daily minimum temperature series by computing the maximum number
@@ -384,8 +379,8 @@ def consecutive_frost_days(tasmin, freq="AS-JUL"):
     ----------
     tasmin : xarray.DataArray
       Minimum daily temperature values [℃] or [K]
-    freq : str, optional
-      Resampling frequency
+    freq : str
+      Resampling frequency; Defaults to "YS" (yearly).
 
     Returns
     -------
@@ -416,7 +411,7 @@ def consecutive_frost_days(tasmin, freq="AS-JUL"):
 
 
 @declare_units("days", tasmin="[temperature]")
-def frost_days(tasmin, freq="YS"):
+def frost_days(tasmin: xarray.DataArray, freq: str = "YS"):
     r"""Frost days index
 
     Number of days where daily minimum temperatures are below 0℃.
@@ -425,8 +420,8 @@ def frost_days(tasmin, freq="YS"):
     ----------
     tasmin : xarray.DataArray
       Minimum daily temperature [℃] or [K]
-    freq : str, optional
-      Resampling frequency
+    freq : str
+      Resampling frequency; Defaults to "YS" (yearly).
 
     Returns
     -------
@@ -452,7 +447,7 @@ def frost_days(tasmin, freq="YS"):
 
 
 @declare_units("days", tasmax="[temperature]")
-def ice_days(tasmax, freq="YS"):
+def ice_days(tasmax: xarray.DataArray, freq: str = "YS"):
     r"""Number of ice/freezing days
 
     Number of days where daily maximum temperatures are below 0℃.
@@ -461,8 +456,8 @@ def ice_days(tasmax, freq="YS"):
     ----------
     tasmax : xarrray.DataArray
       Maximum daily temperature [℃] or [K]
-    freq : str, optional
-      Resampling frequency
+    freq : str
+      Resampling frequency; Defaults to "YS" (yearly).
 
     Returns
     -------
@@ -488,7 +483,7 @@ def ice_days(tasmax, freq="YS"):
 
 
 @declare_units("mm/day", pr="[precipitation]")
-def max_1day_precipitation_amount(pr, freq="YS"):
+def max_1day_precipitation_amount(pr: xarray.DataArray, freq: str = "YS"):
     r"""Highest 1-day precipitation amount for a period (frequency).
 
     Resample the original daily total precipitation temperature series by taking the max over each period.
@@ -497,8 +492,8 @@ def max_1day_precipitation_amount(pr, freq="YS"):
     ----------
     pr : xarray.DataArray
       Daily precipitation values [Kg m-2 s-1] or [mm]
-    freq : str, optional
-      Resampling frequency one of : 'YS' (yearly) ,'M' (monthly), or 'QS-DEC' (seasonal - quarters starting in december)
+    freq : str
+      Resampling frequency; Defaults to "YS" (yearly).
 
     Returns
     -------
@@ -517,9 +512,9 @@ def max_1day_precipitation_amount(pr, freq="YS"):
     --------
     The following would compute for each grid cell of file `pr.day.nc` the highest 1-day total
     at an annual frequency:
-
+    >>> import xarray as xr
     >>> pr = xr.open_dataset('pr.day.nc').pr
-    >>> rx1day = max_1day_precipitation_amount(pr, freq="YS")
+    >>> rx1day = max_1day_precipitation_amount(pr, freq: str = "YS")
     """
 
     out = pr.resample(time=freq).max(dim="time", keep_attrs=True)
@@ -527,7 +522,7 @@ def max_1day_precipitation_amount(pr, freq="YS"):
 
 
 @declare_units("mm", pr="[precipitation]")
-def max_n_day_precipitation_amount(pr, window=1, freq="YS"):
+def max_n_day_precipitation_amount(pr, window: int = 1, freq: str = "YS"):
     r"""Highest precipitation amount cumulated over a n-day moving window.
 
     Calculate the n-day rolling sum of the original daily total precipitation series
@@ -535,12 +530,12 @@ def max_n_day_precipitation_amount(pr, window=1, freq="YS"):
 
     Parameters
     ----------
-    da : xarray.DataArray
+    pr : xarray.DataArray
       Daily precipitation values [Kg m-2 s-1] or [mm]
     window : int
       Window size in days.
-    freq : str, optional
-      Resampling frequency : default 'YS' (yearly)
+    freq : str
+      Resampling frequency; Defaults to "YS" (yearly).
 
     Returns
     -------
@@ -551,10 +546,10 @@ def max_n_day_precipitation_amount(pr, window=1, freq="YS"):
     --------
     The following would compute for each grid cell of file `pr.day.nc` the highest 5-day total precipitation
     at an annual frequency:
-
+    >>> import xarray as xr
     >>> da = xr.open_dataset('pr.day.nc').pr
     >>> window = 5
-    >>> output = max_n_day_precipitation_amount(da, window, freq="YS")
+    >>> output = max_n_day_precipitation_amount(da, window, freq: str = "YS")
     """
 
     # rolling sum of the values

--- a/xclim/indices/_threshold.py
+++ b/xclim/indices/_threshold.py
@@ -1,17 +1,12 @@
-import logging
-
 import numpy as np
-import xarray as xr
+import xarray
 
 from xclim import run_length as rl
 from xclim import utils
 from xclim.utils import declare_units
 from xclim.utils import units
 
-# logging.basicConfig(level=logging.DEBUG)
-# logging.captureWarnings(True)
-
-xr.set_options(enable_cftimeindex=True)  # Set xarray to use cftimeindex
+xarray.set_options(enable_cftimeindex=True)  # Set xarray to use cftimeindex
 
 # Frequencies : YS: year start, QS-DEC: seasons starting in december, MS: month start
 # See http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases
@@ -42,7 +37,7 @@ __all__ = [
 
 # TODO: Add docstring for window
 @declare_units("days", tas="[temperature]", thresh="[temperature]")
-def cold_spell_days(tas, thresh="-10 degC", window=5, freq="AS-JUL"):
+def cold_spell_days(tas, thresh="-10 degC", window: int = 5, freq="AS-JUL"):
     r"""Cold spell days
 
     The number of days that are part of a cold spell, defined as five or more consecutive days with mean daily
@@ -53,11 +48,11 @@ def cold_spell_days(tas, thresh="-10 degC", window=5, freq="AS-JUL"):
     tas : xarrray.DataArray
       Mean daily temperature [℃] or [K]
     thresh : str
-      Threshold temperature below which a cold spell begins [℃] or [K]. Default : '-10 degC'
-        window : int
+      Threshold temperature below which a cold spell begins [℃] or [K]. Default: '-10 degC'
+    window : int
       Minimum number of days with temperature below threshold to qualify as a cold spell.
-    freq : str, optional
-      Resampling frequency
+    freq : str
+      Resampling frequency; Defaults to "AS-JUL".
 
     Returns
     -------
@@ -95,9 +90,9 @@ def daily_pr_intensity(pr, thresh="1 mm/day", freq="YS"):
       Daily precipitation [mm/d or kg/m²/s]
     thresh : str
       precipitation value over which a day is considered wet. Default : '1 mm/day'
-    freq : str, optional
-      Resampling frequency defining the periods
-      defined in http://pandas.pydata.org/pandas-docs/stable/timeseries.html#resampling. Default : '1 mm/day'
+    freq : str
+      Resampling frequency defining the periods defined in
+      http://pandas.pydata.org/pandas-docs/stable/timeseries.html#resampling; Defaults to "YS".
 
     Returns
     -------
@@ -128,7 +123,7 @@ def daily_pr_intensity(pr, thresh="1 mm/day", freq="YS"):
     t = utils.convert_units_to(thresh, pr, "hydro")
 
     # put pr=0 for non wet-days
-    pr_wd = xr.where(pr >= t, pr, 0)
+    pr_wd = xarray.where(pr >= t, pr, 0)
     pr_wd.attrs["units"] = pr.units
 
     # sum over wanted period
@@ -141,7 +136,7 @@ def daily_pr_intensity(pr, thresh="1 mm/day", freq="YS"):
 
 
 @declare_units("days", pr="[precipitation]", thresh="[precipitation]")
-def maximum_consecutive_wet_days(pr, thresh="1 mm/day", freq="YS"):
+def maximum_consecutive_wet_days(pr: xarray.DataArray, thresh="1 mm/day", freq="YS"):
     r"""Consecutive wet days.
 
     Returns the maximum number of consecutive wet days.
@@ -152,8 +147,8 @@ def maximum_consecutive_wet_days(pr, thresh="1 mm/day", freq="YS"):
       Mean daily precipitation flux [Kg m-2 s-1] or [mm]
     thresh : str
       Threshold precipitation on which to base evaluation [Kg m-2 s-1] or [mm]. Default : '1 mm/day'
-    freq : str, optional
-      Resampling frequency
+    freq : str
+      Resampling frequency; Defaults to "YS".
 
     Returns
     -------
@@ -182,7 +177,7 @@ def maximum_consecutive_wet_days(pr, thresh="1 mm/day", freq="YS"):
 
 
 @declare_units("C days", tas="[temperature]", thresh="[temperature]")
-def cooling_degree_days(tas, thresh="18 degC", freq="YS"):
+def cooling_degree_days(tas: xarray.DataArray, thresh="18 degC", freq="YS"):
     r"""Cooling degree days
 
     Sum of degree days above the temperature threshold at which spaces are cooled.
@@ -193,8 +188,8 @@ def cooling_degree_days(tas, thresh="18 degC", freq="YS"):
       Mean daily temperature [℃] or [K]
     thresh : str
       Temperature threshold above which air is cooled. Default : '18 degC'
-    freq : str, optional
-      Resampling frequency
+    freq : str
+      Resampling frequency; Defaults to "YS".
 
     Returns
     -------
@@ -220,7 +215,7 @@ def cooling_degree_days(tas, thresh="18 degC", freq="YS"):
 
 
 @declare_units("", tas="[temperature]", thresh="[temperature]")
-def freshet_start(tas, thresh="0 degC", window=5, freq="YS"):
+def freshet_start(tas: xarray.DataArray, thresh="0 degC", window=5, freq="YS"):
     r"""First day consistently exceeding threshold temperature.
 
     Returns first day of period where a temperature threshold is exceeded
@@ -234,8 +229,8 @@ def freshet_start(tas, thresh="0 degC", window=5, freq="YS"):
       Threshold temperature on which to base evaluation [℃] or [K]. Default '0 degC'
     window : int
       Minimum number of days with temperature above threshold needed for evaluation
-    freq : str, optional
-      Resampling frequency
+    freq : str
+      Resampling frequency; Defaults to "YS".
 
     Returns
     -------
@@ -262,7 +257,7 @@ def freshet_start(tas, thresh="0 degC", window=5, freq="YS"):
 
 
 @declare_units("C days", tas="[temperature]", thresh="[temperature]")
-def growing_degree_days(tas, thresh="4.0 degC", freq="YS"):
+def growing_degree_days(tas: xarray.DataArray, thresh="4.0 degC", freq="YS"):
     r"""Growing degree-days over threshold temperature value [℃].
 
     The sum of degree-days over the threshold temperature.
@@ -273,8 +268,8 @@ def growing_degree_days(tas, thresh="4.0 degC", freq="YS"):
       Mean daily temperature [℃] or [K]
     thresh : str
       Threshold temperature on which to base evaluation [℃] or [K]. Default: '4.0 degC'.
-    freq : str, optional
-      Resampling frequency
+    freq : str
+      Resampling frequency; Defaults to "YS".
 
     Returns
     -------
@@ -297,7 +292,9 @@ def growing_degree_days(tas, thresh="4.0 degC", freq="YS"):
 
 
 @declare_units("days", tas="[temperature]", thresh="[temperature]")
-def growing_season_length(tas, thresh="5.0 degC", window=6, freq="YS"):
+def growing_season_length(
+    tas: xarray.DataArray, thresh="5.0 degC", window=6, freq="YS"
+):
     r"""Growing season length.
 
     The number of days between the first occurrence of at least
@@ -314,8 +311,8 @@ def growing_season_length(tas, thresh="5.0 degC", window=6, freq="YS"):
       Threshold temperature on which to base evaluation [℃] or [K]. Default: '5.0 degC'.
     window : int
       Minimum number of days with temperature above threshold to mark the beginning and end of growing season.
-    freq : str, optional
-      Resampling frequency
+    freq : str
+      Resampling frequency; Defaults to "YS".
 
     Returns
     -------
@@ -368,13 +365,13 @@ def growing_season_length(tas, thresh="5.0 degC", window=6, freq="YS"):
 
     def compute_gsl(c):
         nt = c.time.size
-        i = xr.DataArray(np.arange(nt), dims="time").chunk({"time": 1})
-        ind = xr.broadcast(i, c)[0].chunk(c.chunks)
+        i = xarray.DataArray(np.arange(nt), dims="time").chunk({"time": 1})
+        ind = xarray.broadcast(i, c)[0].chunk(c.chunks)
         i1 = ind.where(c == window).min(dim="time")
-        i1 = xr.where(np.isnan(i1), nt, i1)
+        i1 = xarray.where(np.isnan(i1), nt, i1)
         i11 = i1.reindex_like(c, method="ffill")
         i2 = ind.where((c == 0) & (ind > i11)).where(c.time.dt.month >= 7)
-        i2 = xr.where(np.isnan(i2), nt, i2)
+        i2 = xarray.where(np.isnan(i2), nt, i2)
         d = (i2 - i1).min(dim="time")
         return d
 
@@ -384,7 +381,7 @@ def growing_season_length(tas, thresh="5.0 degC", window=6, freq="YS"):
 
 
 @declare_units("days", tasmax="[temperature]", thresh="[temperature]")
-def heat_wave_index(tasmax, thresh="25.0 degC", window=5, freq="YS"):
+def heat_wave_index(tasmax: xarray.DataArray, thresh="25.0 degC", window=5, freq="YS"):
     r"""Heat wave index.
 
     Number of days that are part of a heatwave, defined as five or more consecutive days over 25℃.
@@ -397,8 +394,8 @@ def heat_wave_index(tasmax, thresh="25.0 degC", window=5, freq="YS"):
       Threshold temperature on which to designate a heatwave [℃] or [K]. Default: '25.0 degC'.
     window : int
       Minimum number of days with temperature above threshold to qualify as a heatwave.
-    freq : str, optional
-      Resampling frequency
+    freq : str
+      Resampling frequency; Defaults to "YS".
 
     Returns
     -------
@@ -413,7 +410,7 @@ def heat_wave_index(tasmax, thresh="25.0 degC", window=5, freq="YS"):
 
 
 @declare_units("C days", tas="[temperature]", thresh="[temperature]")
-def heating_degree_days(tas, thresh="17.0 degC", freq="YS"):
+def heating_degree_days(tas: xarray.DataArray, thresh="17.0 degC", freq="YS"):
     r"""Heating degree days
 
     Sum of degree days below the temperature threshold at which spaces are heated.
@@ -424,8 +421,8 @@ def heating_degree_days(tas, thresh="17.0 degC", freq="YS"):
       Mean daily temperature [℃] or [K]
     thresh : str
       Threshold temperature on which to base evaluation [℃] or [K]. Default: '17.0 degC'.
-    freq : str, optional
-      Resampling frequency
+    freq : str
+      Resampling frequency; Defaults to "YS".
 
     Returns
     -------
@@ -447,7 +444,7 @@ def heating_degree_days(tas, thresh="17.0 degC", freq="YS"):
 
 
 @declare_units("days", tasmin="[temperature]", thresh="[temperature]")
-def tn_days_below(tasmin, thresh="-10.0 degC", freq="YS"):
+def tn_days_below(tasmin: xarray.DataArray, thresh="-10.0 degC", freq="YS"):
     r"""Number of days with tmin below a threshold in
 
     Number of days where daily minimum temperature is below a threshold.
@@ -458,8 +455,8 @@ def tn_days_below(tasmin, thresh="-10.0 degC", freq="YS"):
       Minimum daily temperature [℃] or [K]
     thresh : str
       Threshold temperature on which to base evaluation [℃] or [K] . Default: '-10 degC'.
-    freq : str, optional
-      Resampling frequency
+    freq : str
+      Resampling frequency; Defaults to "YS".
 
     Returns
     -------
@@ -481,7 +478,7 @@ def tn_days_below(tasmin, thresh="-10.0 degC", freq="YS"):
 
 
 @declare_units("days", tasmax="[temperature]", thresh="[temperature]")
-def tx_days_above(tasmax, thresh="25.0 degC", freq="YS"):
+def tx_days_above(tasmax: xarray.DataArray, thresh="25.0 degC", freq="YS"):
     r"""Number of summer days
 
     Number of days where daily maximum temperature exceed a threshold.
@@ -492,8 +489,8 @@ def tx_days_above(tasmax, thresh="25.0 degC", freq="YS"):
       Maximum daily temperature [℃] or [K]
     thresh : str
       Threshold temperature on which to base evaluation [℃] or [K]. Default: '25 degC'.
-    freq : str, optional
-      Resampling frequency
+    freq : str
+      Resampling frequency; Defaults to "YS".
 
     Returns
     -------
@@ -515,7 +512,7 @@ def tx_days_above(tasmax, thresh="25.0 degC", freq="YS"):
 
 
 @declare_units("days", tasmax="[temperature]", thresh="[temperature]")
-def warm_day_frequency(tasmax, thresh="30 degC", freq="YS"):
+def warm_day_frequency(tasmax: xarray.DataArray, thresh="30 degC", freq="YS"):
     r"""Frequency of extreme warm days
 
     Return the number of days with tasmax > thresh per period
@@ -526,8 +523,8 @@ def warm_day_frequency(tasmax, thresh="30 degC", freq="YS"):
       Mean daily temperature [℃] or [K]
     thresh : str
       Threshold temperature on which to base evaluation [℃] or [K]. Default : '30 degC'
-    freq : str, optional
-      Resampling frequency
+    freq : str
+      Resampling frequency; Defaults to "YS".
 
     Returns
     -------
@@ -549,7 +546,7 @@ def warm_day_frequency(tasmax, thresh="30 degC", freq="YS"):
 
 
 @declare_units("days", tasmin="[temperature]", thresh="[temperature]")
-def warm_night_frequency(tasmin, thresh="22 degC", freq="YS"):
+def warm_night_frequency(tasmin: xarray.DataArray, thresh="22 degC", freq="YS"):
     r"""Frequency of extreme warm nights
 
     Return the number of days with tasmin > thresh per period
@@ -560,8 +557,8 @@ def warm_night_frequency(tasmin, thresh="22 degC", freq="YS"):
       Minimum daily temperature [℃] or [K]
     thresh : str
       Threshold temperature on which to base evaluation [℃] or [K]. Default : '22 degC'
-    freq : str, optional
-      Resampling frequency
+    freq : str
+      Resampling frequency; Defaults to "YS".
 
     Returns
     -------
@@ -574,7 +571,7 @@ def warm_night_frequency(tasmin, thresh="22 degC", freq="YS"):
 
 
 @declare_units("days", pr="[precipitation]", thresh="[precipitation]")
-def wetdays(pr, thresh="1.0 mm/day", freq="YS"):
+def wetdays(pr: xarray.DataArray, thresh="1.0 mm/day", freq="YS"):
     r"""Wet days
 
     Return the total number of days during period with precipitation over threshold.
@@ -585,9 +582,9 @@ def wetdays(pr, thresh="1.0 mm/day", freq="YS"):
       Daily precipitation [mm]
     thresh : str
       Precipitation value over which a day is considered wet. Default: '1 mm/day'.
-    freq : str, optional
-      Resampling frequency defining the periods
-      defined in http://pandas.pydata.org/pandas-docs/stable/timeseries.html#resampling.
+    freq : str
+      Resampling frequency defining the periods defined in
+      http://pandas.pydata.org/pandas-docs/stable/timeseries.html#resampling; Defaults to "YS".
 
     Returns
     -------
@@ -609,7 +606,7 @@ def wetdays(pr, thresh="1.0 mm/day", freq="YS"):
 
 
 @declare_units("days", pr="[precipitation]", thresh="[precipitation]")
-def maximum_consecutive_dry_days(pr, thresh="1 mm/day", freq="YS"):
+def maximum_consecutive_dry_days(pr: xarray.DataArray, thresh="1 mm/day", freq="YS"):
     r"""Maximum number of consecutive dry days
 
     Return the maximum number of consecutive days within the period where precipitation
@@ -621,8 +618,8 @@ def maximum_consecutive_dry_days(pr, thresh="1 mm/day", freq="YS"):
       Mean daily precipitation flux [mm]
     thresh : str
       Threshold precipitation on which to base evaluation [mm]. Default : '1 mm/day'
-    freq : str, optional
-      Resampling frequency
+    freq : str
+      Resampling frequency; Defaults to "YS".
 
     Returns
     -------
@@ -650,7 +647,7 @@ def maximum_consecutive_dry_days(pr, thresh="1 mm/day", freq="YS"):
 
 
 @declare_units("days", tasmax="[temperature]", thresh="[temperature]")
-def maximum_consecutive_tx_days(tasmax, thresh="25 degC", freq="YS"):
+def maximum_consecutive_tx_days(tasmax: xarray.DataArray, thresh="25 degC", freq="YS"):
     r"""Maximum number of consecutive summer days (Tx > 25℃)
 
     Return the maximum number of consecutive days within the period where temperature is above a certain threshold.
@@ -661,8 +658,8 @@ def maximum_consecutive_tx_days(tasmax, thresh="25 degC", freq="YS"):
       Max daily temperature [K]
     thresh : str
       Threshold temperature [K].
-    freq : str, optional
-      Resampling frequency
+    freq : str
+      Resampling frequency; Defaults to "YS".
 
     Returns
     -------
@@ -690,7 +687,7 @@ def maximum_consecutive_tx_days(tasmax, thresh="25 degC", freq="YS"):
 
 
 @declare_units("days", tasmin="[temperature]", thresh="[temperature]")
-def tropical_nights(tasmin, thresh="20.0 degC", freq="YS"):
+def tropical_nights(tasmin: xarray.DataArray, thresh="20.0 degC", freq="YS"):
     r"""Tropical nights
 
     The number of days with minimum daily temperature above threshold.
@@ -701,8 +698,8 @@ def tropical_nights(tasmin, thresh="20.0 degC", freq="YS"):
       Minimum daily temperature [℃] or [K]
     thresh : str
       Threshold temperature on which to base evaluation [℃] or [K]. Default: '20 degC'.
-    freq : str, optional
-      Resampling frequency
+    freq : str
+      Resampling frequency; Defaults to "YS".
 
     Returns
     -------

--- a/xclim/indices/_threshold.py
+++ b/xclim/indices/_threshold.py
@@ -116,9 +116,10 @@ def daily_pr_intensity(pr, thresh="1 mm/day", freq="YS"):
     precipitation fallen over days with precipitation >= 5 mm at seasonal
     frequency, ie DJF, MAM, JJA, SON, DJF, etc.:
 
-    >>> pr = xr.open_dataset('pr.day.nc')
-    >>> daily_int = daily_pr_intensity(pr, thresh='5 mm/day', freq="QS-DEC")
-
+    >>> import xarray as xr
+    >>> import xclim.indices
+    >>> pr = xr.open_dataset("pr_day.nc").pr
+    >>> daily_int = xclim.indices.daily_pr_intensity(pr, thresh='5 mm/day', freq="QS-DEC")
     """
     t = utils.convert_units_to(thresh, pr, "hydro")
 
@@ -596,8 +597,10 @@ def wetdays(pr: xarray.DataArray, thresh="1.0 mm/day", freq="YS"):
     The following would compute for each grid cell of file `pr.day.nc` the number days
     with precipitation over 5 mm at the seasonal frequency, ie DJF, MAM, JJA, SON, DJF, etc.:
 
-    >>> pr = xr.open_dataset('pr.day.nc')
-    >>> wd = wetdays(pr, pr_min = 5., freq="QS-DEC")
+    >>> import xarray as xr
+    >>> import xclim.utils
+    >>> pr = xr.open_dataset('pr.day.nc').pr
+    >>> wd = xclim.indices.wetdays(pr, pr_min = 5., freq="QS-DEC")
     """
     thresh = utils.convert_units_to(thresh, pr, "hydro")
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the follwing requirements-->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated

### After merging to master and before closing the branch:
- [ ] bumpversion (minor / major / patch) has been called on `master` branch
- [ ] Tags have been pushed

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
Standardizes all signatures to set default freq as either "YS" or "QS-DEC" and removes optional typing. 

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
Yes. Default values for freq are now explicitly set.

* **Other information**:
Setting a default value is not the same as having an optional call signature. Optional implies that keyword is not necessary to run the function. For indices, `freq` is always necessary.

<!--* When merging, please put `fixes #{issue number}` in your comment to auto-close the issue that your PR addresses. Thanks!-->
This PR fixes #300 
