### PR TITLE
Fix subset bbox with lat/lon without coords

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 0.14.x
 ------
+* Modified `subset_shape` to support subsetting with GeoPandas datatypes directly.
 * Fix in `subset.wrap_lons_and_split_at_greenwich` to preserve multi-region dataframes.
 * Improve the memory use of `indices.growing_season_length`.
 * Better handling of data with atypically named `lat` and `lon` dimensions.

--- a/xclim/subset.py
+++ b/xclim/subset.py
@@ -663,7 +663,9 @@ def subset_bbox(
         args = {}
         for i, d in enumerate(da.lat.dims):
             coords = da[d][ind[i]]
-            args[d] = slice(coords.min(), coords.max())
+            args[d] = slice(coords.min().values, coords.max().values)
+        # If the dims of lat and lon do not have coords, sel defaults to isel,
+        # and then the last element is not returned.
         da = da.sel(**args)
 
         # Recompute condition on cropped coordinates

--- a/xclim/subset.py
+++ b/xclim/subset.py
@@ -345,7 +345,7 @@ def create_mask(
         for (indb, polb) in poly.iloc[i + 1 :].iterrows():
             if pola.geometry.intersects(polb.geometry):
                 warnings.warn(
-                    f"List of shapes contains overlap between {inda} and {indb}. Only {inda} will be used.",
+                    f"List of shapes contains overlap between {inda} and {indb}. Points will be assigned to {inda}.",
                     UserWarning,
                     stacklevel=4,
                 )
@@ -397,7 +397,7 @@ def create_mask(
 @check_latlon_dimnames
 def subset_shape(
     ds: Union[xarray.DataArray, xarray.Dataset],
-    shape: Union[str, Path],
+    shape: Union[str, Path, gpd.GeoDataFrame],
     raster_crs: Optional[Union[str, int]] = None,
     shape_crs: Optional[Union[str, int]] = None,
     buffer: Optional[Union[int, float]] = None,
@@ -414,8 +414,8 @@ def subset_shape(
     ----------
     ds : Union[xarray.DataArray, xarray.Dataset]
       Input values.
-    shape : Union[str, Path]
-      Path to shape file. Supports formats compatible with geopandas.
+    shape : Union[str, Path, gpd.GeoDataFrame]
+      Path to shape file, or directly a geodataframe. Supports formats compatible with geopandas.
     raster_crs : Optional[Union[str, int]]
       EPSG number or PROJ4 string.
     shape_crs : Optional[Union[str, int]]
@@ -457,7 +457,10 @@ def subset_shape(
     """
     # TODO : edge case using polygon splitting decorator touches original ds when subsetting?
     ds_copy = copy.deepcopy(ds)
-    poly = gpd.GeoDataFrame.from_file(shape)
+    if isinstance(shape, gpd.GeoDataFrame):
+        poly = shape
+    else:
+        poly = gpd.GeoDataFrame.from_file(shape)
 
     if buffer is not None:
         poly.geometry = poly.buffer(buffer)


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->

Once again, a small bug fix.  `subset_bbox` was failing on cases where the coordinates of 2D lat/lon had coordinates themselves. In those cases, `dim.min()` returns a DataArray that is not easily castable to a number. I simply added `.values()`. 

Also, was there a reason `subset.subset_shape` didn't accept `GeoDataFrame`s directly? I added that possibility because I am using it in my subsetting notebook.

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->

No