### PR TITLE
Downscaling and bias-correction module

### DIFF
--- a/xclim/downscaling/__init__.py
+++ b/xclim/downscaling/__init__.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+"""
+Downscaling and bias-correction
+===============================
+
+This submodule provides tools for bias-correction and downscaling process on
+climate data using xarray. Once complete and usable, chances are that this
+submodule will move into its own package, so don't get attached too much.
+
+
+Logic:
+
+What the use calls is a "Pipeline".
+Given a detrending, a grouping and a mapping object, a typical pipeline would call:
+
+- detrend.fit() + detrend.detrend() on each of obs, sim and fut
+- grouping.group() on obs and sim
+- mapping.fit() on obs+sim
+- grouping.add_group_axis() on fut
+- mapping.predict() on fut
+- detrend.retrend() on fut
+
+The whole module assumes the bias-correction is made along coord "time", for each group in coord "group", independent of any other coordinates.
+
+The Detrending objects will detrend/retrend DataArrays along "time".
+
+The Grouping objects will group elements of a DataArray along time and give back either a DataArrayGroupBy or a DataArray object with a time coord on which mapping should be done.
+Once the action called, the new dimension is called "group" and has a "group_name" attribute with the real group name (the one a simple groupby(dim) would have given.)
+Also, the add_group_axis() method, adds a coord that says where is each element along the time coord in the group. Ex : If the grouping is monthly, the 15th of April  group = 4, the 30th group = 4.5.
+
+The Mapping objects perform a fit from obs and sim, the reference observation and the simulated climate for the same reference period, the fit is performed point-wise and group-wise, along "time".
+Then, the predict() method takes in fut, the simulated climate for the projection period, that must have a "time" and a "group" coord, as given by the add_group_axis() grouping method.
+It returns the corrected fut timeseries,
+"""

--- a/xclim/downscaling/detrending.py
+++ b/xclim/downscaling/detrending.py
@@ -1,0 +1,74 @@
+"""Detrending classes"""
+from warnings import warn
+
+import xarray as xr
+
+from .utils import ParametrizableClass
+
+
+class NoDetrend(ParametrizableClass):
+    """Base class for detrending objects
+
+    Defines three methods:
+
+    fit(da)     : Compute trend from da and return a new _fitted_ Detrend object.
+    detrend(da) : Return detrended array.
+    retrend(da) : Puts trend back on da.
+
+    * Subclasses should implement _fit(), _detrend() and _retrend(), not the methods themselves.
+    Only _fit() should store data. _detrend() and _retrend() are meant to be used on any dataarray with the trend computed in fit.
+    """
+
+    __fitted = False
+
+    def fit(self, da: xr.DataArray):
+        new = self.__class__(**self.parameters)
+        new._fit(da)
+        new.__fitted = True
+        return new
+
+    def detrend(self, da: xr.DataArray):
+        if not self.__fitted:
+            raise ValueError("You must call fit() before detrending.")
+        return self._detrend(da)
+
+    def retrend(self, da: xr.DataArray):
+        if not self.__fitted:
+            raise ValueError("You must call fit() before retrending")
+        return self._retrend(da)
+
+    def _fit(self, da):
+        pass
+
+    def _detrend(self, da):
+        return da
+
+    def _retrend(self, da):
+        return da
+
+
+class MeanDetrend(NoDetrend):
+    def _fit(self, da):
+        self._mean = da.mean(dim="time")
+
+    def _detrend(self, da):
+        return da - self._mean
+
+    def _retrend(self, da):
+        return da + self._mean
+
+
+class PolyDetrend(NoDetrend):
+    def __init__(self, degree=4):
+        super().__init__(self, degree=degree)
+
+    def _fit(self, da):
+        self._fitds = da.polyfit(dim="time", deg=self.degree, full=True)
+
+    def _detrend(self, da):
+        trend = xr.polyval(coord=da["time"], coeffs=self._fitds.polyfit_coefficients)
+        return da - trend
+
+    def _retrend(self, da):
+        trend = xr.polyval(coord=da["time"], coeffs=self._fitds.polyfit_coefficients)
+        return da - trend

--- a/xclim/downscaling/grouping.py
+++ b/xclim/downscaling/grouping.py
@@ -1,0 +1,66 @@
+"""Grouping classes"""
+import xarray as xr
+
+from .utils import ParametrizableClass
+
+
+class BaseGrouping(ParametrizableClass):
+    def group(self, da: xr.DataArray):
+        return self._group(da)
+
+    def add_group_axis(self, da: xr.DataArray):
+        return self._add_group_axis(da)
+
+    def _group(self, da):
+        raise NotImplementedError
+
+    def _add_group_axis(self, da):
+        raise NotImplementedError
+
+
+class EmptyGrouping(BaseGrouping):
+    def _group(self, da):
+        return da.expand_dims(group=xr.DataArray([1], dims=("group",), name="group"))
+
+    def _add_group_axis(self, da):
+        return da.assign_coords(
+            group=xr.DataArray([1.0] * da["time"].size, dims=("time",), name="group")
+        )
+
+
+class MonthGrouping(BaseGrouping):
+    def _group(self, da):
+        group = da.time.dt.month
+        group.name = "group"
+        group.attrs.update(group_name="month")
+        return da.groupby(group)
+
+    def _add_group_axis(self, da):
+        group = da.time.dt.month - 0.5 + da.time.dt.day / da.time.dt.daysinmonth
+        group.name = "group"
+        group.attrs.update(group_name="month")
+        return da.assign_coords(group=group)
+
+
+class DOYGrouping(BaseGrouping):
+    def __init__(self, window=None):
+        super().__init__(self, window=window)
+
+    def _group(self, da):
+        group = da.time.dt.dayofyear
+        group.name = "group"
+        group.attrs.update(group_name="dayofyear")
+        if self.window is not None:
+            da = da.rolling(time=self.window, center=True).construct(
+                window_dim="window"
+            )
+            group = xr.concat([group] * self.window, da.window)
+            da.rename(time="old_time").stack(time=("old_time", "window"))
+            group.rename(time="old_time").stack(time=("old_time", "window"))
+        return da.groupby(group)
+
+    def _add_group_axis(self, da):
+        group = da.time.dt.dayofyear
+        group.name = "group"
+        group.attrs.update(group_name="dayofyear")
+        return da.assign_coords(group=group)

--- a/xclim/downscaling/mapping.py
+++ b/xclim/downscaling/mapping.py
@@ -1,0 +1,92 @@
+"""Mapping classes"""
+from typing import Union
+from warnings import warn
+
+import numpy as np
+import xarray as xr
+from xarray.core.dataarray import DataArray
+from xarray.core.groupby import DataArrayGroupBy
+
+from .utils import ADDITIVE
+from .utils import MULTIPLICATIVE
+from .utils import ParametrizableClass
+
+
+class BaseMapping(ParametrizableClass):
+
+    __fitted = False
+
+    def fit(
+        self,
+        obs: Union[DataArray, DataArrayGroupBy],
+        sim: Union[DataArray, DataArrayGroupBy],
+    ):
+        if self.__fitted:
+            warn("fit() was already called, overwriting old results.")
+        self._fit(obs, sim)
+        self.__fitted = True
+
+    def predict(self, fut: xr.DataArray):
+        if not self.__fitted:
+            raise ValueError("fit() must be called before predicting.")
+        return self._predict(fut)
+
+    def _fit(self):
+        raise NotImplementedError
+
+    def _predict(self, fut):
+        raise NotImplementedError
+
+
+class DeltaMapping(BaseMapping):
+    def _fit(self, obs, sim):
+        self._delta = obs.mean("time") - sim.mean("time")
+
+    def _predict(self, fut):
+        return fut + self._delta
+
+
+class ScaleMapping(BaseMapping):
+    def _fit(self, obs, sim):
+        self._scale = obs.mean("time") / sim.mean("time")
+
+    def _predict(self, fut):
+        return fut * self._scale
+
+
+class QuantileMapping(BaseMapping):
+    def __init__(self, nquantiles=20, kind=ADDITIVE, interp=False):
+        super().__init__(nquantiles=nquantiles, kind=kind, interp=interp)
+
+    def _fit(self, obs, sim):
+        self._dq = (1 / self.nquantiles) / 2
+        self._quantiles = np.append(
+            np.insert(np.linspace(self._dq, 1 - self._dq, self.nquantiles), 0, 0.0001),
+            0.9999,
+        )
+
+        obsq = obs.quantile(self._quantiles, dim="time")
+        simq = sim.quantile(self._quantiles, dim="time")
+
+        if self.kind == MULTIPLICATIVE:
+            self._qmfit = simq / obsq
+        elif self.kind == ADDITIVE:
+            self._qmfit = simq - obsq
+
+    def _predict(self, fut):
+        if self.interp:
+            raise NotImplementedError
+
+        futq = fut.rank(dim="time", pct=True)
+
+        if self.interp:
+            factor = self._qmfit.interp(quantile=futq, group=futq.group)
+        else:
+            factor = self._qmfit.sel(quantile=futq, group=futq.group, method="nearest")
+
+        if self.kind == MULTIPLICATIVE:
+            out = fut * factor
+        elif self.kind == ADDITIVE:
+            out = fut + factor
+
+        return out.drop("quantile")

