### PR TITLE
Add heatwave options

### DIFF
--- a/tests/test_temperature.py
+++ b/tests/test_temperature.py
@@ -634,7 +634,7 @@ class TestHeatWaveFrequency:
             thresh_tasmin=thresh_tasmin,
             thresh_tasmax=thresh_tasmax,
             freq="YS",
-            **kwargs
+            **kwargs,
         )
         hwfC = atmos.heat_wave_frequency(
             tnC,
@@ -642,7 +642,7 @@ class TestHeatWaveFrequency:
             thresh_tasmin=thresh_tasmin,
             thresh_tasmax=thresh_tasmax,
             freq="YS",
-            **kwargs
+            **kwargs,
         )
         np.testing.assert_array_equal(hwf, hwfC)
         np.testing.assert_allclose(hwf.values[:1], expected)
@@ -694,7 +694,7 @@ class TestHeatWaveMaxLength:
             thresh_tasmin=thresh_tasmin,
             thresh_tasmax=thresh_tasmax,
             freq="YS",
-            **kwargs
+            **kwargs,
         )
         hwfC = atmos.heat_wave_max_length(
             tnC,
@@ -702,7 +702,7 @@ class TestHeatWaveMaxLength:
             thresh_tasmin=thresh_tasmin,
             thresh_tasmax=thresh_tasmax,
             freq="YS",
-            **kwargs
+            **kwargs,
         )
         np.testing.assert_array_equal(hwf, hwfC)
         np.testing.assert_allclose(hwf.values[:1], expected)
@@ -754,7 +754,7 @@ class TestHeatWaveTotalLength:
             thresh_tasmin=thresh_tasmin,
             thresh_tasmax=thresh_tasmax,
             freq="YS",
-            **kwargs
+            **kwargs,
         )
         hwfC = atmos.heat_wave_total_length(
             tnC,
@@ -762,7 +762,7 @@ class TestHeatWaveTotalLength:
             thresh_tasmin=thresh_tasmin,
             thresh_tasmax=thresh_tasmax,
             freq="YS",
-            **kwargs
+            **kwargs,
         )
         np.testing.assert_array_equal(hwf, hwfC)
         np.testing.assert_allclose(hwf.values[:1], expected)

