### PR TITLE
Fail non-translated indicators - translate missing indicators

### DIFF
--- a/.github/CONTRIBUTING.rst
+++ b/.github/CONTRIBUTING.rst
@@ -33,6 +33,9 @@ Implement Features
 Look through the GitHub issues for features. Anything tagged with "enhancement"
 and "help wanted" is open to whoever wants to implement it.
 
+.. warning::
+     If you plan to implement new indicators into xclim, be aware that metadata translations for all official xclim languages (for now only french) must be provided, or else the tests will fail and the PR will not be mergeable. See :ref:`Internationalization` for more details. Don't hesitate to ask for help in your PR for this task.
+
 Write Documentation
 ~~~~~~~~~~~~~~~~~~~
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -29,6 +29,7 @@ Internal changes
 * Indicator subclasses `TasminTasmax` and `PrTas` now inherit from `Daily2D`.
 * Docstring style now enforced using the `pydocstyle` with `numpy` doctsring conventions.
 * Doctests are now performed for all docstring `Examples` using `xdoctest`. Failing examples must be explicitly skipped otherwise build will now fail.
+* Non-translated indicators will now make the tests fail.
 
 0.18.0 (2020-06-26)
 -------------------

--- a/tests/test_locales.py
+++ b/tests/test_locales.py
@@ -159,9 +159,9 @@ def test_xclim_translations(locale):
             assert registry_cp.pop(indicator)
             # Only translatable attributes are translated
             assert set(fields.keys()).issubset(xloc.TRANSLATABLE_ATTRS)
-    # Leftover indicators need to have some translations!
+
     if bool(registry_cp):
-        pytest.xfail(
+        pytest.fail(
             f"Indicators {','.join(registry_cp.keys())} do not have translations for official locale {locale}."
         )
 

--- a/tests/test_locales.py
+++ b/tests/test_locales.py
@@ -153,6 +153,11 @@ def test_xclim_translations(locale):
         default_formatter.mapping.keys()
     ) == {"modifiers"}
 
+    # Remove unofficial indicators (as those created during the tests)
+    for identifier, cls in registry.items():
+        if not cls.__module__.startswith("xclim.indicators"):
+            registry_cp.pop(identifier)
+
     for indicator, fields in dic.items():
         if indicator != "attrs_mapping":
             # Checking that the translated indicator does exist

--- a/xclim/core/locales.py
+++ b/xclim/core/locales.py
@@ -18,31 +18,35 @@ These files are expected to be defined as in this example for french:
             "YS" : ["annuel", "annuelle", "annuels", "annuelles"],
             ... and so on for other frequent parameters translation...
         },
-        "atmos.dtrvar" : {
-            "long_name": "Variabilité de l'intervalle de température moyen",
-            "description": "Variabilité {freq:f} de l'intervalle de température moyen."
-        },
+          "DTRVAR": {
+            "long_name": "Variabilité de l'amplitude de la température diurne",
+            "description": "Variabilité {freq:f} de l'amplitude de la température diurne (définie comme la moyenne de la variation journalière de l'amplitude de température sur une période donnée)",
+            "title": "Variation quotidienne absolue moyenne de l'amplitude de la température diurne",
+            "comment": "",
+            "abstract": "La valeur absolue de la moyenne de l'amplitude de la température diurne."
+          },
         ... and so on for other indicators...
     }
 
-Indicators are named by their module and identifier, which can differ from the callable name.
-In this case, the indicator is called through `atmos.daily_temperature_range_variability`,
-but its identifier is `dtrvar`.
+Indicators are named by subclass identifier, the same as in the indicator registry (`xclim.core.indicators.registry`),
+but which can differ from the callable name. In this case, the indicator is called through
+`atmos.daily_temperature_range_variability`, but its identifier is `DTRVAR`.
+Use the `ind.__class__.__name__` accessor to get its registry name.
 
 Here, the usual parameter passed to the formatting of "description" is "freq" and is usually
 translated from "YS" to "annual". However, in french and in this sentence, the feminine
 form should be used, so the "f" modifier is added by the translator so that the
 formatting function knows which translation to use. Acceptable entries for the mappings
-are limited to what is already defined in `xclim.indicators.utils.default_formatter`.
+are limited to what is already defined in `xclim.core.indicators.utils.default_formatter`.
 
-The "attrs_mapping" and its "modifiers" key are mandatory in the locale dict, all other
-entries (translations of frequent parameters and all indicator entries) are optional.
+For user-provided internationalization dictionaries, only the "attrs_mapping" and
+its "modifiers" key are mandatory, all other entries (translations of frequent parameters
+and all indicator entries) are optional. For xclim-provided translations (for now only french),
+all indicators must have en entry and the "attrs_mapping" entries must match exactly the default formatter.
+Those default translations are found in the `xclim/locales` folder.
 
 Attributes
 ----------
-LOCALES
-    List of currently set locales. Computing indicator through a xclim.indicators.indicator.Indicator
-    object will add metadata in these languages as available.
 TRANSLATABLE_ATTRS
     List of attributes to consider translatable when generating locale dictionaries.
 """

--- a/xclim/locales/fr.json
+++ b/xclim/locales/fr.json
@@ -517,5 +517,41 @@
     "comment": "",
     "title": "Fin de la saison de végétation",
     "abstract": "Jour de l'année de la fin de la saison de végétation. La saison de végétation est définie comme l'intervalle entre la première série de N jours où la température journalière est au-dessus d'un seuil et la première série (après une certaine date) de N jours où elle est sous ce même seuil"
+  },
+  "SFCWIND": {
+    "long_name": "Vitesse du vent de surface",
+    "description": "Magnitude de la vitesse vent calculée à partir des deux composantes uas et vas.",
+    "title": "Magnitude de la vitesse du vent",
+    "abstract": "Calcul de la magnitude de la vitesse du vent à partir des deux composantes ouest-est et sud-nord."
+  },
+  "E_SAT": {
+    "long_name": "Pression de vapeur saturante",
+    "description": "Pression de vapeur saturante calculée à partir de la température en suivant la méthode {method}.",
+    "title": "Pression de vapeur saturante (e_sat)",
+    "abstract": "Calcul de la pression de vapeur saturante à partir de la température, selon une méthode donnée. Si ice_thresh est donné, le calcul se fait en référence à la glace pour les températures sous ce seuil."
+  },
+  "RH_FROMDEWPOINT": {
+    "long_name": "Humidité relative",
+    "description": "Calculée à partir de la température et du point de rosée à l'aide de la pression de vapeur saturante, laquelle fut calculée en suivant la méthode {method}.",
+    "title": "Humidité relative à partir du point de rosée",
+    "abstract": "Calcul de l'humidité relative à partir de la température et du point de rosée à l'aire de la pression de vapeur saturante."
+  },
+  "RH": {
+    "long_name": "Humidité relative",
+    "description": "Calculée à partir de la température, de l'humidité spécifique et de la pression à l'aide de la pression de vapeur saturante, laquelle fut calculée en suivant la méthode {method}",
+    "title": "Humidité relative à partir de l'humidité spécifique et de la pression",
+    "abstract": "Calcul de l'humidité relative à partir de la température, de l'humidité spécifique et de la pression à l'aide de la pression de vapeur saturante."
+  },
+  "HUSS": {
+    "long_name": "Humidité spécifique",
+    "description": "Calculée à partir de la température, de l'humidité relative et de la pression à l'aide de la pression de vapeur saturante, laquelle fut calculée en suivant la méthode {method}",
+    "title": "Humidité spécifique à partir de l'humidité relative et de la pression",
+    "abstract": "Calcul de l'humidité spécifique à partir de la température, de l'humidité relative et de la pression à l'aide de la pression de vapeur saturante."
+  },
+  "FIRST_DAY_BELOW": {
+    "long_name": "Premier jour de l'année avec une température sous {thresh}",
+    "description": "Premier jour de l'année avec une température sous {thresh} pour au moins {window} jours.",
+    "title": "Premier jour de l'année de températures sous un seuil.",
+    "abstract": "Calcule le premier jour d'une période où la température est plus basse qu'un certain seuil durant un nombre de jours donné, limité par une date minimale."
   }
 }


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR completes #352
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
Adds missing translations for some indicators, mainly the "conversion" ones (rh, sfcWind, etc).

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
Yes. Now, every added indicator **MUST** provide its translation, or else the tests will fail. 

* **Other information**:
I added a note to `CONTRIBUTING.rst` and fixes the doc of `xclim.core.locales` to reflect these changes.
