### PR TITLE
Changed sea ice area units from m^2 to m2 to respect CF conventions

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,7 +12,9 @@ History
 * Added indicator `first_day_below` and run length helper `first_run_after_date`.
 * Added ANUCLIM model climate indices mappings.
 * Renamed `areacella` to `areacello` in sea ice tests.
+* Sea ice extent and area outputs now have units of m2 to comply with CF-Convention.
 * Split `checks.py` into `cfchecks.py`, `datachecks.py` and `missing.py`. This change will only affect users creating custom indices using utilities previously located in `checks.py`.
+
 
 0.17.0 (2020-05-15)
 -------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -188,7 +188,7 @@ def areacella():
         data=area,
         dims=("lat", "lon"),
         coords={"lon": lon, "lat": lat},
-        attrs={"r": r, "units": "m^2"},
+        attrs={"r": r, "units": "m2"},
     )
 
 

--- a/tests/test_seaice.py
+++ b/tests/test_seaice.py
@@ -23,13 +23,13 @@ class TestSeaIceExtent:
         a = sea_ice_extent(sic, area)
         expected = 4 * np.pi * area.r ** 2 / 2.0
         np.testing.assert_array_almost_equal(a / expected, 1, 3)
-        assert a.units == "m^2"
+        assert a.units == "m2"
 
     def test_indicator(self, areacello):
         area, sic = self.values(areacello)
 
         a = seaIce.sea_ice_extent(sic, area)
-        assert a.units == "m^2"
+        assert a.units == "m2"
 
     def test_dimensionless(self, areacello):
         area, sic = self.values(areacello)
@@ -39,7 +39,7 @@ class TestSeaIceExtent:
         a = sea_ice_extent(sic, area)
         expected = 4 * np.pi * area.r ** 2 / 2.0
         np.testing.assert_array_almost_equal(a / expected, 1, 3)
-        assert a.units == "m^2"
+        assert a.units == "m2"
 
     def test_area_units(self, areacello):
         area, sic = self.values(areacello)
@@ -62,13 +62,13 @@ class TestSeaIceArea(TestSeaIceExtent):
         a = sea_ice_area(sic, area)
         expected = 4 * np.pi * area.r ** 2 / 2.0 / 2.0
         np.testing.assert_array_almost_equal(a / expected, 1, 3)
-        assert a.units == "m^2"
+        assert a.units == "m2"
 
     def test_indicator(self, areacello):
         area, sic = self.values(areacello)
 
         a = seaIce.sea_ice_area(sic, area)
-        assert a.units == "m^2"
+        assert a.units == "m2"
 
     def test_dimensionless(self, areacello):
         area, sic = self.values(areacello)
@@ -78,7 +78,7 @@ class TestSeaIceArea(TestSeaIceExtent):
         a = sea_ice_area(sic, area)
         expected = 4 * np.pi * area.r ** 2 / 2.0 / 2.0
         np.testing.assert_array_almost_equal(a / expected, 1, 3)
-        assert a.units == "m^2"
+        assert a.units == "m2"
 
     def test_area_units(self, areacello):
         area, sic = self.values(areacello)

--- a/xclim/indicators/seaIce/_seaice.py
+++ b/xclim/indicators/seaIce/_seaice.py
@@ -31,7 +31,7 @@ class SicArea(Indicator2D):
 
 sea_ice_extent = SicArea(
     identifier="sea_ice_extent",
-    units="m^2",
+    units="m2",
     standard_name="sea_ice_extent",
     long_name="Sea ice extent",
     description="The sum of ocean areas where sea ice concentration is at least {thresh}.",
@@ -42,7 +42,7 @@ sea_ice_extent = SicArea(
 
 sea_ice_area = SicArea(
     identifier="sea_ice_area",
-    units="m^2",
+    units="m2",
     standard_name="sea_ice_area",
     long_name="Sea ice area",
     description="The sum of ice-covered areas where sea ice concentration is at least {thresh}.",


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #487 
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
Change in output metadata.

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
Yes, if you expected units to be in Pint format, but this was a bug.

* **Other information**:
