### PR TITLE
Fix run-with-dates bugs and fix #403

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,8 @@ History
 * CRS definitions of projected DataSets are now written to file according to Climate and Forecast-convention standards
 * Add utilities to merge attributes and update history in xclim.core.formatting
 * Ensembles : Allow alignment of datasets with same frequency but different offsets
+* Bug fixes in run_length for run-with-dates methods when the date is not found in the run.
+* Remove deepcopy from subset.subset_shape to improve memory usage.
 
 0.15.x (2020-03-12)
 -------------------

--- a/tests/test_run_length.py
+++ b/tests/test_run_length.py
@@ -37,15 +37,15 @@ class TestLongestRun:
         )
         values[1:11] = 1
         da = xr.DataArray(values != 0, coords={"time": time}, dims="time")
-        lt = da.resample(time="M").apply(rl.longest_run_ufunc)
+        lt = da.resample(time="M").map(rl.longest_run_ufunc)
         assert lt[0] == 10
         np.testing.assert_array_equal(lt[1:], 0)
 
         # n-dim version versus ufunc
         da3d = xr.open_dataset(self.nc_pr).pr[:, 40:50, 50:68] != 0
-        lt_orig = da3d.resample(time="M").apply(rl.longest_run_ufunc)
+        lt_orig = da3d.resample(time="M").map(rl.longest_run_ufunc)
         # override 'auto' usage of ufunc for small number of gridpoints
-        lt_Ndim = da3d.resample(time="M").apply(
+        lt_Ndim = da3d.resample(time="M").map(
             rl.longest_run, dim="time", ufunc_1dim=False
         )
         np.testing.assert_array_equal(lt_orig, lt_Ndim)
@@ -57,7 +57,7 @@ class TestLongestRun:
         )
         values[0:10] = 1
         da = xr.DataArray(values != 0, coords={"time": time}, dims="time")
-        lt = da.resample(time="M").apply(rl.longest_run_ufunc)
+        lt = da.resample(time="M").map(rl.longest_run_ufunc)
         assert lt[0] == 10
         np.testing.assert_array_equal(lt[1:], 0)
 
@@ -65,9 +65,9 @@ class TestLongestRun:
         da3d = xr.open_dataset(self.nc_pr).pr[:, 40:50, 50:68] * 0
         da3d[0:10,] = da3d[0:10,] + 1
         da3d = da3d == 1
-        lt_orig = da3d.resample(time="M").apply(rl.longest_run_ufunc)
+        lt_orig = da3d.resample(time="M").map(rl.longest_run_ufunc)
         # override 'auto' usage of ufunc for small number of gridpoints
