### PR TITLE
Optimize rolling dask

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,7 @@ History
 * Enhancement to utils.Indicator to have more dynamic attributes using callables.
 * Added indices `heat_wave_total_length` and `tas` / `tg`.
 * Fixed a bug with typed call signatures that caused downstream failures on library import.
+* Added a `_rolling` util function to fix memory issues on large dask datasets.
 
 0.11.x-beta (2019-10-17)
 ------------------------

--- a/tests/test_precip.py
+++ b/tests/test_precip.py
@@ -22,51 +22,41 @@ class TestRainOnFrozenGround:
         TESTS_DATA, "NRCANdaily", "nrcan_canada_daily_tasmin_1990.nc"
     )
 
-    def test_3d_data_with_nans(self):
+    @pytest.mark.parametrize("prunits,prfac", [("kg m-2 s-1", 1), ("mm/day", 86400)])
+    @pytest.mark.parametrize(
+        "tasunits,tasoffset,chunks", [(None, None, {"time": 73.0}), ("C", K2C, None)]
+    )
+    def test_3d_data_with_nans(self, prunits, prfac, tasunits, tasoffset, chunks):
         pr = xr.open_dataset(self.nc_pr).pr
-        prMM = pr.copy()
-        prMM.values *= 86400.0
-        prMM.attrs["units"] = "mm/day"
+        pr2 = pr.copy()
+        pr2.values *= prfac
+        pr2.attrs["units"] = prunits
 
-        tasmax = xr.open_dataset(self.nc_tasmax).tasmax
-        tasmin = xr.open_dataset(self.nc_tasmin).tasmin
+        tasmax = xr.open_dataset(self.nc_tasmax, chunks=chunks).tasmax
+        tasmin = xr.open_dataset(self.nc_tasmin, chunks=chunks).tasmin
         tas = 0.5 * (tasmax + tasmin)
         tas.attrs = tasmax.attrs
-        tasC = tas.copy()
-        tasC.values -= K2C
-        tasC.attrs["units"] = "C"
+        tas2 = tas.copy()
+        if chunks:
+            tas2 = tas2.chunk(chunks)
+        if tasunits:
+            tas2.values -= tasoffset
+            tas2.attrs["units"] = tasunits
 
-        prMM.values[10, 1, 0] = np.nan
+        pr2.values[10, 1, 0] = np.nan
         pr.values[10, 1, 0] = np.nan
 
-        out1 = atmos.rain_on_frozen_ground_days(pr, tas, freq="MS")
-        out2 = atmos.rain_on_frozen_ground_days(prMM, tas, freq="MS")
-        out3 = atmos.rain_on_frozen_ground_days(prMM, tasC, freq="MS")
-        out4 = atmos.rain_on_frozen_ground_days(pr, tasC, freq="MS")
-        pr.attrs["units"] = "kg m-2 s-1"
-        out5 = atmos.rain_on_frozen_ground_days(pr, tas, freq="MS")
-        out6 = atmos.rain_on_frozen_ground_days(pr, tasC, freq="MS")
-        np.testing.assert_array_equal(out1, out2)
-        np.testing.assert_array_equal(out1, out3)
-        np.testing.assert_array_equal(out1, out4)
-        np.testing.assert_array_equal(out1, out5)
-        np.testing.assert_array_equal(out1, out6)
+        outref = atmos.rain_on_frozen_ground_days(pr, tas, freq="MS")
+        out21 = atmos.rain_on_frozen_ground_days(pr2, tas, freq="MS")
+        out22 = atmos.rain_on_frozen_ground_days(pr2, tas2, freq="MS")
+        out12 = atmos.rain_on_frozen_ground_days(pr, tas2, freq="MS")
 
-        assert np.isnan(out1.values[0, 1, 0])
+        np.testing.assert_array_equal(outref, out21)
+        np.testing.assert_array_equal(outref, out22)
+        np.testing.assert_array_equal(outref, out12)
 
-        assert np.isnan(out1.values[0, -1, -1])
-
-        # synthetic data
-        tas1 = tas[0:31, 47, 8] * 0 + K2C - 1
-        tas1.attrs = tas.attrs
-        pr1 = pr[0:31, 47, 8] * 0 + 25
-        pr1.attrs = pr.attrs
-        tas1[10] += 5
-        tas1[20] += 5
-
-        rfrz = atmos.rain_on_frozen_ground_days(pr1, tas1, freq="MS")
-
-        np.testing.assert_array_equal(rfrz, 2)
+        assert np.isnan(out22.values[0, 1, 0])
+        assert np.isnan(out22.values[0, -1, -1])
 
 
 class TestPrecipAccumulation:
@@ -245,34 +235,35 @@ class TestMaxNDay:
 
     nc_file = os.path.join(TESTS_DATA, "NRCANdaily", "nrcan_canada_daily_pr_1990.nc")
 
-    def test_3d_data_with_nans(self):
+    @pytest.mark.parametrize(
+        "units,factor,chunks",
+        [
+            ("mm/day", 86400.0, None),
+            ("kg m-2 s-1", 1, None),
+            ("mm/s", 1, {"time": 73.0}),
+        ],
+    )
+    def test_3d_data_with_nans(self, units, factor, chunks):
         # test with 3d data
-        pr = xr.open_dataset(self.nc_file).pr
-        prMM = xr.open_dataset(self.nc_file).pr
-        prMM.values *= 86400.0
-        prMM.attrs["units"] = "mm/day"
+        pr1 = xr.open_dataset(self.nc_file).pr
+        pr2 = xr.open_dataset(self.nc_file, chunks=chunks).pr
+        pr2.values *= factor
+        pr2.attrs["units"] = units
         # put a nan somewhere
-        prMM.values[10, 1, 0] = np.nan
-        pr.values[10, 1, 0] = np.nan
+        pr2.values[10, 1, 0] = np.nan
+        pr1.values[10, 1, 0] = np.nan
         wind = 3
-        out1 = atmos.max_n_day_precipitation_amount(pr, window=wind, freq="MS")
-        out2 = atmos.max_n_day_precipitation_amount(prMM, window=wind, freq="MS")
-
-        # test kg m-2 s-1
-        pr.attrs["units"] = "kg m-2 s-1"
-        out3 = atmos.max_n_day_precipitation_amount(pr, window=wind, freq="MS")
+        out1 = atmos.max_n_day_precipitation_amount(pr1, window=wind, freq="MS")
+        out2 = atmos.max_n_day_precipitation_amount(pr2, window=wind, freq="MS")
 
         np.testing.assert_array_almost_equal(out1, out2, 3)
-        np.testing.assert_array_almost_equal(out1, out3, 3)
 
-        x1 = prMM[:31, 0, 0].values
+        x1 = pr1[:31, 0, 0].values * 86400
         df = pd.DataFrame({"pr": x1})
         rx3 = df.rolling(wind).sum().max()
 
         assert np.allclose(rx3, out1.values[0, 0, 0])
-
         assert np.isnan(out1.values[0, 1, 0])
-
         assert np.isnan(out1.values[0, -1, -1])
 
 

--- a/tests/test_temperature.py
+++ b/tests/test_temperature.py
@@ -762,12 +762,15 @@ class TestDailyFreezeThaw:
 
 
 class TestGrowingSeasonLength:
-    def test_single_year(self, tas_series):
+    @pytest.mark.parametrize("chunks", [None, {"time": 183.0}])
+    def test_single_year(self, tas_series, chunks):
         a = np.zeros(366) + K2C
         ts = tas_series(a, start="1/1/2000")
         tt = (ts.time.dt.month >= 5) & (ts.time.dt.month <= 8)
         offset = np.random.uniform(low=5.5, high=23, size=(tt.sum().values,))
         ts[tt] = ts[tt] + offset
