### PR TITLE
Bump bottleneck version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ requirements = [
     "cftime~=1.0.3.4",
     "netCDF4>=1.4",
     "dask[complete]",
-    "bottleneck~=1.2.1",
+    "bottleneck~=1.3.1",
     "xarray==0.13.0",
     "pyproj==2.4.1",
     "pint>=0.8",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist = py35, py35-macOS, py36, py36-xarray, py37, py37-windows, py38-dev, black, docs
+requires = pip >= 19.0
 
 [travis]
 python =


### PR DESCRIPTION
While investigating https://github.com/pydata/bottleneck/issues/280, I noticed that `tox` was using `pip==10.0` which is relatively ancient and does not support PEP 517-style builds.

By specifying `requires = pip >= 19.0`, we can force a modern version of `pip` and also resolve the build issues preventing `bottleneck=1.3.1` from being used.