-        lt_Ndim = da3d.resample(time="M").apply(
+        lt_Ndim = da3d.resample(time="M").map(
             rl.longest_run, dim="time", ufunc_1dim=False
         )  # override 'auto' for small
         np.testing.assert_array_equal(lt_orig, lt_Ndim)
@@ -80,7 +80,7 @@ class TestLongestRun:
         values[-10:] = 1
         da = xr.DataArray(values != 0, coords={"time": time}, dims="time")
 
-        lt = da.resample(time="M").apply(rl.longest_run_ufunc)
+        lt = da.resample(time="M").map(rl.longest_run_ufunc)
         assert lt[-1] == 10
         np.testing.assert_array_equal(lt[:-1], 0)
 
@@ -88,8 +88,8 @@ class TestLongestRun:
         da3d = xr.open_dataset(self.nc_pr).pr[:, 40:50, 50:68] * 0
         da3d[-10:,] = da3d[-10:,] + 1
         da3d = da3d == 1
-        lt_orig = da3d.resample(time="M").apply(rl.longest_run_ufunc)
-        lt_Ndim = da3d.resample(time="M").apply(
+        lt_orig = da3d.resample(time="M").map(rl.longest_run_ufunc)
+        lt_Ndim = da3d.resample(time="M").map(
             rl.longest_run, dim="time", ufunc_1dim=False
         )
         np.testing.assert_array_equal(lt_orig, lt_Ndim)
@@ -101,14 +101,14 @@ class TestLongestRun:
         )
         da = xr.DataArray(values != 0, coords={"time": time}, dims="time")
 
-        lt = da.resample(time="M").apply(rl.longest_run_ufunc)
+        lt = da.resample(time="M").map(rl.longest_run_ufunc)
         np.testing.assert_array_equal(lt, da.resample(time="M").count(dim="time"))
 
         # n-dim version versus ufunc
         da3d = xr.open_dataset(self.nc_pr).pr[:, 40:50, 50:68] * 0 + 1
         da3d = da3d == 1
-        lt_orig = da3d.resample(time="M").apply(rl.longest_run_ufunc)
-        lt_Ndim = da3d.resample(time="M").apply(
+        lt_orig = da3d.resample(time="M").map(rl.longest_run_ufunc)
+        lt_Ndim = da3d.resample(time="M").map(
             rl.longest_run, dim="time", ufunc_1dim=False
         )
         np.testing.assert_array_equal(lt_orig, lt_Ndim)
@@ -121,7 +121,7 @@ class TestLongestRun:
         )
         da = xr.DataArray(values != 0, coords={"time": time}, dims="time")
 
-        lt = da.resample(time="M").apply(rl.longest_run_ufunc)
+        lt = da.resample(time="M").map(rl.longest_run_ufunc)
         n = da.resample(time="M").count(dim="time")
         np.testing.assert_array_equal(lt[0], n[0])
         np.testing.assert_array_equal(lt[1], 26)
@@ -130,8 +130,8 @@ class TestLongestRun:
         da3d = xr.open_dataset(self.nc_pr).pr[:, 40:50, 50:68] * 0 + 1
         da3d[35,] = da3d[35,] + 1
         da3d = da3d == 1
-        lt_orig = da3d.resample(time="M").apply(rl.longest_run_ufunc)
-        lt_Ndim = da3d.resample(time="M").apply(
+        lt_orig = da3d.resample(time="M").map(rl.longest_run_ufunc)
+        lt_Ndim = da3d.resample(time="M").map(
             rl.longest_run, dim="time", ufunc_1dim=False
         )
         np.testing.assert_array_equal(lt_orig, lt_Ndim)
@@ -186,8 +186,8 @@ class TestWindowedRunEvents:
 
         # n-dim version versus ufunc
         da3d = xr.open_dataset(self.nc_pr).pr[:, 40:50, 50:68] != 0
-        lt_orig = da3d.resample(time="M").apply(rl.windowed_run_events_ufunc, window=4)
-        lt_Ndim = da3d.resample(time="M").apply(
+        lt_orig = da3d.resample(time="M").map(rl.windowed_run_events_ufunc, window=4)
+        lt_Ndim = da3d.resample(time="M").map(
             rl.windowed_run_events, window=4, dim="time", ufunc_1dim=False
         )
         np.testing.assert_array_equal(lt_orig, lt_Ndim)
@@ -204,8 +204,8 @@ class TestWindowedRunCount:
 
         # n-dim version versus ufunc
         da3d = xr.open_dataset(self.nc_pr).pr[:, 40:50, 50:68] != 0
-        lt_orig = da3d.resample(time="M").apply(rl.windowed_run_count_ufunc, window=4)
-        lt_Ndim = da3d.resample(time="M").apply(
+        lt_orig = da3d.resample(time="M").map(rl.windowed_run_count_ufunc, window=4)
+        lt_Ndim = da3d.resample(time="M").map(
             rl.windowed_run_count, window=4, dim="time", ufunc_1dim=False
         )
         np.testing.assert_array_equal(lt_orig, lt_Ndim)
@@ -305,3 +305,20 @@ class TestRunsWithDates:
             runs, window=1, date=date, dim="time", coord=coord
         )
         np.testing.assert_array_equal(np.mean(out.load()), expected)
+
+    @pytest.mark.parametrize(
+        "func",
+        [rl.last_run_before_date, rl.run_end_after_date, rl.run_length_with_date],
+    )
+    @pytest.mark.parametrize("use_dask", [True, False])
+    def test_run_with_dates_no_date(self, tas_series, use_dask, func):
+        t = np.ones(90)
+        tas = tas_series(t, start="2000-01-01")
+        runs = xr.concat((tas, tas), dim="dim0")
+        runs = runs == 1
+
+        if use_dask:
+            runs = runs.chunk({"time": 10, "dim0": 1})
+
+        out = runs.resample(time="MS").map(func, window=1, date="07-01", dim="time")
+        assert out.isnull().all()

--- a/xclim/indices/_multivariate.py
+++ b/xclim/indices/_multivariate.py
@@ -107,7 +107,7 @@ def cold_spell_duration_index(
 
     below = tasmin < thresh
 
-    return below.resample(time=freq).apply(
+    return below.resample(time=freq).map(
         rl.windowed_run_count, window=window, dim="time"
     )
 
@@ -565,7 +565,7 @@ def heat_wave_frequency(
 
     cond = (tasmin > thresh_tasmin) & (tasmax > thresh_tasmax)
     group = cond.resample(time=freq)
-    return group.apply(rl.windowed_run_events, window=window, dim="time")
+    return group.map(rl.windowed_run_events, window=window, dim="time")
 
 
 @declare_units(
@@ -636,7 +636,7 @@ def heat_wave_max_length(
 
     cond = (tasmin > thresh_tasmin) & (tasmax > thresh_tasmax)
     group = cond.resample(time=freq)
-    max_l = group.apply(rl.longest_run, dim="time")
+    max_l = group.map(rl.longest_run, dim="time")
     return max_l.where(max_l >= window, 0)
 
 
@@ -691,7 +691,7 @@ def heat_wave_total_length(
 
     cond = (tasmin > thresh_tasmin) & (tasmax > thresh_tasmax)
     group = cond.resample(time=freq)
-    return group.apply(rl.windowed_run_count, args=(window,), dim="time")
+    return group.map(rl.windowed_run_count, args=(window,), dim="time")
 
 
 @declare_units("", pr="[precipitation]", prsn="[precipitation]", tas="[temperature]")
@@ -1374,7 +1374,7 @@ def warm_spell_duration_index(
 
     above = tasmax > thresh
 
-    return above.resample(time=freq).apply(
+    return above.resample(time=freq).map(
         rl.windowed_run_count, window=window, dim="time"
     )
 

--- a/xclim/indices/_simple.py
+++ b/xclim/indices/_simple.py
@@ -414,7 +414,7 @@ def consecutive_frost_days(tasmin: xarray.DataArray, freq: str = "AS-JUL"):
     if fu != tu:
         frz = units.convert(frz, fu, tu)
     group = (tasmin < frz).resample(time=freq)
-    return group.apply(rl.longest_run, dim="time")
+    return group.map(rl.longest_run, dim="time")
 
 
 @declare_units("days", tasmin="[temperature]")

--- a/xclim/indices/_threshold.py
+++ b/xclim/indices/_threshold.py
@@ -89,7 +89,7 @@ def cold_spell_days(
     over = tas < t
     group = over.resample(time=freq)
 
-    return group.apply(rl.windowed_run_count, window=window, dim="time")
+    return group.map(rl.windowed_run_count, window=window, dim="time")
 
 
 @declare_units("mm/day", pr="[precipitation]", thresh="[precipitation]")
@@ -223,7 +223,7 @@ def maximum_consecutive_wet_days(
     thresh = convert_units_to(thresh, pr, "hydro")
 
     group = (pr > thresh).resample(time=freq)
-    return group.apply(rl.longest_run, dim="time")
+    return group.map(rl.longest_run, dim="time")
 
 
 @declare_units("C days", tas="[temperature]", thresh="[temperature]")
@@ -458,7 +458,7 @@ def growing_season_length(
     )
 
 
-@declare_units("days", tas="[temperature]", thresh="[temperature]")
+@declare_units("", tas="[temperature]", thresh="[temperature]")
 def last_spring_frost(
     tas: xarray.DataArray,
     thresh: str = "0 degC",
@@ -533,7 +533,7 @@ def heat_wave_index(
     over = tasmax > thresh
     group = over.resample(time=freq)
 
-    return group.apply(rl.windowed_run_count, window=window, dim="time")
+    return group.map(rl.windowed_run_count, window=window, dim="time")
 
 
 @declare_units("C days", tas="[temperature]", thresh="[temperature]")
@@ -628,7 +628,7 @@ def hot_spell_max_length(
 
     cond = tasmax > thresh_tasmax
     group = cond.resample(time=freq)
-    max_l = group.apply(rl.longest_run, dim="time")
+    max_l = group.map(rl.longest_run, dim="time")
     return max_l.where(max_l >= window, 0)
 
 
@@ -686,7 +686,7 @@ def hot_spell_frequency(
 
     cond = tasmax > thresh_tasmax
     group = cond.resample(time=freq)
-    return group.apply(rl.windowed_run_events, window=window, dim="time")
+    return group.map(rl.windowed_run_events, window=window, dim="time")
 
 
 @declare_units("days", tasmin="[temperature]", thresh="[temperature]")
@@ -901,7 +901,7 @@ def maximum_consecutive_dry_days(
     t = convert_units_to(thresh, pr, "hydro")
     group = (pr < t).resample(time=freq)
 
-    return group.apply(rl.longest_run, dim="time")
+    return group.map(rl.longest_run, dim="time")
 
 
 @declare_units("days", tasmin="[temperature]", thresh="[temperature]")
@@ -944,7 +944,7 @@ def maximum_consecutive_frost_free_days(
     t = convert_units_to(thresh, tasmin)
     group = (tasmin > t).resample(time=freq)
 
-    return group.apply(rl.longest_run, dim="time")
+    return group.map(rl.longest_run, dim="time")
 
 
 @declare_units("days", tasmax="[temperature]", thresh="[temperature]")
@@ -987,7 +987,7 @@ def maximum_consecutive_tx_days(
     t = convert_units_to(thresh, tasmax)
     group = (tasmax > t).resample(time=freq)
 
-    return group.apply(rl.longest_run, dim="time")
+    return group.map(rl.longest_run, dim="time")
 
 
 @declare_units("[area]", sic="[]", area="[area]", thresh="[]")

--- a/xclim/indices/generic.py
+++ b/xclim/indices/generic.py
@@ -69,7 +69,7 @@ def select_resample_op(da: xr.DataArray, op, freq: str = "YS", **indexer):
     if isinstance(op, str):
         return getattr(r, op)(dim="time", keep_attrs=True)
 
-    return r.apply(op)
+    return r.map(op)
 
 
 def doymax(da: xr.DataArray):

--- a/xclim/subset.py
+++ b/xclim/subset.py
@@ -1,4 +1,3 @@
-import copy
 import logging
 import warnings
 from functools import wraps
@@ -458,11 +457,10 @@ def subset_shape(
     """
     wgs84 = CRS("+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs")
 
-    # TODO : edge case using polygon splitting decorator touches original ds when subsetting?
     if isinstance(ds, xarray.DataArray):
-        ds_copy = copy.deepcopy(ds._to_temp_dataset())
+        ds_copy = ds._to_temp_dataset()
     else:
-        ds_copy = copy.deepcopy(ds)
+        ds_copy = ds.copy()
 
     if isinstance(shape, gpd.GeoDataFrame):
         poly = shape.copy()


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #403 and the issue in bird-house/finch#110.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
This fixes bugs in the "run with date" methods of `run_length` that occurred when the date did not appear in the run (for example when resampling on frequencies smaller than a year). Also, I realized that the code structure inherited from when they were in the indices was not necessary, so it's now a bit simpler.

Also, removed the use of `deepcopy` in `subset_shape` as discussed in #403.

Finally, while I'm at it, replaced all uses of `resample().apply()` by `resample().map()`.

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
No

* **Other information**:
There were no documentation changes cause there were no behaviour changes.