### PR TITLE
Fixes in subset, winter_rain_ratio, percentile_doy and heat_wave_total_length

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,8 @@ History
 
 0.14.x
 ------
+* Add `atmos.heat_wave_total_length` (fixing a namespace issue)
+* Fixes in `utils.percentile_doy` and `indices.winter_rain_ratio` for multidimensionnal datasets.
 * Rewrote the `subset.subset_shape` function to allow for dask.delayed (lazy) computation.
 * Creation of `time_bnds` variables when resampling data encoded with `CFTimeIndex` (non-standard calendars).
 * Fix in `subset.subset_gridpoint` for dask array coordinates.

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -972,13 +972,15 @@ class TestWinterRainRatio:
     def test_simple(self, pr_series, tas_series):
         pr = np.ones(450)
         pr = pr_series(pr, start="12/1/2000")
+        pr = xr.concat((pr, pr), "dim0")
 
         tas = np.zeros(450) - 1
         tas[10:20] += 10
         tas = tas_series(tas + K2C, start="12/1/2000")
+        tas = xr.concat((tas, tas), "dim0")
 
         out = xci.winter_rain_ratio(pr=pr, tas=tas)
-        np.testing.assert_almost_equal(out, [10.0 / (31 + 31 + 28), 0])
+        np.testing.assert_almost_equal(out.isel(dim0=0), [10.0 / (31 + 31 + 28), 0])
 
 
 # I'd like to parametrize some of these tests so we don't have to write individual tests for each indicator.

--- a/tests/test_temperature.py
+++ b/tests/test_temperature.py
@@ -668,6 +668,46 @@ class TestHeatWaveMaxLength:
         np.testing.assert_allclose(hwf.values[:1], 0)
 
 
+class TestHeatWaveTotalLength:
+    def test_1d(self, tasmax_series, tasmin_series):
+        tn1 = np.zeros(366)
+        tx1 = np.zeros(366)
+        tn1[:10] = np.array([20, 23, 23, 23, 23, 21, 23, 23, 23, 23])
+        tx1[:10] = np.array([29, 31, 31, 31, 29, 31, 31, 31, 31, 31])
+
+        tn = tasmin_series(tn1 + K2C, start="1/1/2000")
+        tx = tasmax_series(tx1 + K2C, start="1/1/2000")
+        tnC = tasmin_series(tn1, start="1/1/2000")
+        tnC.attrs["units"] = "C"
+        txC = tasmax_series(tx1, start="1/1/2000")
+        txC.attrs["units"] = "C"
+
+        hwf = atmos.heat_wave_total_length(
+            tn, tx, thresh_tasmin="22 C", thresh_tasmax="30 C", freq="YS"
+        )
+        hwfC = atmos.heat_wave_total_length(
+            tnC, txC, thresh_tasmin="22 C", thresh_tasmax="30 C", freq="YS"
+        )
+        np.testing.assert_array_equal(hwf, hwfC)
+        np.testing.assert_allclose(hwf.values[:1], 7)
+
+        hwf = atmos.heat_wave_total_length(
+            tn, tx, thresh_tasmin="20 C", thresh_tasmax="30 C", window=4, freq="YS"
+        )
+        np.testing.assert_allclose(hwf.values[:1], 5)
+
+        # one long hw
+        hwf = atmos.heat_wave_total_length(
+            tn, tx, thresh_tasmin="10 C", thresh_tasmax="10 C", freq="YS"
+        )
+        np.testing.assert_allclose(hwf.values[:1], 10)
+        # no hw
+        hwf = atmos.heat_wave_total_length(
+            tn, tx, thresh_tasmin="40 C", thresh_tasmax="40 C", freq="YS"
+        )
+        np.testing.assert_allclose(hwf.values[:1], 0)
+
+
 class TestHeatWaveIndex:
     def test_simple(self, tasmax_series):
         tx = np.zeros(366)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -271,6 +271,7 @@ class TestParseDoc:
 class TestPercentileDOY:
     def test_simple(self, tas_series):
         tas = tas_series(np.arange(365), start="1/1/2001")
+        tas = xr.concat((tas, tas), "dim0")
         p1 = percentile_doy(tas, window=5, per=0.5)
         assert p1.sel(dayofyear=3).data == 2
         assert p1.attrs["units"] == "K"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -273,7 +273,7 @@ class TestPercentileDOY:
         tas = tas_series(np.arange(365), start="1/1/2001")
         tas = xr.concat((tas, tas), "dim0")
         p1 = percentile_doy(tas, window=5, per=0.5)
-        assert p1.sel(dayofyear=3).data == 2
+        assert p1.sel(dayofyear=3, dim0=0).data == 2
         assert p1.attrs["units"] == "K"
 
 

--- a/xclim/atmos/_temperature.py
+++ b/xclim/atmos/_temperature.py
@@ -12,6 +12,7 @@ __all__ = [
     "tx_tn_days_above",
     "heat_wave_frequency",
     "heat_wave_max_length",
+    "heat_wave_total_length",
     "heat_wave_index",
     "tg",
     "tg_mean",

--- a/xclim/indices/_multivariate.py
+++ b/xclim/indices/_multivariate.py
@@ -1398,4 +1398,4 @@ def winter_rain_ratio(
     """
     ratio = liquid_precip_ratio(pr, prsn, tas, freq=freq)
     winter = ratio.indexes["time"].month == 12
-    return ratio[winter]
+    return ratio.sel(time=winter)

--- a/xclim/subset.py
+++ b/xclim/subset.py
@@ -273,7 +273,7 @@ def wrap_lons_and_split_at_greenwich(func):
                     # Load split features into a new GeoDataFrame with WGS84 CRS
                     split_gdf = gpd.GeoDataFrame(
                         geometry=[cascaded_union(buffered_split_polygons)],
-                        crs={"epsg:4326"},
+                        crs="epsg:4326",
                     )
                     poly.at[[index], "geometry"] = split_gdf.geometry.values
                     # split_gdf.columns = ["index", "geometry"]

--- a/xclim/utils.py
+++ b/xclim/utils.py
@@ -479,7 +479,7 @@ def percentile_doy(
     # The percentile for the 366th day has a sample size of 1/4 of the other days.
     # To have the same sample size, we interpolate the percentile from 1-365 doy range to 1-366
     if p.dayofyear.max() == 366:
-        p = adjust_doy_calendar(p.loc[p.dayofyear < 366], arr)
+        p = adjust_doy_calendar(p.sel(dayofyear=(p.dayofyear < 366)), arr)
 
     p.attrs.update(arr.attrs.copy())
     return p


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes issues discussed internally and brought up by external users on a different platform.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->

1) This fixes a bug in `subset.wrap_lons_and_split_at_greenwich` caused by a typo, that made the tests core dump.
2) Also, a few fixes for bugs issued by external members:
 
- `utils.percentile_doy` used a panda-like indexing technique that failed with multidimensionnal datasets (not timeseries)
- Similarly, `indices.winter_rain_ratio` would also fail with multidim inputs. Fixed it.
- Finally, `heat_wave_total_length` was coded in `indices` and `atmos`, but wasn't included in the `__all__` making it invisible. And there were no tests?? I don't know how that slipped away for so long.

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->

Only unbreaking-changes.
