### PR TITLE
Downgrade black to release and add flake8 option to ignore sdba tests errors

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,8 @@ ignore =
 	F403
 	W503
 	W504
+per-file-ignores =
+    tests/*:E402
 
 [aliases]
 test = pytest

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ python =
 basepython = python
 deps =
   flake8
-  -e git://github.com/psf/black.git@master#egg=black
+  black
 commands =
   flake8 xclim tests
   black --check --target-version py36 xclim tests


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #444 
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
This changes the black version that is used in the test builds to the latest release, instead of the master. Pre-commit hooks don't seem to have an option to install a hook directly from a git repo, so it can only use the latest pypi release, which is currently a problem since the master acts differently.

Also, added a flake8 exception in its config to ignore "import not a top of file" in the tests files. We need to put pytest's `importorskip` calls before importing anything from `xclim.sdba`.

This PR is a part of #440 that became a bit crowded.

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->


* **Other information**:
