### PR TITLE
Calendar conversion

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+0.17.x
+------
+* Added `convert_calendar` and `interp_calendar` to help in the conversion between calendars.
+
 0.16.0 (2020-04-23)
 -------------------
 * Added `vectorize` flag to `subset_shape` and `create_mask_vectorize` function based on `shapely.vectorize` as default backend for mask creation.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pytest
 import xarray as xr
 
-from xclim.core.calendar import calendars
+from xclim.core.calendar import max_doy
 
 
 @pytest.fixture
@@ -151,7 +151,7 @@ def ndq_series():
 @pytest.fixture
 def per_doy():
     def _per_doy(values, calendar="standard", units="kg m-2 s-1"):
-        n = calendars[calendar]
+        n = max_doy[calendar]
         if len(values) != n:
             raise ValueError(
                 "Values must be same length as number of days in calendar."

--- a/xclim/core/calendar.py
+++ b/xclim/core/calendar.py
@@ -7,6 +7,7 @@ Helper function to handle dates, times and different calendars with xarray.
 """
 import datetime as pydt
 from typing import Optional
+from typing import Sequence
 from typing import Union
 from warnings import warn
 
@@ -51,7 +52,7 @@ max_doy = {
 }
 
 
-def get_calendar(arr: xr.DataArray) -> str:
+def get_calendar(arr: Union[xr.DataArray, xr.Dataset]) -> str:
     """Return the calendar of the time coord of the DataArray
 
     Parameters
@@ -290,7 +291,7 @@ def _convert_datetime(
         return np.nan
 
 
-def ensure_cftime_array(time):
+def ensure_cftime_array(time: Sequence):
     """Convert an input 1D array to an array of cftime objects. Python's datetime are converted to cftime.DatetimeGregorian.
 
     Raises ValueError when unable to cast the input.

--- a/xclim/core/calendar.py
+++ b/xclim/core/calendar.py
@@ -82,17 +82,17 @@ def convert_calendar(
     source: Union[xr.DataArray, xr.Dataset], target: Union[xr.DataArray, str],
 ) -> xr.DataArray:
     """Convert a DataArray/Dataset to another calendar using the specified method.
-    Only converts the individual timestamps, does not modify any data excpet in dropping invalid/surplus dates.
+    Only converts the individual timestamps, does not modify any data except in dropping invalid/surplus dates.
 
     If the source and target calendars are either no_leap, all_leap or standard, only the type of the time array is modified.
-    When converting to a leap year from a non-leap year, the 29th of february is simply removed from the array.
+    When converting to a leap year from a non-leap year, the 29th of February is simply removed from the array.
 
-    If one of the source or target calendars is uniform 360 day, the missing/surplus days are added/removed at regular intervals
+    If one of the source or target calendars is `360_day`, the missing/surplus days are added/removed at regular intervals
     and the other days are translated according to their rank in the year (dayofyear), ignoring their original month and day information.
 
-    Between a 360_day and a leap year, the missing days are (day of year in parenthesis:
+    Between a `360_day` and a leap year, the missing days are (day of year in parenthesis:
         February 6th (37), April 21st (111), July 2nd (183), September 14 (257) and November 25th (329).
-    Between a 306_day and a non-leap year, the missing days are:
+    Between a `360_day` and a non-leap year, the missing days are:
         January 31st (31), April 2nd (93), June 1st (153), August 2nd (215), October 1st (275) and December 3rd (337).
 
     This method is safe to use with sub-daily data as it doesn't touch the time part of the timestamps.
@@ -109,7 +109,7 @@ def convert_calendar(
     -------
     Union[xr.DataArray, xr.Dataset]
       Copy of source with the time coordinate converted to the target calendar.
-      The number of element is the same as `target` if an array was given, otherwise it stays the same as `source`.
+      The length of the array is the same as `target` if an array was given, otherwise it stays the same as `source`.
     """
     cal_src = get_calendar(source)
 
@@ -214,7 +214,7 @@ def _convert_datetime(
     datetime: Union[datetime.datetime, cftime.datetime]
       A datetime object to convert.
     new_doy:  Optional[Union[float, int]]
-      Allows for redefening the day of year (thus ignoring month and day information from the source datetime).
+      Allows for redefining the day of year (thus ignoring month and day information from the source datetime).
     calendar: str
       The target calendar
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->

Adds the new `convert_calendar` and `interp_calendar` methods (and some other utilities) to `xclim.core.calendar` to help in conversion of data between calendars.

`convert_calendar` simply modifies the type of the timestamps, not touching the data, unless invalid dates are found (like 29th of Feb on a "noleap" cal). In that case the timeslices (and data) are simply removed. This goes in the sense of #419 as it is completely agnostic of the data frequency.

`interp_calendar` interpolates the data while converting to the new calendar. While the other accepts named calendars, this one needs the target time coordinate. Interpolation is made on the "decimal year" basis, so the decimal number representing the date as a number of years since 1-01-01 AD. As such, it only gives something useful with daily data or coarser.

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->

Yes, I only kept references to calendars available in cftime (+ 'standard'). So I removed "no_leap" (use "noleap") and "uniform30day" (use "360_day").

* **Other information**:
