### PR TITLE
Use convert_calendar in ensemble alignment

### DIFF
--- a/xclim/ensembles.py
+++ b/xclim/ensembles.py
@@ -264,6 +264,9 @@ def _ens_align_datasets(
     resample_freq : Optional[str]
       If the members of the ensemble have the same frequency but not the same offset, they cannot be properly aligned.
       If resample_freq is set, the time coordinate of each members will be modified to fit this frequency.
+    calendar : str
+      The calendar of the time coordinate of the ensemble. For conversions involving '360_day', the align_on='date' option is used.
+      See `xclim.core.calendar.convert_calendar`. 'default' is the standard calendar using np.datetime64 objects.
     xr_kwargs :
       Any keyword arguments to be given to xarray when opening the files.
 

--- a/xclim/ensembles.py
+++ b/xclim/ensembles.py
@@ -12,6 +12,8 @@ import scipy.stats
 import xarray as xr
 from sklearn.cluster import KMeans
 
+from xclim.core.calendar import convert_calendar
+from xclim.core.calendar import get_calendar
 from xclim.core.formatting import update_history
 
 # Avoid having to include matplotlib in xclim requirements
@@ -30,6 +32,7 @@ def create_ensemble(
     datasets: List[Union[xr.Dataset, xr.DataArray, Path, str, List[Union[Path, str]]]],
     mf_flag: bool = False,
     resample_freq: Optional[str] = None,
+    calendar: str = "default",
     **xr_kwargs,
 ) -> xr.Dataset:
     """Create an xarray dataset of an ensemble of climate simulation from a list of netcdf files. Input data is
@@ -56,6 +59,10 @@ def create_ensemble(
       If the members of the ensemble have the same frequency but not the same offset, they cannot be properly aligned.
       If resample_freq is set, the time coordinate of each members will be modified to fit this frequency.
 
+    calendar : str
+      The calendar of the time coordinate of the ensemble. For conversions involving '360_day', the align_on='date' option is used.
+      See `xclim.core.calendar.convert_calendar`. 'default' is the standard calendar using np.datetime64 objects.
+
     xr_kwargs :
       Any keyword arguments to be given to `xr.open_dataset` when opening the files (or to `xr.open_mfdataset` if mf_flag is True)
 
@@ -81,7 +88,9 @@ def create_ensemble(
     >>> datasets.append(glob.glob('/dir2/*.nc'))  # doctest: +SKIP
     >>> ens = create_ensemble(datasets, mf_flag=True)  # doctest: +SKIP
     """
-    ds = _ens_align_datasets(datasets, mf_flag, resample_freq, **xr_kwargs)
+    ds = _ens_align_datasets(
+        datasets, mf_flag, resample_freq, calendar=calendar, **xr_kwargs
+    )
 
     dim = xr.IndexVariable("realization", np.arange(len(ds)), attrs={"axis": "E"})
 
@@ -239,6 +248,7 @@ def _ens_align_datasets(
     datasets: List[Union[xr.Dataset, Path, str, List[Union[Path, str]]]],
     mf_flag: bool = False,
     resample_freq: str = None,
+    calendar: str = "default",
     **xr_kwargs,
 ) -> List[xr.Dataset]:
     """Create a list of aligned xarray Datasets for ensemble Dataset creation.
@@ -288,9 +298,12 @@ def _ens_align_datasets(
                     )
                 time = counts.time
 
-            ds["time"] = pd.to_datetime(
-                {"year": time.dt.year, "month": time.dt.month, "day": time.dt.day}
-            ).values
+            cal = get_calendar(time)
+            ds["time"] = convert_calendar(
+                time,
+                calendar,
+                align_on="date" if "360_day" in [cal, calendar] else None,
+            )
 
         ds_all.append(ds)
 

--- a/xclim/ensembles.py
+++ b/xclim/ensembles.py
@@ -301,11 +301,11 @@ def _ens_align_datasets(
                     )
                 time = counts.time
 
+            ds["time"] = time
+
             cal = get_calendar(time)
-            ds["time"] = convert_calendar(
-                time,
-                calendar,
-                align_on="date" if "360_day" in [cal, calendar] else None,
+            ds = convert_calendar(
+                ds, calendar, align_on="date" if "360_day" in [cal, calendar] else None,
             )
 
         ds_all.append(ds)


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
Instead of implicitly doing the calendar conversion, `ensembles.create_ensemble` now has an explicit option to control the output calendar. Control is minimal: only the calendar name can be modified and the default options of  `convert_calendar` are used.

In fact, I broke `create_ensemble` in the last PR that modified the alignment process, but didn't realize until now. '360_day' calendar were broken because of the 30th of Feb. This fix has the same default behaviour than the old code and adds some control.

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
No, the default for the `calendar` argument is `default`. 

* **Other information**:
