### PR TITLE
Minor doc fixes and hack for xclim.sdba

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,12 +1,17 @@
+version: 2
+
+sphinx:
+  configuration: docs/conf.py
+
+formats: []
+
 build:
   image: latest
 
 python:
   version: 3.6
   install:
-    method: pip
-    extra_requirements:
-      - docs
-
-formats:
-    - none
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -36,11 +36,6 @@ Unit handling module
    :show-inheritance:
 
 
-.. _sdba-api:
-
-Statistical downscaling and bias-adjustment
-===========================================
-
 .. toctree::
 
      sdba_api

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,8 @@
 import os
 import sys
 
+import xarray as xr
+
 import xclim
 
 # If extensions (or modules to document with autodoc) are in another
@@ -24,6 +26,10 @@ import xclim
 #
 sys.path.insert(0, os.path.abspath(".."))
 sys.path.insert(0, os.path.abspath("."))
+
+# Hack to be able to parse sdba
+# sdba.__init__ fails if xarray doesn't have polyval as a test for the version.
+xr.__dict__["polyval"] = None
 
 
 def _get_indicators(module):

--- a/docs/notebooks/options.ipynb
+++ b/docs/notebooks/options.ipynb
@@ -6,11 +6,7 @@
    "source": [
     "# Customizing and controlling xclim\n",
     "\n",
-    "xclim's behaviour can be controlled globally or contextually through `xclim.set_options`, which acts the same way as `xarray.set_options`.\n",
-    "\n",
-    "## Missing values\n",
-    "\n",
-    "For example, one can globally change the missing method."
+    "xclim's behaviour can be controlled globally or contextually through `xclim.set_options`, which acts the same way as `xarray.set_options`."
    ]
   },
   {
@@ -44,6 +40,45 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Checks\n",
+    "Above, we created fake temperature data from a xarray tutorial dataset that doesn't have all the standard CF attributes. By default, when triggering a computation with an Indicator from xclim, warnings will be raised:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tx_mean = xc.atmos.tx_mean(tasmax=tasmax, freq='MS') # compute monthly max tasmax"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Setting `cf_compliance` to `'log'` mutes those warnings and sends them to the log instead."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xc.set_options(cf_compliance='log')\n",
+    "\n",
+    "tx_mean = xc.atmos.tx_mean(tasmax=tasmax, freq='MS') # compute monthly max tasmax"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Missing values\n",
+    "\n",
+    "For example, one can globally change the missing method.\n",
+    "\n",
     "Change the default missing method to \"pct\" and set its tolerance to 8%:"
    ]
   },

--- a/docs/notebooks/units.ipynb
+++ b/docs/notebooks/units.ipynb
@@ -51,7 +51,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Using [`pint`](https://pint.readthedocs.io/), `xclim` provides useful functions to convert the units of datasets and `DataArray`s. Here, we convert our kelvin data to the very useful Fahrenheits:"
+    "Using [pint](https://pint.readthedocs.io/), `xclim` provides useful functions to convert the units of datasets and `DataArray`s. Here, we convert our kelvin data to the very useful Fahrenheits:"
    ]
   },
   {
@@ -120,7 +120,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.18.0-beta
+current_version = 0.18.0
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+).(?P<patch>\d+)(\-(?P<release>[a-z]+))?

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.17.4-beta
+current_version = 0.18.0-beta
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+).(?P<patch>\d+)(\-(?P<release>[a-z]+))?

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ URL = "https://github.com/Ouranosinc/xclim"
 AUTHOR = "Travis Logan"
 AUTHOR_EMAIL = "logan.travis@ouranos.ca"
 REQUIRES_PYTHON = ">=3.6.0"
-VERSION = "0.17.4-beta"
+VERSION = "0.18.0-beta"
 LICENSE = "Apache Software License 2.0"
 
 with open("README.rst") as readme_file:

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ URL = "https://github.com/Ouranosinc/xclim"
 AUTHOR = "Travis Logan"
 AUTHOR_EMAIL = "logan.travis@ouranos.ca"
 REQUIRES_PYTHON = ">=3.6.0"
-VERSION = "0.18.0-beta"
+VERSION = "0.18.0"
 LICENSE = "Apache Software License 2.0"
 
 with open("README.rst") as readme_file:

--- a/xclim/__init__.py
+++ b/xclim/__init__.py
@@ -10,4 +10,4 @@ from xclim.indicators import seaIce
 
 __author__ = """Travis Logan"""
 __email__ = "logan.travis@ouranos.ca"
-__version__ = "0.17.4-beta"
+__version__ = "0.18.0-beta"

--- a/xclim/core/formatting.py
+++ b/xclim/core/formatting.py
@@ -132,7 +132,8 @@ def merge_attributes(
     missing_str: Optional[str] = None,
     **inputs_kws: Union[xr.DataArray, xr.Dataset],
 ):
-    """Merge attributes from several DataArrays or Datasets.
+    """
+    Merge attributes from several DataArrays or Datasets.
 
     If more than one input is given, its name (if available) is prepended as: "<input name> : <input attribute>".
 
@@ -144,7 +145,7 @@ def merge_attributes(
       The datasets or variables that were used to produce the new object. Inputs given that way will be prefixed by their `name` attribute if available.
     new_line : str
       The character to put between each instance of the attributes. Usually, in CF-conventions,
-      the history attributes uses "\n" while cell_methods uses " ".
+      the history attributes uses '\\n' while cell_methods uses ' '.
     missing_str : str
       A string that is printed if an input doesn't have the attribute. Defaults to None, in which
       case the input is simply skipped.


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [x] `bumpversion (minor / major / patch)` has been called on this branch
- [x] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
Minor templating fixes in the docs, but most importantly a hack that allows for the import of `xclim.sdba` even with the last release of xarray. In `docs/conf.py`, xarray is monkey patched to have a `polyval` attribute, which is how `xclim.sdba` tests for xarray's version.

The config for readthedocs has also been updated to use the version 2 syntax. There was a mistake in the previous file. I am using this branch as test build on RTD.