### PR TITLE
sdba - Fix rechunking in apply and make sdba easier to import

### DIFF
--- a/docs/sdba.rst
+++ b/docs/sdba.rst
@@ -6,8 +6,8 @@ Bias adjustment and downscaling algorithms
 
 For example, given a daily time series of observations `ref`, a model simulation over the observational period `hist` and a model simulation over a future period `sim`, we would apply a bias-adjustment method such as *detrended quantile mapping* (DQM) as::
 
-  from xclim.sdba.adjustment import DetrendedQuantileMapping
-  dqm = DetrendedQuantileMapping()
+  from xclim import sdba
+  dqm = sdba.adjustment.DetrendedQuantileMapping()
   dqm.train(ref, hist)
   scen = dqm.adjust(sim)
 

--- a/tests/test_sdba/test_adjustment.py
+++ b/tests/test_sdba/test_adjustment.py
@@ -5,11 +5,13 @@ from scipy.stats import norm
 from scipy.stats import uniform
 
 sdba = pytest.importorskip("xclim.sdba")  # noqa
+from xclim.sdba.adjustment import BaseAdjustment
 from xclim.sdba.adjustment import DetrendedQuantileMapping
 from xclim.sdba.adjustment import EmpiricalQuantileMapping
 from xclim.sdba.adjustment import LOCI
 from xclim.sdba.adjustment import QuantileDeltaMapping
 from xclim.sdba.adjustment import Scaling
+from xclim.sdba.base import Grouper
 from xclim.sdba.utils import ADDITIVE
 from xclim.sdba.utils import apply_correction
 from xclim.sdba.utils import get_correction
@@ -397,3 +399,10 @@ class TestQM:
 
         # Test predict
         np.testing.assert_array_almost_equal(p, ref, 2)
+
+
+def test_raise_on_multiple_chunks(tas_series):
+    ref = tas_series(np.arange(730)).chunk({"time": 365})
+    Adj = BaseAdjustment(group=Grouper("time.month"))
+    with pytest.raises(ValueError):
+        Adj.train(ref, ref)

--- a/tests/test_sdba/test_base.py
+++ b/tests/test_sdba/test_base.py
@@ -94,11 +94,13 @@ def test_grouper_apply(tas_series, use_dask, group, n):
     np.testing.assert_array_equal(out, out_mean)
 
     # With window
-    grouper = Grouper(group, window=5)
-    out = grouper.apply("mean", tas)
-    rolld = tas.rolling({grouper.dim: 5}, center=True).construct(window_dim="window")
+    win_grouper = Grouper(group, window=5)
+    out = win_grouper.apply("mean", tas)
+    rolld = tas.rolling({win_grouper.dim: 5}, center=True).construct(
+        window_dim="window"
+    )
     if grouper.prop:
-        exp = rolld.groupby(group).mean(dim=[grouper.dim, "window"])
+        exp = rolld.groupby(group).mean(dim=[win_grouper.dim, "window"])
     else:
         exp = rolld.mean(dim=[grouper.dim, "window"])
     np.testing.assert_array_equal(out, exp)
@@ -113,6 +115,10 @@ def test_grouper_apply(tas_series, use_dask, group, n):
     assert normed.shape == tas.shape
     if use_dask:
         assert normed.chunks == ((1, 1), (366,))
+
+    # With window + nongrouping-grouped
+    out = win_grouper.apply(normalize, tas)
+    assert out.shape == tas.shape
 
     # Mixed output
     def mixed_reduce(grdds, dim=None):

--- a/tests/test_sdba/test_detrending.py
+++ b/tests/test_sdba/test_detrending.py
@@ -5,11 +5,10 @@ sdba = pytest.importorskip("xclim.sdba")  # noqa
 from xclim.sdba.detrending import PolyDetrend
 
 
-@pytest.mark.parametrize("freq", (None, "MS", "YS", "QS", "M", "Y", "Q"))
-def test_poly_detrend(series, freq):
+def test_poly_detrend(series):
     x = series(np.arange(20 * 365.25), "tas")
 
-    poly = PolyDetrend(degree=1, freq=freq)
+    poly = PolyDetrend(degree=1)
     fx = poly.fit(x)
     dx = fx.detrend(x)
     xt = fx.retrend(dx)
@@ -17,7 +16,5 @@ def test_poly_detrend(series, freq):
     # The precision suffers due to 2 factors:
     # - The date is approximate (middle of the period)
     # - The last period may not be complete.
-    dec = 6 if freq is None else 0
-
-    np.testing.assert_array_almost_equal(dx, 0, dec)
+    np.testing.assert_array_almost_equal(dx, 0)
     np.testing.assert_array_almost_equal(xt, x)

--- a/xclim/sdba/__init__.py
+++ b/xclim/sdba/__init__.py
@@ -63,7 +63,7 @@ except ImportError as err:
 else:
     del polyval
 
-from . import adjustment
+from .adjustment import *
 from .base import Grouper
 from . import detrending
 from . import processing

--- a/xclim/sdba/__init__.py
+++ b/xclim/sdba/__init__.py
@@ -63,6 +63,11 @@ except ImportError as err:
 else:
     del polyval
 
+from . import adjustment
+from .base import Grouper
+from . import detrending
+from . import processing
+from . import utils
 
 # TODO: ISIMIP ? Used for precip freq adjustment in biasCorrection.R
 # Hempel, S., Frieler, K., Warszawski, L., Schewe, J., & Piontek, F. (2013). A trend-preserving bias correction &ndash;

--- a/xclim/sdba/adjustment.py
+++ b/xclim/sdba/adjustment.py
@@ -18,12 +18,27 @@ from .utils import equally_spaced_nodes
 from .utils import extrapolate_qm
 from .utils import get_correction
 from .utils import interp_on_quantiles
-from .utils import invert
 from .utils import map_cdf
 from .utils import MULTIPLICATIVE
 from .utils import rank
 from xclim.core.calendar import get_calendar
 from xclim.core.formatting import update_history
+
+
+__all__ = [
+    "EmpiricalQuantileMapping",
+    "DetrendedQuantileMapping",
+    "QuantileDeltaMapping",
+    "Scaling",
+    "LOCI",
+]
+
+
+def _raise_on_multiple_chunk(da, main_dim):
+    if da.chunks is not None and len(da.chunks[da.get_axis_num(main_dim)]) > 1:
+        raise ValueError(
+            f"Multiple chunks along the main adjustment dimension {main_dim} is not supported."
+        )
 
 
 class BaseAdjustment(Parametrizable):
@@ -50,20 +65,25 @@ class BaseAdjustment(Parametrizable):
         """
         if self.__trained:
             warn("train() was already called, overwriting old results.")
-        if (
-            hasattr(self, "group")
-            and self.group.prop == "dayofyear"
-            and get_calendar(ref) != get_calendar(hist)
-        ):
-            warn(
-                (
-                    "Input ref and hist are defined on different calendars, "
-                    "this is not recommended when using 'dayofyear' grouping "
-                    "and could give strange results. See `xclim.core.calendar` "
-                    "for tools to convert your data to a common calendar."
-                ),
-                stacklevel=4,
-            )
+
+        if hasattr(self, "group"):
+            # Right now there is no other way of getting the main adjustment dimension
+            _raise_on_multiple_chunk(ref, self.group.dim)
+            _raise_on_multiple_chunk(hist, self.group.dim)
+
+            if self.group.prop == "dayofyear" and get_calendar(ref) != get_calendar(
+                hist
+            ):
+                warn(
+                    (
+                        "Input ref and hist are defined on different calendars, "
+                        "this is not recommended when using 'dayofyear' grouping "
+                        "and could give strange results. See `xclim.core.calendar` "
+                        "for tools to convert your data to a common calendar."
+                    ),
+                    stacklevel=4,
+                )
+
         self._train(ref, hist)
         self._hist_calendar = get_calendar(hist)
         self.__trained = True
@@ -80,20 +100,25 @@ class BaseAdjustment(Parametrizable):
         """
         if not self.__trained:
             raise ValueError("train() must be called before adjusting.")
-        if (
-            hasattr(self, "group")
-            and self.group.prop == "dayofyear"
-            and get_calendar(sim) != self._hist_calendar
-        ):
-            warn(
-                (
-                    "This adjustment was trained on a simulation with the "
-                    f"{self._hist_calendar} calendar but the sim input uses "
-                    f"{get_calendar(sim)}. This is not recommended with dayofyear "
-                    "grouping and could give strange results."
-                ),
-                stacklevel=4,
-            )
+
+        if hasattr(self, "group"):
+            # Right now there is no other way of getting the main adjustment dimension
+            _raise_on_multiple_chunk(sim, self.group.dim)
+
+            if (
+                self.group.prop == "dayofyear"
+                and get_calendar(sim) != self._hist_calendar
+            ):
+                warn(
+                    (
+                        "This adjustment was trained on a simulation with the "
+                        f"{self._hist_calendar} calendar but the sim input uses "
+                        f"{get_calendar(sim)}. This is not recommended with dayofyear "
+                        "grouping and could give strange results."
+                    ),
+                    stacklevel=4,
+                )
+
         scen = self._adjust(sim, **kwargs)
         params = ", ".join([f"{k}={repr(v)}" for k, v in kwargs.items()])
         scen.attrs["history"] = update_history(

--- a/xclim/sdba/base.py
+++ b/xclim/sdba/base.py
@@ -245,7 +245,7 @@ class Grouper(Parametrizable):
                     if d.chunks and self.dim in d.dims
                 ]
                 or [[]],  # pass [[]] if no dataarrays have chunks so min doesnt fail
-                key=lambda d: len(d),
+                key=len,
             )
         else:
             grpd = self.group(da)

--- a/xclim/sdba/base.py
+++ b/xclim/sdba/base.py
@@ -227,9 +227,9 @@ class Grouper(Parametrizable):
         -------
         DataArray or Dataset
           Attributes "group", "group_window" and "group_compute_dims" are added.
-          If the function did not reduce the array, its is sorted along the main dimension.
-          If the function did reduce the array and there is only one group, it is squeezed out of the output.
-
+          If the function did not reduce the array, its is sorted along the main dimension and chunking along it is conserved (apply performs a rechunking)
+          If the function reduces the array and there is only one group, it is squeezed out of the output.
+          If the function reduces the array, it is rechunked to have only 1 chunk along the new dimension.
         Notes
         -----
         For the special case where a Dataset is returned, but only some of its variable where reduced by the grouping, xarray's `GroupBy.map` will


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes a slack-raised issue
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
1) A previous PR added rechunking at the end of `Grouper.apply` calls. However, the default was to rechunk with `{dim: -1}` only if the input had single chunks along `dim`. This changes to use the same chunking in the output  as in the input. Obviously, this only applies to non-grouping operation.

2) Makes it easier to import xclim.sdba by making `adjustment`, `processing`, `detrending`, `utils` and `Grouper` directly in  `sdba`. I suggest using `from xclim import sdba`.

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
No