### PR TITLE
Render CRS metadata written to projected files CF-compliant

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 0.16.x
 ------
 * Allow lazy units conversion
+* CRS definitions of projected DataSets are now written to file according to Climate and Forecast-convention standards
 
 0.15.x (2020-03-12)
 -------------------

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
  - defaults
 dependencies:
  - numpy>=1.16
- - xarray>=0.14.1
+ - xarray>=0.14.1,<=0.15.0
  - scipy>=1.2
  - numba
  - pandas>=0.23

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.15.0
+current_version = 0.15.1-beta
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+).(?P<patch>\d+)(\-(?P<release>[a-z]+))?

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ URL = "https://github.com/Ouranosinc/xclim"
 AUTHOR = "Travis Logan"
 AUTHOR_EMAIL = "logan.travis@ouranos.ca"
 REQUIRES_PYTHON = ">=3.6.0"
-VERSION = "0.15.0"
+VERSION = "0.15.1-beta"
 LICENSE = "Apache Software License 2.0"
 
 with open("README.rst") as readme_file:

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open("HISTORY.rst") as history_file:
 
 requirements = [
     "numpy>=1.16",
-    "xarray==0.15.0",
+    "xarray>=0.14.1,<=0.15.0",
     "scipy>=1.2",
     "numba",
     "pandas>=0.23",

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open("HISTORY.rst") as history_file:
 
 requirements = [
     "numpy>=1.16",
-    "xarray>=0.14.1",
+    "xarray==0.15.0",
     "scipy>=1.2",
     "numba",
     "pandas>=0.23",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,16 @@
+from pathlib import Path
+
 import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
 
 from xclim.core.calendar import calendars
+
+
+@pytest.fixture
+def tmp_netcdf_filename(tmpdir):
+    return Path(tmpdir).joinpath("testfile.nc")
 
 
 @pytest.fixture

--- a/tests/test_subset.py
+++ b/tests/test_subset.py
@@ -608,7 +608,7 @@ class TestSubsetShape:
                     sub[vari].sel(lon=lon1, lat=lat1), ds[vari].sel(lon=lon1, lat=lat1)
                 )
 
-    def test_wraps(self):
+    def test_wraps(self, tmp_netcdf_filename):
         ds = xr.open_dataset(self.nc_file)
 
         # Polygon crosses meridian, a warning should be raised
@@ -631,6 +631,11 @@ class TestSubsetShape:
 
         assert sub.crs.prime_meridian_name == "Greenwich"
         assert sub.crs.grid_mapping_name == "latitude_longitude"
+
+        sub.to_netcdf(tmp_netcdf_filename)
+        assert tmp_netcdf_filename.exists()
+        with xr.open_dataset(filename_or_obj=tmp_netcdf_filename) as f:
+            assert {"tas", "crs"}.issubset(set(f.data_vars))
 
     def test_no_wraps(self):
         ds = xr.open_dataset(self.nc_file)
@@ -698,7 +703,7 @@ class TestSubsetShape:
             not in [q.message for q in record]
         )
 
-    def test_small_poly_buffer(self):
+    def test_small_poly_buffer(self, tmp_netcdf_filename):
         ds = xr.open_dataset(self.nc_file)
 
         with pytest.raises(ValueError):
@@ -714,6 +719,11 @@ class TestSubsetShape:
 
         assert sub.crs.prime_meridian_name == "Greenwich"
         assert sub.crs.grid_mapping_name == "latitude_longitude"
+
+        sub.to_netcdf(tmp_netcdf_filename)
+        assert tmp_netcdf_filename.exists()
+        with xr.open_dataset(filename_or_obj=tmp_netcdf_filename) as f:
+            assert {"tas", "crs"}.issubset(set(f.data_vars))
 
     def test_mask_multiregions(self):
         ds = xr.open_dataset(self.nc_file)

--- a/tests/test_subset.py
+++ b/tests/test_subset.py
@@ -629,6 +629,9 @@ class TestSubsetShape:
             float(np.mean(subtas.isel(time=0))), 281.091553
         )
 
+        assert sub.crs.prime_meridian_name == "Greenwich"
+        assert sub.crs.grid_mapping_name == "latitude_longitude"
+
     def test_no_wraps(self):
         ds = xr.open_dataset(self.nc_file)
 
@@ -708,6 +711,9 @@ class TestSubsetShape:
         self.compare_vals(ds, sub, "tas")
         assert len(sub.lon.values) == 3
         assert len(sub.lat.values) == 3
