### PR TITLE
Bug fix for lat/lon in dask arrays

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 0.14.x
 ------
+* Fix in `subset.subset_gridpoint` for dask array coordinates.
 * Modified `subset_shape` to support subsetting with GeoPandas datatypes directly.
 * Fix in `subset.wrap_lons_and_split_at_greenwich` to preserve multi-region dataframes.
 * Improve the memory use of `indices.growing_season_length`.

--- a/tests/test_subset.py
+++ b/tests/test_subset.py
@@ -183,6 +183,13 @@ class TestSubsetGridPoint:
         np.testing.assert_almost_equal(out.lon, lon, 1)
         np.testing.assert_almost_equal(out.lat, lat, 1)
 
+        # dask for lon lat
+        da.lon.chunk({"rlon": 10})
+        da.lat.chunk({"rlon": 10})
+        out = subset.subset_gridpoint(da, lon=lon, lat=lat)
+        np.testing.assert_almost_equal(out.lon, lon, 1)
+        np.testing.assert_almost_equal(out.lat, lat, 1)
+
         # test_irregular transposed:
         da1 = xr.open_dataset(self.nc_2dlonlat).tasmax
         dims = list(da1.dims)

--- a/xclim/subset.py
+++ b/xclim/subset.py
@@ -937,6 +937,6 @@ def distance(da, lon, lat):
     def func(lons, lats):
         return g.inv(*np.broadcast_arrays(lons, lats, lon, lat))[2]
 
-    out = xarray.apply_ufunc(func, da.lon, da.lat)
+    out = xarray.apply_ufunc(func, da.lon.load(), da.lat.load())
     out.attrs["units"] = "m"
     return out


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes an issue raised verbally by @sbiner 
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->

Fix a bug that made `subset.subset_gridpoint` fail if `lat` and/or `lon` were dask arrays. The arrays are simply loaded when the distance is computed. This assumes that the arrays will never be large enough to justify the use of dask. It's more an arefact of the use of `open_mfdataset`.

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->

No

* **Other information**:
