### PR TITLE
Non resampling indices checks

### DIFF
--- a/xclim/utils.py
+++ b/xclim/utils.py
@@ -960,7 +960,7 @@ class Indicator:
         """Return whether an output is considered missing or not."""
         from functools import reduce
 
-        freq = kwds.get("freq", "D")
+        freq = kwds.get("freq")
         if freq is not None:
             # We flag any period with missing data
             miss = (checks.missing_any(da, freq) for da in args)

--- a/xclim/utils.py
+++ b/xclim/utils.py
@@ -13,9 +13,10 @@ from collections import OrderedDict
 from inspect import signature
 from types import FunctionType
 from typing import Any
+from typing import Callable
 from typing import Optional
 from typing import Union
-from typing import Callable
+
 import dask
 import numpy as np
 import pint
@@ -960,8 +961,12 @@ class Indicator:
         from functools import reduce
 
         freq = kwds.get("freq", "D")
-
-        miss = (checks.missing_any(da, freq) for da in args)
+        if freq is not None:
+            # We flag any period with missing data
+            miss = (checks.missing_any(da, freq) for da in args)
+        else:
+            # There is no resampling, we flag where one of the input is missing
+            miss = (da.isnull() for da in args)
         return reduce(np.logical_or, miss)
 
     def validate(self, da):


### PR DESCRIPTION
<!--Please ensure the PR fulfills the follwing requirements-->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated

### After merging to master and before closing the branch:
- [ ] bumpversion (minor / major / patch) has been called on `master` branch
- [ ] Tags have been pushed

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->

In the case where an indicator is not performing a resampling on the input data, checking for missing values *per period* didn't make sense. When pushing #312 , we had this discussion and decided to default the frequency to daily, which is the expected (and validated) input frequency anyway. However, the `checks.missing_any` performs a quite heavy check by computing the number of non-null days in each period. When the period is a day, then this is the exact same a `da.isnull()`, but with a lot more overhead.

This proposed solution assumes that the indicator doesn't perform resampling if `freq` is not given. Thus, the `missing()` check means all inputs must exist for an output. 

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->

No.

* **Other information**:

A caveat of the previous solution was that `missing_any()` was resampling to `freq`, meaning the output dataset would be rechunked daily. That's how I realized the error.
Also, running `atmos.tg` on a large datasets (not computing, simply creating the output) is 500x times faster with this change.