--- a/xclim/atmos/_temperature.py
+++ b/xclim/atmos/_temperature.py
@@ -12,6 +12,7 @@ __all__ = [
     "tx_tn_days_above",
     "heat_wave_frequency",
     "heat_wave_max_length",
+    "heat_wave_total_length",
     "heat_wave_index",
     "tg",
     "tg_mean",
@@ -131,13 +132,30 @@ heat_wave_frequency = TasminTasmax(
     identifier="heat_wave_frequency",
     units="",
     standard_name="heat_wave_events",
-    long_name="Number of heat wave events (Tmin > {thresh_tasmin}"
-    "and Tmax > {thresh_tasmax} for >= {window} days)",
-    description="{freq} number of heat wave events over a given period. "
-    "An event occurs when the minimum and maximum daily "
-    "temperature both exceeds specific thresholds : "
-    "(Tmin > {thresh_tasmin} and Tmax > {thresh_tasmax}) "
-    "over a minimum number of days ({window}).",
+    long_name=lambda **kws: (
+        "Number of heat wave events (Tmin > {thresh_tasmin} "
+        "and Tmax > {thresh_tasmax} for >= {window} days)"
+    )
+    if kws["mode"] == "consecutive"
+    else (
+        "Number of heat wave events (Tmin > {thresh_tasmin} "
+        "and Tmax > {thresh_tasmax} over a {window} days mean)"
+    ),
+    description=lambda **kws: (
+        "{freq} number of heat wave events over a given period. "
+        "An event occurs when the minimum and maximum daily "
+        "temperature both exceeds specific thresholds : "
+        "(Tmin > {thresh_tasmin} and Tmax > {thresh_tasmax}) "
+        "over a minimum number of days ({window})."
+    )
+    if kws["mode"] == "consecutive"
+    else (
+        "{freq} number of heat wave events over a given period. "
+        "An event occurs when the running averages of the minimum and maximum"
+        " daily temperature both exceeds specific thresholds : "
+        "(Tmin > {thresh_tasmin} and Tmax > {thresh_tasmax}, averaged with a "
+        "window of {window} days)."
+    ),
     cell_methods="",
     keywords="health,",
     compute=indices.heat_wave_frequency,
@@ -147,13 +165,30 @@ heat_wave_max_length = TasminTasmax(
     identifier="heat_wave_max_length",
     units="days",
     standard_name="spell_length_of_days_with_air_temperature_above_threshold",
-    long_name="Maximum length of heat wave events (Tmin > {thresh_tasmin}"
-    "and Tmax > {thresh_tasmax} for >= {window} days)",
-    description="{freq} maximum length of heat wave events occuring in a given period."
-    "An event occurs when the minimum and maximum daily "
-    "temperature both exceeds specific thresholds "
-    "(Tmin > {thresh_tasmin} and Tmax > {thresh_tasmax}) over "
-    "a minimum number of days ({window}).",
+    long_name=lambda **kws: (
+        "Maximum length of heat wave events (Tmin > {thresh_tasmin} "
+        "and Tmax > {thresh_tasmax} for >= {window} days)"
+    )
+    if kws["mode"] == "consecutive"
+    else (
+        "Maximum length of heat wave events (Tmin > {thresh_tasmin} "
+        "and Tmax > {thresh_tasmax} over a {window} days mean)"
+    ),
+    description=lambda **kws: (
+        "{freq} maximum length of heat wave events occuring in a given period. "
+        "An event occurs when the minimum and maximum daily "
+        "temperature both exceeds specific thresholds : "
+        "(Tmin > {thresh_tasmin} and Tmax > {thresh_tasmax}) "
+        "over a minimum number of days ({window})."
+    )
+    if kws["mode"] == "consecutive"
+    else (
+        "{freq} maximum length of heat wave events occuring in a given period. "
+        "An event occurs when the running averages of the minimum and maximum"
+        " daily temperature both exceeds specific thresholds : "
+        "(Tmin > {thresh_tasmin} and Tmax > {thresh_tasmax}, averaged with a "
+        "window of {window} days)."
+    ),
     cell_methods="",
     keywords="health,",
     compute=indices.heat_wave_max_length,
@@ -163,18 +198,34 @@ heat_wave_total_length = TasminTasmax(
     identifier="heat_wave_total_length",
     units="days",
     standard_name="spell_length_of_days_with_air_temperature_above_threshold",
-    long_name="Total length of heat wave events (Tmin > {thresh_tasmin}"
-    "and Tmax > {thresh_tasmax} for >= {window} days)",
-    description="{freq} total length of heat wave events occuring in a given period."
-    "An event occurs when the minimum and maximum daily "
-    "temperature both exceeds specific thresholds "
-    "(Tmin > {thresh_tasmin} and Tmax > {thresh_tasmax}) over "
-    "a minimum number of days ({window}).",
+    long_name=lambda **kws: (
+        "Total length of heat wave events (Tmin > {thresh_tasmin} "
+        "and Tmax > {thresh_tasmax} for >= {window} days)"
+    )
+    if kws["mode"] == "consecutive"
+    else (
+        "Total length of heat wave events (Tmin > {thresh_tasmin} "
+        "and Tmax > {thresh_tasmax} over a {window} days mean)"
+    ),
+    description=lambda **kws: (
+        "{freq} total length of heat wave events occuring in a given period. "
+        "An event occurs when the minimum and maximum daily "
+        "temperature both exceeds specific thresholds : "
+        "(Tmin > {thresh_tasmin} and Tmax > {thresh_tasmax}) "
+        "over a minimum number of days ({window})."
+    )
+    if kws["mode"] == "consecutive"
+    else (
+        "{freq} total length of heat wave events occuring in a given period. "
+        "An event occurs when the running averages of the minimum and maximum"
+        " daily temperature both exceeds specific thresholds : "
+        "(Tmin > {thresh_tasmin} and Tmax > {thresh_tasmax}, averaged with a "
+        "window of {window} days)."
+    ),
     cell_methods="",
     keywords="health,",
     compute=indices.heat_wave_total_length,
 )
-
 
 heat_wave_index = Tasmax(
     identifier="heat_wave_index",

--- a/xclim/indices/_multivariate.py
+++ b/xclim/indices/_multivariate.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Union, Sequence
 
 import numpy as np
 import xarray
@@ -338,7 +338,7 @@ def heat_wave_frequency(
     tasmax: xarray.DataArray,
     thresh_tasmin: str = "22.0 degC",
     thresh_tasmax: str = "30 degC",
-    mode: str = 'consecutive',
+    mode: str = "consecutive",
     window: Union[int, Sequence[float]] = 3,
     freq: str = "YS",
 ) -> xarray.DataArray:
@@ -401,7 +401,9 @@ def heat_wave_frequency(
     https://doi.org/10.1175/1520-0450(2001)040<0762:OTDOAH>2.0.CO;2
     """
     if mode == "consecutive" and not np.isscalar(window):
-        raise ValueError("Window as sequence of weights is only valid for the 'mean' mode.")
+        raise ValueError(
+            "Window as sequence of weights is only valid for the 'mean' mode."
+        )
 
     thresh_tasmax = utils.convert_units_to(thresh_tasmax, tasmax)
     thresh_tasmin = utils.convert_units_to(thresh_tasmin, tasmin)
@@ -412,10 +414,27 @@ def heat_wave_frequency(
         if not np.isscalar(window):
             weights = np.array(window)
             window = len(window)
+            if weights.sum() != 1:
+                raise ValueError("Weights used for the window must sum to 1.")
         else:
-            weigths = np.array([1/window] * window)
-        cond = ((_rolling(tasmin, window=window, dim="time", mode=lambda x, axis: np.sum(x * weights, axis=axis)) > thresh_tasmin) &
-                (_rolling(tasmax, window=window, dim="time", mode=lambda x, axis: np.sum(x * weights, axis=axis)) > thresh_tasmax))
+            weights = np.array([1 / window] * window)
+        cond = (
+            _rolling(
+                tasmin,
+                window=window,
+                dim="time",
+                mode=lambda x, axis: np.sum(x * weights, axis=axis),
+            )
+            > thresh_tasmin
+        ) & (
+            _rolling(
+                tasmax,
+                window=window,
+                dim="time",
+                mode=lambda x, axis: np.sum(x * weights, axis=axis),
+            )
+            > thresh_tasmax
+        )
 
     group = cond.resample(time=freq)
     return group.apply(rl.windowed_run_events, window=window, dim="time")
@@ -433,7 +452,7 @@ def heat_wave_max_length(
     tasmax: xarray.DataArray,
     thresh_tasmin: str = "22.0 degC",
     thresh_tasmax: str = "30 degC",
-    mode: str = 'consecutive',
+    mode: str = "consecutive",
     window: Union[int, Sequence[float]] = 3,
     freq: str = "YS",
 ) -> xarray.DataArray:
@@ -498,7 +517,9 @@ def heat_wave_max_length(
     https://doi.org/10.1175/1520-0450(2001)040<0762:OTDOAH>2.0.CO;2
     """
     if mode == "consecutive" and not np.isscalar(window):
-        raise ValueError("Window as sequence of weights is only valid for the 'mean' mode.")
+        raise ValueError(
+            "Window as sequence of weights is only valid for the 'mean' mode."
+        )
 
     thresh_tasmax = utils.convert_units_to(thresh_tasmax, tasmax)
     thresh_tasmin = utils.convert_units_to(thresh_tasmin, tasmin)
@@ -509,10 +530,27 @@ def heat_wave_max_length(
         if not np.isscalar(window):
             weights = np.array(window)
             window = len(window)
+            if weights.sum() != 1:
+                raise ValueError("Weights used for the window must sum to 1.")
         else:
-            weigths = np.array([1/window] * window)
-        cond = ((_rolling(tasmin, window=window, dim="time", mode=lambda x, axis: np.sum(x * weights, axis=axis)) > thresh_tasmin) &
-                (_rolling(tasmax, window=window, dim="time", mode=lambda x, axis: np.sum(x * weights, axis=axis)) > thresh_tasmax))
+            weights = np.array([1 / window] * window)
+        cond = (
+            _rolling(
+                tasmin,
+                window=window,
+                dim="time",
+                mode=lambda x, axis: np.sum(x * weights, axis=axis),
+            )
+            > thresh_tasmin
+        ) & (
+            _rolling(
+                tasmax,
+                window=window,
+                dim="time",
+                mode=lambda x, axis: np.sum(x * weights, axis=axis),
+            )
+            > thresh_tasmax
+        )
 
     group = cond.resample(time=freq)
     max_l = group.apply(rl.longest_run, dim="time")
@@ -531,7 +569,7 @@ def heat_wave_total_length(
     tasmax: xarray.DataArray,
     thresh_tasmin: str = "22.0 degC",
     thresh_tasmax: str = "30 degC",
-    mode: str = 'consecutive',
+    mode: str = "consecutive",
     window: Union[int, Sequence[float]] = 3,
     freq: str = "YS",
 ) -> xarray.DataArray:
@@ -573,7 +611,9 @@ def heat_wave_total_length(
     See notes and references of `heat_wave_max_length`
     """
     if mode == "consecutive" and not np.isscalar(window):
-        raise ValueError("Window as sequence of weights is only valid for the 'mean' mode.")
+        raise ValueError(
+            "Window as sequence of weights is only valid for the 'mean' mode."
+        )
 
     thresh_tasmax = utils.convert_units_to(thresh_tasmax, tasmax)
     thresh_tasmin = utils.convert_units_to(thresh_tasmin, tasmin)
@@ -586,10 +626,27 @@ def heat_wave_total_length(
         if not np.isscalar(window):
             weights = np.array(window)
             window = len(window)
+            if weights.sum() != 1:
+                raise ValueError("Weights used for the window must sum to 1.")
         else:
-            weigths = np.array([1/window] * window)
-        cond = ((_rolling(tasmin, window=window, dim="time", mode=lambda x, axis: np.sum(x * weights, axis=axis)) > thresh_tasmin) &
-                (_rolling(tasmax, window=window, dim="time", mode=lambda x, axis: np.sum(x * weights, axis=axis)) > thresh_tasmax))
+            weights = np.array([1 / window] * window)
+        cond = (
+            _rolling(
+                tasmin,
+                window=window,
+                dim="time",
+                mode=lambda x, axis: np.sum(x * weights, axis=axis),
+            )
+            > thresh_tasmin
+        ) & (
+            _rolling(
+                tasmax,
+                window=window,
+                dim="time",
+                mode=lambda x, axis: np.sum(x * weights, axis=axis),
+            )
+            > thresh_tasmax
+        )
         return cond.resample(time=freq).sum()
 
 

--- a/xclim/indices/_multivariate.py
+++ b/xclim/indices/_multivariate.py
@@ -618,11 +618,7 @@ def heat_wave_total_length(
     thresh_tasmax = utils.convert_units_to(thresh_tasmax, tasmax)
     thresh_tasmin = utils.convert_units_to(thresh_tasmin, tasmin)
 
-    if mode == "consecutive":
-        cond = (tasmin > thresh_tasmin) & (tasmax > thresh_tasmax)
-        group = cond.resample(time=freq)
-        return group.apply(rl.windowed_run_count, args=(window,), dim="time")
-    elif mode == "mean":
+    if mode == "mean":
         if not np.isscalar(window):
             weights = np.array(window)
             window = len(window)
@@ -648,6 +644,11 @@ def heat_wave_total_length(
             > thresh_tasmax
         )
         return cond.resample(time=freq).sum()
+
+    # else  (mode == consecutive)
+    cond = (tasmin > thresh_tasmin) & (tasmax > thresh_tasmax)
+    group = cond.resample(time=freq)
+    return group.apply(rl.windowed_run_count, args=(window,), dim="time")
 
 
 @declare_units("", pr="[precipitation]", prsn="[precipitation]", tas="[temperature]")

--- a/xclim/indices/_multivariate.py
+++ b/xclim/indices/_multivariate.py
@@ -347,7 +347,7 @@ def heat_wave_frequency(
 
     Number of heat waves over a given period. A heat wave is defined as an event
     where the minimum and maximum daily temperature both exceeds specific thresholds
-    over a minimum number of days. 
+    over a minimum number of days.
 
     Parameters
     ----------
@@ -396,7 +396,7 @@ def heat_wave_frequency(
     Lebel, G., Bustinza, R. & Dubé, M. (2017). Analyse des impacts des vagues régionales de chaleur extrême sur la santé
     au Québec de 2010 à 2015 : changements climatiques. Québec: INSPQ, Institut national de santé publique du Québec.
     https://www.inspq.qc.ca/publications/2221
-    
+
     Robinson, P.J., 2001: On the Definition of a Heat Wave. J. Appl. Meteor., 40, 762–775,
     https://doi.org/10.1175/1520-0450(2001)040<0762:OTDOAH>2.0.CO;2
     """
@@ -437,7 +437,11 @@ def heat_wave_frequency(
         )
 
     group = cond.resample(time=freq)
-    return group.apply(rl.windowed_run_events, window=window, dim="time")
+    return group.apply(
+        rl.windowed_run_events,
+        window=window if mode == "consecutive" else 1,
+        dim="time",
+    )
 
 
 @declare_units(
@@ -512,7 +516,7 @@ def heat_wave_max_length(
     Lebel, G., Bustinza, R. & Dubé, M. (2017). Analyse des impacts des vagues régionales de chaleur extrême sur la santé
     au Québec de 2010 à 2015 : changements climatiques. Québec: INSPQ, Institut national de santé publique du Québec.
     https://www.inspq.qc.ca/publications/2221
-    
+
     Robinson, P.J., 2001: On the Definition of a Heat Wave. J. Appl. Meteor., 40, 762–775,
     https://doi.org/10.1175/1520-0450(2001)040<0762:OTDOAH>2.0.CO;2
     """
@@ -554,7 +558,9 @@ def heat_wave_max_length(
 
     group = cond.resample(time=freq)
     max_l = group.apply(rl.longest_run, dim="time")
-    return max_l.where(max_l >= window, 0)
+    if mode == "consecutive":
+        return max_l.where(max_l >= window, 0)
+    return max_l
 
 
 @declare_units(


### PR DESCRIPTION
<!--Please ensure the PR fulfills the follwing requirements-->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated

### After merging to master and before closing the branch:
- [ ] bumpversion (minor / major / patch) has been called on `master` branch
- [ ] Tags have been pushed

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->

This adds options to the 3 main heat waves indices  so that the definition used by the INSPQ can be computed. Instead of searching for N *consecutive* days where temperatures are above thresholds, they look for days where the length-N running mean is above thresholds. 

Furthermore, they use a weighted mean, so now, `window` can be a sequence of floats. Checks are made to be sure this option is only used with the "mean" mode and that the weights sum to 1.

Atmos indices were modified with dynamic descriptions and long names to fit what mode was used. and tests were added by transforming the previous tests to parametrized tests (as suggested by #52) that also try to follow #303.  Also, this fixes an overlooked bug from #293: `heat_wave_total_length` wasn't accessible through `atmos` and had no tests.

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->

Nope.

* **Other information**:

I chose the names "consecutive" for the default behaviour and "mean" for the added one. Y'all agree?