+        if chunks:
+            ts = ts.chunk(chunks)
 
         out = atmos.growing_season_length(ts)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -778,11 +778,11 @@ class TestRolling:
         assert all(rolld[9:] == 10)
 
         ones[20] = np.nan
-        rolld = utils._get_rolling_func(10, mode='mean')(ones)
+        rolld = utils._get_rolling_func(10, mode="mean")(ones)
 
         assert all(rolld[30:] == 1)
 
-        rolld = utils._get_rolling_func(10, mode='max')(ones)
+        rolld = utils._get_rolling_func(10, mode="max")(ones)
 
         assert all(rolld[30:] == 1)
 
@@ -801,7 +801,9 @@ class TestRolling:
         mean_nd_xc = utils.rolling(
             ds_nd.pr, window=5, dim="time", mode="mean", keep_attrs=False
         )
-        mean_dask = utils.rolling(ds_dask.pr, window=5, dim="time", mode="mean", keep_attrs=True)
+        mean_dask = utils.rolling(
+            ds_dask.pr, window=5, dim="time", mode="mean", keep_attrs=True
+        )
 
         xr.testing.assert_identical(mean_nd_xr, mean_nd_xc)
         xr.testing.assert_allclose(mean_dask, mean_nd_xr)

--- a/xclim/generic.py
+++ b/xclim/generic.py
@@ -4,6 +4,7 @@
 import dask
 import numpy as np
 import xarray as xr
+from xclim.utils import rolling
 
 
 def select_time(da, **indexer):
@@ -262,10 +263,8 @@ def frequency_analysis(da, mode, t, dist, window=1, freq=None, **indexer):
 
     """
     # Apply rolling average
-    attrs = da.attrs.copy()
     if window > 1:
-        da = da.rolling(time=window, center=False).mean()
-        da.attrs.update(attrs)
+        da = rolling(da, window=window, dim="time", keep_attrs=True, mode="mean")
 
     # Assign default resampling frequency if not provided
     freq = freq or default_freq(**indexer)

--- a/xclim/generic.py
+++ b/xclim/generic.py
@@ -4,7 +4,7 @@
 import dask
 import numpy as np
 import xarray as xr
-from xclim.utils import rolling
+from xclim.utils import _rolling
 
 
 def select_time(da, **indexer):
@@ -264,7 +264,7 @@ def frequency_analysis(da, mode, t, dist, window=1, freq=None, **indexer):
     """
     # Apply rolling average
     if window > 1:
-        da = rolling(da, window=window, dim="time", keep_attrs=True, mode="mean")
+        da = _rolling(da, window=window, dim="time", keep_attrs=True, mode="mean")
 
     # Assign default resampling frequency if not provided
     freq = freq or default_freq(**indexer)

--- a/xclim/indices/_multivariate.py
+++ b/xclim/indices/_multivariate.py
@@ -7,7 +7,7 @@ from xclim import run_length as rl
 from xclim import utils
 from xclim.utils import declare_units
 from xclim.utils import units
-from xclim.utils import rolling
+from xclim.utils import _rolling
 
 xarray.set_options(enable_cftimeindex=True)  # Set xarray to use cftimeindex
 
@@ -696,7 +696,7 @@ def rain_on_frozen_ground_days(
         frozen = x == np.array([0, 0, 0, 0, 0, 0, 0, 1], bool)
         return frozen.all(axis=axis)
 
-    tcond = rolling((tas > frz), window=8, dim="time", mode=func)
+    tcond = _rolling((tas > frz), window=8, dim="time", mode=func)
     pcond = pr > t
 
     return (tcond * pcond * 1).resample(time=freq).sum(dim="time")

--- a/xclim/indices/_multivariate.py
+++ b/xclim/indices/_multivariate.py
@@ -7,6 +7,7 @@ from xclim import run_length as rl
 from xclim import utils
 from xclim.utils import declare_units
 from xclim.utils import units
+from xclim.utils import rolling
 
 xarray.set_options(enable_cftimeindex=True)  # Set xarray to use cftimeindex
 
@@ -695,7 +696,7 @@ def rain_on_frozen_ground_days(
         frozen = x == np.array([0, 0, 0, 0, 0, 0, 0, 1], bool)
         return frozen.all(axis=axis)
 
-    tcond = (tas > frz).rolling(time=8).reduce(func)
+    tcond = rolling((tas > frz), window=8, dim="time", mode=func)
     pcond = pr > t
 
     return (tcond * pcond * 1).resample(time=freq).sum(dim="time")

--- a/xclim/indices/_simple.py
+++ b/xclim/indices/_simple.py
@@ -362,7 +362,7 @@ def base_flow_index(q: xarray.DataArray, freq: str = "YS"):
 
     """
 
-    m7 = _rolling(q, dim='time', window=7, center=True, mode='mean').resample(time=freq)
+    m7 = _rolling(q, dim="time", window=7, center=True, mode="mean").resample(time=freq)
     mq = q.resample(time=freq)
 
     m7m = m7.min(dim="time")

--- a/xclim/indices/_simple.py
+++ b/xclim/indices/_simple.py
@@ -1,11 +1,12 @@
 import logging
 
 import xarray as xr
-
+import numpy as np
 from xclim import run_length as rl
 from xclim import utils
 from xclim.utils import declare_units
 from xclim.utils import units
+from xclim.utils import rolling
 
 # logging.basicConfig(level=logging.DEBUG)
 # logging.captureWarnings(True)
@@ -528,7 +529,7 @@ def max_1day_precipitation_amount(pr, freq="YS"):
 
 
 @declare_units("mm", pr="[precipitation]")
-def max_n_day_precipitation_amount(pr, window=1, freq="YS"):
+def max_n_day_precipitation_amount(pr, window=1, use_overlap=False, freq="YS"):
     r"""Highest precipitation amount cumulated over a n-day moving window.
 
     Calculate the n-day rolling sum of the original daily total precipitation series
@@ -559,7 +560,7 @@ def max_n_day_precipitation_amount(pr, window=1, freq="YS"):
     """
 
     # rolling sum of the values
-    arr = pr.rolling(time=window, center=False).sum()
+    arr = rolling(pr, window=window, dim="time", mode="sum")
     out = arr.resample(time=freq).max(dim="time", keep_attrs=True)
 
     out.attrs["units"] = pr.units

--- a/xclim/indices/_simple.py
+++ b/xclim/indices/_simple.py
@@ -362,7 +362,7 @@ def base_flow_index(q: xarray.DataArray, freq: str = "YS"):
 
     """
 
-    m7 = q.rolling(time=7, center=True).mean().resample(time=freq)
+    m7 = _rolling(q, dim='time', window=7, center=True, mode='mean').resample(time=freq)
     mq = q.resample(time=freq)
 
     m7m = m7.min(dim="time")

--- a/xclim/indices/_simple.py
+++ b/xclim/indices/_simple.py
@@ -4,7 +4,7 @@ from xclim import run_length as rl
 from xclim import utils
 from xclim.utils import declare_units
 from xclim.utils import units
-from xclim.utils import rolling
+from xclim.utils import _rolling
 
 xarray.set_options(enable_cftimeindex=True)  # Set xarray to use cftimeindex
 
@@ -554,7 +554,7 @@ def max_n_day_precipitation_amount(pr, window: int = 1, freq: str = "YS"):
     """
 
     # rolling sum of the values
-    arr = rolling(pr, window=window, dim="time", mode="sum")
+    arr = _rolling(pr, window=window, dim="time", mode="sum")
     out = arr.resample(time=freq).max(dim="time", keep_attrs=True)
 
     out.attrs["units"] = pr.units

--- a/xclim/indices/_threshold.py
+++ b/xclim/indices/_threshold.py
@@ -5,7 +5,7 @@ from xclim import run_length as rl
 from xclim import utils
 from xclim.utils import declare_units
 from xclim.utils import units
-from xclim.utils import rolling
+from xclim.utils import _rolling
 
 xarray.set_options(enable_cftimeindex=True)  # Set xarray to use cftimeindex
 
@@ -363,7 +363,7 @@ def growing_season_length(
     # compute growth season length on resampled data
     thresh = utils.convert_units_to(thresh, tas)
 
-    c = rolling(((tas > thresh) * 1), window=window, dim="time", mode="sum")
+    c = _rolling(((tas > thresh) * 1), window=window, dim="time", mode="sum")
 
     def compute_gsl(c):
         nt = c.time.size

--- a/xclim/indices/_threshold.py
+++ b/xclim/indices/_threshold.py
@@ -7,6 +7,7 @@ from xclim import run_length as rl
 from xclim import utils
 from xclim.utils import declare_units
 from xclim.utils import units
+from xclim.utils import rolling
 
 # logging.basicConfig(level=logging.DEBUG)
 # logging.captureWarnings(True)
@@ -364,7 +365,7 @@ def growing_season_length(tas, thresh="5.0 degC", window=6, freq="YS"):
     # compute growth season length on resampled data
     thresh = utils.convert_units_to(thresh, tas)
 
-    c = ((tas > thresh) * 1).rolling(time=window).sum().chunk(tas.chunks)
+    c = rolling(((tas > thresh) * 1), window=window, dim="time", mode="sum")
 
     def compute_gsl(c):
         nt = c.time.size

--- a/xclim/run_length.py
+++ b/xclim/run_length.py
@@ -6,6 +6,8 @@ from warnings import warn
 import numpy as np
 import xarray as xr
 
+from xclim.utils import rolling
+
 logging.captureWarnings(True)
 npts_opt = 9000
 
@@ -201,7 +203,7 @@ def first_run(da, window, dim="time", ufunc_1dim="auto"):
         da = da.astype("int")
         i = xr.DataArray(np.arange(da[dim].size), dims=dim).chunk({"time": 1})
         ind = xr.broadcast(i, da)[0].chunk(da.chunks)
-        wind_sum = da.rolling(time=window).sum()
+        wind_sum = rolling(da, dim="time", window=window, mode="sum")
         out = ind.where(wind_sum >= window).min(dim=dim) - (
             window - 1
         )  # remove window -1 as rolling result index is last element of the moving window

--- a/xclim/run_length.py
+++ b/xclim/run_length.py
@@ -6,7 +6,7 @@ from warnings import warn
 import numpy as np
 import xarray as xr
 
-from xclim.utils import rolling
+from xclim.utils import _rolling
 
 logging.captureWarnings(True)
 npts_opt = 9000
@@ -203,7 +203,7 @@ def first_run(da, window, dim="time", ufunc_1dim="auto"):
         da = da.astype("int")
         i = xr.DataArray(np.arange(da[dim].size), dims=dim).chunk({"time": 1})
         ind = xr.broadcast(i, da)[0].chunk(da.chunks)
-        wind_sum = rolling(da, dim="time", window=window, mode="sum")
+        wind_sum = _rolling(da, dim="time", window=window, mode="sum")
         out = ind.where(wind_sum >= window).min(dim=dim) - (
             window - 1
         )  # remove window -1 as rolling result index is last element of the moving window

--- a/xclim/utils.py
+++ b/xclim/utils.py
@@ -1040,11 +1040,11 @@ def wrapped_partial(func: FunctionType, *args, **kwargs):
     return partial_func
 
 
-def _get_rolling_func(N, mode='sum'):
+def _get_rolling_func(N, mode="sum"):
     """Generate the rolling sum function to be mapped in rolling()"""
 
-    if mode in ['sum', 'mean']:
-        denom = 1 if mode == 'sum' else N
+    if mode in ["sum", "mean"]:
+        denom = 1 if mode == "sum" else N
 
         def rolling_sum_na(x):
             # First we get the rolling sum of the values.
@@ -1065,6 +1065,7 @@ def _get_rolling_func(N, mode='sum'):
                 mode="constant",
                 constant_values=np.nan,
             )
+
         return rolling_sum_na
 
     try:
@@ -1082,11 +1083,18 @@ def _get_rolling_func(N, mode='sum'):
             strides = x.strides + (x.strides[-1],)
             rolling = np.lib.stride_tricks.as_strided(x, shape=shape, strides=strides)
             out = func(rolling, axis=-1)
-            return np.pad(out, [(0, 0)] * (x.ndim - 1) + [(N - 1, 0)],
-                          mode="constant", constant_values=np.nan)
+            return np.pad(
+                out,
+                [(0, 0)] * (x.ndim - 1) + [(N - 1, 0)],
+                mode="constant",
+                constant_values=np.nan,
+            )
+
         return rolling_stride_na
     except AttributeError:
-        raise NotImplementedError('Rolling operation {mode} not known or yet implemented.')
+        raise NotImplementedError(
+            "Rolling operation {mode} not known or yet implemented."
+        )
 
 
 def rolling(

--- a/xclim/utils.py
+++ b/xclim/utils.py
@@ -1109,7 +1109,7 @@ def _rolling(
     window: int = 1,
     mode: Union[str, Callable] = "sum",
     keep_attrs: bool = False,
-    **kwargs,
+    **kwargs
 ):
     """Utility function for rolling.sum and rolling.mean
 

--- a/xclim/utils.py
+++ b/xclim/utils.py
@@ -1163,16 +1163,15 @@ def _rolling(
             out, coords=arr.coords, attrs=arr.attrs if keep_attrs else None
         ).transpose(*dims)
         return out
+    # If not a dask array or with unsupported kwargs, call the normal rolling.
+    rolling = arr.rolling(time=window)
+    if isinstance(mode, str):
+        out = getattr(rolling, mode)(allow_lazy=True)
     else:
-        # If not a dask array or with unsupported kwargs, call the normal rolling.
-        rolling = arr.rolling(time=window)
-        if isinstance(mode, str):
-            out = getattr(rolling, mode)(allow_lazy=True)
-        else:
-            out = rolling.reduce(mode, allow_lazy=True)
-        if keep_attrs:
-            out.attrs.update(**arr.attrs)
-        return out
+        out = rolling.reduce(mode, allow_lazy=True)
+    if keep_attrs:
+        out.attrs.update(**arr.attrs)
+    return out
 
 
 def uas_vas_2_sfcwind(uas: xr.DataArray = None, vas: xr.DataArray = None):

--- a/xclim/utils.py
+++ b/xclim/utils.py
@@ -1099,9 +1099,9 @@ def _get_rolling_func(N, mode="sum"):
 
 def rolling(
     arr: xr.DataArray,
+    dim: str = "time",
     window: int = 1,
     mode: Union[str, Callable] = "sum",
-    dim: str = "time",
     keep_attrs: bool = False,
 ):
     """Utility function for rolling.sum and rolling.mean


### PR DESCRIPTION
<!--Please ensure the PR fulfills the follwing requirements-->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated

### After merging to master and before closing the branch:
- [ ] bumpversion (minor / major / patch) has been called on `master` branch
- [ ] Tags have been pushed

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
Create a new util function  `rolling` to optimize the rolling sums and means over dask arrays.
Sum and mean are implemented as they both use the same `numpy.cumsum` trick. Other rolling operations (min, max, std) could be implemented later on.

The function does the computation lazily, which xarray's `rolling()` didn't. It defaults to xarray's version is the data is not in a dask array as it uses a special dask function :  `dask.Array.map_overlap()`. 

This function is faster than xarray's even for datasets with only one chunk along the rolled dimension. And it solves MemoryErrors when using huge datasets.

I did some Jedi tricks to get the same behaviour as xarray's version when NaNs are encountered. Without the second  `np.cumsum`, we can reduce the computation time by 30-50%, but NaNs will be treated as zeros.

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
No

* **Other information**:
I called the function `xc.utils.rolling`, but in comparison to `xr.DataArray.rolling`, it actually does the sum or mean. So same name, different behaviour. 
