### PR TITLE
sdba - Optimizations for DQM and others

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 0.18.x
 ------
+* Optimization options for `xclim.sdba` : different grouping for the normalization steps of DQM and save training or fitting datasets to temporary files.
 * `xclim.sdba.detrending` objects can now act on groups.
 * Replaced `dask[complete]` with `dask[array]` in basic installation and added `distributed` to `docs` build dependencies.
 * `xclim.core.locales` now supported in Windows build environments.

--- a/tests/test_sdba/test_adjustment.py
+++ b/tests/test_sdba/test_adjustment.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import numpy as np
 import pytest
 import xarray as xr
@@ -202,15 +204,17 @@ class TestDQM:
         np.testing.assert_almost_equal(p.mean(), 41.6, 0)
         np.testing.assert_almost_equal(p.std(), 15.0, 0)
 
-    def test_group_norm(self, tas_series):
+    @pytest.mark.parametrize("norm_group", ["time.dayofyear", "time.month"])
+    @pytest.mark.parametrize("normalize_sim", [True, False])
+    def test_group_norm(self, tas_series, norm_group, normalize_sim):
         x = np.arange(365)
         ref = tas_series(273 - 10 * np.cos(2 * np.pi * x / 365), start="2001-01-01")
         hist = sim = tas_series(
             273 - 8 * np.cos(2 * np.pi * x / 365), start="2001-01-01"
         )
-        DQM = DetrendedQuantileMapping(group="time.month")
+        DQM = DetrendedQuantileMapping(group="time.month", norm_group=norm_group)
         DQM.train(ref, hist)
-        scen = DQM.adjust(sim, interp="linear")
+        scen = DQM.adjust(sim, interp="linear", normalize_sim=normalize_sim)
         xr.testing.assert_allclose(ref, scen, rtol=1e-3)
 
 
@@ -406,3 +410,26 @@ def test_raise_on_multiple_chunks(tas_series):
     Adj = BaseAdjustment(group=Grouper("time.month"))
     with pytest.raises(ValueError):
         Adj.train(ref, ref)
+
+
+def test_save_training(series):
+    x = series(np.arange(20 * 365.25), "tas")
+
+    DQM = DetrendedQuantileMapping()
+    DQM.train(x, x)
+    DQM.save_training()
+
+    tmpfile = Path(DQM.ds.encoding["source"])
+    assert tmpfile.is_file()
+    del DQM
+    assert not tmpfile.is_file()
+
+    DQM = DetrendedQuantileMapping()
+    DQM.train(x, x)
+    DQM.save_training(filename="test.nc")
+
+    tmpfile = Path(DQM.ds.encoding["source"])
+    assert tmpfile.name == "test.nc"
+    del DQM
+    assert tmpfile.is_file()
+    tmpfile.unlink()

--- a/tests/test_sdba/test_detrending.py
+++ b/tests/test_sdba/test_detrending.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 import numpy as np
 import pytest
 
@@ -20,23 +18,3 @@ def test_poly_detrend(series):
     # - The last period may not be complete.
     np.testing.assert_array_almost_equal(dx, 0)
     np.testing.assert_array_almost_equal(xt, x)
-
-
-def test_detrend_save_fit(series):
-    x = series(np.arange(20 * 365.25), "tas")
-    poly = PolyDetrend(degree=1)
-    fx = poly.fit(x)
-    fx2 = poly.fit(x)
-    fx.save_fit()
-    fx2.save_fit(filename="test.nc")
-
-    tmpfile = Path(fx.ds.encoding["source"])
-    tmpfile2 = Path(fx2.ds.encoding["source"])
-    assert tmpfile.is_file()
-    del fx
-    assert not tmpfile.is_file()
-
-    assert tmpfile2.name == "test.nc"
-    del fx2
-    assert tmpfile2.is_file()
-    tmpfile2.unlink()

--- a/tests/test_sdba/test_detrending.py
+++ b/tests/test_sdba/test_detrending.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import numpy as np
 import pytest
 
