### PR TITLE
Revert ensemble percentile behaviour to split

### DIFF
--- a/docs/notebooks/ensembles.ipynb
+++ b/docs/notebooks/ensembles.ipynb
@@ -145,7 +145,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ens_perc = ensembles.ensemble_percentiles(ens, values=[15, 50, 85])\n",
+    "ens_perc = ensembles.ensemble_percentiles(ens, values=[15, 50, 85], split=False)\n",
     "ens_perc"
    ]
   },

--- a/tests/test_ensembles.py
+++ b/tests/test_ensembles.py
@@ -139,11 +139,11 @@ class TestEnsembleStats:
         assert np.all(out1["tg_mean_p90"] > out1["tg_mean_p50"])
         assert np.all(out1["tg_mean_p50"] > out1["tg_mean_p10"])
 
-        out2 = ensembles.ensemble_percentiles(ens, values=(25, 75), split=True)
+        out2 = ensembles.ensemble_percentiles(ens, values=(25, 75))
         assert np.all(out2["tg_mean_p75"] > out2["tg_mean_p25"])
         assert "Computation of the percentiles on" in out1.attrs["history"]
 
-        out3 = ensembles.ensemble_percentiles(ens)
+        out3 = ensembles.ensemble_percentiles(ens, split=False)
         xr.testing.assert_equal(
             out1["tg_mean_p10"], out3.tg_mean.sel(percentiles=10, drop=True)
         )
@@ -152,9 +152,9 @@ class TestEnsembleStats:
     def test_calc_perc_dask(self, keep_chunk_size):
         ens = ensembles.create_ensemble(self.nc_files_simple)
         out2 = ensembles.ensemble_percentiles(
-            ens.chunk({"time": 2}), keep_chunk_size=keep_chunk_size
+            ens.chunk({"time": 2}), keep_chunk_size=keep_chunk_size, split=False
         )
-        out1 = ensembles.ensemble_percentiles(ens.load())
+        out1 = ensembles.ensemble_percentiles(ens.load(), split=False)
         np.testing.assert_array_equal(out1["tg_mean"], out2["tg_mean"])
 
     def test_calc_perc_nans(self):

--- a/xclim/ensembles.py
+++ b/xclim/ensembles.py
@@ -154,7 +154,7 @@ def ensemble_percentiles(
     ens: Union[xr.Dataset, xr.DataArray],
     values: Tuple[int] = (10, 50, 90),
     keep_chunk_size: Optional[bool] = None,
-    split: bool = False,
+    split: bool = True,
 ) -> xr.Dataset:
     """Calculate ensemble statistics between a results from an ensemble of climate simulations.
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->

Revert the change in behaviour from PR #463 for `ensemble_percentiles`. Turns out, having `split` defaulting to False was a bit too breaking.

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->

Quite the opposite.

* **Other information**:
