### PR TITLE
Fix type hints and docstrings

### DIFF
--- a/xclim/indices/_multivariate.py
+++ b/xclim/indices/_multivariate.py
@@ -51,7 +51,7 @@ __all__ = [
 
 @declare_units("days", tasmin="[temperature]", tn10="[temperature]")
 def cold_spell_duration_index(
-    tasmin: xarray.DataArray, tn10: float, window: int = 6, freq: str = "YS"
+    tasmin: xarray.DataArray, tn10: xarray.DataArray, window: int = 6, freq: str = "YS"
 ) -> xarray.DataArray:
     r"""Cold spell duration index
 
@@ -62,8 +62,8 @@ def cold_spell_duration_index(
     ----------
     tasmin : xarray.DataArray
       Minimum daily temperature.
-    tn10 : float
-      10th percentile of daily minimum temperature.
+    tn10 : xarray.DataArray
+      10th percentile of daily minimum temperature with `dayofyear` coordinate.
     window : int
       Minimum number of days with temperature below threshold to qualify as a cold spell. Default: 6.
     freq : str

--- a/xclim/indices/_threshold.py
+++ b/xclim/indices/_threshold.py
@@ -225,7 +225,7 @@ def cooling_degree_days(
 
 @declare_units("", tas="[temperature]", thresh="[temperature]")
 def freshet_start(
-    tas: xarray.DataArray, thresh: str = "0 degC", window: int = 5, freq: int = "YS"
+    tas: xarray.DataArray, thresh: str = "0 degC", window: int = 5, freq: str = "YS"
 ):
     r"""First day consistently exceeding threshold temperature.
 
@@ -245,7 +245,7 @@ def freshet_start(
 
     Returns
     -------
-    float
+    xarray.DataArray
       Day of the year when temperature exceeds threshold over a given number of days for the first time. If there are
       no such day, return np.nan.
 
@@ -400,7 +400,7 @@ def growing_season_length(
 def heat_wave_index(
     tasmax: xarray.DataArray,
     thresh: str = "25.0 degC",
-    window: str = 5,
+    window: int = 5,
     freq: str = "YS",
 ):
     r"""Heat wave index.


### PR DESCRIPTION
Some of these fixes are obvious, others I'm not 100% sure:
 - The type of `tn10` in `cold_spell_duration_index`
 - the return value of `freshet_start`