### PR TITLE
Remove "time" coord from first_run output.

### DIFF
--- a/xclim/indices/run_length.py
+++ b/xclim/indices/run_length.py
@@ -250,7 +250,7 @@ def first_run(
 
         out = lazy_indexing(crd, out)
 
-    if dim in out:
+    if dim in out.coords:
         out = out.drop_vars(dim)
 
     return out


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #458 
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
For some reason, when `first_run` or `last_run` are run with `coords != False`, the array comes back with a `time` coord that contains object of the previous `time` axis. Thus, when using `CFTime` calendars, those are not numpy objects. This was causing errors in dask for some specific cases. 
There was a workaround, but it was wrongly written and wasn't working at all, I fixed it.
I was not able to properly find the source of the issue in #458, but this fixes it...

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
No

* **Other information**:
