### PR TITLE
Add FutureWarning to core.checks and fix other warnings

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -16,6 +16,7 @@ History
 * Split `checks.py` into `cfchecks.py`, `datachecks.py` and `missing.py`. This change will only affect users creating custom indices using utilities previously located in `checks.py`.
 * Changed signature of `daily_freeze_thaw_cycles`, `daily_temperature_range`, `daily_temperature_range_variability` and `extreme_temperature_range` to take (tasmin, tasmax) instead of (tasmax, tasmin) and match signature of other similar multivariate indices.
 * Added `FromContext` subclass of `MissingBase` to have a uniform API for missing value operations.
+* Remove logging commands that captured all xclim warnings. Remove deprecated xr.set_options calls.
 
 0.17.0 (2020-05-15)
 -------------------

--- a/xclim/core/checks.py
+++ b/xclim/core/checks.py
@@ -1,4 +1,16 @@
 # This file is kept for backward compatibility. It will be removed in a later version.
+from warnings import warn
+
 from .cfchecks import *
 from .datachecks import *
 from .missing import *
+
+
+warn(
+    (
+        "Submodule 'checks' is deprecated in favor of 'cfchecks', 'datachecks'"
+        " and 'missing'. It will be removed in xclim 0.19"
+    ),
+    FutureWarning,
+    stacklevel=2,
+)

--- a/xclim/core/options.py
+++ b/xclim/core/options.py
@@ -8,8 +8,6 @@ from boltons.funcutils import wraps
 from .locales import _valid_locales
 from .utils import ValidationError
 
-logging.captureWarnings(True)
-
 
 METADATA_LOCALES = "metadata_locales"
 DATA_VALIDATION = "data_validation"

--- a/xclim/indicators/__init__.py
+++ b/xclim/indicators/__init__.py
@@ -42,8 +42,6 @@ def build_module(
     import warnings
     import logging
 
-    logging.captureWarnings(capture=True)
-
     try:
         out = types.ModuleType(name, doc)
     except TypeError:

--- a/xclim/indices/_anuclim.py
+++ b/xclim/indices/_anuclim.py
@@ -14,9 +14,6 @@ from xclim.core.units import units
 from xclim.core.units import units2pint
 from xclim.core.utils import ensure_chunk_size
 
-
-xarray.set_options(enable_cftimeindex=True)  # Set xarray to use cftimeindex
-
 # Frequencies : YS: year start, QS-DEC: seasons starting in december, MS: month start
 # See http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases
 

--- a/xclim/indices/_multivariate.py
+++ b/xclim/indices/_multivariate.py
@@ -12,9 +12,6 @@ from xclim.core.units import pint_multiply
 from xclim.core.units import units
 from xclim.core.units import units2pint
 
-xarray.set_options(enable_cftimeindex=True)  # Set xarray to use cftimeindex
-
-
 # Frequencies : YS: year start, QS-DEC: seasons starting in december, MS: month start
 # See http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases
 

--- a/xclim/indices/_simple.py
+++ b/xclim/indices/_simple.py
@@ -6,9 +6,6 @@ from xclim.core.units import declare_units
 from xclim.core.units import pint_multiply
 from xclim.core.units import units
 
-xarray.set_options(enable_cftimeindex=True)  # Set xarray to use cftimeindex
-
-
 # Frequencies : YS: year start, QS-DEC: seasons starting in december, MS: month start
 # See http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases
 

--- a/xclim/indices/_threshold.py
+++ b/xclim/indices/_threshold.py
@@ -1,6 +1,3 @@
-import datetime
-
-import numpy as np
 import xarray
 
 from . import run_length as rl
@@ -9,8 +6,6 @@ from xclim.core.units import convert_units_to
 from xclim.core.units import declare_units
 from xclim.core.units import pint_multiply
 from xclim.core.units import units
-
-xarray.set_options(enable_cftimeindex=True)  # Set xarray to use cftimeindex
 
 # Frequencies : YS: year start, QS-DEC: seasons starting in december, MS: month start
 # See http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases

--- a/xclim/indices/run_length.py
+++ b/xclim/indices/run_length.py
@@ -5,7 +5,6 @@ Run length algorithms submodule
 
 Computation of statistics on runs of True values in boolean arrays.
 """
-import logging
 from datetime import datetime
 from functools import partial
 from typing import Optional
@@ -18,7 +17,6 @@ import dask.array as dsk
 import numpy as np
 import xarray as xr
 
-logging.captureWarnings(True)
 npts_opt = 9000
 
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #484
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
This adds a "FutureWarning" directly on `xclim.core.checks` import to warn of the removal of this submodule after PR #480. 

Because of some `logging.captureWarnings(True)` calls, no warnings from xclim were actually raised to the user. I remove all of those. Moreover, in `xclim.indices` we were calling : `xr.set_options(enable_cftimeindex=True)`, but this options has been deprecated since xarray 0.11. I removed these lines too.

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->

This might result in a slightly larger number of warnings emitted, but that's what we want, isn't it?