+
+        assert sub.crs.prime_meridian_name == "Greenwich"
+        assert sub.crs.grid_mapping_name == "latitude_longitude"
 
     def test_mask_multiregions(self):
         ds = xr.open_dataset(self.nc_file)

--- a/xclim/__init__.py
+++ b/xclim/__init__.py
@@ -8,4 +8,4 @@ from xclim.indicators import seaIce
 
 __author__ = """Travis Logan"""
 __email__ = "logan.travis@ouranos.ca"
-__version__ = "0.15.0"
+__version__ = "0.15.1-beta"

--- a/xclim/subset.py
+++ b/xclim/subset.py
@@ -486,7 +486,7 @@ def subset_shape(
 
     if ds_copy.lon.size == 0 or ds_copy.lat.size == 0:
         raise ValueError(
-            "No gridcell centroids found within provided polygon bounding box. "
+            "No grid cell centroids found within provided polygon bounding box. "
             'Try using the "buffer" option to create an expanded area'
         )
 
@@ -530,7 +530,7 @@ def subset_shape(
             CRS(4326).to_proj4() != raster_crs
         ):
             warnings.warn(
-                "CRS definitions are not similar or both not using WGS84 datum. Caveat emptor.",
+                "CRS definitions are not similar or both not using WGS84 datum. Tread with caution.",
                 UserWarning,
                 stacklevel=3,
             )
@@ -541,8 +541,8 @@ def subset_shape(
 
     if np.all(mask_2d.isnull()):
         raise ValueError(
-            "No gridcell centroids found within provided polygon. "
-            'Try using the "buffer" option to create an expanded areas or verify polygon '
+            f"No grid cell centroids found within provided polygon bounds ({poly.bounds}). "
+            'Try using the "buffer" option to create an expanded areas or verify polygon.'
         )
 
     # loop through variables
@@ -555,10 +555,12 @@ def subset_shape(
         mask_2d = mask_2d.dropna(dim, how="all")
     ds_copy = ds_copy.sel({dim: mask_2d[dim] for dim in mask_2d.dims})
 
-    # Add a CRS definition as a coordinate for reference purposes
+    # Add a CRS definition using CF conventions and as a global attribute WKT for reference purposes
     if wrap_lons:
-        ds_copy.coords["crs"] = 0
-        ds_copy.coords["crs"].attrs = dict(spatial_ref=wgs84)
+        ds_copy.attrs["crs"] = wgs84.to_string()
+        ds_copy["crs"] = 1
+        for key, val in wgs84.to_cf().items():
+            ds_copy["crs"].attrs[key] = val
 
     if isinstance(ds, xarray.DataArray):
         return ds._from_temp_dataset(ds_copy)

--- a/xclim/subset.py
+++ b/xclim/subset.py
@@ -562,7 +562,7 @@ def subset_shape(
         ds_copy["crs"].attrs.update(wgs84.to_cf())
 
         for v in ds_copy.variables:
-            if len(ds_copy[v].dims) >= 3:
+            if {"lat", "lon"}.issubset(set(ds_copy[v].dims)):
                 ds_copy[v].attrs["grid_mapping"] = "crs"
 
     if isinstance(ds, xarray.DataArray):

--- a/xclim/subset.py
+++ b/xclim/subset.py
@@ -559,8 +559,7 @@ def subset_shape(
     if wrap_lons:
         ds_copy.attrs["crs"] = wgs84.to_string()
         ds_copy["crs"] = 1
-        for key, val in wgs84.to_cf().items():
-            ds_copy["crs"].attrs[key] = val
+        ds_copy["crs"].attrs.update(wgs84.to_cf())
 
     if isinstance(ds, xarray.DataArray):
         return ds._from_temp_dataset(ds_copy)

--- a/xclim/subset.py
+++ b/xclim/subset.py
@@ -561,6 +561,10 @@ def subset_shape(
         ds_copy["crs"] = 1
         ds_copy["crs"].attrs.update(wgs84.to_cf())
 
+        for v in ds_copy.variables:
+            if len(ds_copy[v].dims) >= 3:
+                ds_copy[v].attrs["grid_mapping"] = "crs"
+
     if isinstance(ds, xarray.DataArray):
         return ds._from_temp_dataset(ds_copy)
     return ds_copy


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #396 
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [x] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
This removes the CRS coordinate as this was introduced as a makeshift means of recording CRS metadata despite there being guidelines on how best to do so. CRS is now saved as a CF-compliant variable with appropriate WKT strings for pertinent information.

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
No. In fact, it reverts a change that was breaking introduced in v0.15.0

* **Other information**:
This PR is presently missing one final feature, which is to add the `gird_mapping` entry to the NetCDF variable attribute. This should be added before merging.