### PR TITLE
Made units.convert_units_to lazy

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+0.16.x
+------
+* Allow lazy units conversion
+
 0.15.x (2020-03-12)
 -------------------
 * Improvement in FWI: Vectorization of DC, DMC and FFMC with numba and small code refactoring for better maintainability.

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,3 +1,4 @@
+import dask.array as dsk
 import numpy as np
 import pytest
 import xarray as xr
@@ -69,6 +70,11 @@ class TestConvertUnitsTo:
     def test_fraction(self):
         out = convert_units_to(xr.DataArray([10], attrs={"units": "%"}), "")
         assert out == 0.1
+
+    def test_lazy(self, pr_series):
+        pr = pr_series(np.arange(365), start="1/1/2001").chunk({"time": 100})
+        out = convert_units_to(pr, "mm/day")
+        assert isinstance(out.data, dsk.Array)
 
 
 class TestUnitConversion:

--- a/xclim/core/units.py
+++ b/xclim/core/units.py
@@ -251,7 +251,7 @@ def convert_units_to(
 
         with units.context(context or "none"):
             out = xr.DataArray(
-                data=units.convert(source.values, fu, tu),
+                data=units.convert(source.data, fu, tu),
                 coords=source.coords,
                 attrs=source.attrs,
                 name=source.name,


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] Tests for the changes have been added (for bug fixes / features)
- [] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->

Simply modifies `xc.core.units.convert_units_to` so that it is lazy when receiving a DataArray with dask. 

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->

No

* **Other information**:

When accessing a DataArray's values we have 2 choices : `da.values` returns the values, loading the array if needed, `da.data` returns the underlying container, either a dask array or a numpy array. With our current config, Pint won't force-cast data into a numpy array if the thing acts like an array.