### PR TITLE
Re-enable nbsphinx execute except for example.ipynb

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -87,7 +87,6 @@ ensembles module
 ----------------
 
 .. automodule:: xclim.ensembles
-   :noindex:
    :members:
    :undoc-members:
    :show-inheritance:
@@ -97,7 +96,6 @@ subset module
 -------------
 
 .. automodule:: xclim.subset
-   :noindex:
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -14,11 +14,13 @@ Indices submodules
 
 
 .. automodule:: xclim.indices.generic
+   :noindex:
    :members:
    :undoc-members:
    :show-inheritance:
 
 .. automodule:: xclim.indices.run_length
+   :noindex:
    :members:
    :undoc-members:
    :show-inheritance:
@@ -28,6 +30,7 @@ Unit handling module
 ====================
 
 .. automodule:: xclim.core.units
+   :noindex:
    :members:
    :undoc-members:
    :show-inheritance:
@@ -47,26 +50,31 @@ Other utilities
 ===============
 
 .. automodule:: xclim.core.calendar
+   :noindex:
    :members:
    :undoc-members:
    :show-inheritance:
 
 .. automodule:: xclim.core.checks
+   :noindex:
    :members:
    :undoc-members:
    :show-inheritance:
 
 .. automodule:: xclim.core.indicator
+   :noindex:
    :members:
    :undoc-members:
    :show-inheritance:
 
 .. automodule:: xclim.core.formatting
+   :noindex:
    :members:
    :undoc-members:
    :show-inheritance:
 
 .. automodule:: xclim.core.utils
+   :noindex:
    :members:
    :undoc-members:
    :show-inheritance:
@@ -79,6 +87,7 @@ ensembles module
 ----------------
 
 .. automodule:: xclim.ensembles
+   :noindex:
    :members:
    :undoc-members:
    :show-inheritance:
@@ -88,6 +97,7 @@ subset module
 -------------
 
 .. automodule:: xclim.subset
+   :noindex:
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -92,7 +92,7 @@ napoleon_use_rtype = False
 napoleon_use_param = False
 napoleon_use_ivar = True
 
-nbsphinx_execute = "never"
+nbsphinx_execute = "auto"
 nbsphinx_prolog = r"""
 {% set docname = env.doc2path(env.docname, base=None) %}
 

--- a/docs/itable.rst
+++ b/docs/itable.rst
@@ -1,3 +1,4 @@
+:orphan:
 .. _table:
 
 Table of indicators

--- a/docs/notebooks/example.ipynb
+++ b/docs/notebooks/example.ipynb
@@ -2,7 +2,9 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "keep_output": true
+   },
    "source": [
     "# Workflow Examples \n",
     "\n",
@@ -19,7 +21,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "keep_output": true
+   },
    "source": [
     "## Environment configuration"
    ]
@@ -27,7 +31,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "keep_output": true
+   },
    "outputs": [],
    "source": [
     "# Imports for xclim and xarray\n",
@@ -47,7 +53,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "keep_output": true
+   },
    "source": [
     "## Setting up the Dask client: parallel processing\n",
     "\n",
@@ -70,8 +78,42 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "keep_output": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table style=\"border: 2px solid white;\">\n",
+       "<tr>\n",
+       "<td style=\"vertical-align: top; border: 0px solid white\">\n",
+       "<h3 style=\"text-align: left;\">Client</h3>\n",
+       "<ul style=\"text-align: left; list-style: none; margin: 0; padding: 0;\">\n",
+       "  <li><b>Scheduler: </b>tcp://127.0.0.1:46333</li>\n",
+       "  <li><b>Dashboard: </b><a href='http://127.0.0.1:8787/status' target='_blank'>http://127.0.0.1:8787/status</a>\n",
+       "</ul>\n",
+       "</td>\n",
+       "<td style=\"vertical-align: top; border: 0px solid white\">\n",
+       "<h3 style=\"text-align: left;\">Cluster</h3>\n",
+       "<ul style=\"text-align: left; list-style:none; margin: 0; padding: 0;\">\n",
+       "  <li><b>Workers: </b>1</li>\n",
+       "  <li><b>Cores: </b>4</li>\n",
+       "  <li><b>Memory: </b>4.00 GB</li>\n",
+       "</ul>\n",
+       "</td>\n",
+       "</tr>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "<Client: 'tcp://127.0.0.1:46333' processes=1 threads=4, memory=4.00 GB>"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from distributed import Client\n",
     "\n",
@@ -83,7 +125,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "keep_output": true
+   },
    "source": [
     "## Creating xarray datasets\n",
     "\n",
@@ -101,7 +145,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "keep_output": true
+   },
    "outputs": [],
    "source": [
     "data_url = 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/ouranos/cb-oura-1.0/ACCESS1-3/rcp85/day/ACCESS1-3_rcp85_day_allvars.ncml'"
@@ -110,27 +156,65 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "keep_output": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<xarray.Dataset>\n",
+      "Dimensions:  (lat: 700, lon: 1064, time: 55152)\n",
+      "Coordinates:\n",
+      "  * lon      (lon) float32 -141.04314 -140.9598 ... -52.54667 -52.46334\n",
+      "  * lat      (lat) float32 83.28931 83.20598 83.12265 ... 25.12497 25.04164\n",
+      "  * time     (time) datetime64[ns] 1950-01-01 1950-01-02 ... 2100-12-31\n",
+      "Data variables:\n",
+      "    tasmin   (time, lat, lon) float32 dask.array<chunksize=(365, 168, 150), meta=np.ndarray>\n",
+      "    tasmax   (time, lat, lon) float32 dask.array<chunksize=(365, 168, 150), meta=np.ndarray>\n",
+      "    pr       (time, lat, lon) float32 dask.array<chunksize=(365, 168, 150), meta=np.ndarray>\n",
+      "Attributes:\n",
+      "    Conventions:     CF-1.5\n",
+      "    title:           ACCESS1-3 model output prepared for CMIP5 historical\n",
+      "    history:         CMIP5 compliant file produced from raw ACCESS model outp...\n",
+      "    institution:     CSIRO (Commonwealth Scientific and Industrial Research O...\n",
+      "    source:          ACCESS1-3 2011. Atmosphere: AGCM v1.0 (N96 grid-point, 1...\n",
+      "    redistribution:  Redistribution prohibited. For internal use only.\n"
+     ]
+    }
+   ],
    "source": [
     "# Chunking in memory along the time dimension.\n",
     "# Note that the data type is a 'dask.array'. xarray will automatically use client workers.\n",
     "ds = xr.open_dataset(data_url, chunks={'time': 365, 'lat': 168, 'lon': 150}, drop_variables=['ts', 'time_vectors'])\n",
-    "ds"
+    "print(ds)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "keep_output": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "((365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 37), (168, 168, 168, 168, 28), (150, 150, 150, 150, 150, 150, 150, 14))\n"
+     ]
+    }
+   ],
    "source": [
     "print(ds.tasmin.chunks)"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "keep_output": true
+   },
    "source": [
     "## Multi-file datasets\n",
     "\n",
@@ -143,7 +227,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "keep_output": true
+   },
    "outputs": [],
    "source": [
     "## Create multi-file data & chunks \n",
@@ -161,11 +247,31 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "keep_output": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<xarray.DataArray 'tasmin' (time: 4017, lat: 60, lon: 60)>\n",
+      "dask.array<getitem, shape=(4017, 60, 60), dtype=float32, chunksize=(365, 60, 47), chunktype=numpy.ndarray>\n",
+      "Coordinates:\n",
+      "  * lon      (lon) float32 -69.96264 -69.87931 -69.79598 ... -65.1295 -65.04617\n",
+      "  * lat      (lat) float32 49.95731 49.87398 49.79065 ... 45.12417 45.04084\n",
+      "  * time     (time) datetime64[ns] 2090-01-01 2090-01-02 ... 2100-12-31\n",
+      "Attributes:\n",
+      "    units:          K\n",
+      "    long_name:      air_temperature\n",
+      "    standard_name:  air_temperature\n",
+      "    _ChunkSizes:    [365  50  56]\n"
+     ]
+    }
+   ],
    "source": [
     "ds2 = ds.sel(lat=slice(50, 45), lon=slice(-70, -65), time=slice('2090', '2100'))\n",
-    "ds2.tasmin"
+    "print(ds2.tasmin)"
    ]
   },
   {
@@ -175,12 +281,14 @@
    "outputs": [],
    "source": [
     "ds3 = ds.sel(lat=46.8, lon=-71.22, method='nearest').sel(time='1993')\n",
-    "ds3.tasmin"
+    "print(ds3.tasmin)"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "keep_output": true
+   },
    "source": [
     "## Climate index calculation & resampling frequencies\n",
     "\n",
@@ -212,16 +320,41 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "keep_output": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<xarray.DataArray 'tx_max' (time: 11, lat: 60, lon: 60)>\n",
+      "dask.array<where, shape=(11, 60, 60), dtype=float32, chunksize=(1, 60, 47), chunktype=numpy.ndarray>\n",
+      "Coordinates:\n",
+      "  * time     (time) datetime64[ns] 2090-01-01 2091-01-01 ... 2100-01-01\n",
+      "  * lon      (lon) float32 -69.96264 -69.87931 -69.79598 ... -65.1295 -65.04617\n",
+      "  * lat      (lat) float32 49.95731 49.87398 49.79065 ... 45.12417 45.04084\n",
+      "Attributes:\n",
+      "    units:          K\n",
+      "    long_name:      Maximum daily maximum temperature\n",
+      "    standard_name:  air_temperature\n",
+      "    _ChunkSizes:    [365  50  56]\n",
+      "    cell_methods:    time: maximum within days time: maximum over days\n",
+      "    history:        <No available history>\\n[2020-06-02 13:11:24] tx_max: tx_...\n",
+      "    description:    Annual maximum of daily maximum temperature.\n"
+     ]
+    }
+   ],
    "source": [
     "out = xc.atmos.tx_max(ds2.tasmax, freq='YS')\n",
-    "out"
+    "print(out)"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "keep_output": true
+   },
    "source": [
     "<div class=\"alert alert-info\">\n",
     "\n",
@@ -232,7 +365,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "keep_output": true
+   },
    "source": [
     "### Comparison of **atmos** vs **indices** modules\n",
     "Using the `xclim.indices` module performs not checks and only fills the `units` attribute."
@@ -241,16 +376,35 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "keep_output": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<xarray.DataArray 'tasmax' (time: 11, lat: 60, lon: 60)>\n",
+      "dask.array<stack, shape=(11, 60, 60), dtype=int64, chunksize=(1, 60, 47), chunktype=numpy.ndarray>\n",
+      "Coordinates:\n",
+      "  * time     (time) datetime64[ns] 2090-01-01 2091-01-01 ... 2100-01-01\n",
+      "  * lon      (lon) float32 -69.96264 -69.87931 -69.79598 ... -65.1295 -65.04617\n",
+      "  * lat      (lat) float32 49.95731 49.87398 49.79065 ... 45.12417 45.04084\n",
+      "Attributes:\n",
+      "    units:    days\n"
+     ]
+    }
+   ],
    "source": [
     "out = xc.indices.tx_days_above(ds2.tasmax, thresh='30 C', freq='YS')\n",
-    "out"
+    "print(out)"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "keep_output": true
+   },
    "source": [
     "With `xclim.atmos`, checks are performed and many CF-compliant attributes are added:"
    ]
@@ -258,30 +412,78 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "keep_output": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<xarray.DataArray 'tx_days_above' (time: 11, lat: 60, lon: 60)>\n",
+      "dask.array<where, shape=(11, 60, 60), dtype=float64, chunksize=(1, 60, 47), chunktype=numpy.ndarray>\n",
+      "Coordinates:\n",
+      "  * time     (time) datetime64[ns] 2090-01-01 2091-01-01 ... 2100-01-01\n",
+      "  * lon      (lon) float32 -69.96264 -69.87931 -69.79598 ... -65.1295 -65.04617\n",
+      "  * lat      (lat) float32 49.95731 49.87398 49.79065 ... 45.12417 45.04084\n",
+      "Attributes:\n",
+      "    units:          days\n",
+      "    cell_methods:    time: maximum within days time: sum over days\n",
+      "    history:        <No available history>\\n[2020-06-02 13:11:25] tx_days_abo...\n",
+      "    standard_name:  number_of_days_with_air_temperature_above_threshold\n",
+      "    long_name:      Number of days with tmax > 30 c\n",
+      "    description:    Annual number of days where daily maximum temperature exc...\n"
+     ]
+    }
+   ],
    "source": [
     "out = xc.atmos.tx_days_above(ds2.tasmax, thresh='30 C', freq='YS')\n",
-    "out"
+    "print(out)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "keep_output": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<xarray.Dataset>\n",
+      "Dimensions:        (lat: 60, lon: 60, time: 11)\n",
+      "Coordinates:\n",
+      "  * time           (time) datetime64[ns] 2090-01-01 2091-01-01 ... 2100-01-01\n",
+      "  * lon            (lon) float32 -69.96264 -69.87931 ... -65.1295 -65.04617\n",
+      "  * lat            (lat) float32 49.95731 49.87398 ... 45.12417 45.04084\n",
+      "Data variables:\n",
+      "    tx_days_above  (time, lat, lon) float64 dask.array<chunksize=(1, 60, 47), meta=np.ndarray>\n",
+      "Attributes:\n",
+      "    Conventions:     CF-1.5\n",
+      "    title:           ACCESS1-3 model output prepared for CMIP5 historical\n",
+      "    history:         CMIP5 compliant file produced from raw ACCESS model outp...\n",
+      "    institution:     CSIRO (Commonwealth Scientific and Industrial Research O...\n",
+      "    source:          ACCESS1-3 2011. Atmosphere: AGCM v1.0 (N96 grid-point, 1...\n",
+      "    redistribution:  Redistribution prohibited. For internal use only.\n"
+     ]
+    }
+   ],
    "source": [
     "# We have created an xarray data-array - We can insert this into an output xr.Dataset object with a copy of the original dataset global attrs\n",
     "dsOut = xr.Dataset(attrs=ds2.attrs)\n",
     "\n",
     "# Add our climate index as a data variable to the dataset\n",
     "dsOut[out.name] = out\n",
-    "dsOut"
+    "print(dsOut)"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "keep_output": true
+   },
    "source": [
     "## *Lazy* computation - Nothing has been computed so far !\n",
     "\n",
@@ -291,8 +493,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "keep_output": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 3.3 s, sys: 338 ms, total: 3.64 s\n",
+      "Wall time: 1min 3s\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "output_file = output_folder / 'test_tx_max.nc'\n",
@@ -301,7 +514,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "keep_output": true
+   },
    "source": [
     "*(Times may of course vary depending on the machine and the Client settings)*\n",
     "\n",
@@ -314,8 +529,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "keep_output": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(330, 365, 365, 365, 365, 365, 365, 365, 365, 365, 365, 37)\n"
+     ]
+    }
+   ],
    "source": [
     "print(ds2.chunks['time'])"
    ]
@@ -323,8 +548,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "keep_output": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(1460, 1460, 1097)\n"
+     ]
+    }
+   ],
    "source": [
     "# rechunk data in memory for the entire grid  \n",
     "ds2c = ds2.chunk(chunks={'time':4 * 365})\n",
@@ -334,8 +569,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "keep_output": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 2.84 s, sys: 350 ms, total: 3.19 s\n",
+      "Wall time: 51.2 s\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "out = xc.atmos.tx_max(ds2c.tasmax, freq='YS')\n",
@@ -348,7 +594,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "keep_output": true
+   },
    "source": [
     "#### Loading the data in memory\n",
     "If the dataset is relatively small, it might be more efficient to simply load the data into the memory and use  numpy arrays instead of dask arrays."
@@ -357,7 +605,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "keep_output": true
+   },
    "outputs": [],
    "source": [
     "ds4 = ds3.load()"
@@ -365,7 +615,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "keep_output": true
+   },
    "source": [
     "## Unit handling in `xclim`\n",
     "\n",
@@ -377,7 +629,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "keep_output": true
+   },
    "outputs": [],
    "source": [
     "# Compute with the original mm s-1 data\n",
@@ -391,7 +645,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "keep_output": true
+   },
    "outputs": [],
    "source": [
     "# import plotting stuff\n",
@@ -404,8 +660,31 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "keep_output": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.legend.Legend at 0x7f39d265ce90>"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAApoAAAFdCAYAAACjCc1uAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjAsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8GearUAAAgAElEQVR4nOzdeVzUdf4H8NccDDCAnAMocl8eKAho4n2Ldqh55qpZVruVaZtraduWrbU/tWMrtbbc0tI80so086jUNFMTEBJTbuSG4T6Gc2Z+f5BTLMcgMPMd4PV8PHzEfOd7vIZP4NvP5/P9fEVarVYLIiIiIqIuJhY6ABERERH1TCw0iYiIiMggWGgSERERkUGw0CQiIiIig2ChSUREREQGwUKTiIiIiAyChSYRERERGYRU6ABE1L1cvnwZL7zwAr799ltBc6xZswbXr1/Xva6srMSwYcOwdetWAMDhw4fx8ssvY8OGDZg1a1aL50hJScGGDRtQWFgIqVSKp556CtOmTQMAVFVV4cUXX8Tx48fx66+/NrnOhg0bEB8fD61Wi5kzZ2L16tUAgKlTp0Kr1UIqbfzV6uLigo8//hgNDQ14/fXXcfbsWdTW1uJPf/oTHnnkkTY/X3u/z3FxcTA3N8eAAQP0fMf002g0WLhwIXx9fbFp0ybd5/373/+O2NhYyGQy/O1vf8P06dObHHf16lWsX7++ybbMzEx88cUX8PX1bfWzl5eX4/nnn0dSUhLMzMzwxBNPYObMmThx4gTeeuutJudLS0tDdHQ0XnrppTbbnYhMCwtNIuqW3njjjSavH330UcyZMwcA8MEHHyAmJgbe3t5tnmP16tV46KGHMHfuXCQkJGDRokWIiIiAjY0NHnjgAUyYMKHZMW+++SbMzMzwzTffQKVSYfbs2QgPD8fo0aNRXl6Oo0ePwtnZuckxn332GeLi4vDVV1+hrq4O8+fPR0hICMLDwzv3TQDw+eefIywsrEsKzX379qGoqAi+vr66bZs2bYJCocDZs2eRmpqKDRs2YPLkybpiGgCGDRuGEydO6F7HxcVh48aNCAgIwL59+1r97K+//jr69u2Lbdu2ITMzEwsWLEBYWBgiIyMRGRmpO98333yD48ePw9raus12JyLTw6FzIuqw2tpavPjii5g+fTpmzJiBTZs2Qa1WAwAmTZqE/fv3Y968eRgzZoyuh8wQfvjhB9TV1WHSpEkAgLvuugvvvfcerKysWj1GrVbj8ccf1/V2BgYGQiaTISsrCwDwz3/+EwsWLGh23NSpU7Fq1SqIxWJYW1tjwIABSEpKAtDYu9anT59mx/z000+45557YG5uDhsbG8ydOxcnT55s9+errq7G008/jenTp2PSpEnYvHkzgMbC8KuvvsJrr72GnTt3tvt8LSkoKMDu3bvx4IMP6rbV1dXh2LFjePzxxyESieDr64vdu3c3KTJb8uqrr2LdunUQiURtfvaTJ09i0aJFAAB3d3eMGDEC33//fZNz1dbW4u2338batWubXed/252ITA97NImowz7++GPk5eXh2LFjaGhowJIlS/D111/rircrV67gwIEDKCwsxOTJk7F8+XK4urrqjq+rq8N9993X7LwBAQF455132p1j69atePbZZ3Wvg4OD9R4jkUhw9913617HxcVBq9XCy8sLABASEqIrOv8oIiJC93VlZSWuXr2KFStWQKVSQa1WY/369UhISIC9vT3WrFmD0NBQiEQiaDQa3XFyuRwZGRnt/nz79u1DVVUVTpw4gfLyckybNg2TJ0/GAw88gG+++Qbz5s1rNj0gKioKL7zwQrNzzZ07F48++miz7f/617+wcuVK1NXV6balp6fD3NwcX3zxBb788kvI5XI888wzGDVqVKtZz549C3Nzc11vbWufvaSkBKWlpfDw8NC95+HhgdTU1CbnO3ToEEJDQ5vsd9v/tjsRmR4WmkTUYWfPnsXDDz8MqVQKqVSKe++9FxcuXNAVPffeey8kEglcXFzg6OiI3NzcJoWmTCZrMuTaEZcuXYJWq8WIESM6fI7c3FysWbMGL7zwAiwtLdt1TF1dHdasWYNJkyZh2LBhqKysxLx587Bw4UIMGTIEJ06cwOOPP45Tp05h1KhR2L9/P2bNmgW1Wo0jR460+zoA8PDDD2Pp0qUQiUSwtbWFv78/srKy2hx6Dw8Pb/f39ty5cygvL8c999yDL774Qre9vLwcFRUVMDc3xzfffIPz589j1apV+O6772BnZ9fiuf773/82mX/a2mevqamBWCyGmZmZbl9zc3MUFxfrXms0Gnz00Uf4z3/+0+w6XdHuRGR4LDSJqMOKi4tha2ure21ra4uioiLda2tra93XEolEN6zeEc8++yx++eUXAI09qS4uLgCAr7/+Gvfcc0+Hz5uamorHHnsMf/7zn1vsXW1JVVUVnnrqKbi4uODll18G0PhZX3nlFd0+kZGR2L59O2JjYzF//nxkZGRg/vz5cHZ2xqhRo5CSktLujOnp6di0aRNSU1MhFouRl5eH+++//84+aCtqamqwZcsWbN++vdl7NjY2UKvVeOCBBwAAY8eORd++fREXF4fx48c32z8vLw+JiYkYO3asbltrn93S0hIajQZ1dXWQyWS6LHK5XHfs1atXIZfL4e/v3+xanW13IjIOFppE1GFOTk4oLS3VvS4tLYWTk1O7j7+TofMtW7a0eI6zZ8/ioYceavc1/yg/Px+PPPII1q5dixkzZrTrmIaGBqxcuRL+/v54/vnnddtVKhXy8vLg4+PTZP/bvb3PPfccnnvuOQDAtm3bEBAQ0O6c//znPzF48GBs374dEolEN6+xLe0dOo+Pj0deXh4WL14MoLHYq6+vR3FxMV5//XWIxWJUVVXpejAlEgnE4pan9589exajR4+GRCJp8vlb+ux2dnZwcHBAWloaAgMDAQDJycmYOHFik/O1VNDefq+j7U5ExsNCk4g6bPz48Th06BAmTZqE2tpafPXVVy3O/2tNZ4fOi4qKUFxcrPfu8ta89NJLePDBB9tdZALA7t27YWVl1aTIvJ1l0aJF2L9/P3x8fHDhwgUUFhYiODgYR44cwZkzZ/DGG29AqVTiyy+/xEcffdTuaxYVFWHgwIGQSCS4cOECbt26haqqKgCNhVxFRUWzY9o7dB4eHo6oqCjd6y+++AI///yz7uatSZMm4aOPPsIzzzyDuLg4ZGdnY8iQIS2e6+bNm03uWAfQ5mefMWMG9uzZg40bNyI5ORlXr15t0it88+ZNzJw5s8XvR2fanYiMh4UmEXXYsmXLkJWVhbvvvhsikQiRkZF3VLR1Vl5eHhwcHJr1sK1YsQLZ2dnIzc1FWloa3nvvPaxZswZTp05FZGQk9uzZA7VajTNnziAtLQ379u3THfvss8/CxcUFa9asQUNDA9RqtW6pnRMnTmD//v2orq5usvxOZGQknn76abz00ktYuXIl1Go1bG1tsX37dlhbW2PKlCk4deoUpkyZAqlUijVr1sDT0xMAsGfPHhQWFuLpp59u9XM+/vjjeOWVV7Bt2zZMnToVK1euxJtvvolBgwZhypQpeO2115CZmdlsLcuu8Morr+jmolpbW+Pf//437OzskJ+fjxUrVuDrr7/W7ZuXl9dsmaW2PvszzzyDdevWYerUqTA3N8err77apEc8Ly+vxR7y1tqdiEyPSKvVaoUOQUTUW+Xn52Pnzp1Yt26d0FGIiLocC00iIgHFx8fD0tKy2ZAzEVFPwEKTiIiIiAyCE1yIiIiIyCBYaBIRERGRQXTLu86VyuZLeRiSvb0cJSUqo16TWsa2MD1sE9PEdjFtbB/TxHbpGIXCptX32KPZDlKpRP9OZBRsC9PDNjFNbBfTxvYxTWyXrsdCk4iIiIgMgoUmERERERkEC00iIiIiMggWmkRERERkECw0iYiIiMggWGgSERERkUGw0CQiIiIig+iWC7YTEVHvEJUfi5Ppp5GnKoCr3BnTvSYh3CVE6FjUi+Xm5mDZskUIDByg2+bvH4jVq9cImKrzNBoNPvjgXXz99WF8/fV3XXZeFppERGSSovJjsfP6Xt3rnKo83WsWmyQkDw9PbNv2gdAxutSePbvg7OwCrVbbpedloUlERCbpZPrpFrefunWGhSaZnJiYKOzfvwcqlQorV/4V2dlZOHDgU0gkEgQGDsTTT/8NH374PsrKSpGVlYWcnGw8+ujjOHbsCPLycvDaa2/Dza2/7nz69s3Pz8PBg/shkUiQmHgTy5Y9jMuXLyIpKQFPPLEa48ZN0J2rsrISL764DnV1daivr8czzzzXpEcWAObNWwi53AoffvifLv2+sNAkIiKTlKcqaHF7blW+kZOQqfrsdDKu3Gz5/5OOkEhECPVXYMEkvw4dn5KSjH37vkBDQwNeemk9du7cC7lcjmef/StiYqIAAOXl5Xjzza14//3tOHHia7z55lbs2PEeLlw4hwULFjc5X1v7+vkFIDk5EZ9+eghxcTF4+eV/4ODBI7h+/Ro+//xAk0IzOvpnKBTOWL/+RWRnZyEj41az7HK5VYc+sz4sNImIyCS5yp2RU5XXbHtfKxcB0hD9LiPjFlaufEz3evjwuzBkSDD8/Pwhk8mQlpaK/v09IJfLAQBDhwYjMfEmAGDQoMEAACcnJ4hEIgCAg4MDysrKml1H3763r+fo6AR3dw9YWlrCwcEBlZWVTc4zePBQ7NjxHl577V8YP34SIiJGd+W3o00sNImIyCSNcByNw1WfN9s+zXOiAGnIFC2Y5Nfh3seWKBQ2UCor9O7X0hzNmJgomJmZAQBEIjSZ66jVaiEWNy70I5FIdNv/+HVLcyP17dveczk5OWHXrn2IiYnCl18ewvXr1+Dj44eDB/cBAN5++70mx3clFppERGSSbsRaoq44GK4Dc1BcVwhNtTXmDpjG+Zlk8tzdPZGVlQGVqgpyuRWuXo3Bgw+uQFTUZUHyXLlyGQ0NDYiIGA0vL2+88cYmPPTQoxg/3vD/aGOhSUREJichowSxyYUIcB+I58Ysxk/xefjw2A3UOroAXdeBRWQQlpaWePLJ1Viz5imIRGIMHRqC4OAQwQrN/v3d8c9//gOffvoxxGIxVqz4c7N9/v3vLUhJSUZlZSVWrnwMY8aMw6JFSzp9bZG2q+9jN4L2dGt3pfZ2pZPhsS1MD9vENHXndtFqtXjlkyik5VbghWXh8OnXB5XV9fjr1h/h7myNF5cPFzpip3Xn9unJ2C4do1DYtPoenwxEREQm5crNAqTlVmD4AGf49OsDALC2NMMADzuk51WgqKxG4IRE1F4sNImIyGTUN2hw6GwKJGIR5o73afJeaKAzACAmUSlENCLqABaaRERkMs5ezUZhWQ0mhrrB2V7e5L1h/k4QAYhmoUnUbbDQJCIik6CqqceRC2mwNJfg3lFezd63szaHb39bJGWWoqyqzvgBieiOsdAkIiKTcOzSLVTVNODuCC/YyGUt7hMWoIAWQGwSezWJugMWmkREJLiishp8eyUL9jbmmBLWv9X9QgMUADh8TtRdcB1NIiIS3JfnU9Gg1uD+cT6QmbX+hBKFnSU8XKxxI70Eqpp6yC3MjJiSCMjNzcGyZYsQGDhAt83fPxCrV68RMNWdufvuyTh27Ptm21NTk7Fu3RosXLgYc+cu7JJrsdAkIiJBZeRX4GJ8HtydrREx2FXv/mEBCmTkVyIupahd+1PvFpUfi5Ppp5GnKoCr3BnTvSZ1+ulSLT2Csrurrq7Gv//9GsLCRnTpeVloEhGRoA6eTYEWwPyJvhCLRXr3Dw10xpfn0xCToGShSW2Kyo/Fzut7da9zqvJ0r7v6UaYxMVHYv38PVCoVVq78K7Kzs3DgwKeQSCQIDByIp5/+Gz788H2UlZUiKysLOTnZePTRx3Hs2BHk5eXgtdfehpvb79NG9O2bn5+Hgwf3QyKRIDHxJpYtexiXL19EUlICnnhiNcaNm6A7V0NDA15++QWUlBQ36Yn9IzMzM7z++tvYs+fjLv2+GHSO5pYtW7Bw4ULMnTsXp06dQm5uLpYuXYrFixdj9erVqKtrvGvwyJEjmDt3LubPn49Dhw4ZMhIREZmQ+LQiXE8rxmAvewR5O7brmH6Ocrg6yHEttQi19WoDJ6Tu7GT66Ra3n7p1xiDXS0lJxptvboOHhyc++GA73nrrXbz33ofIyclGTEwUAKC8vBxvvrkVEydOxokTX//29RRcuHCu2fn07ZucnIgXX9yItWvX4z//2Ybnn38Jf/vbehw/frTJea5cuYSGhgZs2/YBJk2ahrKysmbXkkqlMDe36PLvicF6NC9duoSkpCQcOHAAJSUlmDNnDiIiIrB48WLMmDEDW7ZswaFDhzB79mxs374dhw4dgpmZGWbPno0pU6bAzs7OUNGIiMgEaDRaHDyTAhGA+RPb/wBzkUiEsEAFjl28hfjUYoQFKgwXkrq1PFVBi9tzq/I7dd6MjFtYufIx3evhw+/CkCHB8PPzh0wmQ1paKvr394Bc3rgW7NChwUhMvAkAGDRoMADAyckJIlFjD76Dg0OLxZ++fW9fz9HRCe7uHrC0tISDgwMqKyubnCctLQ1DhgwFAAweHARzc/NOff47YbBCc/jw4Rg6tPFD2draorq6GpcvX8bLL78MAJg8eTJ27doFb29vDBkyBDY2jc/JDA8PR0xMDCZNmmSoaEREZAIuXs9DZkElRgW5wsOl9WcltyQ0oLHQjEksYKFJrXKVOyOnKq/Z9r5WLp06b0tzNGNiomBm1nhzmkgEaLVa3XtarRZiceMgskTy+81uf/z6j/u39H5L+7b/XFqIROJm769b9wwqKysRGTkT99wzu5VP2zkGGzqXSCS6Sv7gwYMYN24cqqurIZM1ro2mUCigVCpRWFgIBwcH3XFOTk5QKrlsBRFRT1ZXr8YX51IhlYhx/zgf/Qf8Dy9XGzj0MUdschEa1BoDJKSeYLpXy51W0zwnGvS67u6eyMrKgEpVBQC4ejUGgYGDDHrNtnh4eOLmzV8BANeuxemmLm7a9Ca2bfvAYEUmYISbgb777jscOnQIH330EaZPn67bfrua/t+qW6vV6rqHW2NvL4dU2vryF4agUNzZv7bJcNgWpodtYppMuV0OnU5CSUUt5k70Q6Bvx3okxwS74cj5VOSW1iJ0gHMXJzQ8U26fnmKGYiz69LHA4V9PIqs8F/379MXsQdMx2mN4q8foa5faWitIpeJm+9nZyWFubvbbdhusX78Ozz33NMRiMcLCwjBlyljcuBELa2sLKBQ2sLa2QH29ebOvb7OyMm9z3z9er6TECjKZtNnXt91zz3R8++03+OtfH8eAAQPg4uLSLH98fDw2b96M7OxsSKVSXLjwA7Zu3drpqYwibUt9tV3k/PnzePvtt/Hf//4XdnZ2mDx5Mo4dOwYLCwv8/PPP2LNnD/70pz/hwIEDePPNNwEA69evx7Rp0zBxYuv/2lAqKwwVuUUKhY3Rr0ktY1uYHraJaTLldqlQ1WHd+xchEYux6c8jO7wWZkJGCTbvvYrxIf3wYGTLd9KaKlNun96M7dIxbRXnBhs6r6iowJYtW/D+++/rquFRo0bh5MmTAIBTp05h7NixCA4OxrVr11BeXo6qqirExMQgPDzcULGIiEhgR39KR3WtGveO8urUguv+/e1gIzfD1UQlNBqD9ZkQUScYbOj8m2++QUlJCZ5++mndtk2bNuGFF17AgQMH0K9fP8yePRtmZmZYs2YNVqxYAZFIhCeffFJ3YxAREfUsBSUqnInJhsLOAhND3Tp1LrFYhGH+CpyLy0FydhkC3LlaCZGpMVihuXDhQixc2PzxRTt37my2LTIyEpGRkYaKQkREJuLzH1Kh1mgxd7wvpJLOD6qFBTYWmtEJShaaRCbIoAu2ExER3ZaSU4YrNwvg3dcGw7vo5p2BnvawNJcgJrGgxeVhiEhYLDSJiMjgtNrGxdkBYMFEP72ri7SXVCJGsJ8TisprcSufN3EQmRoWmkREZHCxyYVIzCxFiJ8TAj3su/TcYQGNyyNFJ3ANZiJTw0KTiIgMSq3R4NDZFIhEwLwJvl1+/iBvR8ikYsQkstAkMjUsNImIyKDOx+Uit0iFccH90M/JqsvPby6TIMjHEblFKuQUVnX5+Ymo41hoEhGRwdTUNeDwj2kwN5Ng9hhvg11HN3zOXk0ik8JCk4iIDObkz5kor6rD9BHusLU2N9h1gv0cIRGLEMN5mkQmhYUmEREZRFllLU5czkAfKxki7/Iw6LXkFmYY6GWPW/kVKCytNui1iKj9WGgSEZFBfPVjGmrr1Zg9xhsWMoM9H0Tn9vA5bwoiMh0sNImIqMvlFFbhXFwuXB3kGBvc1yjXHOavgAicp0lkSlhoEhFRlzt0NgUarRbzJ/hCIjbOXzV9rGTwd7dDclYZyiprjXJNImobC00iIupSCRkliE0uREB/W4T4Oxn12mEBCmgBxCQVGvW6RNQyFppERNRltFotPvvtUZPzJ3XdoybbK/T2PM2EAqNel4haxkKTiIi6zJWbBUjLLUf4AGf49rM1+vUdbS3g5WqDmxmlqKyuN/r1iagpFppERNQlGtQafP5DCiRiEeaN9xEsR1igAmqNFnHJHD4nEhoLTSIi6hJnYrKhLK3BxGFucLaXC5YjlMscEZkMFppERNRpqpp6HP0pHZbmEtw72kvQLH0drdDPyQrxacWoqWsQNAtRb8dCk4iIOu2bSxmorK7HzJGesJHLhI6D0AAF6hs0iE8tFjoKUa/GQpOIiDqluLwG30Zlwt7GHFPD3YWOA+D3pwRx8XYiYbHQJCKiTvnyXCrqGzS4f5wPZGYSoeMAADxcrOFka4G45ELUN2iEjkPUa7HQJCKiDsvIr8BP8Xnor7BGxGBXoePoiEQihAYoUFOnxo1bHD4nEgoLTSIi6rCDZ1OgBbBgoi/EYuMuzq5PWOBvw+cJHD4nEgoLTSIi6pD4tCJcTyvGYC97BPk4Ch2nGV83W9hayXA1qRBqDYfPiYTAQpOIiO6YRqvFwTMpEAGYN8FP6DgtEotEGBagQGV1PZIyy4SOQ9QrSQ158sTERDzxxBNYvnw5lixZglWrVqGkpAQAUFpaipCQEGzcuBFjxoyBt7e37rhdu3ZBIjGNCeVERNTcxfg8ZBZUImKwKzxdbYSO06qwAAXOXs1GdKISAzzthY5D1OsYrNBUqVTYuHEjIiIidNveeecd3dfr16/H/PnzodVq4ezsjN27dxsqChERdaG6ejW+PJ8KqUSM+8cJ96jJ9gj0sIPcXIqYRCUemOIPsci05pES9XQGGzqXyWTYsWMHnJ2dm72XmpqKiooKDB06FCqVCmq12lAxiIioi30XnYXi8lpMDe8PR1sLoeO0SSoRI8TfCSUVtUjPrRA6DlGvY7BCUyqVwsKi5V9An3zyCZYsWQKgseezqKgIq1atwqJFi/DJJ58YKhIREXVShaoOxy6mw8pCirsjPIWO0y6/L95eIHASot7HoHM0W1JXV4fo6Ghs2LABAGBpaYnVq1dj1qxZqK+vx5IlSxAaGoqgoKBWz2FvL4dUatw5nAqF6c5B6m3YFqaHbWKaDNEuh7+6hupaNR6ZFQRPd4cuP78hjLeT44Ovf0VschEenxcCkYkMn/PnxjSxXbqW0QvNK1euYOjQobrX1tbWmD9/PoDG4faIiAgkJCS0WWiWlKgMnvOPFAobKJUccjEFbAvTwzYxTYZol4ISFY79mAYnWwsM93fqVu0+xNsBUQlKxN5oXFxeaPy5MU1sl45pqzg3+vJG165dw4ABA3SvExIS8Nxzz0Gr1aKhoQExMTHw9/c3diwiItLji3OpUGu0mDfBF2bS7rU6Xuhvi7fHcPF2IqMyWI9mfHw8Nm/ejOzsbEilUpw8eRJbt26FUqmEh4eHbr/AwEDY2dlh/vz5EIvFmDhxYpMeTyIiEl5qTjl+vlEA7742CB/Q/CZPUxfs6wSpRIToRCXuG+Ot/wAi6hIGKzSDgoJaXLLoH//4R7Nt69evN1QMIiLqJK1Wi8/OJAMAFkz065ZLBFmaSzHIywG/pBShoEQFZ3u50JGIeoXuNfZBRERGF5dchMTMUoT4OSHQo/sueh76293nMYmFAich6j1YaBIRUavUGg0Onk2GSATMneArdJxOCfF3gkjEZY6IjImFJhERter8L7nILVJh7NB+cHOyEjpOp/SRyxDoboeU7HKUVNQKHYeoV2ChSURELaqpa8BX59MgMxNj9tiecQPN7eHzq0m8+5zIGFhoEhFRi079nImyqjpEjvCAnbW50HG6xO1CM5rLHBEZBQtNIiJqpqyyFscvZ6CP3AzTR3joP6CbcOhjAe++fZCQUYrK6nqh4xD1eCw0iYioma8upKO2Xo1ZY31gaW70h8gZVHigAhqtFrFJvPucyNBYaBIRURO5RVU4F5sDVwc5xg7tK3ScLvf7MkccPicyNBaaRETUxKGzKdBotZg/wRdSSc/7a8LFQY7+CivEpxWjurZB6DhEPVrP+w1CREQdlphZiqtJhfDvb4sQfyeh4xhMaIACDWoNrqUWCR2FqEdjoUlERACaP2pS1A0fNdleYYGNz2vn8DmRYbHQJCIiAEBUghKpOeUIH+AMXzdboeMYVH+FFZztLBGXUoT6BrXQcYh6rFZvJZw8eXKbB2q1WojFYnz33XddHoqIiIyrQa3B52dTIBGLMHe8j9BxDE4kEiE0UIETlzNwPb0EIX49d5oAkZBaLTT79euH3bt3t3nw0qVLuzwQEREZ35mr2SgorcbksP5wsZcLHccowgIaC82YBCULTSIDaXXo/O9//7veg9uzDxERmTZVTQOOXkiHpbkE9472EjqO0Xj36wM7axmuJimh1miEjkPUI7XaozlgwAAAwOHDh/Hxxx+joqICWq0WWq0WIpEI33//vW4fIiLqvo5fvoXK6nrMHe+DPnKZ0HGMRiwSITRAgdMx2UjMKMVALwehIxH1OHof9/Duu+/ilVdegaurqzHyEBGRERWX1+DUlUzY25hjSri70HGMLuy3QjM6UclCk8gA9BaaPj4+GDFihDGyEBGRkX15PhX1DRrMGesDczOJ0HGMLsDDDlYWUsQkKrF4agDEPZBhkhEAACAASURBVHhJJyIh6C00Fy1ahIcffhjBwcGQSH7/JbRy5UqDBiMiIsPKyK/AT9fy0F9hhVFBvXPUSiIWY5i/Aj9ey0VaTnmPX9aJyNj0rqO5efNmuLi4QKvVoqGhQfeHiIi6t0NnU6BF4+LsYnHv7ckLDWx89nk0F28n6nJ6ezQVCgX+7//+zxhZiIjISK6nFSM+rRiDvOwx2Lt3z00c7GUPc5kEMQlKzJ/g26OfiERkbHp7NMeOHYsvvvgCaWlpyMzM1P0hIqLuSaPV4uCZZIgAzJ/Qsx812R5mUgmCfR1RUFqNzIJKoeMQ9Sh6ezT37dvXbNvt5Y2IiKj7uXQ9DxkFlYgY7ApPVxuh45iE0AAFfr5RgJhEJTxc+D0h6ip6C83Tp08bIwcRERlBfYMaX5xLhVQixpxx3kLHMRlDfBwhlYgRnajE7LE9/xGcRMait9BMSEjAl19+ifLycmi1Wt12ztskIup+vovKQnF5LSLv8oCTraXQcUyGpbkUQd4OiE0uRF6xCq4OveMxnESGpneO5urVq2FtbY1hw4YhNDRU96c9EhMTMWXKFOzZswcAsHHjRtx///1YunQpli5dirNnzwIAjhw5grlz52L+/Pk4dOhQxz8NERG1qrK6Hl9fvAUrCynuifAUOo7JCQ1ovPs8hnefE3UZvT2abm5uHVozU6VSYePGjYiIiGiy7dVXX8XAgQObbNu+fTsOHToEMzMzzJ49G1OmTIGdnd0dX5OIiFr39U/pqK5twKJJfpBbmAkdx+SE+DtBLBIhOkGJmSNZiBN1Bb09mrNmzcK7776Lixcv4sqVK7o/+shkMuzYsQPOzs66bVVVVc32i4uLw5AhQ2BjYwMLCwuEh4cjJibmDj8GERG1paC0Gt9HZ8HJ1gITQ/sLHcckWVuaIdDDDmm55SgurxE6DlGPoLdH88iRI0hLS8OPP/6o2yYSifDpp5+2fWKpFFJp09NXVVVh27ZtKC8vh4uLC1544QUUFhbCweH3NdycnJygVLY9bGFvL4dUatxHpSkUvAvRVLAtTA/bxDT9sV12nUiAWqPFQ/cORr++fPpNa8aHuePGrRIk5lTgXl+FQa/FnxvTxHbpWnoLzeLi4i5bymjRokXw8/ODt7c33nvvPWzduhXBwcFN9tFqtXrXdCspUXVJnvZSKGygVFYY9ZrUMraF6WGbmKY/tktabjnOxWbDy9UGgW592F5t8O/bWGSci8nEyAGGKzT5c2Oa2C4d01ZxrnfofPjw4cjIyOiSIFOnToW3t7fu64SEBLi4uKCwsFC3T0FBARQKw/4rkoiot9BqtfjsdDKA3x412csXZ9fH3sYcvm59kJBZinJVndBxiLo9vYXmhQsXMHPmTIwZMwYTJkzA+PHjMWHChA5d7C9/+QtycnIAAJcvX4a/vz+Cg4Nx7do1lJeXo6qqCjExMQgPD+/Q+YmIqKm4lCIkZJYi2NcRAzzthY7TLYQFOEOrBWKTCvXvTERt0jt0/v7773foxPHx8di8eTOys7MhlUpx8uRJPPDAA3jqqacgl8thaWmJ//u//4OFhQXWrFmDFStWQCQS4cknn4SNDedHEBF1llqjaXzUpAiYN9FP6DjdRmiAEz47k4yYRCXGBfcTOg5Rt9Zqobls2TJ88skncHNza/Xg2/u0JCgoCLt37262febMmc22RUZGIjIysj15iYionX78JRe5RSqMC+4HNycroeN0G872crg7W+PX9GKoahogt9DbJ0NErWj1p+fGjRtYtmxZqwdqtVrcvHnTIKGIiKhzamobcPh8GmRmYswaw0dN3qmwAAUO/1iJX1ILMXKQq9BxiLqtVgvNw4cPGzMHERF1gaj8WJxMP43cqnyova0QbD0S9jbmQsfqdkIDFTj8YxpiEpQsNIk6odVCs60hcyIiMi1arRYXs2PwaeIB3TaxvBLxmu8Qle+McJcQAdN1P25OVnCxt8QvqUWoq1dDZmbctZuJegpOPCEiMkH1DRpUVtejQlWHiup6VKoav66srkdFdT0qVPWo/MN7ldX1kA46D7G8+blO3TrDQvMOiUQihAYqcPxSBq6nFWNYAJfdI+oIFppERAam1Wqhqm34rVisR0V1XePXfyggdcVjdR0qVPWoqVO369xycyms5WZwsrNAjmXzx/wCQG5Vfld+nF4jPNAZxy9lIDpRyUKTqIP0Fpq1tbU4f/48ysrKoNVqddvnzZtn0GBERMZ0e25jnqoArnJnTPea1GovYJu9jboC8vfisaq6HmqNtsVz/ZFELIKN3AwKO0tYW5rBRm4GG0sZbORmsJabwUYua9z+23tWlmaQSn5fDvnVy+eQU5XX7Lx9rVw6/o3pxbxcbWBvY47YpEI0qDVNvtdE1D56C81HHnkEIpGo2ZxNFppE1FNE5cdi5/W9utc5VXnYeX0vLl7Pg1zloSsYbxeTd9Lb2Fg4WsDGUtZYLFr+oWD8QwFpY2kGC5lE7yN42zLda1KTz3HbNM+JHT5nbyYSiRAWoMB30VlIyCjFYG8HoSMRdTt6C836+nrs37/fGFmIiARxMv10i9t/VV1BbbwMACCViGAjl+nvbfytmPzf3kZjuN0De+rWGeRV5cPVygXTPCdyfmYnhAU2FprRiUoWmkQdoLfQ9PPzQ0lJCezt+egyIuqZ8lQFLW6Xyqvw8l8iuqS30VjCXUIQ7hIChcIGSmWF0HG6Pf/+drCRmyEmUYklUwMgFpv+/wNEpkRvoZmXl4dp06bB19cXEsnvyzt8+umnBg1GRGQszhYK5FU3v2Gmr7ULnO0sBUhEpkIsFmGYvxPOxeUiJacM/v3thI5E1K3oLTQfe+wxY+QgIhKMtMgfkDcvNDm3kQAgNMAZ5+JyEZ2gZKFJdIf0TiAaMWIExGIxrl+/jl9//RVmZmYYMWKEMbIRERlcTKISSfHWsC+OQD+rvhCLxHCz7ouHBi/m3EYCAAz0tIeluQQxicomq68QkX56ezTffvttXLhwAWFhYQCAV155BdOmTcOf//xng4cjIjIkVU09dp9KgFQiwhMTpqGfk5XQkcgEmUnFCPZ1wqVf85GRXwlPVxuhIxF1G3oLzcuXL2P//v0Qixs7PxsaGrBkyRIWmkTU7R08m4KyyjrMHuvNIpPaFBqgwKVf8xGdqGShSXQH9A6dazQaXZEJAFKptFvceUlE1JaEjBL8EJsDN4UVZo70FDoOmbghPo4wk4oRk6gUOgpRt6K3RzMoKAh/+ctfMGrUKADATz/9hCFDhhg8GBGRodTVq7Hr+E2IACyfMYBPfCG9zGUSBHk74GpSIXKLqtDXkT3gRO2h97fr888/j3vvvRdZWVnIysrCfffdh/Xr1xsjGxGRQRz9KR35JdWYEu4O3362QsehbiIssPF55+zVJGq/Vns0CwoK4OzsjOzsbAwdOhRDhw7VvZeVlQV3d3ejBCQi6koZ+RU4fikDTrYWuH+cj9BxqBsJ9nOCRCxCdIISd0d4CR2HqFtotdDcvHkz3njjDTz44IMQiUTQarVN/vv9998bMycRUaepNRrs/OYmNFotlkUGwlwm0X8Q0W+sLMwwwNMe19OKUVRWA0dbC6EjEZm8VgvNN954AwCwY8cO+Pr6Nnnv6tWrhk1FRGQA317Jwq38CowKckWQt6PQcagbCgtQ4HpaMWISlZg6nCN7RPq0OkezvLwcGRkZeP7555GZman7k5SUhHXr1hkzIxFRpxWUqHD4fCps5GZYNNlf6DjUTQ3zd4IIQDTnaRK1S6s9mlevXsXHH3+MGzdu4MEHH9RtF4vFGDNmjFHCERF1Ba1Wi49PJKCuQYOHZg6EtaWZ0JGom7K1Nodff1skZZairKoOtlYyoSMRmbRWC83x48dj/Pjx2LdvHx544IEm7926dcvgwYiIusqPv+Tixq0SDPV1xIiBzkLHoW4uLECBpKwyxCYpMT7ETeg4RCZN7zqaCxYswA8//ICSkhIAQF1dHf7zn//g9OnTBg9HRNRZpZW1OHA6GRYyCZZND+QDJ6jTQgMU2H86GdGJLDSJ9NFbaK5duxZlZWVISEhAaGgo4uLi8NRTT7Xr5ImJiXjiiSewfPlyLFmyBLm5uVi/fj0aGhoglUrx2muvQaFQYMyYMfD29tYdt2vXLkgkvBuUiDpv77eJUNU2YMm0ADj04V3C1HlOdpbwdLHBjfQSqGrqIbfgVAyi1uhdsD0vLw8ffvghvL298c4772Dv3r24du2a3hOrVCps3LgRERERum1vvfUWFixYgD179mDq1KnYuXMntFotnJ2dsXv3bt0fFplE1BViEpWISlDCr78tJgxjzxN1ndBABdQaLeJSioSOQmTS2v3ctYaGBtTW1sLNzQ3Jycl695fJZNixYwecnX+fD/XSSy9h+vTpAAB7e3uUlpZCpVJBrVZ3IDoRUetUNfXYfSoBUokIyyMHQMwhc+pCYQG/PSUogXefE7VF79D5yJEjsWPHDkyZMgVz5syBQqGARqPRf2KpFFJp09PL5XIAgFqtxt69e/Hkk09CpVKhqKgIq1atQkFBAWbOnIlly5Z18OMQETU6eDYFZZV1mD3WG/2c+Fxq6lr9nKzQ11GOa6lFqK1Xw9yMI3FELdFbaK5atQpqtRoSiQQhISEoLi5uMhx+p9RqNZ599lmMHDkSERERqKysxOrVqzFr1izU19djyZIlCA0NRVBQUKvnsLeXQyo17g+1QmFj1OtR69gWpsfU2uRaSiF+iM2Bp6sNlt0TBDNpuwdvehRTa5eeZkyIGw5+n4TMIhUihvS74+PZPqaJ7dK19BaaK1aswIcffggACAsLAwDMnTsXn3/+eYcuuH79enh6emLlypUAAGtra8yfPx9A43B7REQEEhIS2iw0S0pUHbp2RykUNlAqK4x6TWoZ28L0mFqb1NWr8fa+GIgALJ0WiNKSKqEjCcLU2qUnGuhuCwA4cyUDfq53VpywfUwT26Vj2irOWy00jxw5gu3btyMnJwcTJkzQba+trW0y7/JOHDlyBGZmZli1apVuW0JCAj766CNs2rQJarUaMTExiIyM7ND5iYiOXEhHfkk1poa7w6dfH6HjUA/m6WIDxz7miE0uQoNaA6mkd/acE7Wl1ULzvvvuw913342///3vTZYzEovF7So04+PjsXnzZmRnZ0MqleLkyZMoKiqCubk5li5dCgDw9fXFhg0bYGdnh/nz50MsFmPixIkYOnRoF3w0IuptMvIrcOJyBpxsLXD/OB+h41APJxKJEBrgjG+jMnHjVgmG+DgKHYnI5LRaaP76668YNGgQZs2ahYyMjCbvpaen652nGRQUhN27d7crxPr169u1HxFRa9QaDXZ+cxMarRbLIgNhLuPNGWR4YYEKfBuViegEJQtNoha0WmgePnwYgwYNwrvvvtvsPZFI1KkbgoiIutq3V7JwK78Co4JcEeTNv/DJOPzcbNFHboarSUosmx4IsZjLaBH9UauF5vPPPw8A7e6VJCISSkGJCofPp8JGboZFk/2FjkO9iFgswrAABX6IzUFSVikCPeyFjkRkUvTOXP75559x//33Izg4GCEhIVi4cCFiY2ONkY2ISC+tVouPTySgrkGDxVMCYG3JxwGScd1evD06kYu3E/0vvYXmv/71L6xduxZXrlzB5cuXsWrVKmzYsMEI0YiI9Pvxl1zcuFWCYF9HjBjYsRUxiDpjgKc95OZSxCQqodVqhY5DZFL0Fpp2dnaIiIiATCaDubk5Ro8eDRcXF2NkIyJqU2llLQ6cToaFTIKl0wMh4mMmSQBSiRjBfk4oLq9Feh7XYCT6I72FZnBwMHbt2oXk5GQkJibik08+gZ+fHzIzM5GZmWmMjERELdr7bSJUtQ2YN8EXDn0shI5DvVhY4G/PPufwOVETep8MdPToUQDAJ5980mT78ePHIRKJ8P333xsmGRFRG2ISlYhKUMKvvy0mDHMTOg71coO9HSAzEyMqQYn7x/mwd53oN3oLzdOnTxsjh0mKyo/FyfTTyFMVwFXujOlekxDuEiJ0LKJeT1VTj92nEiCViPDQjAEQ8y91Epi5mQRDfBwRnaBETpEKbk5WQkciMgmtFprvv/8+/vznP2Pt2rUt/stsy5YtBg0mtKj8WOy8vlf3OqcqT/eaxSaRsA6eTUFZZR3mjPVGX0f+hU6mISxAgegEJWISCuDm5C10HCKT0GqhOWjQIADAqFGjjBbGlJxMb7kn99StMyw0iQSUkFGCH2Jz4KawwoyRnkLHIdIZ6usEiViE6EQl7h3NQpMIaONmoLFjxwIApk2bBnNzc8yZMwdz5sxBTU0Npk2bZrSAQslTFbS4Pbcq38hJiOi2uno1dh2/CZEIeGjGQEgleu9nJDIauYUUg7wckJFfCWVptdBxiEyC3t/S69atQ1ZWlu51TU0Nnn32WYOGMgWu8pbX4+trxaWdiIRy5EI68kuqMTXcHT79+ggdh6gZ3n1O1JTeQrO0tBSPPfaY7vVDDz2E8vJyg4YyBdO9JrW4fZrnRCMnISIAuJVXgROXM+Bka4E5Y32EjkPUohA/J4hEfEoQ0W16C836+nqkpKToXl+7dg319fUGDWUKwl1C8NDgxXCz7guxSAxU94EmLQQesgChoxH1OmqNBruO34RGq8WyyECYyyRCRyJqUR8rGQL62yElqwyllbVCxyESnN7ljdavX48nnngCFRUV0Gg0sLe37/F3nN8W7hKCcJcQKBQ2OPpDEj649it2fnMTaxcP43IqREZ06kombuVXYFSQK4K8HYWOQ9Sm0EAFEjJLcTWpEBO5xisZkSkuy6i30AwODsbJkydRUlICkUgEOzs7Y+QyOXcNdMGVGwW4mlSIs1ezMSm0v9CRiHqF/BIVDp9Pg43cDIsm+wsdh0ivsAAF9n2XhJiEAhaaZDSmuiyj3qHz7OxsrFq1CqtWrYKdnR0OHjyI9PR0I0QzLSKRCEunB8LKQoqDZ1JQyDsKiQxOq9XikxMJqG/Q4E9TA2BtaSZ0JCK9HPpYwLuvDW5mlKKyuudPNSPT0NayjELSW2i+/PLLmDVrFrRaLQDAy8sL//jHPwwezBTZWZtj0WR/1NarsevETd33hIgM48dfcnHjVgmCfR0xfEDLK0EQmaLQAAXUGi3ikguFjkK9hKkuy6i30GxoaMDkyZN1TwcaPny4wUOZslFBrhjq64hf00twLi5H6DhEPVZpZS0OnE6GhUyCpdMD+exo6lbCAhv/YcRljshYTHVZxnbddV5eXq77JZ+UlITa2t57J51IJMKy6YGwNJfgwOlkFJfXCB2JqEf69NtEqGobMG+CLxz6WAgdh+iOuDrI4eZkhfi0YtTUNQgdh3qB4fYtP8lR6GUZ9RaaTz75JBYsWIDr16/j3nvvxUMPPYS//vWvxshmshz6WGDhJH/U1HEIncgQohOUiE5Qwr+/LSbwZgrqpkIDFKhv0CA+tVjoKNQLpN+0QV1yMBzMFBCLxHCz7ouHBi82/bvO77rrLhw+fBiJiYmQyWTw9vaGubm5MbKZtLFD++LKzQLEpxbjwrU8jBnaV+hIRD2CqqYee75NgFQiwvIZA7iUGHVbYYEKHP0pHdGJSoRzjjEZUEFpNS7fyIebkx9eHrPYpKYa6e3RXLZsGSwsLDB06FAMGDCAReZvRCIRlkcOgLlMgv3fJ6GkovdOJyDqSgfPpqCssg73jvJCX0croeMQdZi7szWcbC0Ql1yI+gaN0HGoBzt5OQNaLTBzpKdJFZlAOwrNgQMH4u2338a5c+dw8eJF3R8CHG0tsGCiH1S1Ddh9MoFD6ESdlJBRgh9ic9BfYYUZIz2FjkPUKSKRCGGBCtTUqXHjFofPyTDKKmtx/pdcKOwsMHyg6fWc6x06v3HjBgAgKipKt00kEiEiIsJwqbqR8SH9cOVGPmKTC3Hp13xEDHYVOhJRt1RXr8bO4zchEgHLZwyEVKL338FEJi8swBknf85EdIISQ32dhI5DPdCpqEw0qDWIvMsTErHp/d7UW2ju3r27wydPTEzEE088geXLl2PJkiXIzc3Fs88+C7VaDYVCgddeew0ymQxHjhzBxx9/DLFYjIULF2LevHkdvqaxiUUiLJ85EC9+eBl7v03EIE972FpzegHRnTpyIR0FJdWYNtwdPv36CB2HqEv4uPWBrZUMV5MKsUyjMclCgLovVU09zsRko4+VDGOGmGZHl97/43/++Wfcf//9CA4ORkhICBYuXIjY2Fi9J1apVNi4cWOTns933nkHixcvxt69e+Hm5oZDhw5BpVJh+/bt2LVrF3bv3o3//ve/KC0t7dynMjJnO0vMG++LqpoG7DmVyCF0ojt0K68CJy5nwMnWAnPG+ggdh6jLiEUihAYoUFldj6TMMqHjUA9z5mo2aurUmDbcHWZSidBxWqS30PzXv/6FtWvX4sqVK7h8+TJWrVqFDRs26D2xTCbDjh074Oz8+3yBy5cvY/LkyQCAyZMn4+LFi4iLi8OQIUNgY2MDCwsLhIeHIyYmpuOfSCCTwvojoL8tohOVuHKz5dX5iag5tUaDXcdvQqPVYllkIMxlpvnLkqijQgMVAIBoLt5OXaiuXo1vr2TC0lyKiSa8DJzeoXM7O7smvZKjR4/GJ598ov/EUimk0qanr66uhkwmAwAoFAoolUoUFhbCwcFBt4+TkxOUyrZ/GO3t5ZAauXJXKGz07rNmSTieev0M9n6XhDGh7hxCN5D2tAUZV2fa5IszSbiVX4FJ4e6YOMKr60IRf1ZMxBgHK7z/1XXEJhdi1aJQiMWNdwWzfUxTd2mXYz+molxVj/mT/eHR317oOK3SW2gGBwdj165dGDNmDDQaDS5dugQ/Pz9kZmYCANzd3dt9sT/ecn97ePl/h5m1Wq3eW/NLSlTtvmZXUChsoFRW6N3PDMCccT44cDoZ7+yPwV9mBRk+XC/T3rYg4+lMm+SXqLDnxE3YyM0we7QX27YL8WfFtAT7OuJCfB6uXMuBT78+bB8T1V3apUGtwcHvk2AmFWP0IBfBM7dVnOstNI8ePQoAzXoxjx8/DpFIhO+//77dQSwtLVFTUwMLCwvk5+fD2dkZLi4uOHv2rG6fgoIChIQIu4p9Z0wNd0dUQgF+vlGA4QOUCPttyISImtJqtfj4+E3UN2iw4u6BsLY0EzoSkcGEBipwIT4P0YkFvNmNOu3nG/koKq/B5ND+6GMlEzpOm/QWmqdPn+6yi40aNQonT57ErFmzcOrUKYwdOxbBwcF44YUXUF5eDolEgpiYGDz//PNddk1jE4tFeHjmQLz00RXsPpWAQA87/gVK1ILzv+TiZkYpQvycMJxPTaEebrCXA8zNJIhOUGLeeF+h41A3ptFqcfxSBsQiEaaPaP+oslD0FpodFR8fj82bNyM7OxtSqRQnT57E66+/jnXr1uHAgQPo168fZs+eDTMzM6xZswYrVqyASCTCk08+CRub7jE/ojV9Ha0we6w3Dp1Nwb7vEvHovYOFjkRkUkora/HZ6WRYyCRYMi3A5J5kQdTVZGYSDPF1RNTNAmQXVsHZmb2a1DFxyYXILqxCxGBXONlZCh1HL4MVmkFBQS2uwblz585m2yIjIxEZGWmoKIKYPsId0QkFuHg9H8MHuiDEjwv1UqOo/FicTD+NPFUBXOXOmO41CeEu3Xe6SEd8+m0iVLUNWDotAA59LISOQ2QUYQEKRN0sQEyCEsMG9RU6DnVDWq0W31y8BQCYOdJD4DTtw5VjDUQiFuOhmQMhEYvwyYmbUNXUCx2JTEBUfix2Xt+LnKo8aLQa5FTlYef1vYjK1782bU8RnaBEdIIS/v1tMd6El+Qg6mpDfR0hlYi4zBF1WEJGKVJyyjHM3wluCmuh47RLqz2aa9eubXM4a8uWLQYJ1JP0V1jjvtFe+PJ8GvZ/n4yH7x4odCQS2Mn0luc8n7p1plf0aqpq6rHn2wRIJSIsnzEAYg6ZUy9iaS6Fe0A5ciTnseizL3rtiAZ13LFLt3szPQVO0n6tFpqjRo1q9SDOp2q/GSM9EZ2oxI/XcjF8oDOG+DgKHYkElKdqeTH/nMp8lFXVwdbE7x7srM/OpKCssg5zxvmgr6OV0HGIjCoqPxZ5NhcgBqDRQjeiAYDFJul1K68C19OKMcDDDr5utkLHabdWC805c+a0uL2urg5/+9vfMHv2bIOF6kmkEjEenjkQGz+Owq7jN/HKI3fB0txgU2PJxDmZK1BQk99su1plhTXbLmCoryNGD+mLYD9HSCU9a2bLzVslOBeXg/4KK8y4q3vMLSLqSq2NaBxPO81Ck/TS9WZGdJ/eTKAdczQPHz6MkSNHYuDAgRg4cCCGDRuGqqoqY2TrMTxcbHB3hCdKKmrx2ZlkoeOQQEoqalGW1vJSFHc5joa7izVikwux/ctreGbbBez9NhG38kx/4eD2qKtXY9eJmxCJgOUzBva4IpqoPVob0citzMcrn0Th6E/pyCyobPYgE6K8YhWibxbA08UGg70c9B9gQvR2re3evRtHjx7FM888g/fffx9Hjx7t9ssPCeGeUV6ISSzED7E5GD7AGYO62f8o1Dnlqjq8vv8qSoucMKL/FBRbXkduVT76WrlgmufExt6MCCCroBI/XsvFpet5+C46C99FZ8Hd2Rqjh/TFyEEuJr8wb2uOXEhHQUk1pg1352LV1Gu5yp2RU5XXbLtMbYv03Aqk5pTjy3OpcOxjgWA/R4T4OSHQwx5mUv7DrLc7fukWtADujvDsdtMX9RaaNjY2UCgUUKvVkMvlWLhwIVasWIGZM2caI1+PIZWIseLu34fQ/7liBCxkHELvDVQ19XjzQCxyi1SYNtwdC8f5QSSa1uK+/Z2tsWiyP+ZN8EV8ajF+vJaLuORC7P8+CQfPJGOoryPGDOmLIb7dZ2j9Vl4FTlzOgJOtBeaM9RE6DpFgpntN0s3J/KMlITMxYNxgxKcWITa5ENdSi3E6JhunY7Jhi6csCQAAIABJREFULpMgyMsBwX5OGOrniD7y7vmPTeq44vIa/BSfBxcHOUIDut/TBvVWOhKJBGfOnEHfvn2xdetWuLu7Izs72xjZehxPVxvMGOmBYxdv4dDZFCyZFih0JDKw2jo13jr4CzLyKzEuuB8WTvJr179GpRIxQvydEOLvhHJVHS7/mo8L13JxNakQV5MKYSM3w8hBrhgztC/cnU13iQu1RoNdx29Co9XiwcgBMJdJhI5EJJjb8zBP3TqDvKp8uP5xRAPAyMGuGDnYFQ1qDZKyyhCXXIjY5EJEJyoRnaiECICPWx+E+Dkh2M8Jbk5W3a53i+7cqSuZUGu0mHGXB8Ti7tfeIq2eySBFRUUoKCiAs7Mz3nrrLRQWFmLp0qVt3pVuaMZ+eLxCYdNl16xv0ODlXVeQU1iF5xYPQ6CHfZect7foyrYwtPqGxiLzxq0SjBzkgkfuGdTpXxIZ+RW4cC0PF6/nobK6cW1WD5ffh9ZtBOjtaKtNjl++hYNnUjA6yBUr7hlk5GS9W3f6WemN2ts+Wq0WecUqxCYXIi6pEEnZZbj9t7aTrQWC/Zx+G2K36zajHKbM1H5uKqvrsfbdnyC3kGLzXyJMto0VitanVOotNHft2oXly5c32fbOO+9g1apVXRKuI7pzoQkAqTnleHV3FBS2lnh5xQiYm7GXp71M7ZdAaxrUGrz7ZTxikwsxzN8Jj88O6tJfEA1qDX5JKcKFa7n4JaUIao0WErEIwX5OGDOkL4J8HIz2C6m1NskvUeHFD3+GpUyCVx4dCWtLM6PkoUbd5Welt+po+1RW1+NaSuMQe3xaEapr1QAAC5kEQd6/DbH7Ogryj86ewNR+br76MQ1f/ZiGRZP8MG2E6a7W0Vah2erQ+aVLl3Dp0iUcOXIEZWVluu01NTU4cuSIoIVmd+fTrw+mj/DAicsZ+OKHVDwwxV/oSNSFNBotPjx2A7HJhRjkZY+/zBrc5UWfVCJG6P+3d9/hUZX538ffM0kmvZNGAiEhgYSEIr0rIH1FVh+KPOKiqPhzxXVXxN21rK7L+nt0l/1de+liR0UFxP25oNIFpQihJYRUEghpJCG9TTKZcp4/kFgISsnMmfJ9XZeXcJjyGb7MzDf3fe779AtjaL8wmlo7OJxTxYHMCk6crubE6WoCfDwYnRLJ+IFRxKgwta4oCu9ty8NosrB0drI0mUJ0Ez9vD8akRjIm9dsp9tIGMgprOVlYw7H8ao7lX5xi7xsd2LmgqKdMsTuk9g4Tu4+V4uvlzsQhPdWOc92u2GjGx8dTXX3xMllubt+NuPn5+bF69WrrJ3Nyc8fHkV5Qw+5jpQxPCiMxJkjtSKIbKIrC+zvySMupIiE6kOV3DMLD3boj1gG+OqaN6MXU4TGUVLVw8FQFh3Oq2Hm0lJ1HS4mN9Gf8wChGDYiwWcO3P7OCvJIGhiT0YERSuE2eUwhX4+6mJblPCMl9Qlg4JYGKWn3neZ2F5Y0Uljfy76/PEhbkxeC+PRic2IP+vWSK3VHsO1lBa7uJOeP6OPTi4Z+dOi8rKyMmJoaGhgY0Gg2BgervRu/oU+eXFJY18uIHxwkP8eH5e0egkyn0n2Vv0xrfpygKG/cUsvNoKb0j/Fh51034eKkzkmcyWzhZWMPBU5VknqnFolycWh+S+N3Uupu2e75sflyThhYDT72ZhqIo/OX+UYQEeHXL84hrY8/vFWH9+jTrOzh1tpaMwlqyztbS3nFxit3b042UuFCGJIQyqG8PmW34EXt535jMFp587RD6dhMvPzzW7ut0XVPnl1RVVbFkyRJaW1tRFIWgoCBefvllBg4c2K0hXVFCTCC3Du/FrmOl/OdAEfMnJagdSdyAzQeK2Hm0lKhQH363YIhqTSZcHOkY1j+cYf3DaWzt4FBWJQdPVXA8v5rj+dUE+uoYkxLJuIGRRId179T6h7tO02YwsXhaP2kyhVCJv4+OsalRjE2NwmS2kF/awMmCi6Odx/IucCzvAhoNJEQHdq5ijwr1kSl2O3Eoq5L6ZgPTRvSy+ybz5/xso7l69Wr+9a9/0a9fPwBycnJYtWoVH374odXDuYI7bo7nZGENO46UMKx/GH17qj9iLK7d9rQSthw8R1iQFysW3mRXe90F+uqYMao300f2oriqmYOZlRzOqWT7kRK2HykhLsqfcQOjGJl841PrlxrZxJhAbr4puptegRDiRri7aUnpE0JKnxDuujWR8zWtF1exn6mlsLyRgrJGNn11hvAg729XsYeSKFPsqrFYFLamleCm1TBtRNdXk3MkP9toarXaziYTYMCAAT84Z1PcGE8PN+6dlcT/+yidtVvz+NOSEXIVCAezN72cj/cWEuzvyRMLbyLY31PtSF3SaDT0iQygT2QA8ycncLKwhgOnKjh1tpaiimY2fFnATYlhjBsYRUpc8DVPrevbjXywKx93Nw1LZiahlZERIeyORqMhOsyP6DA/Zo/pQ7O+g8wzFxcTZRXVsetYKbuOleLt6c7A+Iur2AfGhzr8qJojOXG6mqo6PRMGRTnFrNBVNZo7d+7s3Ddz37590mh2s/69g5k8NJo9J8rZcrCIO2/uq3YkcZUOZVXywY58/H08WLFwCD2CvNWOdFU83LUMTwpneFI4DS0GDmVXciCzgqN5Fziad4FAPx1jUyIZNzCKnj18r+oxP957hsaWDn45MZ6o0Ku7jxBCXf4+OsYNjGLcwCiMJgunSxsujnYW1nAk9wJHci9OsSdGBzI48eKenVGhvhyrymDHuT1U6i8Q6RPO9D6TOzeeF9dPURS+OFyMBpgxyn63M7oWV1wMtGXLFubMmcO5c+d44YUXyMzMRKvVMnjwYJ5++ml691bvL8BZFgN9X3uHiWffPkJdk4GnfzWMPpFyPeiu2MuJ2nBxmnjNf7Lw0rmxctFN9I648snQjkBRFM5VNnMgs4K0nCr0BhNwcTuui1Pr4fh2cd5pWJg/+4+V8NL6dGLCfHl2yQiZcrMD9vReEZez9/ooikJ5TWvnKvaz5U1cahZCetXSFnX0svvcm7LI4ZtNteuSXVTH3zdmMLx/GA//0nHWwlzXhu333HMP77//vtVC3QhnbDQBcs7V8bcNGfJl/RPU/hC4JKuoln9+kombVsuKhUPoG+1c59YaTWbSCy5OrWcX1aEol/buvLhqfUCfEE5Un+wc0aDdj/ayOP74i9uIi5IfkuyBvbxXRNccrT5Nrd9NsWd7/geN9+XZo/2i+OPI36qQrvuoXZeXPjpBXkkDf1oygthIxxm8uKFV58J2BvQJ4eYhPfk64zyff3OOuRPi1Y4kunC6tIFX/n0K0PDonQOdrskE8HB3Y2RyBCOTI6hv/m5q/dJUWkB0Ncbo49/dwbMJXd+T1GpTiMOxRzSEEJcL8NUxflAU4wdFsXzPh1i6uE1Fa5XNczmTM+cbyStpICUuxKGazJ9zxUYzPT2dW2655bLjiqKg0Wj46quvrBjLdc2flMCps7V8caiYof3CHH461tkUVTTxP5tOYrYoPHLHQJL7hKgdyeqC/T2ZNTqWmaN6c/Z8EwdPVZBmPtjlbXcW73X4qTMhxE+L9A3nfGvlZcejfCNUSOM8th4qBmD26FiVk3SvKzaaAwYMkCsAqcDb050lM5JY/fFJ3tmay9P3DJcpdDtRVt3C6o0ZGIxmls1JYXBCD7Uj2ZRGo6FvdCB9owM5uqdVRjSEcFHT+0xmbfZHlx0fETJWhTTOobymlfSCGuJ7BtC/t3NdKfCKjaZOpyM6WvbBU0NqfCjjB0Zx4FQF29JKuG1sH7UjubyqOj1/35BBa7uJe2clMTLZtX9ylxENIVzXpVmLncV7qWitItAtlKq8nuwv0nBzrFmucncdth3+bjTT2TbNv2KjOWjQIFvmED+ycEoCWUW1fHawiKGJPbr96i3i6tU2tvO3Dek0tnaw6NZEJgzqqXYk1V1pRGNa7CQV0gghbG14xJAfnCbzfls+X6WXs3FPIYun91cxmeOpaWwjLaeKnj18GZzofDNlV2w0n3jiiW5/sk2bNrFly5bO32dlZXHHHXeQnp6Or+/FffeWLl3a5bmhrsbHy4N7ZiTxz08yeWdrLn9cPKzbrk0trl5jawd/25BObZOBOybGc+twx79KQ3f4/ohGZWsVkb4RTIudJOdnCuGiFk5OoKCsgb3p5STHBjM8KVztSA5jR1opZovCrNG9nfJCFzZddT5v3jzmzZsHwJEjR9i2bRt6vZ5Vq1aRnJxsyygOYUhCD8akRHAou4qdR0qZ6WQnCNu7ljYjf9+QTlV9G7NGx/ILOYXhBy6NaKi9HYgQQn06Dzceuj2VF949ytptefSJ9HeYC1ioqam1g32Z5wkN8HLaU7JUGyJ79dVXefjhh2ltbVUrgkO469Z+BPjq+HR/ERW18ndlK20GE//4+CRl1a1MHhrNnTfLVlNCCPFTonv48n+n9qPNYOL1LdmYzF0tGRTft/t4KUaThRmjejvtwl9VXlVmZiZRUVGEhYXR2trKK6+8wuLFi1mxYgUNDQ1qRLJbft4eLJ7WH5PZwjtbc7FYutxfX3Qjg9HMPz/JpKiiiXGpkSya2s/pTs4WQghrGD8oilEDIjhzvon/7C9SO45dazOY+PJ4Of4+HowfFKV2HKu54pWBrOnZZ59l9uzZjBo1il27dpGQkEBcXBxr1qyhpqaGZ5555ifvbzKZcXd3rVVtL607xv6McpbOSWWuXAvdaowmC6vWpnE87wJjB0Wx8u7huDnpT5lCCGEN+nYjj63+moraVp5/cAxD+8v5ml35954C3v0ih8Uzk5l/az+141iNKo3m9OnT+eyzz9DpdD84XlhYyHPPPccHH3zwk/d31ktQ/pQmfQfPvJWGocPM80tHEhHso2oetVizFmaLhdc2Z3M8v5qB8aEsv3Og005ldCd7eH+Iy0ld7Juz16eooom/rjuOr5c7z983kkA/T7UjXRVb1cVoMrNyzSEMRjN/e3gsPl4eVn9Oa/qpS1Da/Fu0qqoKX1/fzibzoYce4vz58wCkpaWRmJho60gOIcBHx/+d2o8Ok4W1W/Ow2P7nA6dmURTWbs3jeH41/XsF8etfpkqTKYQQ1ykuKoB5t/SlSW/kzc9z5DvrRw6cqqSxtYNJQ6Mdvsn8OTa/1nl1dTUhId9dtu/uu+9m+fLl+Pj44O3tzYsvvmjrSA5jRFI4R3MvcPx0NXtPlDNlWIzakZyCoih8uOs032RVEhcVwKP/Z5BsOCyEEDdo6ohe5BbXc/JMLdsOFzN7TB+1I9kFs8XC9rRi3N20THOBLfNs3mimpqby1ltvdf5+/PjxjB8/3tYxHJJGo+Hu6f3JK6nnk6/OMKhvKGGyfcQN+/fXZ9l7opyYMF9+O38w3p42f1sIIYTT0Wg03Dc7mT+9c4RP9xXRv1cwCTGBasdS3dG8C1Q3tHPLTdEOc0rBjZC5QQcT6Ktj0dR+GIxm3t2Whwqn2DqVz785x9bDxUQEe/P4wpvw83buKQwhhLAlfx8dy+akoKDw+pYsWtuNakdSlaIobD1UgkYDM0b1VjuOTUij6YBGD4hgSEIPcovr+TrjvNpxHNauY6X8776zhAZ4smLhTQT66n7+TkIIIa5J/97BzBkXR22TgbVbXXuAJPNMLWXVLYxKjiDcRWYkpdF0QBqNhsXT++Pj6c7GvYXUNLapHcnh7D95nvW7Cwj01bHirpsIDfRSO5IQQjit28b2oX+vIE6crmZvernacVTzxeFiAJe60p80mg4q2N+ThVMSMXSYeU+m0K/Jkdwq3t2eh6+XO48vHOKyW0UJIYStaLUaHpyTgp+3Bxu+LKSkynm3drqS06UNFJY1MqhvKL3C/dSOYzPSaDqwcQMjGRgfSva5evZnVqgdxyFkFNbw5mc5eHq48bsFQ4gJc503uxBCqCnY35Ols5MxmS/uWdzeYVI7kk1t/XY0c/YY1xnNBGk0HZpGo+FXM/rjpXNj454C6pra1Y5k13LP1fGvT7Nw02p4bN5g4qIC1I4khBAuZXBCD6aN6EVlnZ4Pd51WO47NlFQ1k3mmln4xgSTGBKkdx6ak0XRwIQFeLJicQJvBzPs78mUK/QoKyxv5579PAQqP3DmQfr1c640uhBD24s6b+xIb6c/BU5UcyqpUO45NXBrNnOWCe4lKo+kEJg7uyYA+wWSeqeUbF3nTXouSqmb+5+OTGE0Wls1JJTUuVO1IQgjhsjzctTx0ewpeOjfe35lPVZ1e7UhWVVWv52jeBXqF+zEwPuTn7+BkpNF0AhqNhiUzkvD0cGP97gIaWgxqR7IbFbWt/H1jBm0GE0tnJzOsf5jakYQQwuVFBPtwz4z+GDrMrNmchdFkUTuS1exIK0FRYNboWDQajdpxbE4aTSfRI8ibeZP6ojeYWCdT6ABUN7Txtw0ZNOuNLJ7enzGpkWpHEkII8a3RAyKZMCiKkqoWNn1VqHYcq2hoMXDgVAXhQd4MT3LNgQ5pNJ3ILTdFk9Q7iPSCGtJyq9SOo6r6ZgN/25BOfbOB+ZMSuOWmaLUjCSGE+JFFt/YjKtSH3cfKSC+oVjtOt9t5tBSTWWHG6N64aV2z5XLNV+2ktBoNS2YmofPQ8tGuAhpbO9SOpIomfQd/25BOdUM7c8b1cZnLfAkhhKPx1LnxX7en4uGu5Z0vcp1q95TWdiN708sJ9NMxLjVK7TiqkUbTyYQH+3DnxL60tBn5cGe+2nFsTt9uZPXGDCpq9Uwb0Yvbx8epHUkIIcRPiAn3464pibS2m3hjSzZmi3Ocr7nneBmGDjPTRvTCw9112y3XfeVObMrwGBJiAjmWX82xvAtqx7EZQ4eZ/9mUSUlVCxMHR7FgcoJLnngthBCO5uYhPRneP4zTZY1sOXBO7Tg3zGA0s+tYGT6e7twyxLVP3ZJG0wlpNRrum5WMh7uWdTvzadY7/xS60WTmn//OpLC8kVEDIrhnepI0mUII4SA035761SPQi8+/OUducb3akW7I/pPnaWkzMnlYDN6e7mrHUZU0mk4qMsSHX06Ip1lv5KPdBWrHsSqT2cKa/2STW1zPkIQeLJ2djFYrTaYQQjgSHy8Pls1JQavV8MZn2TQ56DoDk9nCjiMl6Ny13Do8Ru04qpNG04lNG9GL+J4BpOVUkX7a+VbzAVgsCm9/kUtGYQ3JscH819wU3N3kn7UQQjiivtGB3DExnsaWDt7+IheLA27Vl5ZTRW2TgYmDexLgo1M7jurkG9mJabUa7p2VjLubhvd35NPSZlQ7UrdSFIX3d+SRllNFQnQgj945CA93N7VjCSGEuAHTR/UmNS6EU2dr2XmkVO0418SiKGw9XIybVsP0kbLjCUij6fSie/hy+/g4Gls72PCl80yhK4rCxj2F7DtZQe8IPx6bNwhPnTSZQgjh6LQaDff/YgCBvjr+/fUZzp5vUjvSVcsoqKGiVs/oARGEBnqpHccuSKPpAmaM6k1spD9p59N5Zv/LLN/7e1alreZYVYba0a7b5gNF7DxaSlSoD79bMAQfLw+1IwkhhOgmAb46HrhtABaLwmubs9C3m9SO9LMUReGLQ8VogJmjY9WOYzek0XQBblotY8aa0SWcpM5YjUWxcL61krXZHzlks7k9rYQtB88RFuTFioU3yTkwQgjhhAb0CWH22FhqGtt5b3ue3V9aOa+4nqKKJm7qF0bPHr5qx7Ebrr3m3oUcrf+my+PvHv+cT0rb8PRwu/if7tv/e2jx1Llf/P8Pjv/4dj/+tdYql9k6VpXBjnN7qGitwqz3JSC6Pytum0Owv2e3P5cQQgj7cPv4OPJKGjiad4EBfYK52Y73pPzicDEAs2Q08wek0XQRlfquN25XPJsxGM006zto7zDTHT8wurtp8fTQ4qVzQ/dtA/r9X3fVpF7884tNrZeHG7pLxz3cyG3KZkPhx52Pr/VpwehznGJDf8IYcuOBhRBC2CU3rZZlt6Xw3NojfLS7gIToQKLD/NSOdZmiiiZyztWTHBtMfM8AtePYFWk0XUSkTzjnWysvOx7tH8kfHxkPXDy/xGS2YDBaaO8wYTBa6DCaae8wYzCaMVz6/xV+3dHF/Zr1RmqN7XSYrv+SYp6pB9D6XH58Z/FehkdIoymEEM4sNNCLe2cl88r/nuK1zdk8/avheHrY1+LPrZdGM8fIaOaPSaPpIqb3mcza7I8uOz4tdlLnrzUaDR7ubni4u+Hn3b2LaywW5bvG9LJG1YLBeLFB/cHxb2+X7t3a5WNWtFZ1a0YhhBD2aWi/MKYMjeHLE2Ws313AkplJakfqVFHbyon8avpE+jMgNljtOHbHpo1mVlYWDz/8MLGxFzv+fv36cf/997Ny5UrMZjNhYWG8/PLL6HSyuKO7XRr521m8l4rWKqJ8I5gWO8lmI4JarQZvT/fruhTXqrSILkdjo3wjuiOaEEIIBzB/cl8KyhrYd/I8A/oEMzLZPr4Dth0uQQFmj4mVSx93waaNpl6vZ/r06Tz11FOdx/7whz+waNEiZs6cyUsvvcQnn3zCokWLbBnLZQyPGOKQU81XMxorhBDCuXm4u7Hs9hT+/O4x3tueR5+oAMKDvFXNVNfUzqHsSiJDfLipX5iqWeyVTbc3am29fAo0LS2NKVOmADBlyhQOHTpky0jCAQyPGMK9KYuI9ovCTaMl2i+Ke1MWOWTTLIQQ4vpFhfpy97R+tBnMvL45C5P5+s//7w7bj5RgtijMHN0brYxmdsnmI5rHjx/n/vvvp62tjeXLl9PW1tY5VR4WFkZ19c9fkzs42Ad3G19qMCzM36bPJ35oZtgEZqZOUDuGuAJ5f9gnqYt9k/pcn7mT/Tlb2cze42VsO1rGfbeldOvjX21dGlsM7M+soEegF7fdnIiHu2xN3hWbNppJSUn8+te/ZsqUKRQVFXHvvfdiMn232//VbsZaX6+3VsQuhYX5U13dbNPnFF2TWtgfqYl9krrYN6nPjZl3czw5Z2v59KtCYsN8GdQ3tFse91rq8p/9ZzF0mLljQjwN9V0vWnUVP9Wc27T97tu3b+c0eVxcHD169KCpqYn29nYAqqqqCA8Pt2UkIYQQQjgYL507/zU3FXc3DW99nkN9s8Gmz99mMPHl8TL8vD2YOLinTZ/b0di00fzkk094//33Aaiurqa2tpY77riDHTt2ALBz504mTJDpUSGEEEL8tN4R/iyYnEhLm5E3P8vGYrHdJSq/zjhPa7uJW4fF4Kmzrz097Y1Np86nTp3KihUr2LFjBx0dHTz33HMkJyfz5JNPsnHjRnr27MncuXNtGUkIIYQQDmry0GhyztWRXlDD54fOMWdcnNWf02iysPNoCZ46NyYPi7H68zk6mzaagYGBvPnmm5cdX7t2rS1jCCGEEMIJaDQa7p2VTPHaI2w+UERS72D69Qqy6nMeyq6koaWD6SN7dfvFTZyRLJESQgghhMPy8/Zg2ZwUNGh4fUs2LW1Gqz2XxaKw7XAx7m4apo3obbXncSbSaAohhBDCoSXGBHH7hDjqmw2880XuVe9ic62O5V+gqr6NsalRBPt7WuU5nI00mkIIIYRweLNHx5IcG0xGYQ27j5d1++MrisLWQ8VoNDBzlIxmXi1pNIUQQgjh8LRaDQ/cNgB/Hw827S2kuLJ79ynNKqqj5EILw/uHExHi062P7cyk0RRCCCGEUwjy8+T+XwzAZFZYszmLNoPp5+90lbYeKgZg1ujYbntMVyCNphBCCCGcxsD4UGaM6s2F+jbW7czvlvM1C8sbyS9tIDU+hNhIuXTotZBGUwghhBBO5Y6J8cT3DOBwdhXfZFXe8ONdGs2cLaOZ10waTSGEEEI4FXc3LcvmpODt6c66nflU1F7/tcjLqlvIKKyhb3SA1ffodEbSaAohhBDC6YQFebNkZhIdRgtr/pON0WS+rsfZevjSaGYfNBpNd0Z0CdJoCiGEEMIpjUgK55YhPSmrbmHjnsJrvn91QxtHci4QHebLoIRQKyR0ftJoCiGEEMJpLZySSHSYL3tOlHM8/8I13Xf7kRIsisKs0bFoZTTzukijKYQQQginpfNw46HbU9G5a1m7NY+axrarul9jawcHMivoEejFyORwK6d0XtJoCiGEEMKpRffwZdHUfugNJl7fko3JbPnZ++w6WorRZGHGqN64aaVdul7yNyeEEEIIpzdhUBQjk8M5U97E5gNFP3lbfbuJvellBPh4MH5glI0SOidpNIUQQgjh9DQaDb+akURYkBdbDxWTXVR3xdvuTS+jzWBm6ohe6DzcbJjS+UijKYQQQgiX4O3pzkO3p6LVanjz8xwaWzsuu02H0cyuo6V4e7ox6aYYFVI6F2k0hRBCCOEy4qICmHdLX5paO3jrs2wsP7pE5YFTFTTpjUweGoOPl7tKKZ2HNJpCCCGEcClTR/RiUN9Qss/Vsz2tpPO42Wxhe1oJHu5abh3eS8WEzkMaTSGEEEK4FI1Gw9LZyQT56fjfr89SWN4IwP6Mcmoa2xk/KIpAX53KKZ2DjAkLIYQQwuX4++hYNieFl9an8+qeHYQkllLZegHPVD9iEqarHc9pyIimEEIIIVxS/97BjBhtoiP6GJX6KtAoaH2a+eTcJxyrylA7nlOQRlMIIYQQLqvWK6vL4zuL99o4iXOSRlMIIYQQLqtS3/X1zytaq2ycxDlJoymEEEIIlxXp0/V1zKN8I2ycxDnZfDHQSy+9xPHjxzGZTCxbtoy0tDTS09Px9fUFYOnSpdxyyy22jiWEEEIIFzS9z2TWZn902fFpsZNUSON8bNpoHj58mIKCAjZu3Eh9fT2//OUvGTNmDKtWrSI5OdmWUYQQQgghGB4xBLh4TmZlaxWRvhFMi53UeVzcGJs2miNGjGDQoEEABAYG0tbWRlNTky0jCCGEEEL8wPCIIQyPGEJYmD/V1c1qx3EqNm003dzc8PHxAWDTpk1MnDiRuro6XnnlFZqamoiIiODpp58mKCh1HhnWAAAOgklEQVTIlrGEEEIIIYQVaBTlRxf5tIHdu3fz+uuv884773D48GESEhKIi4tjzZo11NTU8Mwzz/zk/U0mM+7ubjZKK4QQQgghrofNFwPt37+f1157jbfeegt/f3+mTp3a+WdTp07lueee+9nHqK/XWzHh5WQo3X5ILeyP1MQ+SV3sm9THPkldrk9YmP8V/8ym2xs1Nzfz0ksv8frrr3dOjz/00EOcP38egLS0NBITE20ZSQghhBBCWIlNRzS3bt1KfX09jz32WOexO++8k+XLl+Pj44O3tzcvvviiLSMJIYQQQggrsWmjuWDBAhYsWHDZ8blz59oyhhBCCCGEsAG5MpAQQgghhLAKaTSFEEIIIYRVqLK9kRBCCCGEcH4yoimEEEIIIaxCGk0hhBBCCGEV0mgKIYQQQgirkEZTCCGEEEJYhTSaQgghhBDCKqTRFEIIIYQQViGN5vfITk/qa2lpUTuC6MKFCxeoqalRO4b4kaqqKvbt26d2DHEFBoNB7QiiC/Jdb1su32haLBZeeeUVysvL0Wg0mM1mtSO5JKPRyJo1a3j00Uf59NNPqaysVDuSAEwmE6+99hqPPPKI1MSOmEwm1qxZw6JFizhy5AggX572xGg08uqrr7Jq1SoOHTokP0DbAfmuV4/LN5onTpxgw4YN/OUvfwHAzc1N5USup6Ojg1WrVtHS0sLSpUvZtWsXZWVlasdyednZ2dxzzz20tbXx2muvkZqaqnYkARw8eJCFCxei1Wr5wx/+QGNjIwAajUblZOKS1atXU1NTw8yZMzl8+DAbN27EaDSqHculyXe9elyy0fz+FGBWVhZ//etfKSgoYM+ePQDyk46NVFdXA9DW1sbZs2d54oknGDduHH5+fmi1LvlP0y5cqoufnx8Wi4Xf/va3hISEkJOTQ2FhIRaLReWErunChQsA9OnTh+eff55ly5YxatQoQkND0ev1MqKpsu9/nhUUFPC73/2OMWPGMGHCBDIyMvjyyy9VTuh6Ln1Wmc1msrOz5bteJW7PPffcc2qHsJX6+nr++7//m/Xr11NWVkbPnj1JTU0lOTmZ8PBwVq9ezd13341Wq0VRFBkhsJLv16G0tJSkpCQmTZqEn58f7777Lrt27aKuro6KigpiYmLw8fFRO7JL+H5dSkpKGDZsGAaDgc2bN5Obm8v69evJzMwkPz+f+Ph4/Pz81I7sEi7VZcOGDZSVlRETE8OAAQMAKCwsZPv27cydO1c+r1Ty48+zAQMGkJeXx/79+5k8eTJ6vZ6cnBzKy8sZOHCgfJ7ZgMFg4E9/+hMajYbevXvj7u6Ot7c3w4YNk+96FbjUsNF7772Ht7c3b7/9Nv7+/jz++OOEhoYCMGPGDIKCgnjjjTcAmYayph/X4ZFHHiEmJgatVsvYsWPZtWsXCxYsoKamhu3bt6sd12X8uC4rVqxgyZIlpKenoygK69atY/ny5QBs27ZN5bSu4/t1CQgI4Nlnn+38s5SUFLy9vWVBkIq+Xx9fX18ef/xxnnzySQoKCnjqqad46qmnGDJkCKGhoZ2jnsK6ampqSEtLIzc3l9LSUgD69+8PyHe9Glyi0bw0fO7v709CQgKenp7ce++9uLm58eGHH3be7umnn+78fV5enix+6GZd1eG+++7D3d298++9d+/eAAwdOhRfX1+8vb1Vy+squqrL0qVL0ev17N69m1dffZU5c+YAkJiYiL+/P76+vmpGdgld1WXJkiU/eL8YDAYGDx5MXV2dTJ3bWFf1uf/++2ltbWXXrl1s2LCBJUuWsGbNGubPn09mZiYmk0nl1K6huLiYadOmcf78eTIzM2lvbwfoPE9WvuttyyUazUvn+xkMBlpaWtDr9QCsWLGCt99+u/MfX0pKCn379mX48OF8+OGHcp5gN/u5Ouj1ej777DO+/vprKisrO1fTCuu6Ul2efPJJ/v73vxMVFYWXlxenT5/mwoULpKWlodPp1IzsEq7mc8vT0xOtVsuZM2c6FwUJ27hSfVauXMk//vEPjEYjQUFBlJWVkZ+fT2BgoEyb28igQYNYuXIlkyZN4vjx4xQVFQHg4eEByHe9rTndOZpNTU288cYbtLe3ExAQgLe3N0ajETc3N3x8fNi4cSODBw8mODiY6Oho0tPTKSkpYcSIEaxdu5azZ8/ywAMP8Otf/1pGbW7AtdbhxIkTtLa2Ehsby6effsrHH3/MvHnzmDt3rtovxalcT13q6urw8fHhjTfeYMOGDcyfP5/bb79d7ZfiVK7nc6u4uJgRI0YQEBDA7t27GTdunDQyVnK975uoqCg2b97Me++9x5w5cxg7dqzaL8VpdFUTs9mMVqvFzc0NrVZLXFwcBw4coKWlhYSEBHQ6HUajkffff1++623IqRrNL7/8kr/+9a+EhIRQWlrK3r17mTJlCnDxPIzw8HBOnz7NmTNniI6OJjAwEIPBgKenJykpKbS3t/Pwww+TkpKi8itxbNdbB4Dp06czZcoU5s2bR1JSkpovw+lcb120Wi2TJ09m3LhxLFq0iOTkZJVfiXO53rp4eXmRkpJCUFAQ06ZNky9LK7mR9824ceMYM2YM8+fPl/dNN7pSTRRFQavVdi7y0Wq1eHt7c+zYMXr06MFXX31FYmIi7u7uPPjgg/JdbyNO0WhaLBY0Gg0HDx5k4MCBPPDAA3h5eWEwGBg6dCharRaNRkNubi6BgYGcO3eOI0eO0NDQwEcffcSECROIj4+nV69eMoR+A26kDuvXr+fmm28mLi6u83aie9xoXSZOnEhcXFznNK3oHjf6uXXp/QKyoMEauuvzTKPRSH26ydXUBODYsWPU1NQQGRlJdHQ0mzZtYv369RiNRiZMmND5PSNsw6EbzdOnT7N27VouXLhAUlIS5eXljB49GpPJxG9+8xs8PDyorKxk0KBBvPjii2zcuJHFixczcuRIPDw8SEtLY/HixUycOFHtl+LQuqsOEyZMUPulOBV5f9gneb/YN6mP/bnWmmzZsoXp06cTEBDA5s2bOXnyJE8++WRnYypsS6M42FLFS3te5eXl8cILLzBv3jwyMjIIDw9n7ty59OzZk9LSUtLS0hg2bBhPP/00U6dOZcGCBbKCuRtJHeyT1MU+SV3sm9TH/nRXTc6fP0/Pnj1VfCUCxcF0dHQoiqIoW7ZsUX7zm98oiqIozc3NymOPPaasXbtWaW5u/sHtCwoKlF/84hdKe3u7oiiKYjKZbBvYSUkd7JPUxT5JXeyb1Mf+3GhNjEajbQOLK3KYqfPDhw/zj3/8g9zcXIKCgujVqxd79+6lb9++REdHk5GRQUVFBT169MBgMFBXV0dISAinTp1CURQmTZoEIOdl3CCpg32SutgnqYt9k/rYH6mJ83GIqfPS0lKeeOIJHn74Ydrb28nKyiI2NhaLxcLGjRtJTEzEbDbj7+/PsGHD8Pf35/PPP6e2thaz2czSpUsZP3682i/D4Ukd7JPUxT5JXeyb1Mf+SE2clHqDqT/NZDIpR48eVdrb25VvvvlGeeGFFxRFURSDwaB88MEHyoMPPqjo9XrlzJkzypdffqkoiqJ88803yn333acoiqLo9Xpl3759quV3FlIH+yR1sU9SF/sm9bE/UhPnZ7djy6tWrWL16tVkZWURFxfHoUOHyMnJQafToSgKHh4erFu3jvj4+M4Tf8vKyrjlllsA8Pb2llV/3UDqYJ+kLvZJ6mLfpD72R2ri/Oyy0dTr9RQVFTFkyBCOHDlCZGQkd911F+vWrePuu+8mNzeX+fPnU1dXB8D+/ft56KGH+PTTTxk3bpzK6Z2H1ME+SV3sk9TFvkl97I/UxDXY7TmaOTk5mM1mNm/ezOjRo7n11lsxGo2cOXOGpKQkCgsLefvtt3nxxRcxGo3U1dURERGhdmynI3WwT1IX+yR1sW9SH/sjNXF+drvqPCwsjIiICIqLizl37hyBgYFERkZSUFBAQ0MDBw4cwGQyMWbMGDw8PPDz81M7slOSOtgnqYt9krrYN6mP/ZGaOD+7nDqHi5u1AowbN46Ojg7Onj0LwNmzZ9m0aRO5ubksW7YMd3d3NWM6PamDfZK62Cepi32T+tgfqYnzs9up8+/7+uuv2bJlC2VlZUyYMIEHHngAT09PtWO5HKmDfZK62Cepi32T+tgfqYlzcogfEXbv3k1+fj73338/c+fOVTuOy5I62Cepi32Sutg3qY/9kZo4J7sf0ayqqmLfvn3cfvvt6HQ6teO4LKmDfZK62Cepi32T+tgfqYnzsvtGUwghhBBCOCa7XQwkhBBCCCEcmzSaQgghhBDCKqTRFEIIIYQQViGNphBCCCGEsAppNIUQQgghhFVIoymEEFawefNmqqurefTRR9WOIoQQqpHtjYQQopuZzWZmzZrFjh071I4ihBCqcogrAwkhhCP54x//SHl5Offddx+FhYXs27eP3//+9wQHB3PmzBkKCwt5/PHH2bt3L/n5+QwdOpTnn38egNWrV3PixAk0Gg2pqamsXLkSjUaj8isSQojrI1PnQgjRzZYvX05ISAh//vOff3C8pqaGN954g0ceeYQ///nPPPvss2zatIlPP/2UpqYmtm3bRlVVFR988AHr1q2jpKSEvXv3qvQqhBDixsmIphBC2MjQoUMBiIyMJD4+noCAAACCgoJobm4mLS2NjIwMFi9eDEBzczNlZWWq5RVCiBsljaYQQtiIu7t7l78GUBQFnU7H/PnzWbp0qa2jCSGEVcjUuRBCdDOtVovBYLjm+w0bNoxdu3ZhMpkAeOWVVzh37lw3pxNCCNuREU0hhOhm4eHhREREcOedd2KxWK76ftOmTSMjI4OFCxei1WpJSUmhV69eVkwqhBDWJdsbCSGEEEIIq5CpcyGEEEIIYRXSaAohhBBCCKuQRlMIIYQQQliFNJpCCCGEEMIqpNEUQgghhBBWIY2mEEIIIYSwCmk0hRBCCCGEVUijKYQQQgghrOL/AxIcnu5FOKzyAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 792x360 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "plt.figure()\n",
     "out1.plot(label='From mm s-1', linestyle='-')\n",
@@ -415,7 +694,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "keep_output": true
+   },
    "source": [
     "### Threshold indices\n",
     "\n",
@@ -425,8 +706,31 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "keep_output": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.legend.Legend at 0x7f39d2421050>"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAqAAAAFdCAYAAADc2N+fAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjAsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8GearUAAAgAElEQVR4nOzdd1yV5f/H8ddhbxAZiogIglsBsRy5AHfLlavxTcuytCzLlaZp5UrT0tR+ZlammLOhufcWRBy4GbJlyt7n9wdfzzcCPCjjHPDzfDx6xLnPPd6Hy8P5nOu+7utWKJVKJUIIIYQQQtQQHU0HEEIIIYQQTxYpQIUQQgghRI2SAlQIIYQQQtQoKUCFEEIIIUSNkgJUCCGEEELUKClAhRBCCCFEjZICVAghhBBC1Cg9TQcQQtQNZ8+eZebMmezfv1+jOSZPnszVq1dVjzMyMvD09OTbb78FYOfOnXz22WfMmTOHF154ocx93Llzhzlz5pCYmIienh4TJ06kT58+AGRmZvLpp5/y999/ExISUuI4c+bM4cqVKyiVSgYMGMD7778PQO/evVEqlejpFf/Jtbe356effqKgoICvvvqKI0eOkJuby+jRo3njjTce+voq+nsODg7G0NCQFi1aqPmNqVdUVMTw4cNxdXVlwYIFqtf7ySefcPHiRQwMDPjoo4/o27dvie2CgoKYPn16iWWRkZFs374dV1fXcl97WloaM2bM4NatW+jr6/POO+8wYMAA9uzZw7Jly0rsLywsjMDAQGbPnv3QdhdCaBcpQIUQdcqSJUtKPH7zzTcZNGgQAN9//z0XLlygadOmD93H+++/z+uvv86QIUO4ceMGI0aMoHPnzpibmzNy5Eh69uxZapulS5eir6/P7t27ycrK4sUXX8Tb25uuXbuSlpbGn3/+iZ2dXYltfvvtN4KDg/n999/Jy8tj2LBheHh44O3tXblfArBt2zY6dOhQJQXopk2bSEpKwtXVVbVswYIF2NracuTIEUJDQ5kzZw6+vr6qIhvA09OTPXv2qB4HBwczb9483N3d2bRpU7mv/auvvqJhw4asWLGCyMhIXnrpJTp06EC/fv3o16+fan+7d+/m77//xszM7KHtLoTQPnIKXghR5XJzc/n000/p27cv/fv3Z8GCBRQWFgLg4+ODv78/Q4cO5ZlnnlH1qFWHo0ePkpeXh4+PDwBPP/00q1atwtTUtNxtCgsLGT9+vKp3tHnz5hgYGBAVFQXA3Llzeemll0pt17t3b9577z10dHQwMzOjRYsW3Lp1CyjujbOwsCi1zalTp3j22WcxNDTE3NycIUOGsHfv3gq/vuzsbCZNmkTfvn3x8fFh4cKFQHHB+Pvvv7N48WJ+/PHHCu+vLPfu3eOXX37htddeUy3Ly8tj165djB8/HoVCgaurK7/88kuJ4rMsX3zxBdOmTUOhUDz0te/du5cRI0YA0LhxY5566ikOHjxYYl+5ubksX76cjz/+uNRx/t3uQgjtIz2gQogq99NPPxEXF8euXbsoKCjg5Zdf5q+//lIVdefPn2fz5s0kJibi6+vLf/7zHxo0aKDaPi8vj+eff77Uft3d3fnmm28qnOPbb79lypQpqsft27dXu42uri4DBw5UPQ4ODkapVOLs7AyAh4eHqhj9p86dO6t+zsjIICgoiLFjx5KVlUVhYSHTp0/nxo0b1KtXj8mTJ+Pl5YVCoaCoqEi1nYmJCXfv3q3w69u0aROZmZns2bOHtLQ0+vTpg6+vLyNHjmT37t0MHTq01DCDgIAAZs6cWWpfQ4YM4c033yy1/Msvv2TChAnk5eWploWHh2NoaMj27dvZsWMHJiYmfPjhh3Tp0qXcrEeOHMHQ0FDVu1vea09JSSE1NRUnJyfVc05OToSGhpbY39atW/Hy8iqx3gP/bnchhPaRAlQIUeWOHDnCmDFj0NPTQ09Pj+eee46TJ0+qiqHnnnsOXV1d7O3tqV+/PrGxsSUKUAMDgxKnbh/HmTNnUCqVPPXUU4+9j9jYWCZPnszMmTMxNjau0DZ5eXlMnjwZHx8fPD09ycjIYOjQoQwfPpy2bduyZ88exo8fz759++jSpQv+/v688MILFBYW8scff1T4OABjxozhlVdeQaFQYGlpiZubG1FRUQ89he/t7V3h3+2xY8dIS0vj2WefZfv27arlaWlppKenY2hoyO7duzl+/DjvvfceBw4cwMrKqsx9rV27tsT41vJee05ODjo6Oujr66vWNTQ0JDk5WfW4qKiIdevWsXr16lLHqYp2F0JUPylAhRBVLjk5GUtLS9VjS0tLkpKSVI/NzMxUP+vq6qpOzz+OKVOmcOnSJaC459Xe3h6Av/76i2efffax9xsaGsq4ceN46623yuyNLUtmZiYTJ07E3t6ezz77DCh+rZ9//rlqnX79+rFy5UouXrzIsGHDuHv3LsOGDcPOzo4uXbpw586dCmcMDw9nwYIFhIaGoqOjQ1xcHIMHD360F1qOnJwcFi1axMqVK0s9Z25uTmFhISNHjgSgW7duNGzYkODgYHr06FFq/bi4OG7evEm3bt1Uy8p77cbGxhQVFZGXl4eBgYEqi4mJiWrboKAgTExMcHNzK3Wsyra7EKJmSAEqhKhyNjY2pKamqh6npqZiY2NT4e0f5RT8okWLytzHkSNHeP311yt8zH+Kj4/njTfe4OOPP6Z///4V2qagoIAJEybg5ubGjBkzVMuzsrKIi4vDxcWlxPoPeoenTp3K1KlTAVixYgXu7u4Vzjl37lxat27NypUr0dXVVY2bfJiKnoK/cuUKcXFxjBo1CiguAvPz80lOTuarr75CR0eHzMxMVY+nrq4uOjplX1Zw5MgRunbtiq6ubonXX9Zrt7KywtramrCwMJo3bw7A7du36dWrV4n9lVXoPnjucdtdCFFzpAAVQlS5Hj16sHXrVnx8fMjNzeX3338vc3xheSp7Cj4pKYnk5GS1V7uXZ/bs2bz22msVLj4BfvnlF0xNTUsUnw+yjBgxAn9/f1xcXDh58iSJiYm0b9+eP/74g8OHD7NkyRISEhLYsWMH69atq/Axk5KSaNmyJbq6upw8eZKIiAgyMzOB4gIvPT291DYVPQXv7e1NQECA6vH27ds5d+6c6qIxHx8f1q1bx4cffkhwcDDR0dG0bdu2zH1dv369xBX0wENfe//+/dmwYQPz5s3j9u3bBAUFlehFvn79OgMGDCjz91GZdhdC1BwpQIUQVe7VV18lKiqKgQMHolAo6Nev3yMVc5UVFxeHtbV1qR65sWPHEh0dTWxsLGFhYaxatYrJkyfTu3dv+vXrx4YNGygsLOTw4cOEhYWxadMm1bZTpkzB3t6eyZMnU1BQQGFhoWpKoD179uDv7092dnaJaYL69evHpEmTmD17NhMmTKCwsBBLS0tWrlyJmZkZfn5+7Nu3Dz8/P/T09Jg8eTJNmjQBYMOGDSQmJjJp0qRyX+f48eP5/PPPWbFiBb1792bChAksXbqUVq1a4efnx+LFi4mMjCw1F2dV+Pzzz1VjXc3MzPj666+xsrIiPj6esWPH8tdff6nWjYuLKzUd1MNe+4cffsi0adPo3bs3hoaGfPHFFyV60OPi4srsUS+v3YUQ2kehVCqVmg4hhBCipPj4eH788UemTZum6ShCCFHlpAAVQggtdOXKFYyNjUuduhZCiLpAClAhhBBCCFGjZKCMEEIIIYSoUVKACiGEEEKIGlWnroJPSCg95Uh1qlfPhJSUrBo9piibtIX2kTbRTtIu2k3aRztJuzweW1vzcp+THtBK0NPTVb+SqBHSFtpH2kQ7SbtoN2kf7STtUvWkABVCCCGEEDVKClAhhBBCCFGjpAAVQgghhBA1SgpQIYQQQghRo6QAFUIIIYQQNapOTcMkhBCi7nr30JQKrbfSZ1E1JxFCVJb0gAohhBBCiBolBagQQohaxz08h9G7k5i46R6jdyfhHp6j6UiijoqNjWHw4MGqx8ePH+Hdd98kLy+vSva/YsUydu/+s9znT548zhdfzHnk/RYUFLBq1be8/vooxo8fy3vvvc2dO7crkbRqySl4IYQQtYp7eA79T6WpHtukFqoe33Q20lQs8QS4c+c2a9euYfnyVRgYGGg6zkNt3PgzGRnprFv3KwqFgsuXg5kx4yN+/XUrenqaL/80n0AIIYR4BB1DMstc7h2SJQWoqDapqal8/vmnfPbZl1hZWZV6ft++PWzd6o+urg7Ozq5MnfoJu3f/yaVLF0lNTeHu3QhGjXqFZ599kb17d7Nx4884OjZGqQQXF9cS+7pz5zaff/4ptrZ21K9vq1q+ffsW9u//G4VCh27dejJy5MvcuxfPrFnT0NfX5+mnO3P27GlWrPienTu38dNP/igUCgDatm3P2rW/aEXxCVKACiGEqAUysvNVP1vfLyxzHev7BTUVR2jIb4duc/76vSrdZ8cWdrzk0+yh6xQUFDBz5hR8fHrj7Ny0zHWys7NYsuRbzM3NeffdN1Wnu+/cuc3q1euIiopk9uwZDBz4AmvWrOSHH37B3NyCsWNfLrWv9evXMmbMOLp168lXX82noABiYqI5fPgA3333AwDjx4+lVy8/tmzZhI+PH8OHj+a775YDkJGRgYGBIebmJe/F/u/HmiQFqBBCCK2UkJpN0K1ELt5K4GbkfQw7Fi9PttTFJrV0EZpsKR9ponqEhYXx7ruT2LJlE337DsDOzr7UOhYWFkyfPhmAiIgw7t9PBaBNm3bo6upia2tHZmYG9+/fx8TElHr1rIHinsl/Cw8PpU2b4uWenh04c+YU165dJSoqkokT3wIgKyuTuLgYIiLC8PPrA0DXrt0JCbkKQFFR2V/UtIW8W4UQQmiFIqWSiLh0gm4lEHQrkeiE/51qd3GwIPa/P59vZVpiDOgDAa1Maiip0JSXfJqp7a2sDm5ubgwZ8hLW1tbMnTuL5ctXoaurq3o+Pz+fpUsXsX79RurXt2HKlEmq5/65nlKpRKlUoqOjUC0rKioqdTylEtU6D57X09Onc+euTJnySYl1f/llveo0+4P/m5mZUVBQQHJyEtbW9VXr3rhxHXf35qr1NEmughdCCKEx+QVFXLqTxM97b/DRypPM+ymAv05FEJ+cTTvX+rzWrzlfT+jKzFe9VdvcdDbi7y4WJFjpUaiABCs9/u5iIeM/RbXr1csPB4dGrF+/tsTyrKxMdHV1qV/fhvj4OK5fv0ZBQdlDQiwtLcnIyCA9PZ2CggIuXw4utY6TUxOuX78GwIULgQA0b96SCxcCycnJQalUsmzZV+Tm5tCoUSOuXw8B4MyZU6p9DBnyEsuXL1HluHTpIl9+OafKrt6vLOkBFUIIUaMysvO5fCeJoFsJXA5LJjev+FShmbE+Xds0wMPNltZN62FkUP5H1E1nIyk4hUZMmvQxb7zxCp6eHfDyKv5iZGlpRceOT/PGG6/SrJkbo0a9wjffLOWll0aW2l5HR4cxY8YxYcI4GjZsWOoCJIDXXhvL/Plz2brVn4YNHSgoyKdBgwa89NJI3n33TXR0dOjevSeGhkYMGzaSTz+dxuHDh2jVqjW6usXvm1GjXuXnn9cxZsxoLCwsMTMzY8GCpRgaGlbvL6iCFEqlUqnpENnZ2UybNo2kpCRyc3N55513aNGiBVOmTKGwsBBbW1sWL16sdsqDhIT0GkpczNbWvMaPKcombaF9pE20k6ba5d/jOYv++9FjZ2WMh5sNnm42NHO0RFfn0U/M7Tweyh8nw3mljzu9vByrOnqNkveNdtLmdgkNvUNGRjrt2nmwf/8egoICS52m1xRb2/IvetKKHtDDhw/Tpk0b3nzzTaKjoxkzZgxeXl6MGjWK/v37s2jRIrZu3cqoUaM0HVUIIUQF/G88Z3HRGfWv8ZyebjZ4uNniUN+k0uPRenk2YtfpCA4ERtHDsxE6WjC+TYiaYmJiwuLFX6JQKNDR0WH69E81HalCtKIAHTBggOrn2NhY7O3tOXv2LJ999hkAvr6+rF+/XgpQIYTQYvkFRVy/m6IqOlMzisea6enq0M61Pp5uNrRvZoOVWdWeArQ0M+SplnacvhpPSHgybZrWV7+REHVEgwYNWbXqB03HeGRaUYA+MGLECOLi4li9ejWvv/666pS7ra0tCQkJarevV88EPT1dtetVpYd1L4uaJW2hfaRNtFNVtktGVh7nr8Vz9kocF27Ek51bPJ7T3EQfH+/GPN26AZ7N7TA2rN6Pm2G9m3P6ajzHLsXR6ynnaj1WdZP3jXaSdqlaWlWA+vv7c+3aNT7++OMSp2QqOkw1JSWruqKVSZvHhDxppC20j7SJdqqKdklIzebirUSCyhjP2a1d6fGcGWnZZFQ6+cNZGenRrJElAdfiuXwjngbWtXNKJnnfaCdpl8ej9WNAr1y5Qv369WnYsCEtW7aksLAQY2NjcnJyMDIyIj4+Hjs7O03HFEKIJ5JSqSS8hsZzVoaftyO3o+9zMCCK0X3cNZZDCKGeVhSgAQEBREdH88knn5CYmEhWVhbdunVj7969vPDCC+zbt49u3bppOqYQQtQq7x6aUqH1VvosKrVM3XhODzcbPKphPGdleLnbUs/ckBNXYhnU3QUTI634iBM1oDL/1oVmaMW7c8SIEXzyySeMGjWKnJwcPv30U9q0acPUqVPZvHkzDg4OvPjii5qOKYQQdVpmTj6X7iQRdCuRK6FJ5Px3fk5TIz26tGmAp5sNrZtaP3R+Tk3S09XBx6sR246GcuJSDH2ectJ0JFHHZGVl8eqrw9m69c9H3nbPnl1s2eKPgYE+BQUFjBr1Kr16+VVJrm3bNpOamsrYsW+V+Xxo6G2WLl3EihXfP/K+N23awP79f2NoaAQoefPNd1Tzn1aGVvwVMTIyYsmSJaWW//jjjxpII4QQdY97eA4dQzKxvl9IsqUu51uZqiZy338+sszxnN3bV25+Tk3o4dGIP06GcyAwCj/vxiVueSiEply6dJFt235j2bLvMDc3JyUlmbffHoOrazOcnJw1Ha9c+/YVzyu6evWPGBgYcPduBJMmvcP69ZuwsLCo1L61ogAVQghRfdzDc0rcO90mtVD1+KazEZsO3gL+MZ6zmQ0ONqZacb/oR2VmrE/n1vYcC44l+HYinu62mo4karnMzAymTHmPvLwCWrZsrVoeHBzEmjUr0dPTw87OnqlTZ6JQKJg7dxZxcbF07Pg0u3f/yY4du9m2bTNjxryJuXnxRTn16lmzdu0vqscPnD9/lrVrV6Ovr4+5uTlz5y7g8uVgtm//DYVCh4iIMHr29GXMmHEEBJzjm2+W4ODQCFNTMxwcGpXY17178cyaNQ0zM3OcnJqolh89egh//w3o6urRvHlLJk78gIyMDGbOnEJubi69evmyZYs/W7b8wdat/kyf/qlqViInpyb89JN/qdyPo3Z8pRVCCPHYOoZklrncO6R45pBX+zVn6X/vtz6wszONbM1qZfH5gF+HxgDsD4jUcBJRF+zd+zdubm4sW/YdzZq5qZYvW7aYBQuW8M03q7G2tubw4QOcOXOKvLxcvv9+Pa1atSExsXgKyYiICNzcmpfYb1lFXHp6OrNnf86KFd9jYmLK2bOnAQgJuconn8xh9eof2bZtMwBr1qxg1qx5LFiwlPv3U0vta+tWf3x9+7BkyTfUr188N25WVhY//fQDy5evZsWK77l3L55Lly6yZ89fODu7sGrVD+jp6atmH4qLi8XZuana3I9DekCFEKKOs75fWM7yAgB6ejQq8/naytHOjJZN6nEtIoXIexk0tjPTdCRRi4WHh9K9e1cAPD07AJCcnERUVCQzZnwMQE5ODpaWVgC0a+cBQOfOXdHV/d/c5IWFZb8P/8nKyoqFCz+nsLCQmJhoOnToiImJCc2bt8DIyKjEurGxsbi5Fc/24OHhRW5u7r9yh6nGmHp6enPmzCnCwkKJj4/jww8nAMW9u3FxcYSHh6vGdXbt2o2NG38GoKioCKVSWS1fSKUAFUKIOi7ZUheb1NIffsmWdfcjwM/bkWsRKRwMjOQ//VtqOo6oxZRK0PnvGOiiouKeQT09fWxsbEtd1LNhw3oUiuJ1FQqFqnBr0sSZa9euYm/fQLXu3bvh2NraY2xsrFo2f/48Fi9ehrNzU5YuXaha/s9C9gGdf4zLLmu+9OLCUee/PxcBoK9ffNp96dIVJda9dCmIBzXmP/fbqJEjN2/eoEWL/72Hbt++hbNzU/T0Kvf3Q07BCyFEHXe+lWmZywNa1c7J2iuivasNtlZGnL4aT3pWnqbjiFrMyakJV65cAeDChQAA1QU4YWGhQPHp7tu3b9GokSM3boQAcO7cGVWv57BhI1m37ntSUpIBSEpKZObMqcTFxZY4VmZmBvb2DUhPT+fChUDy8/PLzWVjY8vdu+EolUqCggLLzH39ekiJ3E5OzoSHh6ly/PDDGhIS7uHg4Mj169cAOHPmlGofL700ipUrl5GdnQ0UF82ffjqN9PQ0Kqvufv0VQogn2D97RB5c7e4dkoX1/QKSLfUIaGWiWl4X6ego8PVyxP/QbY4FxzCws7OmI4laql+/gcyePZXAwPG0a+eh6tWcNu1TvvzyM/T1i3tDn39+MI0bO7Fr1x+MHz8WT88OWFhYAtCmTVvGjXuXDz+cgJGRMbq6ukya9DFNm7qUONbgwcMYP34sjRs7MXr0q6xb9z3jxr1TZq5x495h5sypNGjQEDs7+1LPDxs2klmzpnHs2GFcXYvHrhoZGfH++5P56KP3MTDQx82tOTY2tgwY8BzTp3/IhAnj6NjxaVWPq69vb7KyMnn77dcxMzPHwMCAzz6bT7161pX+vSqUFb3PZS1Q07fJkltzaQ9pC+0jbaI5RUol/gducVJ3bYXWr6uTc2flFDD5u5OYGOqx8O3O6Olq/0k/ed88nuqeiL6i7XL/fipBQYH07OlLQsI93n9/PBs3bnusY9akuLhYIiLCefrpzly5col1674vdZr+cWj9rTiFEEJUjaIiJT/tuc7xS7E0sh3CR8M9sPzH3YqepALHxEiPZ9o05OCFKC7cTOCplqV7iUTdoC1fokxNzTh06AAbN/6CUlnExIkfajpShZiamrF586+sX/9/KJUwadJH1X5MKUCFEKKOKCgs4odd1zgbEk+TBuZMHu6BmbG+pmNplK+3IwcvRLE/IFIKUFHt9PT0mDt3vqZjPDJzc/Mq6fF8FNp/PkIIIYRa+QWFrNp5hbMh8TRztOTjEZ5PfPEJ0MDahHau9bkTnUZYbOUvnBBCVA0pQIUQopbLzS/km62XCLqVSCvnekx+yQMTIznB9YCftyMgE9MLoU2kABVCiFosO7eArzdf5Gp4Ch7NbHh/aDsMDUrPGfgka+1sTcP6Jpy/do/UjFz1Gwghqp0UoEIIUUtlZOfzlX8QN6Pu81RLO94Z1AZ9PSk+/02hUODn3ZjCIiVHgqI1HUcIgRSgQghRK93PzGPRxguExabzTNuGjHuuda2YZkhTurRugImhHkeCoskvKNJ0HFFLZWVlMXToc4+17Z49uxg79hXGjx/Dm2++yuHDB6os17Ztm/nhhzUlll24EMDMmf+bnmrLFn9mzZpW5l2TNEEGCQkhRC2TnJbDYv+LxCdn4evlyMjebuhUw72a6xJDA126t3dgz7m7nLsWT9e2DTUdSVSTtHNnSN71F3mxMRg0dMB64LNYPNVJo5kuXbrItm2/sWzZd5ibm5OSkszbb4/B1bUZTk7O1X788+fPcujQPpYt+65a7uv+OKQAFUKIWuReajZfbQoi8X4O/Ts5MbSHq9Z8oGg7nw6N2Hv+LvsDIunSpoH83uqgtHNniPt+tepxXnSU6vHjFqGZmRlMmfIeeXkFtGzZWrU8ODiINWtWoqenh52dPVOnzkShUDB37izi4mLp2PFpdu/+kx07drNt22bGjHkTc/Piidnr1bNm7dpfVI8fOH/+LGvXrkZfXx9zc3Pmzl3A5cvBbN/+GwqFDhERYfTs6cuYMeMICDjHN98swcGhEaamZjg4NCozf2TkXVauXM6SJd9gaKg9dz+T8zVCCFFLxCZlsmBDIIn3cxjUrakUn4/IxtIYLzdb7sZncCvqvqbjiGqQvOuvspfv3vXY+9y792/c3NxYtuw7mjVzUy1ftmwxCxYs4ZtvVmNtbc3hwwc4c+YUeXm5fP/9elq1akNiYgIAERERuLk1L7HffxefAOnp6cye/TkrVnyPiYkpZ8+eBiAk5CqffDKH1at/ZNu2zQCsWbOCWbPmsWDBUu7fTy0ze0ZGBtOmfcjo0a9Sv77NY/8OqoP0gAohRC1wNz6dJZsvkp6VzwifZvR5yknTkWolP29HAm8msD8gEvfGVpqOI6pYXmzMIy2viPDwULp37wqAp2cHAJKTk4iKimTGjI8ByMnJwdKy+N9Tu3YeAHTu3FV1T3WAwsJCtceysrJi4cLPKSwsJCYmmg4dOmJiYkLz5i0wMirZexkbG4ubmzsAHh5e5OaWnuHhxo3rjBv3Dj/9tI6uXbthYmL6qC+/2kgBKoQQWu5OzH2+3hxMdm4Br/ZrTk+Psk+1CfXcG1vhZGfGhZsJJN7PxsbSWNORRBUyaOhAXnRUmcsfl1IJOjrFJ4yLioov4NHT08fGxpYVK74vse6GDetRKIrXVSgUqjMUTZo4c+3aVeztG6jWvXs3HFtbe4yN//dvcP78eSxevAxn56YsXbpQtfyfhewDDzIVZyz7wqIOHbwZNGgo2dnZLF48n9mzP3+k116d5BS8EEJosRt3U/jK/yI5eYW88WwrKT4r6cGUTEolHLogUzLVNdYDny17+YCBj71PJ6cmXLlyBSi+shzAwsICgLCwUAC2bvXn9u1bNGrkyI0bIQCcO3dG1es5bNhI1q37npSUZACSkhKZOXMqcXGxJY6VmZmBvX0D0tPTuXAhkPz8/HJz2djYcvduOEqlkqCgwIe+hpEjXyY5OZldu/541JdfbaQHVAghtNTl0CRWbL9MUZGS8S+2oUNzW01HqhOebmXHliO3OXYxhhe6NpWJ++uQBxcaJe/e9b+r4AcMrNRV8P36DWT27KkEBo6nXTsPVa/mtGmf8uWXn6GvX9wb+vzzg2nc2Ildu/5g/PixeMrcWpIAACAASURBVHp2wMLCEoA2bdoybty7fPjhBIyMjNHV1WXSpI9p2tSlxLEGDx7G+PFjadzYidGjX2Xduu8ZN+6dMnONG/cOM2dOpUGDhtjZ2T/0NSgUCmbN+oy33nqdNm3a0aSJ82P/PqqKQqktE0JVgYSE9Bo9nq2teY0fU5RN2kL7SJtUTuCNBFb/fgUdHQUTBrelrUv9KtmvtEuxHcdC+fNUOK/2bU5PT+3pVZb20U4VbZf791MJCgqkZ09fEhLu8f7749m4cVsNJNROtralL7R6QHpAhRBCy5y+GscPf11DX1+HSUPb0dypnqYj1Tm9vBqx+0wEBwKj6OHhILMJiCphamrGoUMH2LjxF5TKIiZO/FDTkbSWFKBCCKFFjl6M5uc9NzA21OODl9rj2shS05HqJCszQzq2sONMSDwh4Sm0bmqt6UiiDtDT02Pu3PmajlEryEVIQgihJfadj+SnPTcwM9FnyihPKT6rmZ93YwD2B0RqOIkQTx4pQIUQQsOUSiV/ngzD/+AtrMwMmDrKCyf78sdOiarh4mCBq4MFl+4kEZ+cpek4QjxRpAAVQggNUiqVbDsayo7jYdhYGjHt5Q442GjPZNF13YNe0AOBpeeOFEJUHylAhRBCQ4qUSjYeuMXuMxHYW5swbbQXdlYyMXpN6tDclnrmhpy4HEtWToGm4wjxxJACVAghNKCoSMn63dc5GBiFo60p00Z7YW1hpH5DUaX0dHXo5dmI3LxCTlyOVb+BEKJKSAEqhBA1rKCwiO//vMqJy7E0bWjOlFFeWJoaaDrWE6uHhwP6ejocDIxU3WpRCFG9tGYapkWLFhEYGEhBQQFvvfUWZ8+eJSgoCFPT4rFQY8eOpWfPnpoNKYQQlZRfUMiqnVe5eDsRd0dL3h/WHmNDrflT/EQyNzGgUyt7jl+KJfhOIp5ucscpIaqbVvzVO3PmDLdu3WLz5s2kpKQwaNAgOnfuzBdffEHLli01HU8IIapEbl4h326/pJp3csLgthjqy20gtUFv78YcvxTLgYAoKUCFqAFaUYB27NiRdu3aAWBpaUl2djZpaWkaTiWEEFUnK6eAZVuDuR11H083G95+oQ36ejIKSls42pnRwsmKaxEpRCVk4GhrpulIQtRpWvHXT1dXFxMTEwC2bNlC9+7dycnJYcWKFbzyyit89NFHpKamajilEEI8nozsfL7yD+J21H2eamnH+Bel+NRGqimZAmRKJiGqm0KpVGrNiOsDBw6wZs0a1q1bx5kzZ2jWrBlNmzZl1apVJCYmMmvWrIduX1BQiJ6enM4SQmiPlLQcZq05RURcOr2fcuLdYR7o6sh9x7VRYZGSt+YfICUthx8/7YuFXBgmRLXRmgL0+PHjLF++nLVr12JlZVXiudu3bzNnzhw2bNjw0H0kJKRXZ8RSbG3Na/yYomzSFtpH2gSS03JYvCmI+JRs/Do4MsLPDR2FZotPaZeH23vuLpsP3WZIDxcGdnau8eNL+2gnaZfHY2tb/h3dtOIcUHp6OosWLWLNmjWq4vPtt98mJiYGgLNnz+Lm5qbJiEII8UjupWQxf8MF4lOyGdi5CSO1oPgU6nVr1xBDfV0OXYimoLBI03GEqLO04iKk3bt3k5KSwqRJk1TLhgwZwsSJEzExMcHY2Jj58+drMKEQQlRcdGImX/kHcT8jj8HdXXi2i7OmI4kKMjHSp2vbBhy6EM2Fmwk81dJe05GEqJO0ogAdPnw4w4cPL7X8xRdf1EAaIYR4fHfj0/nK/yIZ2fmM9HWjd8fGmo4kHpFvB0cOXYjmQECUFKBCVBOtOAUvhBB1wZ3o+yzaGERmdj7/6d9Cis9aqmF9U9q61Od29H3CYmVKQCGqgxSgQghRBa5HpPCV/0Vy8gp587lWdG/voOlIohJ6ezsCMiWTENVFClAhhKikS3eS+HpLMIVFRbwzqA2dWjfQdCRRSa2bWtOwvgnnrsVzPyNX03GEqHOkABVCiEoIuH6Pb7ddQgG8N6QdXu5yG8e6QKFQ4NvBkcIiJYeDojUdR4g6p0IFaHx8PH/++Wd1ZxFCiFrl1JVYVv1+BT09HT54qT1tXOprOpKoQl3aNMDYUI8jQdHkF8iUTEJUpQoVoKtXr2bt2rWcOXOmuvMIIUStcCQomh/+uoaJoR4fj/CkuVM9TUcSVczIQI/u7RuSlpXPuWvxmo4jRJ2idhqmjIwMrly5wsKFC/nuu+/o1KlTTeQSQgiNeffQlAqtZ27yHJNHeNLYzqyaEwlN8fVyZN/5SA4ERNGlTQMUcjMBIaqE2h7Q7du3M2jQIFq0aEFGRgZxcXE1kUsIIbTe1NFeUnzWcTZWxni62RIRn86tqPuajiNEnaG2AP3zzz8ZPHgwAKNGjWLTpk3VHkoIIbSFe3gOo3cnMXHTPUbvTsI9PEf1XMP6phpMJmrK/6ZkitRwEiHqjocWoMeOHcPLywsjIyMAfHx8OHXqFPn5+TUSTgghNMk9PIf+p9KwSS1ERwk2qYX0P5VWoggVdZ97Yysa25lx4WYiSfel7YWoCg8tQLt378706dP/t7KODlu2bEFfX7/agwkhhKZ1DMksc7l3SFYNJxGapFAo8PN2pEip5NAFmZheiKog84AKIUQ5rO8XlrO8oIaTCE3r1MoeM2N9jgXHkJtf9r8LIUTFSQEqhBDlSLbULWe52glERB2jr6dLT08HMnMKOH1VLsYVorLUFqBZWaVPNcXHy3xoQoi673yrsi8yCmhlUsNJhDbo5emIro6CgwFRKJVKTccRolZTW4AOGTKEgIAA1ePff/+dl19+uVpDCSGENrjpbMTfXSxIsNKjUAEJVnr83cWCm85Gmo4mNKCeuSHeLeyITswkJCJF03GEqNXUnkdauXIl8+bNw93dnZiYGAwMDPD396+JbEIIoXE3nY2k4BQqft6OnA2J58D5SFo7W2s6jhC1ltoC1MXFhYkTJzJp0iRMTU1ZvXo19evL/Y6FEHXXp55zmLX2LBamBnzxRicMDcoeCyqePK4Olrg4WHDpThLxKVnY15PhGEI8DrWn4D/99FO+/vprNmzYwMKFC5k0aRKrVq2qiWxCCKER/gduUVCoZLiPmxSfohQ/b0eUwMEAmZJJiMeltgB1cXHh559/xsnJiXbt2uHv709mZtlz4wkhRG0XfDuR4DtJtHCywru5rabjCC3k3dwOKzMDTlyOJTtXpuQS4nGoLUD/85//kJWVRUxMDDExMcTGxnLmzJmayCaEEDUqv6CITQdvoaNQMLq3OwqFQtORhBbS09Whl5cjOXmFnLgUq+k4QtRKaseA/t///R9r1qwhLy8PExMTcnNzee6552oimxBC1Kh95+9yLyUbP29HGtmaaTqO0GI9PBz482Q4BwOj8PV2REe+rAjxSNT2gO7du5dTp07Rvn17zpw5w1dffYWbm1tNZBNCiBqTnJbDn6fCMTfR58Vnmmo6jtByFiYGdGplz73UbC7dSdJ0HCFqHbUFqKmpKQYGBuTn5wPg6+vLwYMHqz2YEELUpN8O3yYvv4ihPV0xMdLXdBxRC/h5OwJwICBSw0mEqH3UnoK3tLTkjz/+wN3dnenTp+Po6Mi9e/dqIpsQQtSI6xEpnLt2DxcHC7q2bajpOKKWcLI3p3ljK0LCU4hOyJBhG0I8ArU9oAsXLsTLy4vp06fTpEkTUlJSWLp0aU1kE0KIaldYVMTGAzdRAKN7u8tYPvFI/LwbA3AgUKZkEuJRqO0BNTY2xsrKitTUVJ5//vmayCSEEDXm8IVoohIy6dauIU0bWmg6jqhlPN1ssLE04vSVOIb0cMXMWIZvCFERagvQOXPmsGPHDurVqweAUqlEoVBw5MiR6s4mhBDVKi0zj53HwzA21GNID1dNxxG1kI6OAh8vR347fJtjwTEM6NRE05GEqBXUFqAXLlzg3LlzGBoa1kQeIYSoMduO3iErt4BRfm5YmBpoOo6opbq3b8jvJ8I4dCGKvk81RldH7eg2IZ54at8lzZs3V10BL4QQdUVYbBonLsXiaGtKL69Gmo4jajETI326tG1AclouF24majqOELWC2h7QXr164efnh6urK7q6/7sn8s8//1ytwYQQoroUKZVs2HcTJcUXHkmPlagsvw6OHL4QzYGASDq2sNN0HCG0ntoCdMmSJUydOpUGDRrURB4hhKh2Jy/HEhabxlMt7WjuVE/TcUQd0LC+KW2aWnMlLJmIuHSaNDDXdCQhtJraArRZs2YMGjSo2oMsWrSIwMBACgoKeOutt2jbti1TpkyhsLAQW1tbFi9ejIGBjNESQlROVk4+W4/cwUBfh5d6NdN0HFGH+Hk35kpYMvsDInnj2VaajiOEVlNbgLq4uDB16lS8vLxKnIIfOnRolYU4c+YMt27dYvPmzaSkpDBo0CA6d+7MqFGj6N+/P4sWLWLr1q2MGjWqyo4phHgy7TwRRnpWPkN6uGBtYaTpOKIOaeNijb21CeeuxTOsVzMs5cI2IcqlduBTamoqOjo6XLx4kcDAQNV/Valjx44sX74cKL7zUnZ2NmfPnsXX1xcovv3n6dOnq/SYQognT1RCBocCo7GrZ0yfjk6ajiPqGB2FAr8OjhQUKjkSFK3pOEJoNbU9oM888wwDBw4ssWzTpk1VGkJXVxcTExMAtmzZQvfu3Tlx4oTqlLutrS0JCQlVekwhxJNFqVSycf9NipRKRvq6oa8nFx6Jqte1bQO2HwvlcFA0Azo1kX9nQpSj3AI0JCSEq1evsm7dOrKzs1XLc3NzWb16NSNHjiyx/vTp0yt0wPnz55f73IEDB9i6dSvr1q2jb9++quVKpbJC+65XzwQ9PV31K1YhW1sZaK4tpC20jza1yYngaK7fTcW7pT1+nZtqOo5GaVO71EV9OzVh59E7XI9Ow+e/t+p8FNI+2knapWqVW4AaGhqSlJREenp6iVPuCoWCjz/+uNT6165dY8aMGeUeSKlUPrT4PH78OKtXr2bt2rWYm5tjbGxMTk4ORkZGxMfHY2enflqLlJQstetUJVtbcxIS0mv0mKJs0hbaR5vaJDevkO93XEZPV8GQ7k21JpcmaFO71FWdW9rx+7E7bD98izZOligUigpvK+2jnaRdHs/DivZyC1BXV1dcXV3p1KkTHh4eag/y2muv8dRTT6ldpyzp6eksWrSI9evXY2VlBUCXLl3Yu3cvL7zwAvv27aNbt25qMwghRFl2nQknJT2XgZ2bYF/PRNNxRB1na2WMRzMbgm4lcjv6Pm6OVpqOJITWUTs4pSLFJ6Caquno0aP8/vvvAEyePJk+ffqwb9++Euv82+7du0lJSWHSpEm88sorvPLKK7z99tvs3LmTUaNGkZqayosvvlihHEII8U/3UrLYc/Yu9cwNebazs6bjiCdE7/+eet8fEKXhJEJoJ7UXIT2q7777jlWrVnH06FGKiorYsWMHb7/9Nn369Cl3m+HDhzN8+PBSy3/88ceqjieEeML4H7xNQaGS4T7NMDSo2THi4snV3MkKR1szLtxIIDktR6b8EuJfqvzyPCMjI6ytrTl69CgvvPACpqam6Mht7oQQGnDpTiIXbyfSwslKbo8oapRCocDP25EipZJDF2RKJiH+TW0P6OnTp/n5559JT08vcTX6r7/+Wub6ubm5rF27luPHjzN16lTCw8NJT5eBu0KImpVfUMTGA7fQUSgY5ef+SBeCCFEVOrWyZ+uROxy9GM1zXZ0x1JceeCEeUFuAfvbZZ7zzzjsVvhf8vHnz+O2335g/fz6GhoacOHGCjz76qNJBhRDiUew7f5d7Kdn4dXDE0c5M03HEE8hAX5ceHg7sOh3Bmatx9PBopOlIQmgNtQVoo0aNeP755yu8w1WrVjF06FC8vb0BePnllx8/nRBCPIaU9Fz+OhWBuYk+L3Z7suf8FJrl4+XInrN3ORAQRff2DtITL8R/lTs4MzIyksjISLy9vdm8eTNhYWGqZZGRkeXu0M/PD39/fwYOHMjKlSuJi4urluBCCFGe3w7fJje/kCE9XDEx0td0HPEEq2duSIfmtkQnZnItIkXTcYTQGuX2gL722msoFArVuM81a9aonlMoFBw8eLDM7QYMGMCAAQPIysri8OHDfPjhh5iamvL666/TpUuXKo4vhBAl3bibwtmQeJo2NOeZdg01HUcIens35ty1exwIiKKVs7Wm4wihFcotQA8dOgTAnTt3cHV1LfFcUFDQQ3eak5PDvn372LlzJ0VFRfTq1Yuff/6Zs2fP8sEHH1RBbCGEKK2wqIhf998EYHTv5ujI6U6hBVwbWdK0oQXBtxO5l5KFndwMQYjyT8GnpaURGRnJjBkzSpx6v3XrFtOmTSt3h9OnT6dPnz4EBwczbdo0/P39GTVqFKtWreL48ePV8iKEEALgSFAMUQmZPNOuIS4OFpqOI4RKb29HlMCBQJmYXgh4SA9oUFAQP/30E9euXStxC00dHR2eeeaZcnfo5eXFrFmzMDH53ze8Cxcu4OXlxeeff15FsYUQoqS0rDx2HAvF2FCPoT1c1W8gRA3ybmHH5sO3OXEplkHdXDA2rPL7wAhRq5T7DujRowc9evRg06ZNjBw5ssI77NevHzt27CAlpXiwdX5+Ptu2bePEiRO0atWq8omFEKIM24+GkpVbwEhfNyxMDTQdR4gS9HR16OXZiJ3Hwzh5ORa//96qU4gnVbkF6LZt2xgyZAjx8fEsX7681PPvv/9+mdt98MEHODg4cOLECfr27cvJkyeZM2dOlQUWQoh/C4tN43hwDI1sTOnlJXMtCu3U06MRf50K52BgFD4dHGWMsniilTsG9MHtM/X09NDV1S31X3lyc3OZO3cujRo1YurUqfz888/8/fffVZ9cCCGAIqWSX/ffRAmM6u2Onq7c+ldoJwtTA55uZU98SjaX7yRpOo4QGlVuD+igQYMASElJoVu3bjz99NMYGxur3WF+fj5ZWVkUFRWRkpJCvXr1HjpvqBBCVMapy3GExqTRsYUdLZvU03QcIR6qt3djTl6O40BAJO2b2Wg6jhAao3YUtJeXF4cOHWLJkiVYW1vTtWtXunXrRsuWLctc/4UXXuC3335j2LBhDBgwAFNTU9zc3Ko8uBBCZOUUsPXIbQz0dRju00zTcYRQy8neHPfGVlwNTyE6MZNGNqaajiSERqgtQAcOHMjAgQMBuHTpEt999x3Lli0jJCSkzPX/ecFS586dSUpKKrdYFUKIyvj9RBhpWfkM6u6CtYWRpuMIUSG9vR25GZnKwYBIXu3XQtNxhNAItQXozp07OX/+PKGhodjb29O1a1cmTZpUar0VK1aUu49Dhw4xYcKEyiUVQoh/iE7I4GBgFHZWxvR7Sq4oFrWHp5st9S2MOHUljsE9XDEzltvFiieP2gJ00aJFtG7dmtGjR/P0009ja2tb5noFBQUAREREEBERgbe3N0VFRZw7d06mXxJCVCmlUsnGA7coUioZ4eeGvl75F0YKoW10dBT4dnDkt8O3OR4cQ/9OTTQdSYgap7YAPXXqFDdv3uTs2bPMnTuXhIQE3N3dmTt3bon1HvSKTpo0iS1btqiulM/Pz5fbbwohqlTgjQSuRaTQzrU+HnIhh6iFurVvyM4ToRy6EEWfpxqjqyOzN4gnS4X+xTs4OODk5ISzszN6enrcvn273HUjIiJQKpWqxwqFgpiYmMonFUIIIDe/EP9Dt9DTVTDSVy5wFLWTqZE+Xdo0JCktl6CbiZqOI0SNU9sDOnjwYLKzs+nUqRNdu3blrbfewszMrNz1u3fvTt++fWndujU6OjqEhITg6+tbpaGFEE+uXacjSE7LZUCnJthbm6jfQAgt5dfBkSNB0RwIiMS7hZ2m4whRo9QWoN988w2Ojo4V3uEHH3zAoEGDuHnzJkqlkokTJ+LqKvdlFkJU3r3UbPacvUs9c0Oe7SLj5kTt5mBjSuum1lwNSyYiLp0mDcw1HUmIGqP2FHxFi89XX31V9bOzszN9+vShb9++JYrPf64jhBCPyv/ALQoKi3ipVzOMDNR+fxZC6/X2Lv6MPRAgN2wRT5Yq+wt+7dq1hxaYSqWS69evV9XhhBBPmMuhSVy8nUjzxlY81VJOV4ra791DUwAwfgouABcOlb3eSp9FNRdKiBpSoQI0IyMDMzMzEhMTCQ8Px8vLS3Wv+Ad27txZLQGFECK/oIiN+2+iUBTf712hUGg6khBCiEpQW4DOmzePFi1a0Lt3b0aMGEHr1q35448/Sk3D1KhRo2oLKYR4su0PiCQ+JRtfL0ca25V/EaQQtZV7eA4dQzKxvl9IsqUu51uZctNZ7u4l6i61Y0BDQkIYNmwYf//9N4MGDWL58uVERETURDYhhCAlPZc/T4ZjZqzPi92bajqOEFXOPTyH/qfSsEktREcJNqmF9D+Vhnt4jqajCVFt1BagD+b0PHLkCD4+PgDk5eU90kHy8/MfI5oQQsCWw7fJzS9kaE9XTI3kloWi7ukYklnmcu+QrBpOIkTNUVuAOjs7M2DAADIzM2nZsiU7d+7E0tKy3PVnzpxZYiL60NBQhg8fXjVphRBPlBt3UzgTEo9zA3OeaddQ03GEqBbW9wvLWV5Qw0mEqDlqx4BOnTqVuLg41XRKzZo1Y9Gi8q/Is7OzY+LEiSxdupQ//viD7777jlmzZlVdYiHEE6GwqIhf998CYHQfd3TkwiNRRyVb6mKTWroITbaUqcZE3aW2B/S5557jhx9+4MKFCwC0adMGCwuLctd/77338PHxoV+/fuzatYvNmzfTq1evqksshHgiHAmKISohg65tG+DqUP5ZFyFqu/OtTMtcHtBK7vQl6i61X68OHz7MiRMn2L59O4sWLaJPnz4MHjwYO7uS8/Bt3bq1xGMPDw8SEhI4evQoAEOHDq3C2EKIuiw9K4+dx0MxNtRlaM9mmo4jRLV6cLW7d0gW1vcLSLbUI6CViVwFL+o0tQWovr4+vXr1olevXoSFhfHJJ5+watUqevfuzYwZM7C2tgYgMDCwxHaGhoY4OjqqllekAL158ybvvPMO//nPf3j55ZeZN28eQUFBmJoWfzscO3YsPXv2fNTXKISoZbYfCyUzp4ARvm5YmhpoOo4Q1e6ms5EUnOKJorYAzcnJYc+ePezYsYP09HSGDRvG999/z/Hjx3nvvffYsGEDAPPnz69UkKysLObNm0fnzp1LLPviiy9o2bJlpfYthKg9wuPSOHYxBgcbU3y8ZH5hUXeVdYcjW1tzPl5+lOt3U/lyXCcaWMtpeFE3qR0D6uvry/nz55k8eTLbt29n5MiRmJmZ0b9/f1XvZ1UwMDDg//7v/0qc2s/MLHtqCiFE3VSkVPLrvpsogdF+bujpqv0TJUSd0729AwDHg2M0nESI6qO2B3Tv3r2YmZW888jChQuZOnUq33zzTdUF0dNDT69knMzMTFasWEFaWhr29vbMnDkTKyurKjumEEK7nL4Sx52YNLyb29LSueq+4ApRm3Robovpfj1OXo5lUHcX+SIm6iS1BWhwcDBLly4lNTUVKJ6E3tLSkqlTp6rdeVJSEvXr13/scCNGjKBZs2Y0bdqUVatW8e233z50Sqd69UzQ09N97OM9Dltb8xo9niiftIX2eZQ2yczOZ9uxUAz0dRk/zAPbenLqsbrIe0W7OTS0wrejE38cDyXsXiZd2jloOpJA3jdVTW0BumzZMmbNmsWXX37JF198we7du/H29i613tdff80HH3wAwLVr1xg/fjy5ubkYGhqyfPly2rdv/8jhevfuXeLnOXPmPHT9lJSavWuEra05CQnpNXpMUTZpC+3zqG3if/AWqem5DOrWFEVBobRnNZH3inZ70D7e7jb8cTyUP4/fwa2hFD6aJu+bx/Owol1tv76ZmRkeHh7o6+vj5ubG+++/z48//lhqvaCgINXPy5YtY/78+Zw+fZpVq1axcOHCxwr+9ttvExNTPAbm7NmzuLm5PdZ+hBDaLToxk4OBUdhaGdHvaSdNxxFC4xxtzXB1sOBqaDKJ97M1HUeIKqe2B7SgoICAgAAsLCzYsWMHjRs3Jioq6qHb5OTkqK5mb9myJbq66k+LX7lyhYULFxIdHY2enh579+5l5MiRTJw4ERMTE4yNjSt9pb0QQvsolUo27r9JYZGSEb5u6NfwMBohtFX39g7ciUnjxKVYXuzmouk4QlQptQXoZ599RmJiIlOmTGHevHkkJiby9ttvl1ovLS2N4OBgTExMsLKyIjQ0FBcXF2JjY8nKUn9qvE2bNvzyyy+llg8YMKCCL0UIURsF3kjgWkQKbV3q49HMRtNxhNAaHVvasfHgLU5cjuX5rk3R0ZHb0Yq6Q20B6uLigotL8TevdevWlbuem5sbq1evJiMjg4yMDEJCQnBxcWHy5MmMHz++6hILIeqM3PxCNh+6ha6OgpF+bijkfu9CqBgZ6NGplT1HL8ZwJSyZdq6Pf1GvENqm3ALUx8fnoR8GBw8eLPF48eLFZa7366+/yoeKEKJMf5+JICktl/6dnGTCbSHK0L29A0cvxnAsOEYKUFGnlFuArl+/HoDNmzdja2tLp06dKCws5OTJkxU6pf6AQqHg9ddfL/PCJSHEk+teaja7z9zFysyA57o4azqOEFrJuYE5je3MCL6dyP2MXCzNDDUdSYgqUW4B6uRUfCVqaGgoH3/8sWp569atyxwDGhkZWe5BHqVgFUI8GTYfvEVBYREv9WqGkYHa0UBCPJEUCgXd2zvw6/6bnLwSx4BOTTQdSYgqofavfnR0NCdOnMDLywsdHR2CgoKIjo4utV6/fv2wt7cvcx9JSUmVTyqEqDOuhCYRdCsRd0dLnm5V9t8NIUSxTq3t+e3wbY4Fx9D/aScZ1ibqhApdBb9w4UJu3rwJQLNmzcq8G9H777+PUqnkrbfeKvXcK6+8UgVRhRB1QUFhEb8euIVCAaN6u8uHqRBqmBrp493cjtNX47hxN5UWTepp/HIG2gAAIABJREFUOpIQlaa2APX09MTf31/tjsaNG8eaNWvIzMzE1NS0xHPNmjV7/IRCiDplf0Ak8clZ+Hg1wsle7vAiREV0b9+Q01fjOBYcIwWoqBPU3gnpUbz11lulik+A2bNnV+VhhBC1VEp6Ln+cDMfMWF8m1hbiEbg3tqKBtQkBNxLIyM7XdBwhKq1KC9DyHD16tCYOI4TQcluO3CY3r5DBPVwwM9bXdBwhao0HFyMVFBZx+mqcpuMIUWnlFqDbtm0DYMuWLZU+yI0bNyq9DyFE7XYzMpUzV+Np0sCc7u0cNB1HiFqnS5sG6OooOBYcg1Kp1HQcISql3DGgq1atIj8/n59++qnMiwSGDh1a4YOMGzfu8dIJIeqEoiIlv+4vvpDx5d7ucktBIR6DhakBnm42BNxIIDQmDddGlpqOJMRjK7cAnTJlCkePHiU9PZ3AwMBSz/+7AL137x4//PADDRs25NVXX+XLL7/k7NmzNGvWjKlTp9KgQYOqTy+EqBWOXIwm8l4GXds0kA9NISqhu4cDATcSOBYcI+8lUauVW4D26dOHPn36sHfvXvr27at2R5988glt27bl1q1bfPDBBzRu3JjFixcTGBjIjBkzHnofeSFE3ZWelceOY6EYGegytKerpuMIUau1cramvoUR567dY4SvG8aGchMHUTup/Zfr4eHBjBkzuHz5MgqFAg8PDyZNmoS1tXWJ9XJycnjvvfcoKirCz8+PZcuWoVAoaNGiBXv27Km2FyCE0G47joWSmVPAcJ9mchtBISpJR6GgW/uG7Dwexrlr8fTwaKTpSEI8FrUF6OzZs/+/vTuPqrLO/wD+vgvLZQfZQdnUEFAUlxQEU1OnfuOSTuQ46dG0ZcyyRW2ddrXmjHZqcnLsdJyyUrPJNOeUWyaohKKBIgiyyr4ICnjhcpfn94dJqRAucL/Pvff9OqeTXG/x/vrxPs+H5/s83y8SExOxYMECSJKEI0eO4MUXX8T69euvep9Op4PBYIBarcb8+fM77hu9dOkS2traeic9EcnC4z+s6Po37QHNKGBnCzAFfzdfKCIrNXZwAHYcKkZKViUbULJY3S7D1Nrair/85S8YMGAABg4ciPnz53e6t/vUqVOxYMECAMC8efMAABkZGZg2bRqSk5N7ODYREZFt8nJzxODwPiiuasa5mmbRcYhuSbdXQFtbW1FbWwtfX18AQHV1Ndrb269739y5c3HPPfdc9Vrfvn3x73//mzshEdmQgSVtGJlzCV4XjWhwV+FYlDPyQx1FxyKyKuNiA3Gy8DxSs6rwl8ncUYwsT7cN6OLFizFz5kz4+PhAkiQ0NDRg5cqVnb63qqoKW7ZsQW1tLRwcHBAQEIAJEyb0eGgikqeBJW2450hTx9feF4wdX7MJJeo5gyP6wN3ZHmmnq3H/+AjY26lERyK6Kd02oHfddRf27duHkpISAEBYWBgcHK5/kGDDhg04ceIEkpKSkJ+fj+DgYOh0OixZsgSLFy/Gvffe2+PhiUheRuZc6vT1ETlaNqBEPUitUmLskAD8L60Ux/PqMCaGSx2SZbmhrTgdHR0RGRmJyMjITptP4PJ2m+vXr8ecOXOwZs0aFBcX469//Su+/PJLbNq0qUdDE5E8eV00dvG6wcxJiKxf4pAAAMDBrErBSYhuXo/tBd/W1tZxb+ilS5fQ2NgIAFCr1Z0+tERE1qfBvfNpwAZ3rlVI1NN8PZ0wKMQT+WUXUHW+89kHIrnqtgG90f1m7733XkydOhVLly7Ffffd1/Hk+7x58zB16tTbS0lEFuFYlHOnr2dEOZk5CZFtSIoNBACknqwSnITo5nR7WWLevHk3NIW+cOFCJCQkoLi4GE899RTCwsIAAB999BFcXfmEHpEtuHKf54gcLbwuGtDgrkZGlBPv/yTqJXEDveHsqMbhU1WYmRQOtarHJjaJelW3DeigQYPw3nvvYdiwYbCzs+t4fcyYMde9t6WlBWq1+qp9311dXfHf//4Xs2bN6qHIRCRn+aGObDiJzMROrUJ8TAD2ZpQh82w9RkT6io5EdEO6bUBzc3MBXF5U/gqFQnFdA7p69WocP34cHh4eeOedd/DBBx8gMjISALBjxw42oERWbN2Ev+Nf208hI68OS2YORtxAH/j4uKKujotkE/W2pNjLDWhKViUbULIY3TagV6bfJUnq2F6zMydOnMC2bdugUCiQlZWFJ598Ehs2bEBoaOgN30dKRJappLoJGXl1CAtww7AB3qLjENmUIB8XRAS54XRxA+ovtMLbQyM6ElG3ur1Z5MyZM5g5c2bHLkfr1q1DVlbWde9TKBQdDWpsbCxWrVqFxx9/HJWVlb/buBKR5fs6pQgAMGtcOD/vRAIkxQZCAnDoFB9GIsvQbQP69ttvY9WqVfDx8QFw+Wn31atXX/e+MWPGYO7cuWhtbQUAjBgxAq+++ioWLlyIoqKiHo5NRHKRd64R2UUNGBTiiahQL9FxiGzSqEg/ONqrkHqyCiYTZx1J/rptQJVKZce9nMDlnZDU6utn7p9++mksWrToqoXqR40ahc2bN2PBggU9FJeI5ESSpI6rnzOTwgWnIbJdDvYqjI7yQ2OzDtnF50XHIerWDa3XUFZW1jGtdvDgwS7v6Rw3bhyUyqv/lx4eHli4cOFtxiQiOTpV1ICz5RcxtL83IoLcRcchsmlJQy+vCXowkzsjkfx1+xDSc889h8WLF6O4uBhxcXEIDg7GO++8Y45sRCRjJknC1ymFUAC4j1c/iYQL8XNFP18XZBWcx4UWHTxcOt86m0gOur0Cescdd+Dbb79FSkoKUlJSsHPnTgwaNKhXwuTn5+Puu+/GZ599BgCoqqrC3LlzMWfOHCxdurRjq08iEi/jTC3O1bTgzig/9PV1ER2HyOYpFAokDQ2ESZJwmA8jkcx124AWFBRg6dKlmDt3LmbPno1nnnmmVx4q0mq1ePPNN69aX/T999/HnDlz8MUXXyAoKAhfffVVj39fIrp5RpMJ21OLoVIqMD0xTHQcIvrF6Cg/2KuVSM2qgolLIJKMdduArlixAomJiXj//ffx3nvvYfTo0Vi+fHmPB7G3t8dHH30EX99fF9FNT0/HxIkTAQATJ05EWlpaj39fIrp5R05Vo6ZBi8QhAfDz5D7vRHLh5GiHEZG+qL3QirzSRtFxiLrUbQPq5eWFP/3pT4iIiEBERASSk5Ph4eHR40HUajUcHa/evq+1tRX29vYAAB8fH9TV1fX49yWim6M3mLDjcDHUKiWmJvDqJ5HcJMVefhgp5SSn4Um+unwIyWQyAbi8nueePXsQHx8PhUKBtLQ0jBw50izhfrug9Y3spuTp6QS1WtWbka7j4+Nq1u9HXWMtzGNnaiEamnSYMS4CA8N/f9cj1kSeWBd5u936eHu7IHhvPo7n1cHByQFuzvY9lMy28XPTs7psQKOioqBQKDpt/NRqNR577LFeDQYAGo0GbW1tcHR0RE1NzVXT851pbNT2eqbf4l7X8sFamEdbuwFb9+TBwV6F8bEBv/tnzprIE+sibz1Vn/hof3x5oAC7DhZg0si+PZDMtvFzc2t+r2nvsgE9c+ZMr4S5GfHx8di9ezemT5+OPXv2IDExUXQkIpu2L6McTVo9piWEwtWJV1WI5Cp+sD/+e7AQKVmVuHtEMLfIJdnpdh3Qmpoa7NmzB01NTVddDV2yZEmPBsnOzsY777yDiooKqNVq7N69G//4xz/w/PPPY+vWrQgMDMSMGTN69HsS0Y1radXju/RzcHZUY8qofqLjENHvcHOyx7CBPsg4U4vCyib050YRJDPdNqCPPPIIoqKi4Ofn16tBYmJisGnTpute37hxY69+XyK6Md+nn0OrzoDk8f2hcej20EFEgo2LDUTGmVqkZFWyASXZ6fYs4u7ujtWrV5sjCxHJ1MUWHfZllMHDxR4T4oJExyGiGzAo1BPe7o44mluDP08cwB8cSVa6XYZp0qRJ2LlzJ8rKylBZWdnxDxHZjl1HStFuMGFaQhjs7cy70gQR3RqlQoHEIQFo15uQnlsjOg7RVbr9cSgvLw/ffvvtVWt/KhQK/Pjjj72Zi4hkov5CK37MrICPhyPGDgkQHYeIbsLYIYH45lAxUjIrcddQzl6QfHTbgGZlZeHo0aNwcHAwRx4ikpkdh4thNEmYkRgOtarbSRMikhFPVwcMCe+DrMLzOFfTjH5+XMuS5KHbs0lMTAza29vNkYWIZKay/hKOZFcjyMcZdw7q3QcRiah3JA39ZWekLN4+R/JxQ8swTZgwAREREVCpfr336/PPP+/VYEQk3vbUIkgSMDMxHEol1xEkskRDIvrA3cUeaadrcP/4/nDgfdwkA902oObY8YiI5Ke4qgnH8+oQHuiGoQN+f8tNIpIvlVKJsYMD8L+0UhzPq0V8DO/lJvG6nYI3Go2d/kNE1m17ShEAYFZSOHdRIbJwibG/TMNnchqe5KHbK6D/+te/On6t1+tRUFCAuLg4jBkzpleDEZE4eecakV3cgEEhnhgU6iU6DhHdJl8PDQaFeCK3tBFV5y8hoI+z6Ehk47ptQK/dnej8+fNYs2ZNrwUiIrEkScJ/f7n6OXNcuOA0RNRTxg0NRG5pI1KzqpA8ob/oOGTjbnpNlT59+qCoqKg3shCRDJwqOo+C8osYNsAbEYHcvo/IWgwb4AMXjR0OZ1fBYDSJjkM2rtsroMuXL7/q/q+qqioolVwLkMgamSQJXx8sggLAfYm8+klkTezUSsTH+GPPsTJknq3HiEhf0ZHIhnXbgMbHx3f8WqFQwMXFBQkJCb0aiojEyDhTi3O1LRgd7YdgXxfRcYiohyXGBmLPsTIczKpkA0pCdduA3nfffebIQUSCGU0mbE8thkqpwIyxYaLjEFEvCPJ2Rv8gd+QUN6D+Qiu8PTSiI5GN6rIBnTBhwlVT75IkQaFQoL29HfX19cjNzTVLQCIyj8OnqlHToMVdw4Lg6+kkOg4R9ZKk2EAUVFxE6skq3JfEW21IjC4b0B9++OG61/bt24c1a9Zg1qxZvRqKiMxLbzBi5+Fi2KmVmBofKjoOEfWikZG+2Lw/H4dOVWHa2FCo+FwHCdDtFDwAlJSU4K233oKdnR02bNiAvn379nYuIjKjH3+uREOTDn8Y1Q+erg6i4xBRL3KwV+HOKH/8+HMFsosaENufO52R+f1uA6rVarFu3TocPHgQy5cvx7hx48yVi4jMpK3dgF1pJXC0V+Ge0f1ExyEiMxgXG4gff65ASlYlG1ASosvr7rt27cLMmTPh7u6Ob775hs0nkZXam1GOZq0eU0b1g6uTveg4RGQGIf6u6OfngqyC87jQohMdh2xQl1dAly1bhtDQUKSmpuLQoUMdr195GOnTTz81S0Ai6j0trXp8n34OLho7TB7JW2uIbMm42EBs2pOPw6eq8H9jQkXHIRvTZQO6f/9+c+YgIgG+Sy9Fq86A5PH9oXG4oVvCichK3Bnlj60/FCAlqxL3jA6B8jcr3xD1ti7POEFBQebMQURmdqFFh/0Z5fB0dcCEOH7eiWyNk6MaIyN9cTi7GmdKGxEV6iU6EtkQrr1AZKN2HSlBu8GEqQmhsLdTiY5DRAIkDQ0EAKRkVQpOQraGDSiRDaq70IqDmZXw9dBg7OAA0XGISJD+Qe4I6OOEE/l1aNa2i45DNoQNKJEN2nmoGEaThBmJYVCreBggslUKhQJJsYEwGCWkna4RHYdsCM88RDamov4SjpyuRrCPM0ZF+YmOQ0SCxcf4Q6VUICWrEpIkiY5DNoINKJGN+Sa1CJIE3JcUzqdeiQiuTvaIG+iDyvpLKKxoEh2HbAQbUCIbUlzVhON5dYgIdMNQ7n5CRL/gw0hkbmxAiWzI1ylFAICZ4yKg4NVPIvrFoBBPeLs74uiZGrTqDKLjkA1gA0pkI86UNuJ0cQOiQj0xKMRTdBwikhGlQoHE2EC0601Iz+HDSNT72IAS2QBJkn69+pkUITgNEcnR2MEBUCiAg5yGJzOQ9d572dnZWLx4MUJCQgAAAwcOxN/+9jfBqYgsz8nC8yiouIhhA7wRHugmOg4RyZCnqwNiI7yRWVCP0upmhPi7io5EVkzWDahWq8WUKVPw0ksviY5CZLFMv1z9VODyk+9ERF1Jig1EZkE9Uk5WYq7/HaLjkBWT9RT8pUuXREcgsngZZ2pRVtuC0dF+CPZxER2HiGRscIQXPFzs8dPpGuj0RtFxyIrJ/gro8ePHsWjRIrS2tuKJJ57A6NGju3y/p6cT1Grz7mnt48MpCrlgLa5nMJqw83AJVEoFFkwbDB9vZ7N+f9ZEnlgXeRNdn8mjQ/HlvnzkVzZhwoh+QrPIiei6WBtZN6CRkZF4/PHHMXHiRBQXF2PBggXYs2cP7O3tO31/Y6PWrPl8fFxRV9ds1u9JnWMtOpeSVYnK+ksYPywIaslk1j8j1kSeWBd5k0N9hvfvgy/3AbtSizCYK2YAkEddLNHvNe2ynoKPiIjAxIkTAQBhYWHw9vZGTQ2XhyC6EXqDETsOFcNOrcQf40NFxyEiC+HjoUFUqCfOll9EZT1vhaPeIesG9KuvvsKnn34KAKirq8P58+fh58e9q4luxIGfK9HYrMPE4cHwdHUQHYeILEhS7OWdkVJPckkm6h2ynoKfNGkSli1bht27d6O9vR2vvfZal9PvRPSrVp0B/0srgaO9CveODhEdh4gszLABPnDR2OHwqWrMTIqAnVrW16vIAsm6AXV3d8dHH30kOgaRxdmXUYZmrR4zxobBRWMnOg4RWRg7tRLxMf7Yc6wMmQX1GBnpKzoSWRn+SENkZVpa9fj+6Dm4aOwwaWRf0XGIyEJdmYZPyawQnISsERtQIivz3U+laNUZ8X9jQqBxkPUkBxHJWKC3MwYEu+N0SSPqLrSKjkNWhg0okRVpbNZh//FyeLo6YEJckOg4RGThfn0YqUpwErI2bECJrMiutBK0G0yYlhAKOzNvykBE1mdEpC80DiocOlkJo8kkOg5ZETagRFai9kIrUjIr4eupQcLgANFxiMgKONipMDrKHxda2nGqsEF0HLIibECJrMTOQ8UwmiTMSAyDWsWPNhH1jI6HkbK4Jij1HJ6liKxARV0L0rKrEezjjFGDuFkDEfWcEH9XhPi74mTheTQ260THISvBBpTICnyTWgwJwMykCCgVCtFxiMjKJMUGwiRJOHyKDyNRz2ADSmThiquacDy/DhFBbojt30d0HCKyQqOj/GBvp0RKViVMkiQ6DlkBNqBEFu7rg4UAgFlJEVDw6icR9QKNgxojI31Rf7ENuaWNouOQFWADSmTBcksbcbqkEdGhnogM8RQdh4is2LjYy2sLp/JhJOoBbECJLJQkSfg65fLVz5njIgSnISJrFxHkhkBvZ5zIr0Oztl10HLJwbECJLFRW4XkUVjQhbqAPwgLcRMchIiunUCiQNCQABqOEtOxq0XHIwrEBJbJAJknC1weLoABwX2KY6DhEZCPGxPhDrVLgYFYlJD6MRLeBDSiRBTqWW4vyuhaMjvZHkI+L6DhEZCNcnewRN9AHVee1KKi4KDoOWTA2oEQWxmA0YXtqEVRKBabz6icRmRl3RqKewAaUyMIcPlWF2sZWJA0NhK+HRnQcIrIxkSGe8PFwxLHcWmjbDKLjkIViA0pkQfQGI3YeLoG9Womp8aGi4xCRDVIqFEgcEoh2gwnpuTWi45CFYgNKZEEOnKhAY7MOE4cHw8PFQXQcIrJRY4cEQKlQICWT0/B0a9iAElmIVp0Bu9JKoXFQ4Z7RIaLjEJEN83BxQGz/PiitaUZpdbPoOGSB2IASWYi9GWVoadVjyqh+cNHYiY5DRDYukQ8j0W1gA0pkAVpa9dh99BxcNHaYNKKv6DhERBgc7gVPVwf8lFMNXbtRdByyMGxAiSzAdz+VolVnxB/HhEDjoBYdh4gIKqUSCYMD0KozIiOvVnQcsjBsQIlkrrFZh33Hy+Hp6oDxcUGi4xARdUgaEgAFgIOchqebxAaUSOZ2HSmB3mDC9LFhsFOrRMchIurg7aFBVJgXCsovoqL+kug4ZEHYgBLJWO2FVqRkVcLPU4P4GH/RcYiIrnNlZ6RUXgWlm8AGlEjGdqQWw2iSMCMxHGoVP65EJD/DBnjD1ckOR7KroTeYRMchC8EzGpFMVdS14KfT1Qj2ccHIQb6i4xARdUqtUiIhJgAtrXr8fLZOdByyEGxAiWRqe2oxJAAzx4VDqVCIjkNE1KXE2AAAXBOUbpxCkiRJdIieUlfXe7sxPP7Diht637oJf++1DD3JksdjydmvZU1juZaPj2uvfibp1rAu8maJ9bG245i1jEcO4/Dxce3y93gFlIiIiIjMSvYrWq9atQpZWVlQKBR48cUXMWTIENGRMLCkDSNzLsHrohEN7ioci3JGfqij6Fi3zJLHY8nZr2VNYyEi22RtxzFrGY8cxyHrBvTo0aMoLS3F1q1bUVBQgBdeeAHbtm0TmmlgSRvuOdLU8bX3BWPH16KLeSsseTyWnP1a1jQWIrJN1nYcs5bxyHUcsm5A09LScPfddwMA+vfvj6amJrS0tMDFxUVYppE5nS+0OyJHi/xQR6zfkW3mRLfol9syLHI8lpz9Wjc4FiIiubOKYzJgPecYmZ9fZN2A1tfXIzo6uuPrPn36oK6urssG1NPTCepe3inG66Kxi9cNAICjuZaxH65m1OV/W+J4LDn7tW50LL93I7ecWWpua8e6yJul1scajsmA9Zxj5H5+kXUDeu0D+pIkQfE7y9E0Nmp7OxIa3FXwvnB9MRvcL/9Rrl2S0OsZesJLR78HYJnjseTs17rRsVjaU7GAZT7NawtYF3mz5PpYwzEZsJ5zjBzOL7/X3Mq6AfXz80N9fX3H17W1tfD29haYCDgW5XzVvRRXZEQ5AQA8XBzMHem2WPJ4LDn7tbobCxGR3FnTMRmwnvHI9fwi6wY0ISEB//znPzF79mzk5OTA19dX6P2fwK837I7I0cLrogEN7mpkRDlZ7H16ljweS85+LWsaCxHZJms7jlnLeOQ6Dlk3oHFxcYiOjsbs2bOhUCjw6quvio4E4HIxRReuJ1nyeCw5+7WsaSxEZJus7ThmLeOR4zi4E9JtsOR7dawNayE/rIk8sS7yxvrIE+tya7gTEhERERHJBhtQIiIiIjIrNqBEREREZFZsQImIiIjIrNiAEhEREZFZsQElIiIiIrNiA0pEREREZmVV64ASERERkfzxCigRERERmRUbUCIiIiIyKzagRERERGRWbECJiIiIyKzYgBIRERGRWbEBJSIiIiKzYgN6A7hSlXgtLS2iI1AnamtrUV9fLzoGXaOmpgYpKSmiY1AXdDqd6AjUCZ7rzYsNaBdMJhM++OADVFRUQKFQwGg0io5kk/R6PT788EM8+eST2L59O6qrq0VHIgAGgwHr16/HkiVLWBMZMRgM+PDDDzFnzhwcPXoUAE+qcqLX67Fu3TqsXLkSaWlp/MFaBniuF4cNaBdOnDiBLVu24K233gIAqFQqwYlsT3t7O1auXImWlhYsXLgQe/fuRXl5uehYNu/06dOYN28eWltbsX79esTExIiORAAOHz6M2bNnQ6lU4oUXXsDFixcBAAqFQnAyumLt2rWor6/HPffcg59++glbt26FXq8XHcum8VwvDhvQ3/jtVGJ2djZWrVqFs2fP4ocffgAA/mRkJnV1dQCA1tZWFBUVYfny5UhISICLiwuUSv6VFeVKXVxcXGAymfD000/Dy8sLOTk5KCgogMlkEpzQNtXW1gIAQkND8frrr+PRRx/FnXfeiT59+kCr1fIKqGC/PZ6dPXsWzzzzDMaMGYPExERkZmZi//79ghPanivHKqPRiNOnT/NcL4jqtddee010CNEaGxvx9ttvY/PmzSgvL0dgYCBiYmIwaNAg+Pr6Yu3atXjwwQehVCohSRKvKPSS39ahrKwMkZGRGD9+PFxcXPCf//wHe/fuRUNDA6qqqhAcHAwnJyfRkW3Cb+ty7tw5DB8+HDqdDjt27EBubi42b96MkydPIi8vD+Hh4XBxcREd2SZcqcuWLVtQXl6O4OBgREVFAQAKCgrw/fffY8aMGTxeCXLt8SwqKgpnzpxBamoqJkyYAK1Wi5ycHFRUVGDw4ME8npmBTqfDq6++CoVCgX79+kGtVkOj0WD48OE81wvAy0kAPvnkE2g0Gnz88cdwdXXFs88+iz59+gAA/vCHP8DDwwMbNmwAwOms3nRtHZYsWYLg4GAolUrEx8dj7969eOCBB1BfX4/vv/9edFybcW1dli1bhvnz5+Pnn3+GJEnYtGkTnnjiCQDAd999Jzit7fhtXdzc3PDKK690/F50dDQ0Gg0fRBLot/VxdnbGs88+i+eeew5nz57FSy+9hJdeeglDhw5Fnz59Oq6SUu+qr69Heno6cnNzUVZWBgC44447APBcL4JNN6BXLsO7urqif//+cHBwwIIFC6BSqfD55593vO/ll1/u+PrMmTN86KKHdVaHhx56CGq1uuPPvV+/fgCAuLg4ODs7Q6PRCMtrKzqry8KFC6HVarFv3z6sW7cO06ZNAwAMGDAArq6ucHZ2FhnZJnRWl/nz51/1edHpdIiNjUVDQwOn4M2ss/osWrQIly5dwt69e7FlyxbMnz8fH374IZKTk3Hy5EkYDAbBqW1DaWkpJk+ejMrKSpw8eRJtbW0A0HEfLs/15mXTDeiV+wl1Oh1aWlqg1WoBAMuWLcPHH3/c8ZcyOjoaERERGDFiBD7//HPeh9jDuquDVqvFt99+i4MHD6K6urrj6V7qXV3V5bnnnsOaNWsQEBAAR0dH5Ofno7a2Funp6bC3txcZ2SbcyHHLwcEBSqUShYWFHQ8jkXl0VZ8VK1bg3XffhV6vh4eHB8rLy5GXlwd3d3dOv5vJkCFDsGLFCowfPx7Hjx9HcXExAMDOzg4Az/XmZjP3gDY1NWHDhg1oa2thVSIHAAAIS0lEQVSDm5sbNBoN9Ho9VCoVnJycsHXrVsTGxsLT0xNBQUH4+eefce7cOYwcORIbN25EUVERHn74YTz++OO8ynMbbrYOJ06cwKVLlxASEoLt27fjyy+/xP33348ZM2aIHopVuZW6NDQ0wMnJCRs2bMCWLVuQnJyM6dOnix6KVbmV41ZpaSlGjhwJNzc37Nu3DwkJCWxwesmtfm4CAgKwY8cOfPLJJ5g2bRri4+NFD8VqdFYTo9EIpVIJlUoFpVKJsLAwHDp0CC0tLejfvz/s7e2h1+vx6aef8lxvRjbRgO7fvx+rVq2Cl5cXysrKcODAAUycOBHA5fs8fH19kZ+fj8LCQgQFBcHd3R06nQ4ODg6Ijo5GW1sbFi9ejOjoaMEjsWy3WgcAmDJlCiZOnIj7778fkZGRIodhdW61LkqlEhMmTEBCQgLmzJmDQYMGCR6JdbnVujg6OiI6OhoeHh6YPHkyT6K95HY+NwkJCRgzZgySk5P5uelBXdVEkiQolcqOh4uUSiU0Gg0yMjLg7e2NH3/8EQMGDIBarcYjjzzCc72ZWHUDajKZoFAocPjwYQwePBgPP/wwHB0dodPpEBcXB6VSCYVCgdzcXLi7u6OkpARHjx7FhQsX8MUXXyAxMRHh4eHo27cvL8Xfhtupw+bNmzFu3DiEhYV1vI96xu3WJSkpCWFhYR3TvdQzbve4deXzAvBBit7QU8czhULB+vSQG6kJAGRkZKC+vh7+/v4ICgrCtm3bsHnzZuj1eiQmJnacZ8g8rLIBzc/Px8aNG1FbW4vIyEhUVFRg9OjRMBgMWLp0Kezs7FBdXY0hQ4Zg9erV2Lp1K+bOnYtRo0bBzs4O6enpmDt3LpKSkkQPxaL1VB0SExNFD8Wq8PMhT/y8yBvrIz83W5OdO3diypQpcHNzw44dO5CVlYXnnnuuo2El81JIVvKI5JU1u86cOYM333wT999/PzIzM+Hr64sZM2YgMDAQZWVlSE9Px/Dhw/Hyyy9j0qRJeOCBB/hEdQ9iHeSJdZEn1kXeWB/56amaVFZWIjAwUOBICJKVaG9vlyRJknbu3CktXbpUkiRJam5ulp566ilp48aNUnNz81XvP3v2rPTHP/5RamtrkyRJkgwGg3kDWynWQZ5YF3liXeSN9ZGf262JXq83b2DqksVPwf/000949913kZubCw8PD/Tt2xcHDhxAREQEgoKCkJmZiaqqKnh7e0On06GhoQFeXl44deoUJEnC+PHjAYD3fdwm1kGeWBd5Yl3kjfWRH9bE+lj0FHxZWRmWL1+OxYsXo62tDdnZ2QgJCYHJZMLWrVsxYMAAGI1GuLq6Yvjw4XB1dcWuXbtw/vx5GI1GLFy4EGPHjhU9DIvHOsgT6yJPrIu8sT7yw5pYKXEXX2+NwWCQjh07JrW1tUlHjhyR3nzzTUmSJEmn00mfffaZ9Mgjj0harVYqLCyU9u/fL0mSJB05ckR66KGHJEmSJK1WK6WkpAjLby1YB3liXeSJdZE31kd+WBPrZ3HXoleuXIm1a9ciOzsbYWFhSEtLQ05ODuzt7SFJEuzs7LBp0yaEh4d33HBcXl6Ou+66CwCg0Wj4FGIPYB3kiXWRJ9ZF3lgf+WFNrJ9FNaBarRbFxcUYOnQojh49Cn9/f/z5z3/Gpk2b8OCDDyI3NxfJycloaGgAAKSmpuKxxx7D9u3bkZCQIDi99WAd5Il1kSfWRd5YH/lhTWyDxd0DmpOTA6PRiB07dmD06NG4++67odfrUVhYiMjISBQUFODjjz/G6tWrodfr0dDQAD8/P9GxrQ7rIE+sizyxLvLG+sgPa2L9LO4peB8fH/j5+aG0tBQlJSVwd3eHv78/zp49iwsXLuDQoUMwGAwYM2YM7Ozs4OLiIjqyVWId5Il1kSfWRd5YH/lhTayfRU3BA5cXoQWAhIQEtLe3o6ioCABQVFSEbdu2ITc3F48++ijUarXImFaPdZAn1kWeWBd5Y33khzWxfhY3Bf9bBw8exM6dO1FeXo7ExEQ8/PDDcHBwEB3L5rAO8sS6yBPrIm+sj/ywJtbJon902LdvH/Ly8rBo0SLMmDFDdBybxTrIE+siT6yLvLE+8sOaWCeLvQJaU1ODlJQUTJ8+Hfb29qLj2CzWQZ5YF3liXeSN9ZEf1sR6WWwDSkRERESWyeIeQiIiIiIiy8YGlIiIiIjMig0oEREREZkVG1AiIiIiMis2oERERERkVmxAiYjMaMeOHairq8OTTz4pOgoRkTBchomIyEyMRiPuvfde7N69W3QUIiKhLHonJCIiS/Liiy+ioqICDz30EAoKCpCSkoLnn38enp6eKCwsREFBAZ599lkcOHAAeXl5iIuLw+uvvw4AWLt2LU6cOAGFQoGYmBisWLECCoVC8IiIiG4Np+CJiMzkiSeegJeXF954442rXq+vr8eGDRuwZMkSvPHGG3jllVewbds2bN++HU1NTfjuu+9QU1ODzz77DJs2bcK5c+dw4MABQaMgIrp9vAJKRCRYXFwcAMDf3x/h4eFwc3MDAHh4eKC5uRnp6enIzMzE3LlzAQDNzc0oLy8XlpeI6HaxASUiEkytVnf6awCQJAn29vZITk7GwoULzR2NiKhXcAqeiMhMlEoldDrdTf93w4cPx969e2EwGAAAH3zwAUpKSno4HRGR+fAKKBGRmfj6+sLPzw+zZs2CyWS64f9u8uTJyMzMxOzZs6FUKhEdHY2+ffv2YlIiot7FZZiIiIiIyKw4BU9EREREZsUGlIiIiIjMig0oEREREZkVG1AiIiIiMis2oERERERkVmxAiYiIiMis2IASERERkVmxASUiIiIis/p/145GSATkfncAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 792x360 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# Create a copy of the data converted to C\n",
     "tasmax_C = ds4.tasmax - 273.15\n",
@@ -448,13 +752,6 @@
     "out3.plot(label='degC and K', marker='o', linestyle='none')\n",
     "plt.legend()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/docs/notebooks/usage.ipynb
+++ b/docs/notebooks/usage.ipynb
@@ -132,7 +132,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with xclim.set_options(missing_options={'pct': dict(tolerance=0.1)}):\n",
+    "with xclim.set_options(check_missing='pct', missing_options={'pct': dict(tolerance=0.1)}):\n",
     "    # Change the missing method to \"percent\", instead of the default \"any\"\n",
     "    # Set the tolerance to 10%, periods with more than 10% of missing data\n",
     "    #     in the input will be masked in the ouput.\n",

--- a/docs/notebooks/usage.ipynb
+++ b/docs/notebooks/usage.ipynb
@@ -132,7 +132,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with xclim.set_options(check_missing='pct', missing_pct=0.1):\n",
+    "with xclim.set_options(missing_options={'pct': dict(tolerance=0.1)}):\n",
     "    # Change the missing method to \"percent\", instead of the default \"any\"\n",
     "    # Set the tolerance to 10%, periods with more than 10% of missing data\n",
     "    #     in the input will be masked in the ouput.\n",

--- a/xclim/core/calendar.py
+++ b/xclim/core/calendar.py
@@ -105,7 +105,7 @@ def convert_calendar(
     target : Union[xr.DataArray, str]
       Either a calendar name or the 1D time coordinate to convert to.
       If an array is provided, the output will be reindexed using it and in that case, days in `target`
-         that are missing in the converted `source` are filled by NaNs.
+      that are missing in the converted `source` are filled by NaNs.
     align_on : {None, 'date', 'year'}
       Must be specified when either source or target is a `360_day` calendar, ignored otherwise. See Notes.
 
@@ -160,11 +160,13 @@ def convert_calendar(
     out = source.copy()
     if (cal_src == "360_day" or cal_tgt == "360_day") and align_on is None:
         raise ValueError(
-            "Argument `align_on` must be specified with either 'date'  or 'year' when converting to or from a '360_day' calendar."
+            "Argument `align_on` must be specified with either 'date' or "
+            "'year' when converting to or from a '360_day' calendar."
         )
     if (cal_src != "360_day" and cal_tgt != "360_day") and align_on is not None:
         warn(
-            "Argument `align_on` was specified, but none of the source or target calendars is '360_day'. `align_on` will be ignored."
+            "Argument `align_on` was specified, but none of the source or "
+            "target calendars is '360_day'. `align_on` will be ignored."
         )
         align_on = None
 
@@ -172,7 +174,7 @@ def convert_calendar(
     if align_on == "year":
 
         def _yearly_interp_doy(time):
-            # This returns the nearest day in the target calendar of the corresponding "decimal year" in the source calendar
+            # Returns the nearest day in the target calendar of the corresponding "decimal year" in the source calendar
             yr = int(time.dt.year[0])
             return np.round(
                 days_in_year(yr, cal_tgt)

--- a/xclim/core/formatting.py
+++ b/xclim/core/formatting.py
@@ -128,11 +128,11 @@ def parse_doc(doc):
 def merge_attributes(
     attribute: str,
     *inputs_list: Union[xr.DataArray, xr.Dataset],
-    new_line="\n",
+    new_line: str = "\n",
     missing_str: Optional[str] = None,
     **inputs_kws: Union[xr.DataArray, xr.Dataset],
 ):
-    """Merge attributes from several DataArrays or Datasets
+    """Merge attributes from several DataArrays or Datasets.
 
     If more than one input is given, its name (if available) is prepended as: "<input name> : <input attribute>".
 
@@ -143,10 +143,10 @@ def merge_attributes(
     *inputs_list : Union[xr.DataArray, xr.Dataset]
         The datasets or variables that were used to produce the new object.
         Inputs given that way will be prefixed by their "name" attribute if available.
-    new_line : str:
+    new_line : str
         The character to put between each instance of the attributes. Usually, in CF-conventions,
         the history attributes uses "\n" while cell_methods uses " ".
-    missing_str : str:
+    missing_str : str
         A string that is printed if an input doesn't have the attribute. Defaults to None, in which
         case the input is simply skipped.
     **inputs_kws : Union[xr.DataArray, xr.Dataset]

--- a/xclim/sdba/__init__.py
+++ b/xclim/sdba/__init__.py
@@ -32,7 +32,7 @@ Modular approach
 ================
 
 This module adopts a modular approach instead of implementing published and named methods directly.
-A generic bias adjustment process is to layed out like:
+A generic bias adjustment process is laid out as follows:
 
 - preprocessing on `ref`, `hist` and `sim` (using methods in `xclim.sdba.processing` or `xclim.sdba.detrending`)
 - creating the adjustment object `Adj = Adjustment(**kwargs)` (from `xclim.sdba.adjustment`)


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #471 
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
This adds the following metdata flags to the `example.ipynb` notebook, preventing nbstripout from removing the information if it is present.
```
   "metadata": {
    "keep_output": true
   },
```
I also re-enabled `"automatic"` execution of the `nbsphinx_execute` option. This means it will only execute the notebook if there is not already output in the cells, therefore ignoring `example.ipynb`.

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
No.

* **Other information**:
This is primarily a bugfix, no need for documentation changes, IMO.