--- a/xclim/downscaling/pipeline.py
+++ b/xclim/downscaling/pipeline.py
@@ -1,0 +1,30 @@
+"""Pipeline objects"""
+from xarray import DataArray
+
+from .detrending import NoDetrend
+from .grouping import EmptyGrouping
+from .mapping import DeltaMapping
+
+
+def basicpipeline(
+    obs: DataArray,
+    sim: DataArray,
+    fut: DataArray,
+    detrender=NoDetrend(),
+    grouper=EmptyGrouping(),
+    mapper=DeltaMapping(),
+):
+    obs_trend = detrender.fit(obs)
+    sim_trend = detrender.fit(sim)
+    fut_trend = detrender.fit(fut)
+
+    obs = obs_trend.detrend(obs)
+    sim = sim_trend.detrend(sim)
+    fut = fut_trend.detrend(fut)
+
+    mapper.fit(grouper.group(obs), grouper.group(sim))
+    fut_corr = mapper.predict(grouper.add_group_axis(fut))
+
+    fut_corr = fut_trend.retrend(fut_corr)
+
+    return fut_corr.drop_vars("group")

--- a/xclim/downscaling/utils.py
+++ b/xclim/downscaling/utils.py
@@ -1,0 +1,21 @@
+"""Utilities for the downscaling module"""
+MULTIPLICATIVE = "*"
+ADDITIVE = "+"
+
+
+class ParametrizableClass(object):
+    """Helper base class that sets as attribute every kwarg it receives in __init__.
+
+    Parameters are all public attributes. Subclasses should use private attributes (starting with _).
+    """
+
+    def __init__(self, **kwargs):
+        for key, val in kwargs.items():
+            setattr(self, key, val)
+
+    @property
+    def parameters(self):
+        """Return all parameters as a dictionary"""
+        return {
+            key: val for key, val in self.__dict__.items() if not key.startswith("_")
+        }


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->

Development of a new `xclim.downscaling` module for downscaling and post-processing of climate data.  Decision was made to implement our own version because we wanted to stay as close as possible to the xclim way-of-life, i.e.: 1) follow xarray and dask tightly, with a minimum of other dependencies, 2) a programming style that is easy to understand for science people already used to xarray.   The main alternative, `scikit-downscale` did not completely fit both conditions.

Moreover, after discussion with @Paattrriicckk, we wanted something that is not Method-specific, but rather modular. C-à-d: We don't want a "Cannon et al. (2015)" method, but rather a bias-correction pipeline that uses this kind of detrending and this other kind of mapping with these specific parameters. Thus, what I suggest here is as follows:

Each substep of the process has different flavors : Different subclasses of a main generic class.  The final processing is either done by provided "pipelines" or just by the user chaining appropriate instances 

Copy from the doc in xclim/downscaling/__init__.py:

> What the use calls is a "Pipeline".
> Given a detrending, a grouping and a mapping object, a typical pipeline would call:
> 
> - detrend.fit() + detrend.detrend() on each of obs, sim and fut
> - grouping.group() on obs and sim
> - mapping.fit() on obs+sim
> - grouping.add_group_axis() on fut
> - mapping.predict() on fut
> - detrend.retrend() on fut
> 
> The whole module assumes the bias-correction is made along coord "time", for each group in coord "group", independent of any other coordinates.
> 
> The Detrending objects will detrend/retrend DataArrays along "time".
> 
> The Grouping objects will group elements of a DataArray along time and give back either a DataArrayGroupBy or a DataArray object with a time coord on which mapping should be done.
> Once the action called, the new dimension is called "group" and has a "group_name" attribute with the real group name (the one a simple groupby(dim) would have given.)
> Also, the add_group_axis() method, adds a coord that says where is each element along the time coord in the group. Ex : If the grouping is monthly, the 15th of April  group = 4, the 30th group = 4.5.
> 
> The Mapping objects perform a fit from obs and sim, the reference observation and the simulated climate for the same reference period, the fit is performed point-wise and group-wise, along "time".
> Then, the predict() method takes in fut, the simulated climate for the projection period, that must have a "time" and a "group" coord, as given by the add_group_axis() grouping method.
> It returns the corrected fut timeseries.

Example from `pipeline.py`
```python
def basicpipeline(
    obs: DataArray,
    sim: DataArray,
    fut: DataArray,
    detrender=NoDetrend(),
    grouper=EmptyGrouping(),
    mapper=DeltaMapping(),
):
    obs_trend = detrender.fit(obs)  # <- Each call to fit() returns a new copy of the detrending object
    sim_trend = detrender.fit(sim)  #    that has __fitted == True.
    fut_trend = detrender.fit(fut)

    obs = obs_trend.detrend(obs)
    sim = sim_trend.detrend(sim)
    fut = fut_trend.detrend(fut)

    mapper.fit(grouper.group(obs), grouper.group(sim))  # <- compute fitting parameters
    fut_corr = mapper.predict(grouper.add_group_axis(fut))  # <- apply them

    fut_corr = fut_trend.retrend(fut_corr)

    return fut_corr
```

In the current structure, instances of detrending, grouping and mapping classes are initialized with their parameters and then used on data. Subclasses should only implement the private (with '_') versions of the methods so that the generic classes take care of basic checks and that the signature stays the same always.


This is all work-in-progress, what looks now simple might be not as maintainable as I think.... Let's discuss it here!

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
No