### PR TITLE
Fix pytest dependency and matplotlib backend switch

### DIFF
--- a/xclim/sdba/__init__.py
+++ b/xclim/sdba/__init__.py
@@ -52,12 +52,14 @@ Most methods acting on grouped data also accept a `window` int argument to pad t
 Units of `window` are the sampling frequency of the main grouping dimension (usually `time`). For more complex grouping,
 one can pass a :py:class:`xclim.sdba.base.Grouper` directly.
 """
-import xarray
-from xarray.tests import LooseVersion
+try:
+    from xarray import polyval  # noqa
+except ImportError as err:
+    raise ImportError("Update xarray to master to use the sdba package.") from err
+else:
+    del polyval
 
 
 # TODO: ISIMIP ? Used for precip freq adjustment in biasCorrection.R
 # Hempel, S., Frieler, K., Warszawski, L., Schewe, J., & Piontek, F. (2013). A trend-preserving bias correction &ndash;
 # The ISI-MIP approach. Earth System Dynamics, 4(2), 219–236. https://doi.org/10.5194/esd-4-219-2013
-if LooseVersion(xarray.__version__) <= "0.15.1":
-    raise ImportError("Update xarray to master to use the sdba package.")


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes a slack-raised issue.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
Change the way we check for the version of xarray. Importing `LooseVersion` from `xarray.test` had the side effects of requiring "pytest" and of switching the backend of matplotlib. 

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
No.

* **Other information**:
