### PR TITLE
Add xdoctest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,13 @@ jobs:
         apt:
           packages:
             - libspatialindex-dev
+    - env: TOXENV=doctests
+      name: "Linting suggestions and Doctests"
+      python: 3.6
+      addons:
+        apt:
+          packages:
+            - libspatialindex-dev
     - env: TOXENV=py38
       name: "Python3.8 (Linux)"
       python: 3.8
@@ -55,13 +62,6 @@ jobs:
         - /usr/local/opt/python@3.8/bin/pip3 install -U tox-travis
     - env: TOXENV=py37
       name: "Python3.7 (Linux)"
-      python: 3.7
-      addons:
-        apt:
-          packages:
-            - libspatialindex-dev
-    - env: TOXENV=py37-doctests
-      name: "Python3.7 (Linux + Linting and Doctests)"
       python: 3.7
       addons:
         apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ jobs:
           packages:
             - pandoc
     - env: TOXENV=black
-      name: "Black, flake8, and numpy-like Docstring compliance"
+      name: "Black, Flake8, and Numpy-like Docstring compliance"
       python: 3.6
       addons:
         apt:
@@ -152,7 +152,6 @@ jobs:
   allow_failures:
     - env: TOXENV=py38-anaconda
     - env: TOXENV=py38-macOS
-    - env: TOXENV=py37-doctests
     - env:
       - TOXENV=py37-windows
       - DESIRED_PYTHON=3.7

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,7 @@ Breaking changes
   the fly and stores it in a registry, allowing users to subclass existing indicators easily. The algorithm for
   missing values is identified by its registered name, e.g. "any", "pct", etc, along with its `missing_options`.
 * xclim now requires xarray >= 0.16, ensuring that xclim.sdba is fully functional.
+* The dev requirements now include `xdoctest` -- a rewrite of the standard library module, `doctest`.
 
 New features and enhancements
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -27,7 +28,7 @@ Internal changes
 * Indicator subclasses `Tas`, `Tasmin`, `Tasmax`, `Pr` and `Streamflow` now inherit from `Daily`.
 * Indicator subclasses `TasminTasmax` and `PrTas` now inherit from `Daily2D`.
 * Docstring style now enforced using the `pydocstyle` with `numpy` doctsring conventions.
-
+* Doctests are now performed for all docstring `Examples` using `xdoctest`. Failing examples must be explicitly skipped otherwise build will now fail.
 
 0.18.0 (2020-06-26)
 -------------------

--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ This package was created with Cookiecutter_ and the `audreyr/cookiecutter-pypack
 
 
 .. |build| image:: https://img.shields.io/travis/Ouranosinc/xclim.svg
-        :target: https://travis-ci.org/Ouranosinc/xclim
+        :target: https://travis-ci.com/Ouranosinc/xclim
         :alt: Build Status
 
 .. |coveralls| image:: https://coveralls.io/repos/github/Ouranosinc/xclim/badge.svg

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -9,4 +9,5 @@ twine
 pytest
 pytest-runner
 pylint
+xdoctest
 pre-commit

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.18.1-beta
+current_version = 0.18.2-beta
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+).(?P<patch>\d+)(\-(?P<release>[a-z]+))?
@@ -66,7 +66,6 @@ disable =
 [pydocstyle]
 convention = numpy
 match = (?!test_).*\.py
-;ignore = D107,D203,D212,D213,D402,D413,D415,D416,D417
 
 [isort]
 multi_line_output = 3

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ URL = "https://github.com/Ouranosinc/xclim"
 AUTHOR = "Travis Logan"
 AUTHOR_EMAIL = "logan.travis@ouranos.ca"
 REQUIRES_PYTHON = ">=3.6.0"
-VERSION = "0.18.1-beta"
+VERSION = "0.18.2-beta"
 LICENSE = "Apache Software License 2.0"
 
 with open("README.rst") as readme_file:

--- a/tox.ini
+++ b/tox.ini
@@ -41,9 +41,11 @@ whitelist_externals =
 basepython = python3.7
 deps =
     pylint
+    xdoctest
 commands =
     pylint --rcfile=setup.cfg --exit-zero xclim
-    py.test --rootdir tests/ --doctest-modules xclim --doctest-glob="*.rst"
+    pytest --xdoctest xclim
+    pytest --rootdir tests/ --doctest-modules xclim --doctest-glob="*.rst"
 
 [testenv]
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py36-xarray, py36-bottleneck, py37, py37-doctests, py37-windows, py38, py38-anaconda, py38-macOS, black, docs
+envlist = py36, py36-xarray, py36-bottleneck, py37, py37-windows, py38, py38-anaconda, py38-macOS, black, docs, doctests
 requires = pip >= 20.0
 opts = -v
 
@@ -9,13 +9,13 @@ python =
     3.8: py38-anaconda
     3.8: py38-macOS
     3.7: py37
-    3.7: py37-doctests
     3.7: py37-windows
     3.6: py36
     3.6: py36-bottleneck
     3.6: py36-xarray
     3.6: black
     3.6: docs
+    3.6: doctests
 
 [testenv:black]
 basepython = python3.6
@@ -37,8 +37,7 @@ commands =
 whitelist_externals =
     make
 
-[testenv:py37-doctests]
-basepython = python3.7
+[testenv:doctests]
 deps =
     pylint
     xdoctest

--- a/xclim/__init__.py
+++ b/xclim/__init__.py
@@ -6,4 +6,4 @@ from xclim.indicators import ICCLIM, anuclim, atmos, land, seaIce
 
 __author__ = """Travis Logan"""
 __email__ = "logan.travis@ouranos.ca"
-__version__ = "0.18.1-beta"
+__version__ = "0.18.2-beta"

--- a/xclim/core/calendar.py
+++ b/xclim/core/calendar.py
@@ -622,12 +622,13 @@ def time_bnds(group, freq):
 
     Examples
     --------
+    >>> import xarray as xr
+    >>> from xclim.core.calendar import time_bnds
     >>> index = xr.cftime_range(start='2000-01-01', periods=3, freq='2QS', calendar='360_day')
-    >>> time_bnds(index, '2Q')  # doctest: +SKIP
-    (cftime.Datetime360Day(2000-01-01 00:00:00), cftime.Datetime360Day(2000-03-30 23:59:59.999999)),
+    >>> time_bnds(index, '2Q')
+    ((cftime.Datetime360Day(2000-01-01 00:00:00), cftime.Datetime360Day(2000-03-30 23:59:59.999999)),
     (cftime.Datetime360Day(2000-07-01 00:00:00), cftime.Datetime360Day(2000-09-30 23:59:59.999999)),
     (cftime.Datetime360Day(2001-01-01 00:00:00), cftime.Datetime360Day(2001-03-30 23:59:59.999999)))
-
     """
     if isinstance(group, CFTimeIndex):
         cfindex = group

--- a/xclim/core/calendar.py
+++ b/xclim/core/calendar.py
@@ -622,10 +622,10 @@ def time_bnds(group, freq):
 
     Examples
     --------
-    >>> import xarray as xr
-    >>> from xclim.core.calendar import time_bnds
-    >>> index = xr.cftime_range(start='2000-01-01', periods=3, freq='2QS', calendar='360_day')
-    >>> time_bnds(index, '2Q')
+    >>> import xarray as xr  # doctest: +SKIP
+    >>> from xclim.core.calendar import time_bnds  # doctest: +SKIP
+    >>> index = xr.cftime_range(start='2000-01-01', periods=3, freq='2QS', calendar='360_day')  # doctest: +SKIP
+    >>> time_bnds(index, '2Q')  # doctest: +SKIP
     ((cftime.Datetime360Day(2000-01-01 00:00:00), cftime.Datetime360Day(2000-03-30 23:59:59.999999)),
     (cftime.Datetime360Day(2000-07-01 00:00:00), cftime.Datetime360Day(2000-09-30 23:59:59.999999)),
     (cftime.Datetime360Day(2001-01-01 00:00:00), cftime.Datetime360Day(2001-03-30 23:59:59.999999)))

--- a/xclim/core/formatting.py
+++ b/xclim/core/formatting.py
@@ -41,8 +41,8 @@ class AttrFormatter(string.Formatter):
         of value is given. If `format_spec` is not specified but `value` is in the
         mapping, the first variation is returned.
 
-        Example
-        -------
+        Examples
+        --------
         Let's say the string "The dog is {adj1}, the goose is {adj2}" is to be translated
         to french and that we know that possible values of `adj` are `nice` and `evil`.
         In french, the genre of the noun changes the adjective (cat = chat is masculine,

--- a/xclim/core/indicator.py
+++ b/xclim/core/indicator.py
@@ -49,13 +49,13 @@ Subclass registries
 All subclasses that are created from :class:`Indicator` are stored in a *registry*. So for
 example::
 
-  >>> my_indicator = Daily(identifier="my_indicator", compute=lambda x: x.mean())
-  >>> assert "MY_INDICATOR" in xclim.core.indicator.registry
+  >>> my_indicator = Daily(identifier="my_indicator", compute=lambda x: x.mean())  # doctest: +SKIP
+  >>> assert "MY_INDICATOR" in xclim.core.indicator.registry  # doctest: +SKIP
 
 This registry is meant to facilitate user customization of existing indicators. So for example, it you'd like
 a `tg_mean` indicator returning values in Celsius instead of Kelvins, you could simply do::
-
-  >>> tg_mean_c = xclim.core.indicator.registry["TG_MEAN"](identifier="tg_mean_c", units="C")
+  >>> import xclim
+  >>> tg_mean_c = xclim.core.indicator.registry["TG_MEAN"](identifier="tg_mean_c", units="C")  # doctest: +SKIP
 
 """
 import re

--- a/xclim/core/indicator.py
+++ b/xclim/core/indicator.py
@@ -48,14 +48,14 @@ Subclass registries
 -------------------
 All subclasses that are created from :class:`Indicator` are stored in a *registry*. So for
 example::
-
+  >>> from xclim.core.indicator import Daily, registry  # doctest: +SKIP
   >>> my_indicator = Daily(identifier="my_indicator", compute=lambda x: x.mean())  # doctest: +SKIP
-  >>> assert "MY_INDICATOR" in xclim.core.indicator.registry  # doctest: +SKIP
+  >>> assert "MY_INDICATOR" in registry  # doctest: +SKIP
 
 This registry is meant to facilitate user customization of existing indicators. So for example, it you'd like
 a `tg_mean` indicator returning values in Celsius instead of Kelvins, you could simply do::
-  >>> import xclim
-  >>> tg_mean_c = xclim.core.indicator.registry["TG_MEAN"](identifier="tg_mean_c", units="C")  # doctest: +SKIP
+  >>> from xclim.core.indicator import registry
+  >>> tg_mean_c = registry["TG_MEAN"](identifier="tg_mean_c", units="C")  # doctest: +SKIP
 
 """
 import re
@@ -452,6 +452,7 @@ class Indicator:
           Attributes containing tags to replace with arguments' values.
         args : dict
           Function call arguments.
+        formatter : AttrFormatter
         """
         if args is None:
             return attrs

--- a/xclim/core/options.py
+++ b/xclim/core/options.py
@@ -136,13 +136,13 @@ class set_options:
         missing method and values must be mappings from option names to values.
 
     You can use ``set_options`` either as a context manager:
-
-    >>> with xclim.set_options(metadata_locales=['fr']):
-    ...     out = xclim.atmos.tg_mean(tas)
+    >>> import xclim  # doctest: +SKIP
+    >>> with xclim.set_options(metadata_locales=['fr'])  # doctest: +SKIP
+    ...     out = xclim.atmos.tg_mean(tas)  # doctest: +SKIP
 
     Or to set global options:
 
-    >>> xclim.set_options(missing_options={'pct': {'tolerance': 0.04}})
+    >>> xclim.set_options(missing_options={'pct': {'tolerance': 0.04}})  # doctest: +SKIP
     <xclim.core.options.set_options object at ...>
     """
 

--- a/xclim/ensembles.py
+++ b/xclim/ensembles.py
@@ -75,7 +75,9 @@ def create_ensemble(
 
     Examples
     --------
-    >>> ens = create_ensemble(temperature_datasets)
+    >>> import glob  # doctest: +SKIP
+    >>> from xclim.ensembles import create_ensemble  # doctest: +SKIP
+    >>> ens = create_ensemble(temperature_datasets) #doctest: +SKIP
 
     Using multifile datasets:
     Simulation 1 is a list of .nc files (e.g. separated by time)
@@ -118,10 +120,11 @@ def ensemble_mean_std_max_min(ens: xr.Dataset) -> xr.Dataset:
     Examples
     --------
     Create ensemble dataset
-    >>> ens = create_ensemble(temperature_datasets)
+    >>> from xclim.ensembles import create_ensemble, ensemble_mean_std_max_min  # doctest: +SKIP
+    >>> ens = create_ensemble(temperature_datasets)  # doctest: +SKIP
 
     Calculate ensemble statistics
-    >>> ens_mean_std = ensemble_mean_std_max_min(ens)
+    >>> ens_mean_std = ensemble_mean_std_max_min(ens)  # doctest: +SKIP
     """
     ds_out = xr.Dataset(attrs=ens.attrs)
     for v in ens.data_vars:
@@ -180,16 +183,17 @@ def ensemble_percentiles(
     Examples
     --------
     Create ensemble dataset
-    >>> ens = create_ensemble(temperature_datasets)
+    >>> from xclim.ensembles import create_ensemble, ensemble_percentiles  # doctest: +SKIP
+    >>> ens = create_ensemble(temperature_datasets)  # doctest: +SKIP
 
     Calculate default ensemble percentiles
-    >>> ens_percs = ensemble_percentiles(ens)
+    >>> ens_percs = ensemble_percentiles(ens)  # doctest: +SKIP
 
     Calculate non-default percentiles (25th and 75th)
-    >>> ens_percs = ensemble_percentiles(ens, values=(25, 50, 75))
+    >>> ens_percs = ensemble_percentiles(ens, values=(25, 50, 75))  # doctest: +SKIP
 
     If the original array has many small chunks, it might be more efficient to do:
-    >>> ens_percs = ensemble_percentiles(ens, keep_chunk_size=False)
+    >>> ens_percs = ensemble_percentiles(ens, keep_chunk_size=False)  # doctest: +SKIP
     """
     if isinstance(ens, xr.Dataset):
         out = xr.merge(
@@ -524,23 +528,28 @@ def kmeans_reduce_ensemble(
 
     Examples
     --------
+    >>> import xarray as xr  # doctest: +SKIP
+    >>> from xclim.ensembles import create_ensemble, kmeans_reduce_ensemble  # doctest: +SKIP
+
     Start with ensemble datasets for temperature and precipitation
-    >>> ensTas = create_ensemble(temperature_datasets)
-    >>> ensPr = create_ensemble(precipitation_datasets)
+    >>> ensTas = create_ensemble(temperature_datasets)  # doctest: +SKIP
+    >>> ensPr = create_ensemble(precipitation_datasets)  # doctest: +SKIP
 
     Calculate selection criteria -- Use annual climate change Δ fields between 2071-2100 and 1981-2010 normals
     Total annual precipation
-    >>> HistPr = ensPr.pr.sel(time=slice('1981','2010')).sum(dim='time').mean(dim=['lat','lon'])
-    >>> FutPr = ensPr.pr.sel(time=slice('2071','2100')).sum(dim='time').mean(dim=['lat','lon'])
-    >>> dPr = 100*((FutPr / HistPr) - 1)  # expressed in percent change
+    >>> HistPr = ensPr.pr.sel(time=slice('1981','2010')).sum(dim='time').mean(dim=['lat','lon'])  # doctest: +SKIP
+    >>> FutPr = ensPr.pr.sel(time=slice('2071','2100')).sum(dim='time').mean(dim=['lat','lon'])  # doctest: +SKIP
+
+    # expressed in percent change
+    >>> dPr = 100*((FutPr / HistPr) - 1)  # doctest: +SKIP
 
     Average annual temperature
-    >>> HistTas = ensTas.tg_mean.sel(time=slice('1981','2010')).mean(dim=['time','lat','lon'])
-    >>> FutTas = ensTas.tg_mean.sel(time=slice('2071','2100')).mean(dim=['time','lat','lon'])
-    >>> dTas = FutTas - HistTas
+    >>> HistTas = ensTas.tg_mean.sel(time=slice('1981','2010')).mean(dim=['time','lat','lon'])  # doctest: +SKIP
+    >>> FutTas = ensTas.tg_mean.sel(time=slice('2071','2100')).mean(dim=['time','lat','lon'])  # doctest: +SKIP
+    >>> dTas = FutTas - HistTas  # doctest: +SKIP
 
     Create selection criteria xr.DataArray
-    >>> crit = xr.concat((dTas,dPr), dim='criteria')
+    >>> crit = xr.concat((dTas,dPr), dim='criteria')  # doctest: +SKIP
 
     Create clusters and select realization ids of reduced ensemble
     >>> ids, cluster, fig_data = kmeans_reduce_ensemble(data=crit, method={'rsq_cutoff':0.9}, random_state=42, make_graph=False)  # doctest: +SKIP
@@ -710,6 +719,8 @@ def plot_rsqprofile(fig_data):
 
     Examples
     --------
+    >>> import xarray as xr  # doctest: +SKIP
+    >>> from xclim.ensembles import kmeans_reduce_ensemble, plot_rsqprofile  # doctest: +SKIP
     >>> crit = xr.open_dataset(path_to_ensemble_file).data  # doctest: +SKIP
     >>> ids, cluster, fig_data = kmeans_reduce_ensemble(data=crit, method={'rsq_cutoff':0.9}, random_state=42)  # doctest: +SKIP
     >>> plot_rsqprofile(fig_data)  # doctest: +SKIP

--- a/xclim/ensembles.py
+++ b/xclim/ensembles.py
@@ -78,12 +78,12 @@ def create_ensemble(
     >>> import glob  # doctest: +SKIP
     >>> from xclim.ensembles import create_ensemble  # doctest: +SKIP
     >>> ens = create_ensemble(temperature_datasets) #doctest: +SKIP
-
-    Using multifile datasets:
-    Simulation 1 is a list of .nc files (e.g. separated by time)
+    ...
+    # Using multifile datasets:
+    # Simulation 1 is a list of .nc files (e.g. separated by time)
     >>> datasets = glob.glob('/dir/*.nc')  # doctest: +SKIP
-
-    simulation 2 is also a list of .nc files
+    ...
+    # Simulation 2 is also a list of .nc files
     >>> datasets.append(glob.glob('/dir2/*.nc'))  # doctest: +SKIP
     >>> ens = create_ensemble(datasets, mf_flag=True)  # doctest: +SKIP
     """
@@ -119,11 +119,11 @@ def ensemble_mean_std_max_min(ens: xr.Dataset) -> xr.Dataset:
 
     Examples
     --------
-    Create ensemble dataset
     >>> from xclim.ensembles import create_ensemble, ensemble_mean_std_max_min  # doctest: +SKIP
+    # Create ensemble dataset
     >>> ens = create_ensemble(temperature_datasets)  # doctest: +SKIP
-
-    Calculate ensemble statistics
+    ...
+    # Calculate ensemble statistics
     >>> ens_mean_std = ensemble_mean_std_max_min(ens)  # doctest: +SKIP
     """
     ds_out = xr.Dataset(attrs=ens.attrs)
@@ -182,17 +182,17 @@ def ensemble_percentiles(
 
     Examples
     --------
-    Create ensemble dataset
     >>> from xclim.ensembles import create_ensemble, ensemble_percentiles  # doctest: +SKIP
+    # Create ensemble dataset
     >>> ens = create_ensemble(temperature_datasets)  # doctest: +SKIP
-
-    Calculate default ensemble percentiles
+    ...
+    # Calculate default ensemble percentiles
     >>> ens_percs = ensemble_percentiles(ens)  # doctest: +SKIP
-
-    Calculate non-default percentiles (25th and 75th)
+    ...
+    # Calculate non-default percentiles (25th and 75th)
     >>> ens_percs = ensemble_percentiles(ens, values=(25, 50, 75))  # doctest: +SKIP
-
-    If the original array has many small chunks, it might be more efficient to do:
+    ...
+    # If the original array has many small chunks, it might be more efficient to do:
     >>> ens_percs = ensemble_percentiles(ens, keep_chunk_size=False)  # doctest: +SKIP
     """
     if isinstance(ens, xr.Dataset):
@@ -525,33 +525,32 @@ def kmeans_reduce_ensemble(
     ----------
     Casajus et al. 2016. https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0152495
 
-
     Examples
     --------
     >>> import xarray as xr  # doctest: +SKIP
     >>> from xclim.ensembles import create_ensemble, kmeans_reduce_ensemble  # doctest: +SKIP
-
-    Start with ensemble datasets for temperature and precipitation
+    ...
+    # Start with ensemble datasets for temperature and precipitation
     >>> ensTas = create_ensemble(temperature_datasets)  # doctest: +SKIP
     >>> ensPr = create_ensemble(precipitation_datasets)  # doctest: +SKIP
-
-    Calculate selection criteria -- Use annual climate change Δ fields between 2071-2100 and 1981-2010 normals
-    Total annual precipation
+    ...
+    # Calculate selection criteria -- Use annual climate change Δ fields between 2071-2100 and 1981-2010 normals
+    # Total annual precipation
     >>> HistPr = ensPr.pr.sel(time=slice('1981','2010')).sum(dim='time').mean(dim=['lat','lon'])  # doctest: +SKIP
     >>> FutPr = ensPr.pr.sel(time=slice('2071','2100')).sum(dim='time').mean(dim=['lat','lon'])  # doctest: +SKIP
-
+    ...
     # expressed in percent change
     >>> dPr = 100*((FutPr / HistPr) - 1)  # doctest: +SKIP
-
-    Average annual temperature
+    ...
+    # Average annual temperature
     >>> HistTas = ensTas.tg_mean.sel(time=slice('1981','2010')).mean(dim=['time','lat','lon'])  # doctest: +SKIP
     >>> FutTas = ensTas.tg_mean.sel(time=slice('2071','2100')).mean(dim=['time','lat','lon'])  # doctest: +SKIP
     >>> dTas = FutTas - HistTas  # doctest: +SKIP
-
-    Create selection criteria xr.DataArray
+    ...
+    # Create selection criteria xr.DataArray
     >>> crit = xr.concat((dTas,dPr), dim='criteria')  # doctest: +SKIP
-
-    Create clusters and select realization ids of reduced ensemble
+    ...
+    # Create clusters and select realization ids of reduced ensemble
     >>> ids, cluster, fig_data = kmeans_reduce_ensemble(data=crit, method={'rsq_cutoff':0.9}, random_state=42, make_graph=False)  # doctest: +SKIP
     >>> ids, cluster, fig_data = kmeans_reduce_ensemble(data=crit, method={'rsq_optimize':None}, random_state=42, make_graph=True)  # doctest: +SKIP
     """

--- a/xclim/indices/_anuclim.py
+++ b/xclim/indices/_anuclim.py
@@ -110,13 +110,12 @@ def temperature_seasonality(tas: xarray.DataArray):
 
     Examples
     --------
-    The following would compute for each grid cell of file `tas.day.nc` the annual temperature
-    temperature seasonality:
+    The following would compute for each grid cell of file `tas.day.nc` the annual temperature seasonality:
+
     >>> import xarray as xr  # doctest: +SKIP
     >>> import xclim.indices as xci  # doctest: +SKIP
     >>> t = xr.open_dataset('tas.day.nc').tas   # doctest: +SKIP
     >>> tday_seasonality = xci.temperature_seasonality(t)  # doctest: +SKIP
-
     >>> t_weekly = xci.tg_mean(t, freq='7D')  # doctest: +SKIP
     >>> tweek_seasonality = xci.temperature_seasonality(t_weekly)  # doctest: +SKIP
 
@@ -161,12 +160,12 @@ def precip_seasonality(pr: xarray.DataArray,):
     --------
     The following would compute for each grid cell of file `pr.day.nc` the annual precipitation seasonality:
 
-    >>> import xclim.indices as xci
-    >>> p = xarray.open_dataset('pr.day.nc')  # doctest: +SKIP
+    >>> import xarray as xr  # doctest: +SKIP
+    >>> import xclim.indices as xci  # doctest: +SKIP
+    >>> p = xr.open_dataset('pr.day.nc')  # doctest: +SKIP
     >>> pday_seasonality = xci.precip_seasonality(p)  # doctest: +SKIP
-
     >>> p_weekly = xci.precip_accumulation(p, freq='7D')  # doctest: +SKIP
-    # input units need to be a rate
+    # Input units need to be a rate
     >>> p_weekly.attrs['units'] = "mm/week"  # doctest: +SKIP
     >>> pweek_seasonality = xci.precip_seasonality(p_weekly)  # doctest: +SKIP
 
@@ -317,6 +316,7 @@ def prcptot_wetdry_quarter(
     Examples
     --------
     The following would compute for each grid cell of file `pr.day.nc` the annual wettest quarter total precipitation:
+
     >>> import xarray as xr  # doctest: +SKIP
     >>> from xclim.indices import prcptot_wetdry_quarter  # doctest: +SKIP
     >>> p = xr.open_dataset('pr.day.nc')  # doctest: +SKIP

--- a/xclim/indices/_anuclim.py
+++ b/xclim/indices/_anuclim.py
@@ -114,11 +114,11 @@ def temperature_seasonality(tas: xarray.DataArray):
     temperature seasonality:
 
     >>> import xclim.indices as xci
-    >>> t = xr.open_dataset('tas.day.nc').tas
-    >>> tday_seasonality = xci.temperature_seasonality(t)
+    >>> t = xarray.open_dataset('tas.day.nc').tas   # doctest: +SKIP
+    >>> tday_seasonality = xci.temperature_seasonality(t)  # doctest: +SKIP
 
-    >>> t_weekly = xci.tg_mean(t, freq='7D')
-    >>> tweek_seasonality = xci.temperature_seasonality(t_weekly)
+    >>> t_weekly = xci.tg_mean(t, freq='7D')  # doctest: +SKIP
+    >>> tweek_seasonality = xci.temperature_seasonality(t_weekly)  # doctest: +SKIP
 
     Notes
     -----
@@ -162,12 +162,13 @@ def precip_seasonality(pr: xarray.DataArray,):
     The following would compute for each grid cell of file `pr.day.nc` the annual precipitation seasonality:
 
     >>> import xclim.indices as xci
-    >>> p = xr.open_dataset('pr.day.nc')
-    >>> pday_seasonality = xci.precip_seasonality(p)
+    >>> p = xarray.open_dataset('pr.day.nc')  # doctest: +SKIP
+    >>> pday_seasonality = xci.precip_seasonality(p)  # doctest: +SKIP
 
-    >>> p_weekly = xci.precip_accumulation(p, freq='7D')
-    >>> p_weekly.attrs['units'] = "mm/week" # input units need to be a rate
-    >>> pweek_seasonality = xci.precip_seasonality(p_weekly)
+    >>> p_weekly = xci.precip_accumulation(p, freq='7D')  # doctest: +SKIP
+    # input units need to be a rate
+    >>> p_weekly.attrs['units'] = "mm/week"  # doctest: +SKIP
+    >>> pweek_seasonality = xci.precip_seasonality(p_weekly)  # doctest: +SKIP
 
     Notes
     -----
@@ -223,8 +224,8 @@ def tg_mean_warmcold_quarter(
 
     >>> import xarray as xr
     >>> import xclim.indices as xci
-    >>> t = xr.open_dataset('tas.day.nc')
-    >>> t_warm_qrt = xci.tg_mean_warmest_quarter(tas=t.tas, op='warmest', input_freq='daily')
+    >>> t = xr.open_dataset('tas.day.nc')  # doctest: +SKIP
+    >>> t_warm_qrt = xci.tg_mean_warmest_quarter(tas=t.tas, op='warmest', input_freq='daily')  # doctest: +SKIP
 
     Notes
     -----
@@ -318,8 +319,8 @@ def prcptot_wetdry_quarter(
     The following would compute for each grid cell of file `pr.day.nc` the annual wettest quarter total precipitation:
 
     >>> import xclim.indices as xci
-    >>> p = xr.open_dataset('pr.day.nc')
-    >>> pr_warm_qrt = xci.prcptot_wetdry_quarter(pr=p.pr, op='wettest', input_freq='daily')
+    >>> p = xr.open_dataset('pr.day.nc')  # doctest: +SKIP
+    >>> pr_warm_qrt = xci.prcptot_wetdry_quarter(pr=p.pr, op='wettest', input_freq='daily')  # doctest: +SKIP
 
     Notes
     -----

--- a/xclim/indices/_anuclim.py
+++ b/xclim/indices/_anuclim.py
@@ -112,9 +112,9 @@ def temperature_seasonality(tas: xarray.DataArray):
     --------
     The following would compute for each grid cell of file `tas.day.nc` the annual temperature
     temperature seasonality:
-
-    >>> import xclim.indices as xci
-    >>> t = xarray.open_dataset('tas.day.nc').tas   # doctest: +SKIP
+    >>> import xarray as xr  # doctest: +SKIP
+    >>> import xclim.indices as xci  # doctest: +SKIP
+    >>> t = xr.open_dataset('tas.day.nc').tas   # doctest: +SKIP
     >>> tday_seasonality = xci.temperature_seasonality(t)  # doctest: +SKIP
 
     >>> t_weekly = xci.tg_mean(t, freq='7D')  # doctest: +SKIP
@@ -222,8 +222,8 @@ def tg_mean_warmcold_quarter(
     The following would compute for each grid cell of file `tas.day.nc` the annual temperature
     warmest quarter mean temperature:
 
-    >>> import xarray as xr
-    >>> import xclim.indices as xci
+    >>> import xarray as xr  # doctest: +SKIP
+    >>> import xclim.indices as xci  # doctest: +SKIP
     >>> t = xr.open_dataset('tas.day.nc')  # doctest: +SKIP
     >>> t_warm_qrt = xci.tg_mean_warmest_quarter(tas=t.tas, op='warmest', input_freq='daily')  # doctest: +SKIP
 
@@ -317,10 +317,10 @@ def prcptot_wetdry_quarter(
     Examples
     --------
     The following would compute for each grid cell of file `pr.day.nc` the annual wettest quarter total precipitation:
-
-    >>> import xclim.indices as xci
+    >>> import xarray as xr  # doctest: +SKIP
+    >>> from xclim.indices import prcptot_wetdry_quarter  # doctest: +SKIP
     >>> p = xr.open_dataset('pr.day.nc')  # doctest: +SKIP
-    >>> pr_warm_qrt = xci.prcptot_wetdry_quarter(pr=p.pr, op='wettest', input_freq='daily')  # doctest: +SKIP
+    >>> pr_warm_qrt = prcptot_wetdry_quarter(pr=p.pr, op='wettest', input_freq='daily')  # doctest: +SKIP
 
     Notes
     -----

--- a/xclim/indices/_conversion.py
+++ b/xclim/indices/_conversion.py
@@ -413,19 +413,19 @@ def specific_humidity(
     the relative humidity and the air pressure. With :math:`w`, :math:`w_{sat}`, :math:`e_{sat}` the mixing ratio,
     the saturation mixing ratio and the saturation vapor pressure, specific humidity :math:`q` is computed as:
 
-        ... math::
+    .. math::
 
-            w_{sat} = 0.622\frac{e_{sat}}{P - e_{sat}}
-            w = w_{sat} * rh / 100
-            q = w / (1 + w)
+        w_{sat} = 0.622\frac{e_{sat}}{P - e_{sat}}
+        w = w_{sat} * rh / 100
+        q = w / (1 + w)
 
     The methods differ by how :math:`e_{sat}` is computed. See the doc of `xclim.core.utils.saturation_vapor_pressure`.
 
     If `invalid_values` is not `None`, the saturation specific humidity :math:`q_{sat}` is computed as:
 
-        ... math::
+    .. math::
 
-            q_{sat} = w_{sat} / (1 + w_{sat})
+        q_{sat} = w_{sat} / (1 + w_{sat})
     """
     ps = convert_units_to(ps, "Pa")
     rh = convert_units_to(rh, "")

--- a/xclim/indices/_multivariate.py
+++ b/xclim/indices/_multivariate.py
@@ -96,9 +96,9 @@ def cold_spell_duration_index(
 
     Example
     -------
-    >>> import xclim.utils as xcu
-    >>> tn10 = xcu.percentile_doy(historical_tasmin, per=.1)
-    >>> cold_spell_duration_index(reference_tasmin, tn10)
+    >>> from xclim.core.calendar import percentile_doy
+    >>> tn10 = percentile_doy(historical_tasmin, per=.1)  # doctest: +SKIP
+    >>> cold_spell_duration_index(reference_tasmin, tn10)  # doctest: +SKIP
     """
     tn10 = convert_units_to(tn10, tasmin)
 
@@ -731,7 +731,6 @@ def liquid_precip_ratio(
 
         PR_{ij} = \sum_{i=a}^{b} PR_i
 
-
         PRwet_{ij}
 
     See Also
@@ -797,10 +796,10 @@ def precip_accumulation(
     --------
     The following would compute for each grid cell of file `pr_day.nc` the total
     precipitation at the seasonal frequency, ie DJF, MAM, JJA, SON, DJF, etc.:
-
-    >>> import xarray as xr
-    >>> pr_day = xr.open_dataset('pr_day.nc').pr
-    >>> prcp_tot_seasonal = precip_accumulation(pr_day, freq="QS-DEC")
+    >>> import xarray as xr  # doctest: +SKIP
+    >>> from xclim.indices import precip_accumulation  # doctest: +SKIP
+    >>> pr_day = xr.open_dataset('pr_day.nc').pr  # doctest: +SKIP
+    >>> prcp_tot_seasonal = precip_accumulation(pr_day, freq="QS-DEC")  # doctest: +SKIP
     """
     if phase in ["liquid", "solid"]:
         frz = convert_units_to("0 degC", tas)
@@ -908,9 +907,11 @@ def days_over_precip_thresh(
 
     Example
     -------
-    >>> pr = xr.open_dataset(path_to_pr_file).pr
-    >>> p75 = pr.quantile(.75, dim="time", keep_attrs=True)
-    >>> r75p = xclim.indices.days_over_precip_thresh(pr, p75)
+    >>> import xarray as xr  # doctest: +SKIP
+    >>> from xclim.indices import days_over_precip_thresh  # doctest: +SKIP
+    >>> pr = xr.open_dataset(path_to_pr_file).pr  # doctest: +SKIP
+    >>> p75 = pr.quantile(.75, dim="time", keep_attrs=True)  # doctest: +SKIP
+    >>> r75p = days_over_precip_thresh(pr, p75)  # doctest: +SKIP
     """
     per = convert_units_to(per, pr)
     thresh = convert_units_to(thresh, pr)
@@ -1002,11 +1003,12 @@ def tg90p(
 
     Example
     -------
-    >>> import xarray as xr
-    >>> import xclim.utils
-    >>> tas = xr.open_dataset("temperature_data.nc").tas
-    >>> t90 = xclim.utils.percentile_doy(tas, per=0.9)
-    >>> hot_days = tg90p(tas, t90)
+    >>> import xarray as xr  # doctest: +SKIP
+    >>> from xclim.core.calendar import percentile_doy  # doctest: +SKIP
+    >>> from xclim.indices import tg90p  # doctest: +SKIP
+    >>> tas = xr.open_dataset("temperature_data.nc").tas  # doctest: +SKIP
+    >>> t90 = percentile_doy(tas, per=0.9)  # doctest: +SKIP
+    >>> hot_days = tg90p(tas, t90)  # doctest: +SKIP
     """
     t90 = convert_units_to(t90, tas)
 
@@ -1047,11 +1049,12 @@ def tg10p(
 
     Example
     -------
-    >>> import xarray as xr
-    >>> import xclim.utils
-    >>> tas = xr.open_dataset("temperature_data.nc").tas
-    >>> t10 = xclim.utils.percentile_doy(tas, per=0.1)
-    >>> cold_days = tg10p(tas, t10)
+    >>> import xarray as xr  # doctest: +SKIP
+    >>> from xclim.core.calendar import percentile_doy  # doctest: +SKIP
+    >>> from xclim.indices import tg10p  # doctest: +SKIP
+    >>> tas = xr.open_dataset("temperature_data.nc").tas  # doctest: +SKIP
+    >>> t10 = percentile_doy(tas, per=0.1)  # doctest: +SKIP
+    >>> cold_days = tg10p(tas, t10)  # doctest: +SKIP
     """
     t10 = convert_units_to(t10, tas)
 
@@ -1092,11 +1095,12 @@ def tn90p(
 
     Example
     -------
-    >>> import xarray as xr
-    >>> import xclim.utils
-    >>> tas = xr.open_dataset("temperature_data.nc").tas
-    >>> t90 = xclim.utils.percentile_doy(tas, per=0.9)
-    >>> hot_days = tn90p(tas, t90)
+    >>> import xarray as xr  # doctest: +SKIP
+    >>> from xclim.core.calendar import percentile_doy  # doctest: +SKIP
+    >>> from xclim.indices import tn90p  # doctest: +SKIP
+    >>> tas = xr.open_dataset("temperature_data.nc").tas  # doctest: +SKIP
+    >>> t90 = percentile_doy(tas, per=0.9)  # doctest: +SKIP
+    >>> hot_days = tn90p(tas, t90)  # doctest: +SKIP
     """
     t90 = convert_units_to(t90, tasmin)
 
@@ -1137,11 +1141,12 @@ def tn10p(
 
     Example
     -------
-    >>> import xarray as xr
-    >>> import xclim.utils
-    >>> tas = xr.open_dataset("temperature_data.nc").tas
-    >>> t10 = xclim.utils.percentile_doy(tas, per=0.1)
-    >>> cold_days = tg10p(tas, t10)
+    >>> import xarray as xr  # doctest: +SKIP
+    >>> from xclim.core.calendar import percentile_doy  # doctest: +SKIP
+    >>> from xclim.indices import tn10p  # doctest: +SKIP
+    >>> tas = xr.open_dataset("temperature_data.nc").tas  # doctest: +SKIP
+    >>> t10 = percentile_doy(tas, per=0.1)  # doctest: +SKIP
+    >>> cold_days = tn10p(tas, t10)  # doctest: +SKIP
     """
     t10 = convert_units_to(t10, tasmin)
 
@@ -1182,11 +1187,12 @@ def tx90p(
 
     Example
     -------
-    >>> import xarray as xr
-    >>> import xclim.utils
-    >>> tas = xr.open_dataset("temperature_data.nc").tas
-    >>> t90 = xclim.utils.percentile_doy(tas, per=0.9)
-    >>> hot_days = tg90p(tas, t90)
+    >>> import xarray as xr  # doctest: +SKIP
+    >>> from xclim.core.calendar import percentile_doy  # doctest: +SKIP
+    >>> from xclim.indices import tx90p  # doctest: +SKIP
+    >>> tas = xr.open_dataset("temperature_data.nc").tas  # doctest: +SKIP
+    >>> t90 = percentile_doy(tas, per=0.9)  # doctest: +SKIP
+    >>> hot_days = tx90p(tas, t90)  # doctest: +SKIP
     """
     t90 = convert_units_to(t90, tasmax)
 
@@ -1227,11 +1233,12 @@ def tx10p(
 
     Example
     -------
-    >>> import xarray as xr
-    >>> import xclim.utils
-    >>> tas = xr.open_dataset("temperature_data.nc").tas
-    >>> t10 = xclim.utils.percentile_doy(tas, per=0.1)
-    >>> cold_days = tg10p(tas, t10)
+    >>> import xarray as xr  # doctest: +SKIP
+    >>> from xclim.core.calendar import percentile_doy  # doctest: +SKIP
+    >>> from xclim.indices import tx10p  # doctest: +SKIP
+    >>> tas = xr.open_dataset("temperature_data.nc").tas  # doctest: +SKIP
+    >>> t10 = percentile_doy(tas, per=0.1)  # doctest: +SKIP
+    >>> cold_days = tx10p(tas, t10)  # doctest: +SKIP
     """
     t10 = convert_units_to(t10, tasmax)
 

--- a/xclim/indices/_multivariate.py
+++ b/xclim/indices/_multivariate.py
@@ -795,10 +795,11 @@ def precip_accumulation(
 
     Examples
     --------
+    The following would compute for each grid cell of file `pr_day.nc` the total
+    precipitation at the seasonal frequency, ie DJF, MAM, JJA, SON, DJF, etc.:
+
     >>> import xarray as xr  # doctest: +SKIP
     >>> from xclim.indices import precip_accumulation  # doctest: +SKIP
-    # The following would compute for each grid cell of file `pr_day.nc` the total
-    # precipitation at the seasonal frequency, ie DJF, MAM, JJA, SON, DJF, etc.:
     >>> pr_day = xr.open_dataset('pr_day.nc').pr  # doctest: +SKIP
     >>> prcp_tot_seasonal = precip_accumulation(pr_day, freq="QS-DEC")  # doctest: +SKIP
     """

--- a/xclim/indices/_multivariate.py
+++ b/xclim/indices/_multivariate.py
@@ -94,9 +94,10 @@ def cold_spell_duration_index(
     ----------
     From the Expert Team on Climate Change Detection, Monitoring and Indices (ETCCDMI).
 
-    Example
-    -------
-    >>> from xclim.core.calendar import percentile_doy
+    Examples
+    --------
+    >>> from xclim.core.calendar import percentile_doy  # doctest: +SKIP
+    >>> from xclim.indices import cold_spell_duration_index  # doctest: +SKIP
     >>> tn10 = percentile_doy(historical_tasmin, per=.1)  # doctest: +SKIP
     >>> cold_spell_duration_index(reference_tasmin, tn10)  # doctest: +SKIP
     """
@@ -794,10 +795,10 @@ def precip_accumulation(
 
     Examples
     --------
-    The following would compute for each grid cell of file `pr_day.nc` the total
-    precipitation at the seasonal frequency, ie DJF, MAM, JJA, SON, DJF, etc.:
     >>> import xarray as xr  # doctest: +SKIP
     >>> from xclim.indices import precip_accumulation  # doctest: +SKIP
+    # The following would compute for each grid cell of file `pr_day.nc` the total
+    # precipitation at the seasonal frequency, ie DJF, MAM, JJA, SON, DJF, etc.:
     >>> pr_day = xr.open_dataset('pr_day.nc').pr  # doctest: +SKIP
     >>> prcp_tot_seasonal = precip_accumulation(pr_day, freq="QS-DEC")  # doctest: +SKIP
     """
@@ -905,8 +906,8 @@ def days_over_precip_thresh(
     xarray.DataArray
       Count of days with daily precipitation above the given percentile [days]
 
-    Example
-    -------
+    Examples
+    --------
     >>> import xarray as xr  # doctest: +SKIP
     >>> from xclim.indices import days_over_precip_thresh  # doctest: +SKIP
     >>> pr = xr.open_dataset(path_to_pr_file).pr  # doctest: +SKIP
@@ -1001,8 +1002,8 @@ def tg90p(
     -----
     The 90th percentile should be computed for a 5 day window centered on each calendar day for a reference period.
 
-    Example
-    -------
+    Examples
+    --------
     >>> import xarray as xr  # doctest: +SKIP
     >>> from xclim.core.calendar import percentile_doy  # doctest: +SKIP
     >>> from xclim.indices import tg90p  # doctest: +SKIP
@@ -1047,8 +1048,8 @@ def tg10p(
     -----
     The 10th percentile should be computed for a 5 day window centered on each calendar day for a reference period.
 
-    Example
-    -------
+    Examples
+    --------
     >>> import xarray as xr  # doctest: +SKIP
     >>> from xclim.core.calendar import percentile_doy  # doctest: +SKIP
     >>> from xclim.indices import tg10p  # doctest: +SKIP
@@ -1093,8 +1094,8 @@ def tn90p(
     -----
     The 90th percentile should be computed for a 5 day window centered on each calendar day for a reference period.
 
-    Example
-    -------
+    Examples
+    --------
     >>> import xarray as xr  # doctest: +SKIP
     >>> from xclim.core.calendar import percentile_doy  # doctest: +SKIP
     >>> from xclim.indices import tn90p  # doctest: +SKIP
@@ -1139,8 +1140,8 @@ def tn10p(
     -----
     The 10th percentile should be computed for a 5 day window centered on each calendar day for a reference period.
 
-    Example
-    -------
+    Examples
+    --------
     >>> import xarray as xr  # doctest: +SKIP
     >>> from xclim.core.calendar import percentile_doy  # doctest: +SKIP
     >>> from xclim.indices import tn10p  # doctest: +SKIP
@@ -1185,8 +1186,8 @@ def tx90p(
     -----
     The 90th percentile should be computed for a 5 day window centered on each calendar day for a reference period.
 
-    Example
-    -------
+    Examples
+    --------
     >>> import xarray as xr  # doctest: +SKIP
     >>> from xclim.core.calendar import percentile_doy  # doctest: +SKIP
     >>> from xclim.indices import tx90p  # doctest: +SKIP
@@ -1231,8 +1232,8 @@ def tx10p(
     -----
     The 10th percentile should be computed for a 5 day window centered on each calendar day for a reference period.
 
-    Example
-    -------
+    Examples
+    --------
     >>> import xarray as xr  # doctest: +SKIP
     >>> from xclim.core.calendar import percentile_doy  # doctest: +SKIP
     >>> from xclim.indices import tx10p  # doctest: +SKIP

--- a/xclim/indices/_simple.py
+++ b/xclim/indices/_simple.py
@@ -93,9 +93,9 @@ def tg_mean(tas: xarray.DataArray, freq: str = "YS"):
     --------
     The following would compute for each grid cell of file `tas.day.nc` the mean temperature
     at the seasonal frequency, ie DJF, MAM, JJA, SON, DJF, etc.:
-
-    >>> t = xr.open_dataset(path_to_tas_file).tas
-    >>> tg = tg_mean(t, freq="QS-DEC")
+    >>> import xarray as xr  # doctest: +SKIP
+    >>> t = xr.open_dataset(path_to_tas_file).tas  # doctest: +SKIP
+    >>> tg = tg_mean(t, freq="QS-DEC")  # doctest: +SKIP
     """
     arr = tas.resample(time=freq) if freq else tas
     return arr.mean(dim="time", keep_attrs=True)
@@ -503,9 +503,10 @@ def max_1day_precipitation_amount(pr: xarray.DataArray, freq: str = "YS"):
     --------
     The following would compute for each grid cell the highest 1-day total
     at an annual frequency:
-
-    >>> pr = xr.open_dataset(path_to_pr_file).pr
-    >>> rx1day = max_1day_precipitation_amount(pr, freq="YS")
+    >>> import xarray as xr  # doctest: +SKIP
+    >>> from xclim.indices import max_1day_precipitation_amount  # doctest: +SKIP
+    >>> pr = xr.open_dataset(path_to_pr_file).pr  # doctest: +SKIP
+    >>> rx1day = max_1day_precipitation_amount(pr, freq="YS")  # doctest: +SKIP
     """
     out = pr.resample(time=freq).max(dim="time", keep_attrs=True)
     return convert_units_to(out, "mm/day", "hydro")
@@ -536,9 +537,10 @@ def max_n_day_precipitation_amount(pr, window: int = 1, freq: str = "YS"):
     --------
     The following would compute for each grid cell the highest 5-day total precipitation
     at an annual frequency:
-
-    >>> pr = xr.open_dataset(path_to_pr_file).pr
-    >>> out = max_n_day_precipitation_amount(pr, window=5, freq="YS")
+    >>> import xarray as xr  # doctest: +SKIP
+    >>> from xclim.indices import max_n_day_precipitation_amount  # doctest: +SKIP
+    >>> pr = xr.open_dataset(path_to_pr_file).pr  # doctest: +SKIP
+    >>> out = max_n_day_precipitation_amount(pr, window=5, freq="YS")  # doctest: +SKIP
     """
     # Rolling sum of the values
     arr = pr.rolling(time=window).sum(allow_lazy=True, skipna=False)

--- a/xclim/indices/_simple.py
+++ b/xclim/indices/_simple.py
@@ -88,12 +88,13 @@ def tg_mean(tas: xarray.DataArray, freq: str = "YS"):
 
        TG_p = \frac{\sum_{i=a}^{b} TN_i}{b - a + 1}
 
-
     Examples
     --------
     The following would compute for each grid cell of file `tas.day.nc` the mean temperature
     at the seasonal frequency, ie DJF, MAM, JJA, SON, DJF, etc.:
+
     >>> import xarray as xr  # doctest: +SKIP
+    >>> from xclim.indices import tg_mean  # doctest: +SKIP
     >>> t = xr.open_dataset(path_to_tas_file).tas  # doctest: +SKIP
     >>> tg = tg_mean(t, freq="QS-DEC")  # doctest: +SKIP
     """
@@ -501,10 +502,10 @@ def max_1day_precipitation_amount(pr: xarray.DataArray, freq: str = "YS"):
 
     Examples
     --------
-    The following would compute for each grid cell the highest 1-day total
-    at an annual frequency:
     >>> import xarray as xr  # doctest: +SKIP
     >>> from xclim.indices import max_1day_precipitation_amount  # doctest: +SKIP
+    # The following would compute for each grid cell the highest 1-day total
+    # at an annual frequency:
     >>> pr = xr.open_dataset(path_to_pr_file).pr  # doctest: +SKIP
     >>> rx1day = max_1day_precipitation_amount(pr, freq="YS")  # doctest: +SKIP
     """
@@ -535,10 +536,10 @@ def max_n_day_precipitation_amount(pr, window: int = 1, freq: str = "YS"):
 
     Examples
     --------
-    The following would compute for each grid cell the highest 5-day total precipitation
-    at an annual frequency:
     >>> import xarray as xr  # doctest: +SKIP
     >>> from xclim.indices import max_n_day_precipitation_amount  # doctest: +SKIP
+    # The following would compute for each grid cell the highest 5-day total precipitation
+    #at an annual frequency:
     >>> pr = xr.open_dataset(path_to_pr_file).pr  # doctest: +SKIP
     >>> out = max_n_day_precipitation_amount(pr, window=5, freq="YS")  # doctest: +SKIP
     """

--- a/xclim/indices/_threshold.py
+++ b/xclim/indices/_threshold.py
@@ -124,9 +124,10 @@ def daily_pr_intensity(pr, thresh: str = "1 mm/day", freq: str = "YS"):
     The following would compute for each grid cell of file `pr.day.nc` the average
     precipitation fallen over days with precipitation >= 5 mm at seasonal
     frequency, ie DJF, MAM, JJA, SON, DJF, etc.:
-
-    >>> pr = xr.open_dataset(path_to_pr_file).pr
-    >>> daily_int = daily_pr_intensity(pr, thresh='5 mm/day', freq="QS-DEC")
+    >>> import xarray as xr  # doctest: +SKIP
+    >>> from xclim.indices import daily_pr_intensity  # doctest: +SKIP
+    >>> pr = xr.open_dataset(path_to_pr_file).pr  # doctest: +SKIP
+    >>> daily_int = daily_pr_intensity(pr, thresh='5 mm/day', freq="QS-DEC")  # doctest: +SKIP
     """
     t = convert_units_to(thresh, pr, "hydro")
 
@@ -440,8 +441,8 @@ def growing_season_length(
     Examples
     --------
     If working in the Southern Hemisphere, one can use:
-
-    >>> gsl = growing_season_length(tas, mid_date='01-01', freq='AS-Jul')
+    >>> from xclim.indices import growing_season_length  # doctest: +SKIP
+    >>> gsl = growing_season_length(tas, mid_date='01-01', freq='AS-Jul')  # doctest: +SKIP
     """
     thresh = convert_units_to(thresh, tas)
     cond = tas >= thresh
@@ -888,10 +889,10 @@ def wetdays(pr: xarray.DataArray, thresh: str = "1.0 mm/day", freq: str = "YS"):
     The following would compute for each grid cell of file `pr.day.nc` the number days
     with precipitation over 5 mm at the seasonal frequency, ie DJF, MAM, JJA, SON, DJF, etc.:
 
-    >>> import xarray as xr
-    >>> import xclim.utils
-    >>> pr = xr.open_dataset('pr.day.nc').pr
-    >>> wd = xclim.indices.wetdays(pr, pr_min=5., freq="QS-DEC")
+    >>> import xarray as xr  # doctest: +SKIP
+    >>> from xclim.indices import wetdays  # doctest: +SKIP
+    >>> pr = xr.open_dataset('pr.day.nc').pr  # doctest: +SKIP
+    >>> wd = wetdays(pr, pr_min=5., freq="QS-DEC")  # doctest: +SKIP
     """
     thresh = convert_units_to(thresh, pr, "hydro")
 

--- a/xclim/indices/_threshold.py
+++ b/xclim/indices/_threshold.py
@@ -124,6 +124,7 @@ def daily_pr_intensity(pr, thresh: str = "1 mm/day", freq: str = "YS"):
     The following would compute for each grid cell of file `pr.day.nc` the average
     precipitation fallen over days with precipitation >= 5 mm at seasonal
     frequency, ie DJF, MAM, JJA, SON, DJF, etc.:
+
     >>> import xarray as xr  # doctest: +SKIP
     >>> from xclim.indices import daily_pr_intensity  # doctest: +SKIP
     >>> pr = xr.open_dataset(path_to_pr_file).pr  # doctest: +SKIP
@@ -440,9 +441,13 @@ def growing_season_length(
 
     Examples
     --------
-    If working in the Southern Hemisphere, one can use:
+    >>> import xarray as xr
     >>> from xclim.indices import growing_season_length  # doctest: +SKIP
-    >>> gsl = growing_season_length(tas, mid_date='01-01', freq='AS-Jul')  # doctest: +SKIP
+    >>> tas = xr.open_dataset("tas.nc").tas
+    # For the Northern Hemisphere:
+    >>> gsl_nh = growing_season_length(tas, mid_date='07-01', freq='AS-Jan')  # doctest: +SKIP
+    # If working in the Southern Hemisphere, one can use:
+    >>> gsl_sh = growing_season_length(tas, mid_date='01-01', freq='AS-Jul')  # doctest: +SKIP
     """
     thresh = convert_units_to(thresh, tas)
     cond = tas >= thresh

--- a/xclim/indices/_threshold.py
+++ b/xclim/indices/_threshold.py
@@ -441,9 +441,9 @@ def growing_season_length(
 
     Examples
     --------
-    >>> import xarray as xr
+    >>> import xarray as xr  # doctest: +SKIP
     >>> from xclim.indices import growing_season_length  # doctest: +SKIP
-    >>> tas = xr.open_dataset("tas.nc").tas
+    >>> tas = xr.open_dataset("tas.nc").tas  # doctest: +SKIP
     # For the Northern Hemisphere:
     >>> gsl_nh = growing_season_length(tas, mid_date='07-01', freq='AS-Jan')  # doctest: +SKIP
     # If working in the Southern Hemisphere, one can use:

--- a/xclim/indices/run_length.py
+++ b/xclim/indices/run_length.py
@@ -503,6 +503,7 @@ def rle_1d(
 
     Examples
     --------
+    >>> from xclim.indices.run_length import rle_1d
     >>> a = [1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3]
     >>> rle_1d(a)
     (array([1, 2, 3]), array([2, 4, 6]), array([0, 2, 6]))

--- a/xclim/sdba/adjustment.py
+++ b/xclim/sdba/adjustment.py
@@ -154,7 +154,6 @@ class EmpiricalQuantileMapping(BaseAdjustment):
 
     where :math:`F` is the cumulative distribution function (CDF) and `mod` stands for model data.
 
-
     Parameters
     ----------
     At instantiation:

--- a/xclim/subset.py
+++ b/xclim/subset.py
@@ -17,6 +17,7 @@ from shapely.ops import cascaded_union, split
 
 __all__ = [
     "create_mask",
+    "distance",
     "subset_bbox",
     "subset_gridpoint",
     "subset_shape",
@@ -325,20 +326,22 @@ def create_mask_vectorize(
 
     Examples
     --------
-    >>> import geopandas as gpd
-    >>> ds = xr.open_dataset(path_to_tasmin_file)
-    >>> polys = gpd.read_file(path_to_multi_shape_file)
+    >>> import geopandas as gpd  # doctest: +SKIP
+    >>> import xarray as xr  # doctest: +SKIP
+    >>> from xclim.subset import create_mask_vectorize  # doctest: +SKIP
+    >>> ds = xr.open_dataset(path_to_tasmin_file)  # doctest: +SKIP
+    >>> polys = gpd.read_file(path_to_multi_shape_file)  # doctest: +SKIP
 
     Get a mask from all polygons in the shape file
-    >>> mask = create_mask_vectorize(x_dim=ds.lon, y_dim=ds.lat, poly=polys)
-    >>> ds = ds.assign_coords(regions=mask)
+    >>> mask = create_mask_vectorize(x_dim=ds.lon, y_dim=ds.lat, poly=polys)  # doctest: +SKIP
+    >>> ds = ds.assign_coords(regions=mask)  # doctest: +SKIP
 
     Operations can be applied to each regions with  `groupby`. Ex:
-    >>> ds = ds.groupby('regions').mean()
+    >>> ds = ds.groupby('regions').mean()  # doctest: +SKIP
 
     Extra step to retrieve the names of those polygons stored in another column (here "id")
-    >>> region_names = xr.DataArray(polys.id, dims=('regions',))
-    >>> ds = ds.assign_coords(regions_names=region_names)
+    >>> region_names = xr.DataArray(polys.id, dims=('regions',))  # doctest: +SKIP
+    >>> ds = ds.assign_coords(regions_names=region_names)  # doctest: +SKIP
     """
     if check_overlap:
         _check_has_overlaps(polygons=poly)
@@ -406,20 +409,22 @@ def create_mask(
 
     Examples
     --------
-    >>> import geopandas as gpd
-    >>> ds = xr.open_dataset(path_to_tasmin_file)
-    >>> polys = gpd.read_file(path_to_multi_shape_file)
+    >>> import xarray as xr  # doctest: +SKIP
+    >>> import geopandas as gpd  # doctest: +SKIP
+    >>> from xclim.subset import create_mask  # doctest: +SKIP
+    >>> ds = xr.open_dataset(path_to_tasmin_file)  # doctest: +SKIP
+    >>> polys = gpd.read_file(path_to_multi_shape_file)  # doctest: +SKIP
 
     Get a mask from all polygons in the shape file
-    >>> mask = create_mask(x_dim=ds.lon, y_dim=ds.lat, poly=polys)
-    >>> ds = ds.assign_coords(regions=mask)
+    >>> mask = create_mask(x_dim=ds.lon, y_dim=ds.lat, poly=polys)  # doctest: +SKIP
+    >>> ds = ds.assign_coords(regions=mask)  # doctest: +SKIP
 
     Operations can be applied to each regions with  `groupby`. Ex:
-    >>> ds = ds.groupby('regions').mean()
+    >>> ds = ds.groupby('regions').mean()  # doctest: +SKIP
 
     Extra step to retrieve the names of those polygons stored in the "id" column
-    >>> region_names = xr.DataArray(polys.id, dims=('regions',))
-    >>> ds = ds.assign_coords(regions_names=region_names)
+    >>> region_names = xr.DataArray(polys.id, dims=('regions',))  # doctest: +SKIP
+    >>> ds = ds.assign_coords(regions_names=region_names)  # doctest: +SKIP
     """
     wgs84 = CRS(4326)
 
@@ -514,17 +519,19 @@ def subset_shape(
 
     Examples
     --------
-    >>> pr = xr.open_dataset(path_to_pr_file).pr
+    >>> import xarray as xr
+    >>> from xclim.subset import subset_shape
+    >>> pr = xr.open_dataset(path_to_pr_file).pr  # doctest: +SKIP
 
     Subset data array by shape
-    >>> prSub = subset_shape(pr, shape=path_to_shape_file)
+    >>> prSub = subset_shape(pr, shape=path_to_shape_file)  # doctest: +SKIP
 
     Subset data array by shape and single year
-    >>> prSub = subset_shape(pr, shape=path_to_shape_file, start_date='1990-01-01', end_date='1990-12-31')
+    >>> prSub = subset_shape(pr, shape=path_to_shape_file, start_date='1990-01-01', end_date='1990-12-31')  # doctest: +SKIP
 
     Subset multiple variables in a single dataset
-    >>> ds = xr.open_mfdataset([path_to_tasmin_file, path_to_tasmax_file])
-    >>> dsSub = subset_shape(ds, shape=path_to_shape_file)
+    >>> ds = xr.open_mfdataset([path_to_tasmin_file, path_to_tasmax_file])  # doctest: +SKIP
+    >>> dsSub = subset_shape(ds, shape=path_to_shape_file)  # doctest: +SKIP
     """
     wgs84 = CRS(4326)
     # PROJ4 definition for WGS84 with longitudes ranged between -180/+180.
@@ -679,10 +686,12 @@ def subset_bbox(
 
     Examples
     --------
-    >>> ds = xr.open_dataset(path_to_pr_file)
+    >>> import xarray as xr
+    >>> from xclim.subset import subset_bbox
+    >>> ds = xr.open_dataset(path_to_pr_file)  # doctest: +SKIP
 
     Subset lat lon
-    >>> prSub = subset_bbox(ds.pr, lon_bnds=[-75, -70], lat_bnds=[40, 45])
+    >>> prSub = subset_bbox(ds.pr, lon_bnds=[-75, -70], lat_bnds=[40, 45])  # doctest: +SKIP
     """
     # Rectilinear case (lat and lon are the 1D dimensions)
     if ("lat" in da.dims) or ("lon" in da.dims):
@@ -887,14 +896,16 @@ def subset_gridpoint(
 
     Examples
     --------
-    >>> ds = xarray.open_dataset(path_to_pr_file)
+    >>> import xarray as xr
+    >>> from xclim.subset import subset_gridpoint
+    >>> ds = xr.open_dataset(path_to_pr_file)  # doctest: +SKIP
 
     Subset lat lon point
-    >>> prSub = subset_gridpoint(ds.pr, lon=-75,lat=45)
+    >>> prSub = subset_gridpoint(ds.pr, lon=-75,lat=45)  # doctest: +SKIP
 
     Subset multiple variables in a single dataset
-    >>> ds = xr.open_mfdataset([path_to_tasmax_file, path_to_tasmin_file])
-    >>> dsSub = subset_gridpoint(ds, lon=-75, lat=45)
+    >>> ds = xr.open_mfdataset([path_to_tasmax_file, path_to_tasmin_file])  # doctest: +SKIP
+    >>> dsSub = subset_gridpoint(ds, lon=-75, lat=45)  # doctest: +SKIP
     """
     if lat is None or lon is None:
         raise ValueError("Insufficient coordinates provided to locate grid point(s).")
@@ -984,23 +995,25 @@ def subset_time(
 
     Examples
     --------
-    >>> ds = xarray.open_dataset(path_to_pr_file)
+    >>> import xarray as xr
+    >>> from xclim.subset import subset_time
+    >>> ds = xr.open_dataset(path_to_pr_file)  # doctest: +SKIP
 
     Subset complete years
-    >>> prSub = subset_time(ds.pr,start_date='1990',end_date='1999')
+    >>> prSub = subset_time(ds.pr,start_date='1990',end_date='1999')  # doctest: +SKIP
 
     Subset single complete year
-    >>> prSub = subset_time(ds.pr,start_date='1990',end_date='1990')
+    >>> prSub = subset_time(ds.pr,start_date='1990',end_date='1990')  # doctest: +SKIP
 
     Subset multiple variables in a single dataset
-    >>> ds = xr.open_mfdataset([path_to_tasmax_file, path_to_tasmin_file])
-    >>> dsSub = subset_time(ds,start_date='1990',end_date='1999')
+    >>> ds = xr.open_mfdataset([path_to_tasmax_file, path_to_tasmin_file])  # doctest: +SKIP
+    >>> dsSub = subset_time(ds,start_date='1990',end_date='1999')  # doctest: +SKIP
 
     Subset with year-month precision - Example subset 1990-03-01 to 1999-08-31 inclusively
-    >>> txSub = subset_time(ds.tasmax,start_date='1990-03',end_date='1999-08')
+    >>> txSub = subset_time(ds.tasmax,start_date='1990-03',end_date='1999-08')  # doctest: +SKIP
 
     Subset with specific start_dates and end_dates
-    >>> tnSub = subset_time(ds.tasmin,start_date='1990-03-13',end_date='1990-08-17')
+    >>> tnSub = subset_time(ds.tasmin,start_date='1990-03-13',end_date='1990-08-17')  # doctest: +SKIP
 
     Notes
     -----
@@ -1035,10 +1048,12 @@ def distance(
     Note
     ----
     To get the indices from closest point, use:
-    >>> da = xr.open_dataset(path_to_pr_file).pr
-    >>> d = distance(da, lon=-75, lat=45)
-    >>> k = d.argmin()
-    >>> i, j, _ = np.unravel_index(k, d.shape)
+    >>> import xarray as xr  # doctest: +SKIP
+    >>> from xclim.subset import distance  # doctest: +SKIP
+    >>> da = xr.open_dataset(path_to_pr_file).pr  # doctest: +SKIP
+    >>> d = distance(da, lon=-75, lat=45)  # doctest: +SKIP
+    >>> k = d.argmin()  # doctest: +SKIP
+    >>> i, j, _ = np.unravel_index(k, d.shape)  # doctest: +SKIP
     """
     ptdim = lat.dims[0]
 

--- a/xclim/subset.py
+++ b/xclim/subset.py
@@ -17,6 +17,7 @@ from shapely.ops import cascaded_union, split
 
 __all__ = [
     "create_mask",
+    "create_mask_vectorize",
     "distance",
     "subset_bbox",
     "subset_gridpoint",
@@ -331,15 +332,15 @@ def create_mask_vectorize(
     >>> from xclim.subset import create_mask_vectorize  # doctest: +SKIP
     >>> ds = xr.open_dataset(path_to_tasmin_file)  # doctest: +SKIP
     >>> polys = gpd.read_file(path_to_multi_shape_file)  # doctest: +SKIP
-
-    Get a mask from all polygons in the shape file
+    ...
+    # Get a mask from all polygons in the shape file
     >>> mask = create_mask_vectorize(x_dim=ds.lon, y_dim=ds.lat, poly=polys)  # doctest: +SKIP
     >>> ds = ds.assign_coords(regions=mask)  # doctest: +SKIP
-
-    Operations can be applied to each regions with  `groupby`. Ex:
+    ...
+    # Operations can be applied to each regions with  `groupby`. Ex:
     >>> ds = ds.groupby('regions').mean()  # doctest: +SKIP
-
-    Extra step to retrieve the names of those polygons stored in another column (here "id")
+    ...
+    # Extra step to retrieve the names of those polygons stored in another column (here "id")
     >>> region_names = xr.DataArray(polys.id, dims=('regions',))  # doctest: +SKIP
     >>> ds = ds.assign_coords(regions_names=region_names)  # doctest: +SKIP
     """
@@ -414,15 +415,15 @@ def create_mask(
     >>> from xclim.subset import create_mask  # doctest: +SKIP
     >>> ds = xr.open_dataset(path_to_tasmin_file)  # doctest: +SKIP
     >>> polys = gpd.read_file(path_to_multi_shape_file)  # doctest: +SKIP
-
-    Get a mask from all polygons in the shape file
+    ...
+    # Get a mask from all polygons in the shape file
     >>> mask = create_mask(x_dim=ds.lon, y_dim=ds.lat, poly=polys)  # doctest: +SKIP
     >>> ds = ds.assign_coords(regions=mask)  # doctest: +SKIP
-
-    Operations can be applied to each regions with  `groupby`. Ex:
+    ...
+    # Operations can be applied to each regions with  `groupby`. Ex:
     >>> ds = ds.groupby('regions').mean()  # doctest: +SKIP
-
-    Extra step to retrieve the names of those polygons stored in the "id" column
+    ...
+    # Extra step to retrieve the names of those polygons stored in the "id" column
     >>> region_names = xr.DataArray(polys.id, dims=('regions',))  # doctest: +SKIP
     >>> ds = ds.assign_coords(regions_names=region_names)  # doctest: +SKIP
     """
@@ -519,17 +520,17 @@ def subset_shape(
 
     Examples
     --------
-    >>> import xarray as xr
-    >>> from xclim.subset import subset_shape
+    >>> import xarray as xr  # doctest: +SKIP
+    >>> from xclim.subset import subset_shape  # doctest: +SKIP
     >>> pr = xr.open_dataset(path_to_pr_file).pr  # doctest: +SKIP
-
-    Subset data array by shape
+    ...
+    # Subset data array by shape
     >>> prSub = subset_shape(pr, shape=path_to_shape_file)  # doctest: +SKIP
-
-    Subset data array by shape and single year
+    ...
+    # Subset data array by shape and single year
     >>> prSub = subset_shape(pr, shape=path_to_shape_file, start_date='1990-01-01', end_date='1990-12-31')  # doctest: +SKIP
-
-    Subset multiple variables in a single dataset
+    ...
+    # Subset multiple variables in a single dataset
     >>> ds = xr.open_mfdataset([path_to_tasmin_file, path_to_tasmax_file])  # doctest: +SKIP
     >>> dsSub = subset_shape(ds, shape=path_to_shape_file)  # doctest: +SKIP
     """
@@ -686,11 +687,11 @@ def subset_bbox(
 
     Examples
     --------
-    >>> import xarray as xr
-    >>> from xclim.subset import subset_bbox
+    >>> import xarray as xr  # doctest: +SKIP
+    >>> from xclim.subset import subset_bbox  # doctest: +SKIP
     >>> ds = xr.open_dataset(path_to_pr_file)  # doctest: +SKIP
-
-    Subset lat lon
+    ...
+    # Subset lat lon
     >>> prSub = subset_bbox(ds.pr, lon_bnds=[-75, -70], lat_bnds=[40, 45])  # doctest: +SKIP
     """
     # Rectilinear case (lat and lon are the 1D dimensions)
@@ -896,14 +897,14 @@ def subset_gridpoint(
 
     Examples
     --------
-    >>> import xarray as xr
-    >>> from xclim.subset import subset_gridpoint
+    >>> import xarray as xr  # doctest: +SKIP
+    >>> from xclim.subset import subset_gridpoint  # doctest: +SKIP
     >>> ds = xr.open_dataset(path_to_pr_file)  # doctest: +SKIP
-
-    Subset lat lon point
+    ...
+    # Subset lat lon point
     >>> prSub = subset_gridpoint(ds.pr, lon=-75,lat=45)  # doctest: +SKIP
-
-    Subset multiple variables in a single dataset
+    ...
+    # Subset multiple variables in a single dataset
     >>> ds = xr.open_mfdataset([path_to_tasmax_file, path_to_tasmin_file])  # doctest: +SKIP
     >>> dsSub = subset_gridpoint(ds, lon=-75, lat=45)  # doctest: +SKIP
     """
@@ -995,24 +996,24 @@ def subset_time(
 
     Examples
     --------
-    >>> import xarray as xr
-    >>> from xclim.subset import subset_time
+    >>> import xarray as xr  # doctest: +SKIP
+    >>> from xclim.subset import subset_time  # doctest: +SKIP
     >>> ds = xr.open_dataset(path_to_pr_file)  # doctest: +SKIP
-
-    Subset complete years
+    ...
+    # Subset complete years
     >>> prSub = subset_time(ds.pr,start_date='1990',end_date='1999')  # doctest: +SKIP
-
-    Subset single complete year
+    ...
+    # Subset single complete year
     >>> prSub = subset_time(ds.pr,start_date='1990',end_date='1990')  # doctest: +SKIP
-
-    Subset multiple variables in a single dataset
+    ...
+    # Subset multiple variables in a single dataset
     >>> ds = xr.open_mfdataset([path_to_tasmax_file, path_to_tasmin_file])  # doctest: +SKIP
     >>> dsSub = subset_time(ds,start_date='1990',end_date='1999')  # doctest: +SKIP
-
-    Subset with year-month precision - Example subset 1990-03-01 to 1999-08-31 inclusively
+    ...
+    # Subset with year-month precision - Example subset 1990-03-01 to 1999-08-31 inclusively
     >>> txSub = subset_time(ds.tasmax,start_date='1990-03',end_date='1999-08')  # doctest: +SKIP
-
-    Subset with specific start_dates and end_dates
+    ...
+    # Subset with specific start_dates and end_dates
     >>> tnSub = subset_time(ds.tasmin,start_date='1990-03-13',end_date='1990-08-17')  # doctest: +SKIP
 
     Notes
@@ -1045,11 +1046,12 @@ def distance(
     xarray.DataArray
       Distance in meters to point.
 
-    Note
-    ----
-    To get the indices from closest point, use:
+    Examples
+    --------
     >>> import xarray as xr  # doctest: +SKIP
     >>> from xclim.subset import distance  # doctest: +SKIP
+    ...
+    To get the indices from closest point, use:
     >>> da = xr.open_dataset(path_to_pr_file).pr  # doctest: +SKIP
     >>> d = distance(da, lon=-75, lat=45)  # doctest: +SKIP
     >>> k = d.argmin()  # doctest: +SKIP


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #450 
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [x] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->

This PR adds the [`xdoctest`](https://github.com/Erotemic/xdoctest) library to the dev build and implements it in the tox builds that check the documentation. This library uses a much better parser and is able to find all the documentation examples within the code and properly run evaluation tests on them.

I've also reformatted many docstrings that simply weren't being formatted properly on ReadTheDocs. Consequently, locally-building the docs via `make docs` at the top-level now raises MANY warnings that should eventually be addressed.

Another problem relates to discussion in #506. I have elected to set all tests that only marginally pass to be skipped entirely. If we can figure out how best to deal with the example test data problem, we can re-enable these checks.

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->

No, though docstring standards are getting generally stricter.

* **Other information**:

I've made the decision to import global and locally-imported libraries within the examples to show users how to gain access to the functions being presented. This is more of a stylistic decision, and we can discuss whether we like examples to be short and sweet or longer and more elaborate, albeit more redundant.