@@ -18,3 +20,23 @@ def test_poly_detrend(series):
     # - The last period may not be complete.
     np.testing.assert_array_almost_equal(dx, 0)
     np.testing.assert_array_almost_equal(xt, x)
+
+
+def test_detrend_save_fit(series):
+    x = series(np.arange(20 * 365.25), "tas")
+    poly = PolyDetrend(degree=1)
+    fx = poly.fit(x)
+    fx2 = poly.fit(x)
+    fx.save_fit()
+    fx2.save_fit(filename="test.nc")
+
+    tmpfile = Path(fx.ds.encoding["source"])
+    tmpfile2 = Path(fx2.ds.encoding["source"])
+    assert tmpfile.is_file()
+    del fx
+    assert not tmpfile.is_file()
+
+    assert tmpfile2.name == "test.nc"
+    del fx2
+    assert tmpfile2.is_file()
+    tmpfile2.unlink()

--- a/xclim/sdba/adjustment.py
+++ b/xclim/sdba/adjustment.py
@@ -175,7 +175,7 @@ class BaseAdjustment(Parametrizable):
 
     def __del__(self):
         # Delete the training data file if it was saved to a temporary file.
-        if self.__ds_is_tempfile and hasattr(self, "_ds_filename"):
+        if self.__ds_is_tempfile and hasattr(self, "_ds_file"):
             self._ds_file.unlink()
 
     def _train(self):

--- a/xclim/sdba/adjustment.py
+++ b/xclim/sdba/adjustment.py
@@ -303,6 +303,7 @@ class DetrendedQuantileMapping(EmpiricalQuantileMapping):
       The type of extrapolation to use. See :py:func:`xclim.sdba.utils.extrapolate_qm` for details. Defaults to "constant".
     normalize_sim : bool
       If True, scaled sim is normalized using `norm_group` and then detrended using `group`.
+        The norm is broadcasted and added back on scen using `interp='nearest'`, ignoring the passed `interp`.
       If False, scaled sim is detrended using `norm_group`.
       This is useful on large datasets using dask, when `norm_group` is a very small division (e.g. 'time.dayofyear')
         because normalisation is a more efficient operation than detrending for similarly sized groups.
@@ -384,7 +385,7 @@ class DetrendedQuantileMapping(EmpiricalQuantileMapping):
         if normalize_sim:
             return apply_correction(
                 scen_anom,
-                broadcast(ds.norm, scen_anom, group=self.norm_group, interp=interp),
+                broadcast(ds.norm, scen_anom, group=self.norm_group, interp="nearest"),
                 self.kind,
             )
         return scen_anom

--- a/xclim/sdba/adjustment.py
+++ b/xclim/sdba/adjustment.py
@@ -247,7 +247,7 @@ class DetrendedQuantileMapping(EmpiricalQuantileMapping):
     kind : {'+', '*'}
       The adjustment kind, either additive or multiplicative.
     group : Union[str, Grouper]
-      The grouping information use in the quantile mappgin process. See :py:class:`xclim.sdba.base.Grouper` for details.
+      The grouping information used in the quantile mapping process. See :py:class:`xclim.sdba.base.Grouper` for details.
       the normalization step is always performed on each day of the year.
     norm_window : 1
       The window size used in the normalization grouping. Defaults to 1.

--- a/xclim/sdba/adjustment.py
+++ b/xclim/sdba/adjustment.py
@@ -1,4 +1,8 @@
 """Adjustment objects"""
+import os
+import tempfile
+from pathlib import Path
+from typing import Optional
 from typing import Union
 from warnings import warn
 
@@ -49,6 +53,7 @@ class BaseAdjustment(Parametrizable):
 
     def __init__(self, **kwargs):
         self.__trained = False
+        self.__ds_is_tempfile = False
         super().__init__(**kwargs)
 
     def train(
@@ -134,6 +139,44 @@ class BaseAdjustment(Parametrizable):
         """
         self.ds = xr.Dataset(data_vars=kwargs)
         self.ds.attrs["adj_params"] = str(self)
+
+    def save_training(
+        self, filename: Optional[Union[Path, str]] = None, tempdir: Optional[str] = None
+    ):
+        """Save training data to a (temporary) file.
+
+        Save to a temporary file if `filename` is not given. The file will be
+        deleted when this Adjustment instance is deleted.
+
+        The dataset is immediately reload from file. This is meant to help divide dask's
+        workload when needed.
+
+        Parameters
+        ----------
+        filename : Optional[Union[Path, str]]
+          Filename of the saved file. When given, the file is not considered "temporary"
+          and is not deleted when the Adjustment object is deleted by Python.
+        tempdir : Optional[str]
+          The path to a directory where to save the temporary file. Ignored if `filename`
+          is given.
+        """
+        if filename is None:
+            # We use mkstemp to be sure the filename is reserved.
+            fid, filename = tempfile.mkstemp(suffix=".nc", dir=tempdir)
+            os.close(fid)  # Passing file-like objects is too restrictive with xarray.
+            self._ds_is_tempfile = True  # So that the file is deleted when this instance is garbage collected
+
+        self._ds_file = Path(filename)
+        previous_chunking = self.ds.chunks  # Expected behavior is to conserve chunking
+        self.ds.to_netcdf(self._ds_file)
+        # chunks: non-dask data will return an empty set on ds.chunks, but that means 1 chunk for open_dataset
+        # `previous_chunking or None` returns None is ds.chunks was an empty set
+        self.ds = xr.open_dataset(self._ds_file, chunks=previous_chunking or None)
+
+    def __del__(self):
+        # Delete the training data file if it was saved to a temporary file.
+        if self._ds_is_tempfile and hasattr(self, "_ds_filename"):
+            self._ds_file.unlink()
 
     def _train(self):
         raise NotImplementedError
@@ -262,13 +305,28 @@ class DetrendedQuantileMapping(EmpiricalQuantileMapping):
     .. [Cannon2015] Cannon, A. J., Sobie, S. R., & Murdock, T. Q. (2015). Bias correction of GCM precipitation by quantile mapping: How well do methods preserve changes in quantiles and extremes? Journal of Climate, 28(17), 6938–6959. https://doi.org/10.1175/JCLI-D-14-00754.1
     """
 
+    @parse_group
+    def __init__(
+        self,
+        *,
+        nquantiles: int = 20,
+        kind: str = ADDITIVE,
+        group: Union[str, Grouper] = "time",
+        norm_group: Optional[Union[str, Grouper]] = None,
+        prescale: bool = True,
+    ):
+        super().__init__(
+            nquantiles=nquantiles, kind=kind, group=group,
+        )
+        self["norm_group"] = norm_group or group
+
     def _train(self, ref, hist):
+        refn = normalize(ref, group=self.norm_group, kind=self.kind)
+        histn = normalize(hist, group=self.norm_group, kind=self.kind)
+        super()._train(refn, histn)
+
         mu_ref = self.group.apply("mean", ref)
         mu_hist = self.group.apply("mean", hist)
-        ref = normalize(ref, group=self.group, kind=self.kind)
-        hist = normalize(hist, group=self.group, kind=self.kind)
-        super()._train(ref, hist)
-
         self.ds["scaling"] = get_correction(mu_hist, mu_ref, kind=self.kind)
         self.ds.scaling.attrs.update(
             standard_name="Scaling factor",
@@ -276,6 +334,7 @@ class DetrendedQuantileMapping(EmpiricalQuantileMapping):
         )
 
     def _adjust(self, sim, interp="nearest", extrapolation="constant", detrend=1):
+
         # Apply preliminary scaling from obs to hist
         sim = apply_correction(
             sim,
@@ -285,7 +344,7 @@ class DetrendedQuantileMapping(EmpiricalQuantileMapping):
 
         # Find trend on sim
         if isinstance(detrend, int):
-            detrend = PolyDetrend(degree=detrend, kind=self.kind, group=self.group)
+            detrend = PolyDetrend(degree=detrend, kind=self.kind, group=self.norm_group)
 
         sim_fit = detrend.fit(sim)
         sim_detrended = sim_fit.detrend(sim)

--- a/xclim/sdba/adjustment.py
+++ b/xclim/sdba/adjustment.py
@@ -290,6 +290,8 @@ class DetrendedQuantileMapping(EmpiricalQuantileMapping):
       The adjustment kind, either additive or multiplicative.
     group : Union[str, Grouper]
       The grouping information. See :py:class:`xclim.sdba.base.Grouper` for details.
+    norm_group : Union[str, Grouper]
+      If given, the normalization steps are done using this group. Otherwise, they use the main `group`.
 
     In adjustment:
 
@@ -299,6 +301,11 @@ class DetrendedQuantileMapping(EmpiricalQuantileMapping):
       The method to use when detrending. If an int is passed, it is understood as a PolyDetrend (polynomial detrending) degree. Defaults to 1 (linear detrending)
     extrapolation : {'constant', 'nan'}
       The type of extrapolation to use. See :py:func:`xclim.sdba.utils.extrapolate_qm` for details. Defaults to "constant".
+    normalize_sim : bool
+      If True, scaled sim is normalized using `norm_group` and then detrended using `group`.
+      If False, scaled sim is detrended using `norm_group`.
+      This is useful on large datasets using dask, when `norm_group` is a very small division (e.g. 'time.dayofyear')
+        because normalisation is a more efficient operation than detrending for similarly sized groups.
 
     References
     ----------
@@ -319,6 +326,7 @@ class DetrendedQuantileMapping(EmpiricalQuantileMapping):
         )
         norm_group = norm_group or group
         if isinstance(norm_group, str):
+            # parse_group only manages kwargs named "group"
             norm_group = Grouper(norm_group)
         self["norm_group"] = norm_group
 

--- a/xclim/sdba/base.py
+++ b/xclim/sdba/base.py
@@ -170,9 +170,9 @@ class Grouper(Parametrizable):
         ind = da.indexes[self.dim]
         i = getattr(ind, self.prop)
 
-        if i.dtype != np.int:
+        if np.issubdtype(i.dtype, np.integer):
             raise ValueError(
-                f"Index {self.name} is not of type int (rather {ind.dtype}), but {self.__class__.__name__} requires integer indexes."
+                f"Index {self.name} is not of type int (rather {i.dtype}), but {self.__class__.__name__} requires integer indexes."
             )
 
         interp = (

--- a/xclim/sdba/base.py
+++ b/xclim/sdba/base.py
@@ -209,7 +209,6 @@ class Grouper(Parametrizable):
         func: Union[FunctionType, str],
         da: Union[xr.DataArray, Mapping[str, xr.DataArray]],
         main_only: bool = False,
-        manage_chunking: bool = True,
         **kwargs,
     ):
         """Apply a function group-wise on DataArrays.

--- a/xclim/sdba/base.py
+++ b/xclim/sdba/base.py
@@ -170,7 +170,7 @@ class Grouper(Parametrizable):
         ind = da.indexes[self.dim]
         i = getattr(ind, self.prop)
 
-        if np.issubdtype(i.dtype, np.integer):
+        if not np.issubdtype(i.dtype, np.integer):
             raise ValueError(
                 f"Index {self.name} is not of type int (rather {i.dtype}), but {self.__class__.__name__} requires integer indexes."
             )

--- a/xclim/sdba/base.py
+++ b/xclim/sdba/base.py
@@ -50,6 +50,7 @@ class Grouper(Parametrizable):
         window: int = 1,
         add_dims: Optional[Sequence[str]] = None,
         interp: Union[bool, str] = False,
+        manage_chunking: bool = True,
     ):
         """Create the Grouper object.
 
@@ -70,6 +71,9 @@ class Grouper(Parametrizable):
           Whether to return an interpolatable index in the `get_index` method. Only effective for `month` grouping.
           Interpolation method names are accepted for convenience, "nearest" is translated to False, all other names are translated to True.
           This modifies the default, but `get_index` also accepts an `interp` argument overriding the one defined here..
+        manage_chunking : bool
+          If True (default), apply's output will have the same chunking as in the input.
+          If False, apply output's chunking is whatever the groupby.map call returns, usually one chunk per contiguous group.
         """
         if "." in group:
             dim, prop = group.split(".")
@@ -89,6 +93,7 @@ class Grouper(Parametrizable):
             name=group,
             window=window,
             interp=interp,
+            manage_chunking=manage_chunking,
         )
 
     def group(self, da: xr.DataArray = None, **das: xr.DataArray):
@@ -209,6 +214,7 @@ class Grouper(Parametrizable):
         func: Union[FunctionType, str],
         da: Union[xr.DataArray, Mapping[str, xr.DataArray]],
         main_only: bool = False,
+        manage_chunking: bool = True,
         **kwargs,
     ):
         """Apply a function group-wise on DataArrays.
@@ -234,11 +240,11 @@ class Grouper(Parametrizable):
           Attributes "group", "group_window" and "group_compute_dims" are added.
           If the function did not reduce the array:
             - The output is sorted along the main dimension.
-            - The output is rechunked to match the chunks on the input
+            - If self.manage_chunking is True, the output is rechunked to match the chunks on the input
                 If multiple inputs with differing chunking were given as inputs, the chunking with the smallest number of chunks is used.
           If the function reduces the array:
             - If there is only one group, the singleton dimension is squeezed out of the output
-            - The output is rechunked as to have only 1 chunk along the new dimension.
+            - If self.manage_chunking is True, the output is rechunked as to have only 1 chunk along the new dimension.
 
 
         Notes
@@ -305,10 +311,10 @@ class Grouper(Parametrizable):
             else:
                 out = out.sortby(self.dim)
                 # The expected behavior for downstream methods would be to conserve chunking along dim
-                if out.chunks is not None:
+                if self.manage_chunking and out.chunks is not None:
                     # or -1 in case dim_chunks is [], when no input is chunked (only happens if the operation is chunking the output)
                     out = out.chunk({self.dim: dim_chunks or -1})
-        if self.prop in out.dims and bool(out.chunks):
+        if self.manage_chunking and self.prop in out.dims and bool(out.chunks):
             # Same as above : downstream methods expect only one chunk along the group
             out = out.chunk({self.prop: -1})
 

--- a/xclim/sdba/detrending.py
+++ b/xclim/sdba/detrending.py
@@ -62,11 +62,18 @@ class BaseDetrend(Parametrizable):
         return new
 
     def get_trend(self, da: xr.DataArray):
-        return self.group.apply(
+        """Get the trend computed from the fit, the fitting dim as found on da.
+
+        If da is a DataArray (and has a "dtype" attribute), the trend is casted to have the same dtype.
+        """
+        out = self.group.apply(
             self._get_trend,
             {self.group.dim: da[self.group.dim], **self.fit_ds.data_vars},
             main_only=True,
         )
+        if hasattr(da, 'dtype'):
+            out = out.astype(da.dtype)
+        return out
 
     def detrend(self, da: xr.DataArray):
         """Removes the previously fitted trend from a DataArray."""

--- a/xclim/sdba/detrending.py
+++ b/xclim/sdba/detrending.py
@@ -1,8 +1,4 @@
 """Detrending objects"""
-import os
-import tempfile
-from pathlib import Path
-from typing import Optional
 from typing import Union
 
 import xarray as xr
@@ -48,7 +44,6 @@ class BaseDetrend(Parametrizable):
             The way the trend is removed or added, either additive or multiplicative.
         """
         self.__fitted = False
-        self.__ds_is_tempfile = False
         super().__init__(group=group, kind=kind, **kwargs)
 
     def fit(self, da: xr.DataArray):
@@ -89,40 +84,6 @@ class BaseDetrend(Parametrizable):
         trend = self.get_trend(da)
         return self._retrend(da, trend)
 
-    def save_fit(
-        self, filename: Optional[Union[Path, str]] = None, tempdir: Optional[str] = None
-    ):
-        """Save fit data to a (temporary) file.
-
-        Save to a temporary file if `filename` is not given. The file will be
-        deleted when this Adjustment instance is deleted.
-
-        The dataset is immediately reload from file. This is meant to help divide dask's
-        workload when needed.
-
-        Parameters
-        ----------
-        filename : Optional[Union[Path, str]]
-          Filename of the saved file. When given, the file is not considered "temporary"
-          and is not deleted when the Detrending object is deleted by Python.
-        tempdir : Optional[str]
-          The path to a directory where to save the temporary file. Ignored if `filename`
-          is given.
-        """
-        if filename is None:
-            # We use mkstemp to be sure the filename is reserved.
-            fid, filename = tempfile.mkstemp(suffix=".nc", dir=tempdir)
-            os.close(fid)  # Passing file-like objects is too restrictive with xarray.
-            self.__ds_is_tempfile = True  # So that the file is deleted when this instance is garbage collected
-
-        self._ds_file = Path(filename)
-        # Expected behavior is to conserve chunking
-        previous_chunking = self.ds.chunks
-        self.ds.to_netcdf(self._ds_file)
-        # chunks: non-dask data will return an empty set on ds.chunks, but that means 1 chunk for open_dataset
-        # `previous_chunking or None` returns None is ds.chunks was an empty set
-        self.ds = xr.open_dataset(self._ds_file, chunks=previous_chunking or None)
-
     def _set_ds(self, ds):
         self.ds = ds
         self.ds.attrs["fit_params"] = str(self)
@@ -140,11 +101,6 @@ class BaseDetrend(Parametrizable):
 
     def _fit(self, da):
         raise NotImplementedError
-
-    def __del__(self):
-        # Delete the training data file if it was saved to a temporary file.
-        if self.__ds_is_tempfile and hasattr(self, "_ds_file"):
-            self._ds_file.unlink()
 
 
 class NoDetrend(BaseDetrend):

--- a/xclim/sdba/processing.py
+++ b/xclim/sdba/processing.py
@@ -179,7 +179,7 @@ def normalize(
     kind: str = ADDITIVE,
     return_norm: bool = False,
 ):
-    """Normalize an array by remove its mean.
+    """Normalize an array by removing its mean.
 
     Normalization if performed group-wise.
 
@@ -191,6 +191,16 @@ def normalize(
       Grouping information. See :py:class:`xclim.sdba.base.Grouper` for details.
     kind : {'+', '*'}
       How to apply the adjustment, either additively or multiplicatively.
+    return_norm : bool
+      Whether to return only the normalized array or also the grouped norm.
+
+    Returns
+    -------
+    xr.DataArray or xr.Dataset
+      if `return_norm is True`, returns a Dataset with:
+        - `anomaly` the normalized array along the main dimension
+        - `norm` the groupwise mean that was removed.
+      otherwise onl the `anomaly` dataarray is returned.
     """
 
     def _normalize_group(grp, dim=["time"]):

--- a/xclim/sdba/processing.py
+++ b/xclim/sdba/processing.py
@@ -167,7 +167,12 @@ def jitter_under_thresh(x: xr.DataArray, thresh: float):
     If thresh is high, this will change the mean value of x.
     """
     epsilon = np.finfo(x.dtype).eps
-    jitter = np.random.uniform(low=epsilon, high=thresh, size=x.shape)
+    if isinstance(x.data, dsk.Array):
+        jitter = dsk.random.uniform(
+            low=epsilon, high=thresh, size=x.shape, chunks=x.chunks
+        )
+    else:
+        jitter = np.random.uniform(low=epsilon, high=thresh, size=x.shape)
     return x.where(~((x < thresh) & (x.notnull())), jitter)
 
 

--- a/xclim/sdba/processing.py
+++ b/xclim/sdba/processing.py
@@ -173,7 +173,11 @@ def jitter_under_thresh(x: xr.DataArray, thresh: float):
 
 @parse_group
 def normalize(
-    x: xr.DataArray, *, group: Union[str, Grouper] = "time", kind: str = ADDITIVE
+    x: xr.DataArray,
+    *,
+    group: Union[str, Grouper] = "time",
+    kind: str = ADDITIVE,
+    return_norm: bool = False,
 ):
     """Normalize an array by remove its mean.
 
@@ -190,6 +194,11 @@ def normalize(
     """
 
     def _normalize_group(grp, dim=["time"]):
-        return apply_correction(grp, invert(grp.mean(dim=dim), kind), kind)
+        norm = grp.mean(dim=dim)
+        anomaly = apply_correction(grp, invert(norm, kind), kind)
+        if return_norm:
+            norm.attrs["_group_apply_reshape"] = True
+            return xr.Dataset(data_vars={"norm": norm, "anomaly": anomaly})
+        return anomaly
 
     return group.apply(_normalize_group, x)

--- a/xclim/sdba/processing.py
+++ b/xclim/sdba/processing.py
@@ -1,4 +1,5 @@
 """Pre and post processing for bias adjustement"""
+from typing import Optional
 from typing import Union
 
 import dask.array as dsk
@@ -9,6 +10,7 @@ from .base import Grouper
 from .base import parse_group
 from .utils import ADDITIVE
 from .utils import apply_correction
+from .utils import broadcast
 from .utils import ecdf
 from .utils import invert
 
@@ -182,7 +184,7 @@ def normalize(
     *,
     group: Union[str, Grouper] = "time",
     kind: str = ADDITIVE,
-    return_norm: bool = False,
+    norm: Optional[xr.DataArray] = None,
 ):
     """Normalize an array by removing its mean.
 
@@ -196,24 +198,21 @@ def normalize(
       Grouping information. See :py:class:`xclim.sdba.base.Grouper` for details.
     kind : {'+', '*'}
       How to apply the adjustment, either additively or multiplicatively.
-    return_norm : bool
-      Whether to return only the normalized array or also the grouped norm.
+    norm : xr.DataArray
+      If the norm was already computed (for example with `group.apply("mean", x)`), skip the
+        computation step. The array should have the same dimensions as `x` except for "time" that should
+        be replaced by `group.prop`.
 
     Returns
     -------
     xr.DataArray or xr.Dataset
-      if `return_norm is True`, returns a Dataset with:
-        - `anomaly` the normalized array along the main dimension
-        - `norm` the groupwise mean that was removed.
-      otherwise onl the `anomaly` dataarray is returned.
+      Group-wise anomaly of x
     """
 
     def _normalize_group(grp, dim=["time"]):
-        norm = grp.mean(dim=dim)
-        anomaly = apply_correction(grp, invert(norm, kind), kind)
-        if return_norm:
-            norm.attrs["_group_apply_reshape"] = True
-            return xr.Dataset(data_vars={"norm": norm, "anomaly": anomaly})
-        return anomaly
+        return apply_correction(grp, invert(grp.mean(dim=dim), kind), kind)
 
-    return group.apply(_normalize_group, x)
+    if norm is None:
+        return group.apply(_normalize_group, x)
+
+    return apply_correction(x, broadcast(norm, x, group=group, interp="nearest"), kind,)

--- a/xclim/sdba/utils.py
+++ b/xclim/sdba/utils.py
@@ -462,7 +462,7 @@ def interp_on_quantiles(
         output_core_dims=[[dim]],
         vectorize=True,
         dask="parallelized",
-        output_dtypes=[np.float],
+        output_dtypes=[yq.dtype],
     )
 
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #455
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->

- Added `norm_group` to `DetrendedQuantileMapping` so that a different grouping can be used in the normalization steps. `DQM.adjust` also has a new  `normalize_sim` arg. When True, `sim` is normalized along `norm_group` before being detrended along `group`. When False (default), `sim` is only detrended along `norm_group`. This is quite useful as the detrending process has poor performance compared to simple normalization, but only detrending by month creates artefacts at the month boundaries.  Optimal performance is obtained with: `norm_group='time.dayofyear', group='time.group', normalize_sim=True`.

- Added `BaseAdjustment.save_training()` and  `BaseDetrending.save_fit()` to save the training/fit datasets. This can help dask as adjustment processes create an enormous amount of small operations, especially with "time.dayofyear" grouping. Default is to save to a temporary file that is deleted when the adjustment object is garbage-collected. A persistent file can be created by passing `filename` or the temporary file's directory can be given with `tempdir`.

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->

No