### PR TITLE
Employ `assign_coords` to address api deprecations in 0.15.1

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
  - defaults
 dependencies:
  - numpy>=1.16
- - xarray>=0.14.1,<=0.15.0
+ - xarray>=0.14.1
  - scipy>=1.2
  - numba
  - pandas>=0.23

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open("HISTORY.rst") as history_file:
 
 requirements = [
     "numpy>=1.16",
-    "xarray>=0.14.1,<=0.15.0",
+    "xarray>=0.14.1",
     "scipy>=1.2",
     "numba",
     "pandas>=0.23",

--- a/tests/test_subset.py
+++ b/tests/test_subset.py
@@ -41,7 +41,7 @@ class TestSubsetGridPoint:
         np.testing.assert_almost_equal(out.lat, lat, 1)
 
         da = xr.open_dataset(self.nc_poslons).tas
-        da["lon"] -= 360
+        da = da.assign_coords(lon=(da.lon - 360))
         yr_st = 2050
         yr_ed = 2059
 
@@ -66,7 +66,7 @@ class TestSubsetGridPoint:
         lat = 46.1
 
         da = xr.open_dataset(self.nc_poslons).tas
-        da["lon"] -= 360
+        da = da.assign_coords(lon=(da.lon - 360))
         yr_st = "2050"
         yr_ed = "2059"
 
@@ -95,7 +95,7 @@ class TestSubsetGridPoint:
 
     def test_time_dates_outofbounds(self):
         da = xr.open_dataset(self.nc_poslons).tas
-        da["lon"] -= 360
+        da = da.assign_coords(lon=(da.lon - 360))
         yr_st = "1950"
         yr_ed = "2099"
 
@@ -108,7 +108,7 @@ class TestSubsetGridPoint:
 
     def test_time_start_only(self):
         da = xr.open_dataset(self.nc_poslons).tas
-        da["lon"] -= 360
+        da = da.assign_coords(lon=(da.lon - 360))
         yr_st = "2050"
 
         # start date only
@@ -135,7 +135,7 @@ class TestSubsetGridPoint:
     def test_time_end_only(self):
 
         da = xr.open_dataset(self.nc_poslons).tas
-        da["lon"] -= 360
+        da = da.assign_coords(lon=(da.lon - 360))
 
         yr_ed = "2059"
 
@@ -156,7 +156,7 @@ class TestSubsetGridPoint:
 
     def test_time_incomplete_years(self):
         da = xr.open_dataset(self.nc_poslons).tas
-        da["lon"] -= 360
+        da = da.assign_coords(lon=(da.lon - 360))
         yr_st = "2050"
         yr_ed = "2059"
 
@@ -314,7 +314,7 @@ class TestSubsetBbox:
         assert np.all(out.lat <= np.max(self.lat))
 
         da = xr.open_dataset(self.nc_poslons).tas
-        da["lon"] -= 360
+        da = da.assign_coords(lon=(da.lon - 360))
         yr_st = 2050
         yr_ed = 2059
 
@@ -486,7 +486,7 @@ class TestSubsetBbox:
 
     def test_time(self):
         da = xr.open_dataset(self.nc_poslons).tas
-        da["lon"] -= 360
+        da = da.assign_coords(lon=(da.lon - 360))
 
         out = subset.subset_bbox(
             da,
@@ -545,7 +545,7 @@ class TestSubsetBbox:
 
     def test_warnings(self):
         da = xr.open_dataset(self.nc_poslons).tas
-        da["lon"] -= 360
+        da = da.assign_coords(lon=(da.lon - 360))
 
         with pytest.warns(FutureWarning):
             subset.subset_bbox(


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #405 
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
Unpins xarray to allow 0.15.1 and changes API usage in tests  

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
Yes? Performing operations on a coordinate now REQUIRES `DataArray.assign_coords(dict( ... ))`, Operations like `da["lon"] += 180` will now loudly fail.

* **Other information**:
This is more of a hotfix to keep us in line with `xarray`. I don't think this requires a History update or a `bump2version patch`.
