### PR TITLE
Bugfix: add poppler to Anaconda dependencies

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,7 @@ dependencies:
  - pandas>=0.23
  - cftime>=1.0.4
  - netCDF4>=1.4
+ - poppler>=0.67
  - fiona>=1.8
  - geojson>=2.5.0
  - shapely>=1.6


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
This PR adds the C-library `poppler` as an explicitly-installed library for the Anaconda environment. 

But why, you ask? Well, if you happen to run a rolling-release distribution (Arch, Manjaro, openSUSE Tumbleweed, etc.) that has a bleeding-edge version of `poppler` in its system libraries, Anaconda will not install `poppler` nor will it see the system-installed version. This crashes `xclim` on import of the GIS functions (`xclim.subset`).

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
No.

* **Other information**:
Yes, this is a very specific case, but this is a show-stopper preventing me from working on bleeding edge systems. If it can happen to me, it can happen to others.