### PR TITLE
Minor sdba fixes

### DIFF
--- a/tests/test_sdba/test_adjustment.py
+++ b/tests/test_sdba/test_adjustment.py
@@ -39,6 +39,9 @@ class TestLoci:
         p = loci.adjust(sim)
         np.testing.assert_array_almost_equal(p, ref, dec)
 
+        assert "history" in p.attrs
+        assert "Bias-adjusted with method" in p.attrs["history"]
+
 
 class TestScaling:
     @pytest.mark.parametrize("kind,name", [(ADDITIVE, "tas"), (MULTIPLICATIVE, "pr")])
@@ -174,9 +177,8 @@ class TestDQM:
         sim = series(apply_correction(x, trend, kind), name)
 
         if spatial_dims:
-            hist = hist.expand_dims(**spatial_dims)
-            ref = ref.expand_dims(**spatial_dims)
-            sim = sim.expand_dims(**spatial_dims)
+            hist = hist.expand_dims(**spatial_dims).chunk({"lat": 10})
+            sim = sim.expand_dims(**spatial_dims).chunk({"lat": 10})
             ref_t = ref_t.expand_dims(**spatial_dims)
 
         DQM = DetrendedQuantileMapping(kind=kind, group="time.month", nquantiles=5)

--- a/xclim/sdba/adjustment.py
+++ b/xclim/sdba/adjustment.py
@@ -20,6 +20,7 @@ from .utils import get_correction
 from .utils import interp_on_quantiles
 from .utils import map_cdf
 from .utils import MULTIPLICATIVE
+from xclim import __version__
 from xclim.core.calendar import get_calendar
 
 
@@ -88,7 +89,10 @@ class BaseAdjustment(ParametrizableClass):
                 stacklevel=4,
             )
         scen = self._adjust(sim, **kwargs)
-        scen.attrs["bias_adjusted"] = True
+        scen.attrs["history"] = update_history(
+            f"Bias-adjusted with method {str(self)}",
+            sim
+        )
         return scen
 
     def _make_dataset(self, **kwargs):

--- a/xclim/sdba/adjustment.py
+++ b/xclim/sdba/adjustment.py
@@ -20,8 +20,8 @@ from .utils import get_correction
 from .utils import interp_on_quantiles
 from .utils import map_cdf
 from .utils import MULTIPLICATIVE
-from xclim import __version__
 from xclim.core.calendar import get_calendar
+from xclim.core.formatting import update_history
 
 
 class BaseAdjustment(ParametrizableClass):
@@ -90,8 +90,7 @@ class BaseAdjustment(ParametrizableClass):
             )
         scen = self._adjust(sim, **kwargs)
         scen.attrs["history"] = update_history(
-            f"Bias-adjusted with method {str(self)}",
-            sim
+            f"Bias-adjusted with method {str(self)}", sim
         )
         return scen
 

--- a/xclim/sdba/base.py
+++ b/xclim/sdba/base.py
@@ -228,18 +228,19 @@ class Grouper(ParametrizableClass):
         """
         if isinstance(da, dict):
             grpd = self.group(**da)
-            dim_is_chunked = any(map(
-                lambda d: (
-                    d.chunks is not None and
-                    len(d.chunks[d.get_axis_num(self.dim)]) > 1
-                ),
-                da.values()
-            ))
+            dim_is_chunked = any(
+                map(
+                    lambda d: (
+                        d.chunks is not None
+                        and len(d.chunks[d.get_axis_num(self.dim)]) > 1
+                    ),
+                    da.values(),
+                )
+            )
         else:
             grpd = self.group(da)
             dim_is_chunked = (
-                da.chunks is not None and
-                len(da.chunks[da.get_axis_num(self.dim)]) > 1
+                da.chunks is not None and len(da.chunks[da.get_axis_num(self.dim)]) > 1
             )
 
         dims = self.dim
@@ -275,8 +276,11 @@ class Grouper(ParametrizableClass):
             else:
                 out = out.sortby(self.dim)
                 if out.chunks is not None and not dim_is_chunked:
+                    # If the main dim consisted of only one chunk, the expected behavior of downstream
+                    # methods is to conserve this, but grouping rechunks
                     out = out.chunk({self.dim: -1})
         elif self.prop in out.dims and out.chunks is not None:
+            # Same as above : downstream methods expect only one chunk along the group
             out = out.chunk({self.prop: -1})
 
         return out

--- a/xclim/sdba/utils.py
+++ b/xclim/sdba/utils.py
@@ -277,6 +277,7 @@ def add_cyclic_bounds(da: xr.DataArray, att: str, cyclic_coords: bool = True):
         qmf = qmf.assign_coords({att: vals})
         qmf[att].attrs.update(da.coords[att].attrs)
     if da.chunks is not None and len(da.chunks[da.get_axis_num(att)]) == 1:
+        # Downstream methos do not expect this method to change the number of chunks
         return qmf.chunk({att: -1})
     return qmf
 
@@ -363,6 +364,7 @@ def add_endpoints(
     l, r = elems  # pylint: disable=unbalanced-tuple-unpacking
     out = xr.concat((l, da, r), dim=dim)
     if da.chunks is not None and len(da.chunks[da.get_axis_num(dim)]) == 1:
+        # Downstream methos do not expect this method to change the number of chunks
         return out.chunk({dim: -1})
     return out
 
@@ -421,12 +423,13 @@ def interp_on_quantiles(
     # else:
 
     def _interp_quantiles_2D(newx, newg, oldx, oldy, oldg):
-        print('|')
         if method != "nearest":
             oldx = np.clip(oldx, newx.min() - 1, newx.max() + 1)
         if np.all(np.isnan(newx)):
-            warn('All-NaN slice encountered in interp_on_quantiles',
-                 category=RuntimeWarning)
+            warn(
+                "All-NaN slice encountered in interp_on_quantiles",
+                category=RuntimeWarning,
+            )
             return newx
         return griddata(
             (oldx.flatten(), oldg.flatten()),

--- a/xclim/sdba/utils.py
+++ b/xclim/sdba/utils.py
@@ -276,6 +276,8 @@ def add_cyclic_bounds(da: xr.DataArray, att: str, cyclic_coords: bool = True):
         vals[-1] = vals[-2] + diff[-1]
         qmf = qmf.assign_coords({att: vals})
         qmf[att].attrs.update(da.coords[att].attrs)
+    if da.chunks is not None and len(da.chunks[da.get_axis_num(att)]) == 1:
+        return qmf.chunk({att: -1})
     return qmf
 
 
@@ -359,7 +361,10 @@ def add_endpoints(
             y = xr.DataArray(y, coords={dim: x}, dims=(dim,))
         elems.append(y)
     l, r = elems  # pylint: disable=unbalanced-tuple-unpacking
-    return xr.concat((l, da, r), dim=dim)
+    out = xr.concat((l, da, r), dim=dim)
+    if da.chunks is not None and len(da.chunks[da.get_axis_num(dim)]) == 1:
+        return out.chunk({dim: -1})
+    return out
 
 
 @parse_group
@@ -416,8 +421,13 @@ def interp_on_quantiles(
     # else:
 
     def _interp_quantiles_2D(newx, newg, oldx, oldy, oldg):
+        print('|')
         if method != "nearest":
             oldx = np.clip(oldx, newx.min() - 1, newx.max() + 1)
+        if np.all(np.isnan(newx)):
+            warn('All-NaN slice encountered in interp_on_quantiles',
+                 category=RuntimeWarning)
+            return newx
         return griddata(
             (oldx.flatten(), oldg.flatten()),
             oldy.flatten(),


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->

Small tweaks and workarounds that are needed for proper usage of the sdba module.

1) All-NaN slices : `interp_on_quantiles` would fail on all-nan slices, I added a check.

2) Chunking after grouping ops. Dask arrays are returned chunked along the grouped dimension after `groupby` calls, but  sdba was written assuming the main dimension (time) has only one chunk. I added checks and rechunking in `Group.apply`. Moreover,  `add_cyclic_bounds` and `add_endpoints` need to rechunk their output to 1 chunk if the input has only one chunk. If not, sdba also fails.
Here I chose to fix the problems by rechunking the arrays just after the operation that added problematic chunks. I could have done the opposite: rechunk the arrays just before the operation that needs individual chunks (interps and apply_ufuncs)... Any opinions on this?

3) The  `adjust` methods were adding a boolean `bias_adjusted` attribute, but netCDF4 was failing when writing this to disk. I modified by updating the history of `scen`, appending the one of `sim`.

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
No, since nobody uses `sdba` except me.

* **Other information**:
