### PR TITLE
Ensemble percentiles as dim

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,7 @@ History
 =======
 0.18.x
 ------
+* `ensembles.ensemble_percentiles` modified to compute along a `percentiles` dimension by default, instead of creating different variables.
 * Added indicator `first_day_below` and run length helper `first_run_after_date`
 * Added ANUCLIM model climate indices mappings.
 

--- a/docs/notebooks/ensembles.ipynb
+++ b/docs/notebooks/ensembles.ipynb
@@ -136,7 +136,7 @@
     "### Ensemble percentiles\n",
     "\n",
     "Here we use xclim's `ensemble_percentiles()` to calculate percentile values across the 10 realizations. \n",
-    "Output variables are created for combining the original variable name `tas` with the addtional ending `_p{x}` where x are the input percentile values `default = [10, 50, 90]`. Compared to numpy's `percentile()` and xarray's `quantile()`, this method handles more efficiently dataset with invalid values and the chunking along the realization dimension (which is automatic when dask arrays are used)."
+    "The output has now a `percentiles` dimension instead of `realization`. Split variables can be created instead, by specifying `split=True` (the variable name `tas` will be appended with `_p{x}`). Compared to numpy's `percentile()` and xarray's `quantile()`, this method handles more efficiently dataset with invalid values and the chunking along the realization dimension (which is automatic when dask arrays are used)."
    ]
   },
   {
@@ -157,13 +157,20 @@
    "source": [
     "fig, ax = plt.subplots()\n",
     "ax.fill_between(ens_stats.time.values, ens_stats.tas_min, ens_stats.tas_max, alpha=0.3, label='Min-Max')\n",
-    "ax.fill_between(ens_perc.time.values, ens_perc.tas_p15, ens_perc.tas_p85, alpha=0.5, label='Perc. 15-85')\n",
+    "ax.fill_between(ens_perc.time.values, ens_perc.tas.sel(percentiles=15), ens_perc.tas.sel(percentiles=85), alpha=0.5, label='Perc. 15-85')\n",
     "ax._get_lines.get_next_color()  # Hack to get different line\n",
     "ax._get_lines.get_next_color()\n",
     "ax.plot(ens_stats.time.values, ens_stats.tas_mean, linewidth=2, label='Mean')\n",
-    "ax.plot(ens_perc.time.values, ens_perc.tas_p50, linewidth=2, label='Median')\n",
+    "ax.plot(ens_perc.time.values, ens_perc.tas.sel(percentiles=50), linewidth=2, label='Median')\n",
     "ax.legend()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -182,7 +189,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.0"
+   "version": "3.8.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #462 
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
Changes the behaviour of `ensembles.ensemble_percentiles` to concatenate the percentiles along a `percentiles` dimension by default. The old behaviour can be obtained by specifying `split=True`. 

Also, the method now accepts DataArrays. (In fact when passing a dataset, it simply loops on the variables with `realization` as a dim.)

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
Yes!

* **Other information**:
