### PR TITLE
Fix units problem for tas (and atmos.tg)

### DIFF
--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -733,18 +733,20 @@ class TestTGXN90p:
 
 
 class TestTas:
-    @pytest.mark.parametrize("tasmin_units", ['K', 'degC'])
-    @pytest.mark.parametrize("tasmax_units", ['K', 'degC'])
-    def test_tas(self, tasmin_series, tasmax_series, tas_series, tasmin_units, tasmax_units):
-        tas = tas_series(np.ones(10) + (K2C if tasmin_units == 'K' else 0))
-        tas.attrs['units'] = tasmin_units
-        tasmin = tasmin_series(np.zeros(10) + (K2C if tasmin_units == 'K' else 0))
-        tasmin.attrs['units'] = tasmin_units
-        tasmax = tasmax_series(np.ones(10) * 2 + (K2C if tasmax_units == 'K' else 0))
-        tasmax.attrs['units'] = tasmax_units
+    @pytest.mark.parametrize("tasmin_units", ["K", "degC"])
+    @pytest.mark.parametrize("tasmax_units", ["K", "degC"])
+    def test_tas(
+        self, tasmin_series, tasmax_series, tas_series, tasmin_units, tasmax_units
+    ):
+        tas = tas_series(np.ones(10) + (K2C if tasmin_units == "K" else 0))
+        tas.attrs["units"] = tasmin_units
+        tasmin = tasmin_series(np.zeros(10) + (K2C if tasmin_units == "K" else 0))
+        tasmin.attrs["units"] = tasmin_units
+        tasmax = tasmax_series(np.ones(10) * 2 + (K2C if tasmax_units == "K" else 0))
+        tasmax.attrs["units"] = tasmax_units
 
         tas_xc = xci.tas(tasmin, tasmax)
-        assert tas_xc.attrs['units'] == tasmin_units
+        assert tas_xc.attrs["units"] == tasmin_units
         xr.testing.assert_equal(tas, tas_xc)
 
 

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -733,12 +733,18 @@ class TestTGXN90p:
 
 
 class TestTas:
-    def test_tas(self, tasmin_series, tasmax_series, tas_series):
-        tas = tas_series(np.ones(10))
-        tasmin = tasmin_series(np.zeros(10))
-        tasmax = tasmax_series(np.ones(10) * 2)
+    @pytest.mark.parametrize("tasmin_units", ['K', 'degC'])
+    @pytest.mark.parametrize("tasmax_units", ['K', 'degC'])
+    def test_tas(self, tasmin_series, tasmax_series, tas_series, tasmin_units, tasmax_units):
+        tas = tas_series(np.ones(10) + (K2C if tasmin_units == 'K' else 0))
+        tas.attrs['units'] = tasmin_units
+        tasmin = tasmin_series(np.zeros(10) + (K2C if tasmin_units == 'K' else 0))
+        tasmin.attrs['units'] = tasmin_units
+        tasmax = tasmax_series(np.ones(10) * 2 + (K2C if tasmax_units == 'K' else 0))
+        tasmax.attrs['units'] = tasmax_units
 
         tas_xc = xci.tas(tasmin, tasmax)
+        assert tas_xc.attrs['units'] == tasmin_units
         xr.testing.assert_equal(tas, tas_xc)
 
 

--- a/xclim/indices/_multivariate.py
+++ b/xclim/indices/_multivariate.py
@@ -985,7 +985,7 @@ def tas(tasmin: xarray.DataArray, tasmax: xarray.DataArray) -> xarray.DataArray:
     """
     tasmax = utils.convert_units_to(tasmax, tasmin)
     tas = (tasmax + tasmin) / 2
-    tas.attrs['units'] = tasmin.attrs['units']
+    tas.attrs["units"] = tasmin.attrs["units"]
     return tas
 
 

--- a/xclim/indices/_multivariate.py
+++ b/xclim/indices/_multivariate.py
@@ -965,7 +965,7 @@ def fraction_over_precip_thresh(
     return over / total
 
 
-@declare_units("K", tasmin="[temperature]", tasmax="[temperature]")
+@declare_units("[temperature]", tasmin="[temperature]", tasmax="[temperature]")
 def tas(tasmin: xarray.DataArray, tasmax: xarray.DataArray) -> xarray.DataArray:
     """Average temperature from minimum and maximum temperatures.
 
@@ -981,9 +981,12 @@ def tas(tasmin: xarray.DataArray, tasmax: xarray.DataArray) -> xarray.DataArray:
     Returns
     -------
     xarray.DataArray
-        Mean (daily) temperature [°C]
+        Mean (daily) temperature [same units as tasmin]
     """
-    return (tasmax + tasmin) / 2
+    tasmax = utils.convert_units_to(tasmax, tasmin)
+    tas = (tasmax + tasmin) / 2
+    tas.attrs['units'] = tasmin.attrs['units']
+    return tas
 
 
 @declare_units("days", tas="[temperature]", t90="[temperature]")


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an opened issue (for bug fixes / features)
    - This PR fixes an issue raised in a private internal xclim-mailing list 
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->

Previous PR #312 had a bug where units of `xclim.indices.tas` (and `atmos.tg`) were set to "K" no matter what the input units were. Now `tasmax` is converted to units of `tasmin` and the output is explicitly set to units of `tasmin`.  If "degC" (or ergs or Rankin or °F) were to be used, then `atmos.tg` would convert them to "K", but `xclim.indices.tas` would keep them the same.

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->

No

* **Other information**:

Do I need to update History.rst for such a minor change? 