### PR TITLE
fix identifier name for hot_spell_max_length

### DIFF
--- a/xclim/indicators/atmos/_temperature.py
+++ b/xclim/indicators/atmos/_temperature.py
@@ -209,7 +209,7 @@ hot_spell_frequency = Tasmax(
 )
 
 hot_spell_max_length = Tasmax(
-    identifier="heat_wave_max_length",
+    identifier="hot_spell_max_length",
     units="days",
     standard_name="spell_length_of_days_with_air_temperature_above_threshold",
     long_name="Maximum length of hot spell events (Tmax > {thresh_tasmax} for >= {window} days)",


### PR DESCRIPTION
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

Fix typo in identifier name of `xclim.indicators.atmos.hot_spell_max_length` ~~heat_wave_max_length~~ -> hot_spell_max_length
