### PR TITLE
Better lazy_indexing - Fix #470

### DIFF
--- a/tests/test_run_length.py
+++ b/tests/test_run_length.py
@@ -352,13 +352,17 @@ class TestRunsWithDates:
         assert out.isnull().all()
 
 
-def test_lazy_indexing_nd():
-    a = xr.DataArray(
-        np.random.rand(10, 10, 10), dims=("x", "y", "z"), coords={"x": np.arange(10)}
-    )
-    b = xr.DataArray(
-        np.random.rand(10, 10, 10), dims=("x", "y", "z"), coords={"x": np.arange(10)}
-    )
+@pytest.mark.parametrize(
+    "x",
+    [
+        np.arange(10),
+        xr.cftime_range("2000-01-01", periods=10, freq="MS"),
+        pd.date_range("2000-01-01", periods=10, freq="MS"),
+    ],
+)
+def test_lazy_indexing_nd(x):
+    a = xr.DataArray(np.random.rand(10, 10, 10), dims=("x", "y", "z"), coords={"x": x})
+    b = xr.DataArray(np.random.rand(10, 10, 10), dims=("x", "y", "z"), coords={"x": x})
 
     ac = a.chunk({"y": 5, "z": 5})
     bc = b.chunk({"y": 5, "z": 1})

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,8 +4,10 @@
 from inspect import signature
 
 import numpy as np
+import xarray as xr
 
 from xclim.core.indicator import Indicator
+from xclim.core.utils import ensure_chunk_size
 from xclim.core.utils import walk_map
 from xclim.core.utils import wrapped_partial
 
@@ -60,3 +62,19 @@ def test_wrapped_indicator(tas_series):
 
     assert ind2(tas, tas2) == 366
     assert ind1(tas, thresh=1111) == 366
+
+
+def test_ensure_chunk_size():
+    da = xr.DataArray(np.zeros((20, 21, 20)), dims=("x", "y", "z"))
+
+    out = ensure_chunk_size(da, x=10, y=-1)
+
+    assert da is out
+
+    dac = da.chunk({"x": (1,) * 20, "y": (10, 10, 1), "z": (10, 10)})
+
+    out = ensure_chunk_size(dac, x=3, y=5, z=-1)
+
+    assert out.chunks[0] == (3, 3, 3, 3, 3, 5)
+    assert out.chunks[1] == (10, 11)
+    assert out.chunks[2] == (20,)

--- a/xclim/core/utils.py
+++ b/xclim/core/utils.py
@@ -91,7 +91,8 @@ def ensure_chunk_size(da: xr.DataArray, max_iter=10, **minchunks):
     """Ensure that the input dataarray has chunks of at least the given size.
 
     If only one chunk is too small, it is merged with an adjacent chunk.
-    If many chunks are too small, they are grouped tog
+    If many chunks are too small, they are grouped together by merging adjacent chunks.
+
     Parameters
     ----------
     da : xr.DataArray

--- a/xclim/core/utils.py
+++ b/xclim/core/utils.py
@@ -114,18 +114,20 @@ def ensure_chunk_size(da: xr.DataArray, max_iter=10, **minchunks):
         toosmall = np.array(chunks) < minchunk  # Chunks that are too small
         if toosmall.sum() > 1:
             # Many chunks are too small, merge them by groups
-            fac = np.ceil(minchunk / min(chunks))
-            chunking[dim] = [sum(chunks[i : i + fac]) for i in range(len(chunks), fac)]
+            fac = np.ceil(minchunk / min(chunks)).astype(int)
+            chunking[dim] = tuple(
+                sum(chunks[i : i + fac]) for i in range(0, len(chunks), fac)
+            )
             # Reset counter is case the last chunks are still too small
             chunks = chunking[dim]
             toosmall = np.array(chunks) < minchunk
         if toosmall.sum() == 1:
             # Only one, merge it with adjacent chunk
-            ind = np.where(toosmall)[0]
+            ind = np.where(toosmall)[0][0]
             new_chunks = list(chunks)
             sml = new_chunks.pop(ind)
             new_chunks[max(ind - 1, 0)] += sml
-            chunking[dim] = new_chunks
+            chunking[dim] = tuple(new_chunks)
 
     if chunking:
         return da.chunk(chunks=chunking)

--- a/xclim/indices/_anuclim.py
+++ b/xclim/indices/_anuclim.py
@@ -562,4 +562,4 @@ def _to_quarter(freq, pr=None, tas=None):
             )
             out.attrs = tas.attrs
 
-    return out
+    return out.chunk({'time': -1})

--- a/xclim/indices/_anuclim.py
+++ b/xclim/indices/_anuclim.py
@@ -516,7 +516,9 @@ def _from_other_arg(criteria, output, op, freq):
     dim = "time"
 
     def get_other_op(ds):
-        return lazy_indexing(ds.output, index=op(ds.criteria, dim=dim), dim=dim)
+        all_nans = ds.criteria.isnull().all(dim=dim)
+        index = op(ds.criteria.where(~all_nans, 0), dim=dim)
+        return lazy_indexing(ds.output, index=index, dim=dim).where(~all_nans)
 
     return ds.resample(time=freq).map(get_other_op)
 

--- a/xclim/indices/_anuclim.py
+++ b/xclim/indices/_anuclim.py
@@ -1,3 +1,4 @@
+import numpy as np
 import xarray
 
 from ._multivariate import daily_temperature_range
@@ -11,6 +12,7 @@ from xclim.core.units import declare_units
 from xclim.core.units import pint_multiply
 from xclim.core.units import units
 from xclim.core.units import units2pint
+from xclim.core.utils import ensure_chunk_size
 
 
 xarray.set_options(enable_cftimeindex=True)  # Set xarray to use cftimeindex
@@ -549,6 +551,11 @@ def _to_quarter(freq, pr=None, tas=None):
             f'Unknown input time frequency "{freq}": must be one of "daily", "weekly" or "monthly".'
         )
 
+    if tas is not None:
+        tas = ensure_chunk_size(tas, time=np.ceil(window / 2))
+    if pr is not None:
+        pr = ensure_chunk_size(pr, time=np.ceil(window / 2))
+
     with xarray.set_options(keep_attrs=True):
         if pr is not None:
             pr = pint_multiply(pr, 1 * u, "mm")
@@ -562,4 +569,5 @@ def _to_quarter(freq, pr=None, tas=None):
             )
             out.attrs = tas.attrs
 
-    return out.chunk({'time': -1})
+    out = ensure_chunk_size(out, time=-1)
+    return out

--- a/xclim/indices/run_length.py
+++ b/xclim/indices/run_length.py
@@ -18,10 +18,6 @@ import dask.array as dsk
 import numpy as np
 import xarray as xr
 
-from xclim.core.calendar import convert_calendar
-from xclim.core.calendar import get_calendar
-
-
 logging.captureWarnings(True)
 npts_opt = 9000
 

--- a/xclim/indices/run_length.py
+++ b/xclim/indices/run_length.py
@@ -752,9 +752,10 @@ def lazy_indexing(da: xr.DataArray, index: xr.DataArray, dim=None):
 
     return xr.apply_ufunc(
         _index_from_nd_array,
-        da, index,
+        da,
+        index,
         input_core_dims=[[dim], []],
         output_core_dims=[[]],
-        dask='parallelized',
+        dask="parallelized",
         output_dtypes=[da.dtype],
     )

--- a/xclim/indices/run_length.py
+++ b/xclim/indices/run_length.py
@@ -738,7 +738,7 @@ def lazy_indexing(da: xr.DataArray, index: xr.DataArray, dim=None):
             raise ValueError(
                 "da must have at least one dimension more than index for lazy_indexing."
             )
-        elif len(diff_dims) > 1:
+        if len(diff_dims) > 1:
             raise ValueError(
                 "If da has more than one dimension more than index, the indexing dim must be given through `dim`"
             )

--- a/xclim/sdba/utils.py
+++ b/xclim/sdba/utils.py
@@ -14,7 +14,7 @@ from scipy.interpolate import interp1d
 from .base import Grouper
 from .base import parse_group
 from xclim.core.calendar import _interpolate_doy_calendar
-
+from xclim.core.utils import ensure_chunk_size
 
 MULTIPLICATIVE = "*"
 ADDITIVE = "+"
@@ -278,10 +278,7 @@ def add_cyclic_bounds(da: xr.DataArray, att: str, cyclic_coords: bool = True):
         vals[-1] = vals[-2] + diff[-1]
         qmf = qmf.assign_coords({att: vals})
         qmf[att].attrs.update(da.coords[att].attrs)
-    if da.chunks is not None and len(da.chunks[da.get_axis_num(att)]) == 1:
-        # Downstream methos do not expect this method to change the number of chunks
-        return qmf.chunk({att: -1})
-    return qmf
+    return ensure_chunk_size(qmf, **{att: -1})
 
 
 def extrapolate_qm(qf: xr.DataArray, xq: xr.DataArray, method: str = "constant"):
@@ -365,10 +362,7 @@ def add_endpoints(
         elems.append(y)
     l, r = elems  # pylint: disable=unbalanced-tuple-unpacking
     out = xr.concat((l, da, r), dim=dim)
-    if da.chunks is not None and len(da.chunks[da.get_axis_num(dim)]) == 1:
-        # Downstream methos do not expect this method to change the number of chunks
-        return out.chunk({dim: -1})
-    return out
+    return ensure_chunk_size(out, **{dim: -1})
 
 
 @parse_group


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #470 
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
1) The error in #470 was coming from all-nan slices failing in `np.nanargmax`. This modifies the `_from_other_arg` so that  all-nan slices are first filled with 0, then masked back on the result.

2) Not directly in #470, but that issue shows that `lazy_indexing` was not lazy.  Dask doesn't implement `np.take_along_axis` (yet) . I modified the whole function using the same code as in `xr.DataArray.idxmax`. We are pretty much doing the exact same as this function, but it's not yet released.
