### PR TITLE
Subset gridpoint nd latlon

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+0.15.x
+------
+* Fix bug in subset_gridpoint to work on lat/lon coords of any dimension when they are not a dimension of the data.
+
 0.14.x (2020-02-21)
 -------------------
 * Refactoring of the documentation.

--- a/tests/test_subset.py
+++ b/tests/test_subset.py
@@ -222,6 +222,26 @@ class TestSubsetGridPoint:
         np.testing.assert_almost_equal(out2.lat, lat, 1)
         np.testing.assert_array_equal(out, out2.tasmax)
 
+        # Dataset with lon and lat as 1D arrays
+        lon = -60
+        lat = -45
+        da = xr.DataArray(
+            np.random.rand(5, 4),
+            dims=("time", "site"),
+            coords={"time": np.arange(5), "site": np.arange(4)},
+        )
+        ds = xr.Dataset(
+            data_vars={
+                "da": da,
+                "lon": ("site", np.linspace(lon, lon + 10, 4)),
+                "lat": ("site", np.linspace(lat, lat + 5, 4)),
+            }
+        )
+        gp = subset.subset_gridpoint(ds, lon=lon, lat=lat)
+        np.testing.assert_almost_equal(gp.lon, lon)
+        np.testing.assert_almost_equal(gp.lat, lat)
+        assert gp.site == 0
+
     def test_positive_lons(self):
         da = xr.open_dataset(self.nc_poslons).tas
         lon = -72.4

--- a/xclim/subset.py
+++ b/xclim/subset.py
@@ -832,13 +832,10 @@ def subset_gridpoint(
                 dist = distance(da, lon, lat)
 
                 # Find the indices for the closest point
-                iy, ix = np.unravel_index(dist.argmin(), dist.shape)
+                inds = np.unravel_index(dist.argmin(), dist.shape)
 
                 # Select data from closest point
-                xydims = [x for x in dist.dims]
-                args = dict()
-                args[xydims[0]] = iy
-                args[xydims[1]] = ix
+                args = {xydim: ind for xydim, ind in zip(dist.dims, inds)}
                 da = da.isel(**args)
         else:
             raise (


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #369 
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->

This modifies `subset_gridpoint` to work on cases where lat / lon are not dimensions of the dataset/dataArray and have 1 or more then 2 dimensions. Example : a "station" dimension and 1D lat and lon. 

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->

No
