### PR TITLE
Fix alignment bug when RLE is called with first dim not time

### DIFF
--- a/xclim/indices/run_length.py
+++ b/xclim/indices/run_length.py
@@ -43,8 +43,9 @@ def get_npts(da: xr.DataArray) -> int:
 
 def rle(da: xr.DataArray, dim: str = "time", max_chunk: int = 1_000_000):
     n = len(da[dim])
-    i = xr.DataArray(np.arange(da[dim].size), dims=dim).chunk({"time": 1})
-    ind = xr.broadcast(i, da)[0].chunk(da.chunks)
+    i = xr.DataArray(np.arange(da[dim].size), dims=dim)
+    ind, da = xr.broadcast(i, da)
+    ind = ind.chunk(da.chunks)
     b = ind.where(~da)  # find indexes where false
     end1 = (
         da.where(b[dim] == b[dim][-1], drop=True) * 0 + n

--- a/xclim/indices/run_length.py
+++ b/xclim/indices/run_length.py
@@ -43,8 +43,10 @@ def get_npts(da: xr.DataArray) -> int:
 
 def rle(da: xr.DataArray, dim: str = "time", max_chunk: int = 1_000_000):
     n = len(da[dim])
-    i = xr.DataArray(np.arange(da[dim].size), dims=dim)
+    # Need to chunk here to ensure the broadcasting is not made in memory
+    i = xr.DataArray(np.arange(da[dim].size), dims=dim).chunk({"time": -1})
     ind, da = xr.broadcast(i, da)
+    # Rechunk, but with broadcasted da
     ind = ind.chunk(da.chunks)
     b = ind.where(~da)  # find indexes where false
     end1 = (


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #494 
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
Changes the code of `rle` so that the failing `chunk` call is done with the correct chunks.

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
No.
