### PR TITLE
Reformat lon and lat dimnames for atypically named data dimensions

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,7 +6,7 @@ History
 ------
 * Fix in `subset.wrap_lons_and_split_at_greenwich` to preserve multi-region dataframes.
 * Improve the memory use of `indices.growing_season_length`.
-
+* Better handling of data with atypically named `lat` and `lon` dimensions.
 
 0.13.x (2020-01-10)
 -------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.13.1-beta
+current_version = 0.13.2-beta
 commit = False
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+).(?P<patch>\d+)(\-(?P<release>[a-z]+))?

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ URL = "https://github.com/Ouranosinc/xclim"
 AUTHOR = "Travis Logan"
 AUTHOR_EMAIL = "logan.travis@ouranos.ca"
 REQUIRES_PYTHON = ">=3.6.0"
-VERSION = "0.13.1-beta"
+VERSION = "0.13.2-beta"
 LICENSE = "Apache Software License 2.0"
 
 with open("README.rst") as readme_file:

--- a/tests/test_subset.py
+++ b/tests/test_subset.py
@@ -236,7 +236,7 @@ class TestSubsetGridPoint:
             subset.subset_gridpoint(
                 da, lon=-72.4, lat=46.1, start_date="2055", end_date="2052"
             )
-        da = xr.open_dataset(self.nc_2dlonlat).tasmax.drop(["lon", "lat"])
+        da = xr.open_dataset(self.nc_2dlonlat).tasmax.drop_vars(names=["lon", "lat"])
         with pytest.raises(Exception):
             subset.subset_gridpoint(da, lon=-72.4, lat=46.1)
 
@@ -487,7 +487,7 @@ class TestSubsetBbox:
                 end_date="2055",
             )
 
-        da = xr.open_dataset(self.nc_2dlonlat).tasmax.drop(["lon", "lat"])
+        da = xr.open_dataset(self.nc_2dlonlat).tasmax.drop_vars(names=["lon", "lat"])
         with pytest.raises(Exception):
             subset.subset_bbox(da, lon_bnds=self.lon, lat_bnds=self.lat)
 

--- a/tests/test_subset.py
+++ b/tests/test_subset.py
@@ -382,6 +382,13 @@ class TestSubsetBbox:
         assert np.all(out.lat >= np.min(self.lat))
         assert np.all(out.lat <= np.max(self.lat))
 
+    def test_badly_named_latlons(self):
+        da = xr.open_dataset(self.nc_file)
+        new_latlons = {"lat": "latitude", "lon": "longitude"}
+        da = da.rename(new_latlons)
+        out = subset.subset_bbox(da, lon_bnds=self.lon, lat_bnds=self.lat)
+        assert {"latitude", "longitude"}.issubset(out.dims)
+
     def test_single_bounds_rectilinear(self):
         da = xr.open_dataset(self.nc_file).tasmax
 

--- a/tests/test_subset.py
+++ b/tests/test_subset.py
@@ -384,10 +384,22 @@ class TestSubsetBbox:
 
     def test_badly_named_latlons(self):
         da = xr.open_dataset(self.nc_file)
-        new_latlons = {"lat": "latitude", "lon": "longitude"}
-        da = da.rename(new_latlons)
-        out = subset.subset_bbox(da, lon_bnds=self.lon, lat_bnds=self.lat)
+        extended_latlons = {"lat": "latitude", "lon": "longitude"}
+        da_extended_names = da.rename(extended_latlons)
+        out = subset.subset_bbox(
+            da_extended_names, lon_bnds=self.lon, lat_bnds=self.lat
+        )
         assert {"latitude", "longitude"}.issubset(out.dims)
+
+        long_for_some_reason = {"lon": "long"}
+        da_long = da.rename(long_for_some_reason)
+        out = subset.subset_bbox(da_long, lon_bnds=self.lon, lat_bnds=self.lat)
+        assert {"long"}.issubset(out.dims)
+
+        lons_lats = {"lon": "lons", "lat": "lats"}
+        da_lonslats = da.rename(lons_lats)
+        out = subset.subset_bbox(da_lonslats, lon_bnds=self.lon, lat_bnds=self.lat)
+        assert {"lons", "lats"}.issubset(out.dims)
 
     def test_single_bounds_rectilinear(self):
         da = xr.open_dataset(self.nc_file).tasmax

--- a/xclim/__init__.py
+++ b/xclim/__init__.py
@@ -12,7 +12,7 @@ from xclim import seaIce
 
 __author__ = """Travis Logan"""
 __email__ = "logan.travis@ouranos.ca"
-__version__ = "0.13.1-beta"
+__version__ = "0.13.2-beta"
 
 
 def build_module(name, objs, doc="", source=None, mode="ignore"):

--- a/xclim/subset.py
+++ b/xclim/subset.py
@@ -183,8 +183,8 @@ def check_latlon_dimnames(func):
                     dims = argument.dims
                 else:
                     raise TypeError
-            except (IndexError, TypeError):
-                logging.error(f"No file or no dimensions found in arg {argument}.")
+            except TypeError:
+                logging.error(f"No file or no dimensions found in arg `{argument}`.")
                 formatted_args.append(argument)
                 continue
             try:

--- a/xclim/subset.py
+++ b/xclim/subset.py
@@ -178,13 +178,10 @@ def check_latlon_dimnames(func):
         formatted_args = list()
         conv = dict()
         for argument in args:
-            try:
-                if isinstance(argument, (xarray.DataArray, xarray.Dataset)):
-                    dims = argument.dims
-                else:
-                    raise TypeError
-            except TypeError:
-                logging.error(f"No file or no dimensions found in arg `{argument}`.")
+            if isinstance(argument, (xarray.DataArray, xarray.Dataset)):
+                dims = argument.dims
+            else:
+                logging.info(f"No file or no dimensions found in arg `{argument}`.")
                 formatted_args.append(argument)
                 continue
 

--- a/xclim/subset.py
+++ b/xclim/subset.py
@@ -187,26 +187,21 @@ def check_latlon_dimnames(func):
                 logging.error(f"No file or no dimensions found in arg `{argument}`.")
                 formatted_args.append(argument)
                 continue
-            try:
-                if not {"lon", "lat"}.issubset(dims) or {"rlon", "rlat"}.issubset(dims):
 
-                    if {"long"}.issubset(dims):
-                        conv["long"] = "lon"
-                    elif {"latitude", "longitude"}.issubset(dims):
-                        conv["latitude"] = "lat"
-                        conv["longitude"] = "lon"
-                    elif {"lats", "lons"}.issubset(dims):
-                        conv["lats"] = "lat"
-                        conv["lons"] = "lon"
-                    else:
-                        pass
-                    argument = argument.rename(conv)
-
-            except ValueError:
-                logging.error(
-                    f"Lat and Lon dimensions are not found among dimensions: {list(dims)}."
-                )
-                raise
+            if not {"lon", "lat"}.issubset(dims) or not {"rlon", "rlat"}.issubset(dims):
+                if {"long"}.issubset(dims):
+                    conv["long"] = "lon"
+                elif {"latitude", "longitude"}.issubset(dims):
+                    conv["latitude"] = "lat"
+                    conv["longitude"] = "lon"
+                elif {"lats", "lons"}.issubset(dims):
+                    conv["lats"] = "lat"
+                    conv["lons"] = "lon"
+                if not conv:
+                    warnings.warn(
+                        f"lat and lon-like dimensions are not found among arg `{argument}` dimensions: {list(dims)}."
+                    )
+                argument = argument.rename(conv)
 
             formatted_args.append(argument)
 

--- a/xclim/subset.py
+++ b/xclim/subset.py
@@ -174,24 +174,23 @@ def check_latlon_dimnames(func):
 
         if range(len(args)) == 0:
             return func(*args, **kwargs)
-        else:
-            formatted_args = list()
-            for i in range(len(args)):
-                try:
-                    ds = args[i]
-                    if isinstance(ds, (xarray.DataArray, xarray.Dataset)):
-                        dims = ds.dims
-                    else:
-                        raise TypeError
-                except (IndexError, TypeError):
-                    logging.error(f"No file or no dimensions found in arg {args[i]}.")
-                    formatted_args.append(args[i])
-                    continue
 
-                if not {"lon", "lat"}.issubset(dims):
-                    if {"latitude", "longitude"}.issubset(dims):
-                        ds = ds.rename({"latitude": "lat", "longitude": "lon"})
-                formatted_args.append(ds)
+        formatted_args = list()
+        for argument in args:
+            try:
+                if isinstance(argument, (xarray.DataArray, xarray.Dataset)):
+                    dims = argument.dims
+                else:
+                    raise TypeError
+            except (IndexError, TypeError):
+                logging.error(f"No file or no dimensions found in arg {argument}.")
+                formatted_args.append(argument)
+                continue
+
+            if not {"lon", "lat"}.issubset(dims):
+                if {"latitude", "longitude"}.issubset(dims):
+                    argument = argument.rename({"latitude": "lat", "longitude": "lon"})
+            formatted_args.append(argument)
         return func(*formatted_args, **kwargs)
 
     return func_checker

--- a/xclim/subset.py
+++ b/xclim/subset.py
@@ -169,7 +169,9 @@ def check_latlon_dimnames(func):
     @wraps(func)
     def func_checker(*args, **kwargs):
         """
-        A decorator examining the names of the latitude and longitude dimensions and renames them temporarily if needed.
+        A decorator examining the names of the latitude and longitude dimensions and renames them temporarily.
+         Checks here ensure that the names supplied via the xarray object dims are changed to be synonymous with subset
+         algorithm dimensions, conversions are saved and are then undone to the processed file.
         """
 
         if range(len(args)) == 0:

--- a/xclim/subset.py
+++ b/xclim/subset.py
@@ -188,7 +188,7 @@ def check_latlon_dimnames(func):
                 formatted_args.append(argument)
                 continue
 
-            if not {"lon", "lat"}.issubset(dims) or not {"rlon", "rlat"}.issubset(dims):
+            if not {"lon", "lat"}.issubset(dims):
                 if {"long"}.issubset(dims):
                     conv["long"] = "lon"
                 elif {"latitude", "longitude"}.issubset(dims):
@@ -197,7 +197,7 @@ def check_latlon_dimnames(func):
                 elif {"lats", "lons"}.issubset(dims):
                     conv["lats"] = "lat"
                     conv["lons"] = "lon"
-                if not conv:
+                if not conv and not {"rlon", "rlat"}.issubset(dims):
                     warnings.warn(
                         f"lat and lon-like dimensions are not found among arg `{argument}` dimensions: {list(dims)}."
                     )


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [x] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
This PR includes another checking decorator (`check_latlon_dimnames`; not married to the function name) that renames the latitude and longitude coordinates so that they are synonymous with the rest of our subsetting tools. There are plenty of edge cases where this can occur ("x" and "y"; "longitude" and "latitude"; "lats" and "lons") and this is indeed a case for data extracted via the CDSAPI (ERA5, ERA5-Land and other Copernicus data sets).

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
As it stands, any xarray.Dataset or DataArray that is read by `subset_bbox`, `subset_gripoint`, or `susbset_shape` that has non `lat` and `lon` coordinates will have those coordinates renamed. One way to prevent that from happening would be to style the decorator to rename these dimensions to their previous names after the subsetting function has been passed on them. This might require more work, I'm not sure.

* **Other information**:
