### PR TITLE
Enable doctests using xdoctest conventions

### DIFF
--- a/.github/CONTRIBUTING.rst
+++ b/.github/CONTRIBUTING.rst
@@ -34,7 +34,10 @@ Look through the GitHub issues for features. Anything tagged with "enhancement"
 and "help wanted" is open to whoever wants to implement it.
 
 .. warning::
-     If you plan to implement new indicators into xclim, be aware that metadata translations for all official xclim languages (for now only French) must be provided, or else the tests will fail and the PR will not be mergeable. See :ref:`Internationalization` for more details. Don't hesitate to ask for help in your PR for this task!
+     If you plan to implement new indicators into xclim, be aware that metadata translations
+     for all official xclim languages (for now only French) must be provided, or else the tests
+     will fail and the PR will not be mergeable. See :ref:`Internationalization` for more details.
+     Don't hesitate to ask for help in your PR for this task!
 
 Write Documentation
 ~~~~~~~~~~~~~~~~~~~
@@ -72,10 +75,10 @@ Ready to contribute? Here's how to set up `xclim` for local development.
     $ mkvirtualenv xclim
 
     # For Anaconda/Miniconda environments:
-    $ conda create -n xclim python=3.6
+    $ conda create -n xclim python=3.6 --file=environment.yml
 
     $ cd xclim/
-    $ pip install -e .
+    $ pip install -e .[dev]
 
 4. Create a branch for local development::
 
@@ -86,14 +89,15 @@ Ready to contribute? Here's how to set up `xclim` for local development.
 5. When you're done making changes, check that you verify your changes with `black`, `pydocstyle`, and run the tests, including testing other available Python versions with `tox`::
 
     # For virtualenv environments:
-    $ pip install black pytest pydocstyle tox
+    $ pip install black pytest pydocstyle xdoctest tox
 
     # For Anaconda/Miniconda environments:
-    $ conda install -c conda-forge black pytest pydocstyle tox
+    $ conda install -c conda-forge black pytest pydocstyle xdoctest tox
 
-    $ black xclim tests
-    $ python setup.py test
-    $ pydocstyle --conventions=numpy xclim
+    $ black --check --target-version py36 xclim tests
+    $ flake8 xclim tests
+    $ pytest --root-dir tests/ --xdoctest xclim
+    $ pydocstyle --convention=numpy --match="(?!test_).*\.py" xclim
     $ tox
 
 6. Before committing your changes, we ask that you install `pre-commit` in your dev environment. `Pre-commit` runs git hooks that ensure that your code resembles that of the project and catches and corrects any small errors or inconsistencies when you `git commit`::
@@ -147,11 +151,11 @@ Before you submit a pull request, please follow these guidelines:
    Pull requests are also checked for documentation build status and for `PEP8`_ compliance.
 
    The build statuses and build errors for pull requests can be found at:
-    https://travis-ci.org/Ouranosinc/xclim/pull_requests
+    https://travis-ci.com/Ouranosinc/xclim/pull_requests
 
 .. warning::
-    PEP8, Black, and Pydocstyle (for numpy docstrings) conventions are strongly enforced. Ensure that your
-    changes pass **Flake8** and **Black** tests prior to pushing your final commits to your branch.
+    PEP8, Black, Pytest(doctest) and Pydocstyle (for numpy docstrings) conventions are strongly enforced.
+    Ensure that your changes pass all tests prior to pushing your final commits to your branch.
     Code formatting errors are treated as build errors and will block your pull request from being accepted.
 
 Tips

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,7 +103,7 @@ jobs:
           - conda create -n xclim -c conda-forge python=$TRAVIS_PYTHON_VERSION
           - source activate xclim
           - conda env update -f environment.yml
-          - conda install pytest coveralls pytest-cov xdoctest
+          - conda install -c conda-forge pytest coveralls pytest-cov xdoctest
       install:
           - conda install pip
           - pip install -e .
@@ -127,28 +127,12 @@ jobs:
         - conda create -n xclim -c conda-forge python=$DESIRED_PYTHON
         - source activate xclim
         - conda env update -f environment.yml
-        - conda install pytest coveralls pytest-cov xdoctest
+        - conda install -c conda-forge pytest coveralls pytest-cov xdoctest
       install:
         - conda install pip
         - pip install -e .
       script:
         - py.test --cov=xclim
-#    - env:
-#        - TOXENV=py37-windows
-#        - PROJ_DIR=/c/OSGeo4W64
-#        - GDAL_VERSION=3.0.0
-#        - GDAL_DATA=/c/OSGeo4W64/share/gdal
-#      name: "Python3.7 (Windows)"
-#      os: windows
-#      language: shell
-#      before_install:
-#        - wget --directory-prefix=/c/temp/ https://download.osgeo.org/osgeo4w/osgeo4w-setup-x86_64.exe
-#        - /c/temp/osgeo4w-setup-x86_64.exe -b -q -k -r -A -s http://download.osgeo.org/osgeo4w/ -a x86_64 -P proj,gdal,libspatialindex,geos
-#        - choco install python --version=3.7.5
-#        - export PATH="/c/Python37:/c/Python37/Scripts:$PATH"
-#        - export PATH="/c/OSGeo4W64/include:/c/OSGeo4W64/bin:$PATH"
-#        - printenv
-#        - python -m pip install --upgrade pip wheel
   allow_failures:
     - env: TOXENV=py38-anaconda
     - env: TOXENV=py38-macOS
@@ -158,11 +142,6 @@ jobs:
       - MINICONDA_PATH=$(cygpath --windows /c/miniconda)
     - env: TOXENV=py36-xarray
     - env: TOXENV=py36-bottleneck
-#    - env:
-#      - TOXENV=py37-windows
-#      - PROJ_DIR=/c/OSGeo4W64
-#      - GDAL_VERSION=3.0.0
-#      - GDAL_DATA=/c/OSGeo4W64/share/gdal
 
 before_install:
     - printenv

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,7 +103,7 @@ jobs:
           - conda create -n xclim -c conda-forge python=$TRAVIS_PYTHON_VERSION
           - source activate xclim
           - conda env update -f environment.yml
-          - conda install pytest coveralls pytest-cov
+          - conda install pytest coveralls pytest-cov xdoctest
       install:
           - conda install pip
           - pip install -e .
@@ -127,7 +127,7 @@ jobs:
         - conda create -n xclim -c conda-forge python=$DESIRED_PYTHON
         - source activate xclim
         - conda env update -f environment.yml
-        - conda install pytest coveralls pytest-cov
+        - conda install pytest coveralls pytest-cov xdoctest
       install:
         - conda install pip
         - pip install -e .

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -13,8 +13,11 @@ Breaking changes
   missing values is identified by its registered name, e.g. "any", "pct", etc, along with its `missing_options`.
 * xclim now requires xarray >= 0.16, ensuring that xclim.sdba is fully functional.
 * The dev requirements now include `xdoctest` -- a rewrite of the standard library module, `doctest`.
-* `xclim.core.locales.get_local_attrs` now uses the indicator's class name instead of the indicator itself and no longer accepts the `fill_missing` keyword. Behaviour is now the same as passing `False`.
-* `Indicator.cf_attrs` is now a list of dictionaries. `Indicator.json` puts all the metadata attributes in the key "outputs" (a list of dicts). All variable metadata (names in `Indicator._cf_names`) might be strings or lists of strings when accessed as object attributes.
+* `xclim.core.locales.get_local_attrs` now uses the indicator's class name instead of the indicator itself and no
+  longer accepts the `fill_missing` keyword. Behaviour is now the same as passing `False`.
+* `Indicator.cf_attrs` is now a list of dictionaries. `Indicator.json` puts all the metadata attributes in the key "outputs" (a list of dicts).
+  All variable metadata (names in `Indicator._cf_names`) might be strings or lists of strings when accessed as object attributes.
+* Passing doctests are now strictly enforced as a build requirement in the Travis CI testing ensemble.
 
 New features and enhancements
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -22,6 +25,7 @@ New features and enhancements
 * Create new Indicator `Daily`, `Daily2D` subclasses for indicators using daily input data.
 * The `Indicator` class now supports outputing multiple indices for the same inputs.
 * `xclim.core.units.declare_units` now works with indices outputting multiple DataArrays.
+* Doctests now make use of the `xdoctest_namespace` in order to more easily access mdoules and tesdata.
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -67,11 +67,11 @@ Once you have a copy of the source, you can install it with:
 
     $ python setup.py install
 
-Alternatively, you can also install a local copy via pip:
+Alternatively, you can also install a local development copy via pip:
 
 .. code-block:: console
 
-    $ pip install .
+    $ pip install -e .[dev]
 
 .. _Github repo: https://github.com/Ouranosinc/xclim
 .. _tarball: https://github.com/Ouranosinc/xclim/tarball/master
@@ -86,4 +86,4 @@ To create a conda development environment including all xclim dependencies, ente
 
     $ conda create -n my_xclim_env python=3.6 --file=requirements_dev.txt
     $ conda activate my_xclim_env
-    $ python setup.py install
+    $ pip install .[dev]

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,7 @@ addopts = --verbose
 filterwarnings =
 	ignore::UserWarning
 testpaths = tests tests/test_sdba
+usefixtures = xdoctest_namespace
 doctest_optionflags = NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL NUMBER ELLIPSIS
 
 [tool:pylint]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.18.3-beta
+current_version = 0.18.4-beta
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+).(?P<patch>\d+)(\-(?P<release>[a-z]+))?

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ URL = "https://github.com/Ouranosinc/xclim"
 AUTHOR = "Travis Logan"
 AUTHOR_EMAIL = "logan.travis@ouranos.ca"
 REQUIRES_PYTHON = ">=3.6.0"
-VERSION = "0.18.3-beta"
+VERSION = "0.18.4-beta"
 LICENSE = "Apache Software License 2.0"
 
 with open("README.rst") as readme_file:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -271,7 +271,7 @@ def add_imports(xdoctest_namespace):
 
 
 @pytest.fixture(autouse=True)
-def add_example_file_paths(xdoctest_namespace):
+def add_example_file_paths(xdoctest_namespace, tas_series):
     """Add these datasets in the doctests scope."""
     ns = xdoctest_namespace
     ns["path_to_pr_file"] = str(TD / "NRCANdaily" / "nrcan_canada_daily_pr_1990.nc")
@@ -292,24 +292,21 @@ def add_example_file_paths(xdoctest_namespace):
 
     ns["path_to_shape_file"] = str(TD / "cmip5" / "southern_qc_geojson.json")
 
+    time = xr.cftime_range("1990-01-01", "2049-12-31", freq="D")
     ns["temperature_datasets"] = [
-        str(
-            TD
-            / "EnsembleStats"
-            / "BCCAQv2+ANUSPLIN300_ACCESS1-0_historical+rcp45_r1i1p1_1950-2100_tg_mean_YS.nc"
+        xr.DataArray(
+            12 * np.random.random_sample(time.size) + 273,
+            coords={"time": time},
+            name="tas",
+            dims=("time",),
+            attrs={"units": "K"},
         ),
-        str(
-            TD
-            / "EnsembleStats"
-            / "BCCAQv2+ANUSPLIN300_CCSM4_historical+rcp45_r1i1p1_1950-2100_tg_mean_YS.nc"
-        ),
-    ]
-    ns["precipitation_datasets"] = [
-        str(TD / "NRCANdaily" / "nrcan_canada_daily_pr_1990.nc"),
-        str(
-            TD
-            / "CanESM2_365day"
-            / "pr_day_CanESM2_rcp85_r1i1p1_na10kgrid_qm-moving-50bins-detrend_2095.nc"
+        xr.DataArray(
+            12 * np.random.random_sample(time.size) + 273,
+            coords={"time": time},
+            name="tas",
+            dims=("time",),
+            attrs={"units": "K"},
         ),
     ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -262,18 +262,18 @@ def ps_series():
 
 
 @pytest.fixture(autouse=True)
-def add_imports(doctest_namespace):
+def add_imports(xdoctest_namespace):
     """Add these imports into the doctests scope."""
-    ns = doctest_namespace
+    ns = xdoctest_namespace
     ns["np"] = np
     ns["xr"] = xr
     ns["xclim"] = xclim
 
 
 @pytest.fixture(autouse=True)
-def add_example_file_paths(doctest_namespace):
+def add_example_file_paths(xdoctest_namespace):
     """Add these datasets in the doctests scope."""
-    ns = doctest_namespace
+    ns = xdoctest_namespace
     ns["path_to_pr_file"] = str(TD / "NRCANdaily" / "nrcan_canada_daily_pr_1990.nc")
 
     ns["path_to_tasmax_file"] = str(
@@ -313,8 +313,12 @@ def add_example_file_paths(doctest_namespace):
         ),
     ]
 
+    ns["path_to_ensemble_file"] = str(
+        TD / "EnsembleReduce" / "TestEnsReduceCriteria.nc"
+    )
+
 
 @pytest.fixture(autouse=True)
-def add_example_dataarray(doctest_namespace, tas_series):
-    ns = doctest_namespace
+def add_example_dataarray(xdoctest_namespace, tas_series):
+    ns = xdoctest_namespace
     ns["tas"] = tas_series(np.random.rand(365) * 20 + 253.15)

--- a/tox.ini
+++ b/tox.ini
@@ -40,11 +40,12 @@ whitelist_externals =
 
 [testenv:doctests]
 deps =
+    pytest
     pylint
     xdoctest
 commands =
     pylint --rcfile=setup.cfg --exit-zero xclim
-    pytest --xdoctest xclim
+    pytest --rootdir tests/ --xdoctest xclim
     pytest --rootdir tests/ --doctest-modules xclim --doctest-glob="*.rst"
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,6 @@ deps =
 commands =
     pylint --rcfile=setup.cfg --exit-zero xclim
     pytest --rootdir tests/ --xdoctest xclim
-    pytest --rootdir tests/ --doctest-modules xclim --doctest-glob="*.rst"
 
 [testenv]
 setenv =

--- a/xclim/__init__.py
+++ b/xclim/__init__.py
@@ -6,4 +6,4 @@ from xclim.indicators import ICCLIM, anuclim, atmos, land, seaIce
 
 __author__ = """Travis Logan"""
 __email__ = "logan.travis@ouranos.ca"
-__version__ = "0.18.3-beta"
+__version__ = "0.18.4-beta"

--- a/xclim/core/calendar.py
+++ b/xclim/core/calendar.py
@@ -626,7 +626,9 @@ def time_bnds(group, freq):
     >>> from xclim.core.calendar import time_bnds
     >>> index = xr.cftime_range(start='2000-01-01', periods=3, freq='2QS', calendar='360_day')
     >>> time_bnds(index, '2Q')
-    ((cftime.Datetime360Day(2000, 1, 1, 0, 0, 0, 0), cftime.Datetime360Day(2000, 3, 30, 23, 59, 59, 999999)), (cftime.Datetime360Day(2000, 7, 1, 0, 0, 0, 0), cftime.Datetime360Day(2000, 9, 30, 23, 59, 59, 999999)), (cftime.Datetime360Day(2001, 1, 1, 0, 0, 0, 0), cftime.Datetime360Day(2001, 3, 30, 23, 59, 59, 999999)))
+    ((cftime.Datetime360Day(2000, 1, 1, 0, 0, 0, 0), cftime.Datetime360Day(2000, 3, 30, 23, 59, 59, 999999)),
+    (cftime.Datetime360Day(2000, 7, 1, 0, 0, 0, 0), cftime.Datetime360Day(2000, 9, 30, 23, 59, 59, 999999)),
+    (cftime.Datetime360Day(2001, 1, 1, 0, 0, 0, 0), cftime.Datetime360Day(2001, 3, 30, 23, 59, 59, 999999)))
     """
     if isinstance(group, CFTimeIndex):
         cfindex = group

--- a/xclim/core/calendar.py
+++ b/xclim/core/calendar.py
@@ -626,9 +626,7 @@ def time_bnds(group, freq):
     >>> from xclim.core.calendar import time_bnds
     >>> index = xr.cftime_range(start='2000-01-01', periods=3, freq='2QS', calendar='360_day')
     >>> time_bnds(index, '2Q')
-    ((cftime.Datetime360Day(2000-01-01 00:00:00), cftime.Datetime360Day(2000-03-30 23:59:59.999999)),
-    (cftime.Datetime360Day(2000-07-01 00:00:00), cftime.Datetime360Day(2000-09-30 23:59:59.999999)),
-    (cftime.Datetime360Day(2001-01-01 00:00:00), cftime.Datetime360Day(2001-03-30 23:59:59.999999)))
+    ((cftime.Datetime360Day(2000, 1, 1, 0, 0, 0, 0), cftime.Datetime360Day(2000, 3, 30, 23, 59, 59, 999999)), (cftime.Datetime360Day(2000, 7, 1, 0, 0, 0, 0), cftime.Datetime360Day(2000, 9, 30, 23, 59, 59, 999999)), (cftime.Datetime360Day(2001, 1, 1, 0, 0, 0, 0), cftime.Datetime360Day(2001, 3, 30, 23, 59, 59, 999999)))
     """
     if isinstance(group, CFTimeIndex):
         cfindex = group

--- a/xclim/core/calendar.py
+++ b/xclim/core/calendar.py
@@ -622,10 +622,10 @@ def time_bnds(group, freq):
 
     Examples
     --------
-    >>> import xarray as xr  # doctest: +SKIP
-    >>> from xclim.core.calendar import time_bnds  # doctest: +SKIP
-    >>> index = xr.cftime_range(start='2000-01-01', periods=3, freq='2QS', calendar='360_day')  # doctest: +SKIP
-    >>> time_bnds(index, '2Q')  # doctest: +SKIP
+    >>> import xarray as xr
+    >>> from xclim.core.calendar import time_bnds
+    >>> index = xr.cftime_range(start='2000-01-01', periods=3, freq='2QS', calendar='360_day')
+    >>> time_bnds(index, '2Q')
     ((cftime.Datetime360Day(2000-01-01 00:00:00), cftime.Datetime360Day(2000-03-30 23:59:59.999999)),
     (cftime.Datetime360Day(2000-07-01 00:00:00), cftime.Datetime360Day(2000-09-30 23:59:59.999999)),
     (cftime.Datetime360Day(2001-01-01 00:00:00), cftime.Datetime360Day(2001-03-30 23:59:59.999999)))

--- a/xclim/ensembles.py
+++ b/xclim/ensembles.py
@@ -2,7 +2,7 @@
 import logging
 import warnings
 from pathlib import Path
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import scipy.stats
@@ -75,15 +75,14 @@ def create_ensemble(
 
     Examples
     --------
-    >>> import glob  # doctest: +SKIP
-    >>> from xclim.ensembles import create_ensemble  # doctest: +SKIP
-    >>> ens = create_ensemble(temperature_datasets) #doctest: +SKIP
-    ...
-    # Using multifile datasets:
-    # Simulation 1 is a list of .nc files (e.g. separated by time)
+    >>> from xclim.ensembles import create_ensemble
+    >>> ens = create_ensemble(temperature_datasets)
+
+    Using multifile datasets:
+    Simulation 1 is a list of .nc files (e.g. separated by time)
     >>> datasets = glob.glob('/dir/*.nc')  # doctest: +SKIP
-    ...
-    # Simulation 2 is also a list of .nc files
+
+    Simulation 2 is also a list of .nc files
     >>> datasets.append(glob.glob('/dir2/*.nc'))  # doctest: +SKIP
     >>> ens = create_ensemble(datasets, mf_flag=True)  # doctest: +SKIP
     """
@@ -119,12 +118,13 @@ def ensemble_mean_std_max_min(ens: xr.Dataset) -> xr.Dataset:
 
     Examples
     --------
-    >>> from xclim.ensembles import create_ensemble, ensemble_mean_std_max_min  # doctest: +SKIP
+    >>> from xclim.ensembles import create_ensemble, ensemble_mean_std_max_min
+
     # Create ensemble dataset
-    >>> ens = create_ensemble(temperature_datasets)  # doctest: +SKIP
-    ...
+    >>> ens = create_ensemble(temperature_datasets)
+
     # Calculate ensemble statistics
-    >>> ens_mean_std = ensemble_mean_std_max_min(ens)  # doctest: +SKIP
+    >>> ens_mean_std = ensemble_mean_std_max_min(ens)
     """
     ds_out = xr.Dataset(attrs=ens.attrs)
     for v in ens.data_vars:
@@ -151,7 +151,7 @@ def ensemble_mean_std_max_min(ens: xr.Dataset) -> xr.Dataset:
 
 def ensemble_percentiles(
     ens: Union[xr.Dataset, xr.DataArray],
-    values: Tuple[int] = (10, 50, 90),
+    values: Sequence[int] = (10, 50, 90),
     keep_chunk_size: Optional[bool] = None,
     split: bool = True,
 ) -> xr.Dataset:
@@ -163,7 +163,7 @@ def ensemble_percentiles(
     ----------
     ens: Union[xr.Dataset, xr.DataArray]
       Ensemble dataset or dataarray (see xclim.ensembles.create_ensemble).
-    values : Tuple[int]
+    values : Tuple[int, int, int]
       Percentile values to calculate. Default: (10, 50, 90).
     keep_chunk_size : Optional[bool]
       For ensembles using dask arrays, all chunks along the 'realization' axis are merged.
@@ -182,18 +182,19 @@ def ensemble_percentiles(
 
     Examples
     --------
-    >>> from xclim.ensembles import create_ensemble, ensemble_percentiles  # doctest: +SKIP
+    >>> from xclim.ensembles import create_ensemble, ensemble_percentiles
+
     # Create ensemble dataset
-    >>> ens = create_ensemble(temperature_datasets)  # doctest: +SKIP
-    ...
+    >>> ens = create_ensemble(temperature_datasets)
+
     # Calculate default ensemble percentiles
-    >>> ens_percs = ensemble_percentiles(ens)  # doctest: +SKIP
-    ...
+    >>> ens_percs = ensemble_percentiles(ens)
+
     # Calculate non-default percentiles (25th and 75th)
-    >>> ens_percs = ensemble_percentiles(ens, values=(25, 50, 75))  # doctest: +SKIP
-    ...
+    >>> ens_percs = ensemble_percentiles(ens, values=(25, 50, 75))
+
     # If the original array has many small chunks, it might be more efficient to do:
-    >>> ens_percs = ensemble_percentiles(ens, keep_chunk_size=False)  # doctest: +SKIP
+    >>> ens_percs = ensemble_percentiles(ens, keep_chunk_size=False)
     """
     if isinstance(ens, xr.Dataset):
         out = xr.merge(
@@ -527,32 +528,31 @@ def kmeans_reduce_ensemble(
 
     Examples
     --------
-    >>> import xarray as xr  # doctest: +SKIP
-    >>> from xclim.ensembles import create_ensemble, kmeans_reduce_ensemble  # doctest: +SKIP
-    ...
+    >>> from xclim.ensembles import create_ensemble, kmeans_reduce_ensemble
+
     # Start with ensemble datasets for temperature and precipitation
-    >>> ensTas = create_ensemble(temperature_datasets)  # doctest: +SKIP
-    >>> ensPr = create_ensemble(precipitation_datasets)  # doctest: +SKIP
-    ...
+    >>> ensTas = create_ensemble(temperature_datasets)
+    >>> ensPr = create_ensemble(precipitation_datasets)
+
     # Calculate selection criteria -- Use annual climate change Δ fields between 2071-2100 and 1981-2010 normals
     # Total annual precipation
-    >>> HistPr = ensPr.pr.sel(time=slice('1981','2010')).sum(dim='time').mean(dim=['lat','lon'])  # doctest: +SKIP
-    >>> FutPr = ensPr.pr.sel(time=slice('2071','2100')).sum(dim='time').mean(dim=['lat','lon'])  # doctest: +SKIP
-    ...
-    # expressed in percent change
-    >>> dPr = 100*((FutPr / HistPr) - 1)  # doctest: +SKIP
-    ...
+    >>> HistPr = ensPr.pr.sel(time=slice('1981','2010')).sum(dim='time').mean(dim=['lat','lon'])
+    >>> FutPr = ensPr.pr.sel(time=slice('2071','2100')).sum(dim='time').mean(dim=['lat','lon'])
+
+    # Expressed in percent change
+    >>> dPr = 100*((FutPr / HistPr) - 1)
+
     # Average annual temperature
-    >>> HistTas = ensTas.tg_mean.sel(time=slice('1981','2010')).mean(dim=['time','lat','lon'])  # doctest: +SKIP
-    >>> FutTas = ensTas.tg_mean.sel(time=slice('2071','2100')).mean(dim=['time','lat','lon'])  # doctest: +SKIP
-    >>> dTas = FutTas - HistTas  # doctest: +SKIP
-    ...
+    >>> HistTas = ensTas.tg_mean.sel(time=slice('1981','2010')).mean(dim=['time','lat','lon'])
+    >>> FutTas = ensTas.tg_mean.sel(time=slice('2071','2100')).mean(dim=['time','lat','lon'])
+    >>> dTas = FutTas - HistTas
+
     # Create selection criteria xr.DataArray
-    >>> crit = xr.concat((dTas,dPr), dim='criteria')  # doctest: +SKIP
-    ...
+    >>> crit = xr.concat((dTas,dPr), dim='criteria')
+
     # Create clusters and select realization ids of reduced ensemble
-    >>> ids, cluster, fig_data = kmeans_reduce_ensemble(data=crit, method={'rsq_cutoff':0.9}, random_state=42, make_graph=False)  # doctest: +SKIP
-    >>> ids, cluster, fig_data = kmeans_reduce_ensemble(data=crit, method={'rsq_optimize':None}, random_state=42, make_graph=True)  # doctest: +SKIP
+    >>> ids, cluster, fig_data = kmeans_reduce_ensemble(data=crit, method={'rsq_cutoff':0.9}, random_state=42, make_graph=False)
+    >>> ids, cluster, fig_data = kmeans_reduce_ensemble(data=crit, method={'rsq_optimize':None}, random_state=42, make_graph=True)
     """
     if make_graph:
         fig_data = {}
@@ -718,11 +718,10 @@ def plot_rsqprofile(fig_data):
 
     Examples
     --------
-    >>> import xarray as xr  # doctest: +SKIP
-    >>> from xclim.ensembles import kmeans_reduce_ensemble, plot_rsqprofile  # doctest: +SKIP
-    >>> crit = xr.open_dataset(path_to_ensemble_file).data  # doctest: +SKIP
-    >>> ids, cluster, fig_data = kmeans_reduce_ensemble(data=crit, method={'rsq_cutoff':0.9}, random_state=42)  # doctest: +SKIP
-    >>> plot_rsqprofile(fig_data)  # doctest: +SKIP
+    >>> from xclim.ensembles import kmeans_reduce_ensemble, plot_rsqprofile
+    >>> crit = xr.open_dataset(path_to_ensemble_file).data
+    >>> ids, cluster, fig_data = kmeans_reduce_ensemble(data=crit, method={'rsq_cutoff':0.9}, random_state=42)
+    >>> plot_rsqprofile(fig_data)
     """
     rsq = fig_data["rsq"]
     n_sim = fig_data["realizations"]

--- a/xclim/indices/_anuclim.py
+++ b/xclim/indices/_anuclim.py
@@ -112,12 +112,11 @@ def temperature_seasonality(tas: xarray.DataArray):
     --------
     The following would compute for each grid cell of file `tas.day.nc` the annual temperature seasonality:
 
-    >>> import xarray as xr  # doctest: +SKIP
-    >>> import xclim.indices as xci  # doctest: +SKIP
-    >>> t = xr.open_dataset('tas.day.nc').tas   # doctest: +SKIP
-    >>> tday_seasonality = xci.temperature_seasonality(t)  # doctest: +SKIP
-    >>> t_weekly = xci.tg_mean(t, freq='7D')  # doctest: +SKIP
-    >>> tweek_seasonality = xci.temperature_seasonality(t_weekly)  # doctest: +SKIP
+    >>> import xclim.indices as xci
+    >>> t = xr.open_dataset(path_to_tas_file).tas
+    >>> tday_seasonality = xci.temperature_seasonality(t)
+    >>> t_weekly = xci.tg_mean(t, freq='7D')
+    >>> tweek_seasonality = xci.temperature_seasonality(t_weekly)
 
     Notes
     -----
@@ -160,14 +159,14 @@ def precip_seasonality(pr: xarray.DataArray,):
     --------
     The following would compute for each grid cell of file `pr.day.nc` the annual precipitation seasonality:
 
-    >>> import xarray as xr  # doctest: +SKIP
-    >>> import xclim.indices as xci  # doctest: +SKIP
-    >>> p = xr.open_dataset('pr.day.nc')  # doctest: +SKIP
-    >>> pday_seasonality = xci.precip_seasonality(p)  # doctest: +SKIP
-    >>> p_weekly = xci.precip_accumulation(p, freq='7D')  # doctest: +SKIP
+    >>> import xclim.indices as xci
+    >>> p = xr.open_dataset(path_to_pr_file).pr
+    >>> pday_seasonality = xci.precip_seasonality(p)
+    >>> p_weekly = xci.precip_accumulation(p, freq='7D')
+
     # Input units need to be a rate
-    >>> p_weekly.attrs['units'] = "mm/week"  # doctest: +SKIP
-    >>> pweek_seasonality = xci.precip_seasonality(p_weekly)  # doctest: +SKIP
+    >>> p_weekly.attrs['units'] = "mm/week"
+    >>> pweek_seasonality = xci.precip_seasonality(p_weekly)
 
     Notes
     -----
@@ -221,10 +220,9 @@ def tg_mean_warmcold_quarter(
     The following would compute for each grid cell of file `tas.day.nc` the annual temperature
     warmest quarter mean temperature:
 
-    >>> import xarray as xr  # doctest: +SKIP
-    >>> import xclim.indices as xci  # doctest: +SKIP
-    >>> t = xr.open_dataset('tas.day.nc')  # doctest: +SKIP
-    >>> t_warm_qrt = xci.tg_mean_warmest_quarter(tas=t.tas, op='warmest', input_freq='daily')  # doctest: +SKIP
+    >>> import xclim.indices as xci
+    >>> t = xr.open_dataset(path_to_tas_file)
+    >>> t_warm_qrt = xci.tg_mean_warmcold_quarter(tas=t.tas, op='warmest', input_freq='daily')
 
     Notes
     -----
@@ -317,10 +315,9 @@ def prcptot_wetdry_quarter(
     --------
     The following would compute for each grid cell of file `pr.day.nc` the annual wettest quarter total precipitation:
 
-    >>> import xarray as xr  # doctest: +SKIP
-    >>> from xclim.indices import prcptot_wetdry_quarter  # doctest: +SKIP
-    >>> p = xr.open_dataset('pr.day.nc')  # doctest: +SKIP
-    >>> pr_warm_qrt = prcptot_wetdry_quarter(pr=p.pr, op='wettest', input_freq='daily')  # doctest: +SKIP
+    >>> from xclim.indices import prcptot_wetdry_quarter
+    >>> p = xr.open_dataset(path_to_pr_file)
+    >>> pr_warm_qrt = prcptot_wetdry_quarter(pr=p.pr, op='wettest', input_freq='daily')
 
     Notes
     -----

--- a/xclim/indices/_multivariate.py
+++ b/xclim/indices/_multivariate.py
@@ -96,10 +96,13 @@ def cold_spell_duration_index(
 
     Examples
     --------
-    >>> from xclim.core.calendar import percentile_doy  # doctest: +SKIP
-    >>> from xclim.indices import cold_spell_duration_index  # doctest: +SKIP
-    >>> tn10 = percentile_doy(historical_tasmin, per=.1)  # doctest: +SKIP
-    >>> cold_spell_duration_index(reference_tasmin, tn10)  # doctest: +SKIP
+    >>> from xclim.core.calendar import percentile_doy # doctest: +SKIP
+    >>> from xclim.indices import cold_spell_duration_index # doctest: +SKIP
+
+    >>> historical_tasmin = xr.open_dataset(path_to_historical_tasmin_file).tasmin # doctest: +SKIP
+    >>> reference_tasmin = xr.open_dataset(path_to_tasmin_file).tasmin # doctest: +SKIP
+    >>> tn10 = percentile_doy(historical_tasmin, per=.1) # doctest: +SKIP
+    >>> cold_spell_duration_index(reference_tasmin, tn10) # doctest: +SKIP
     """
     tn10 = convert_units_to(tn10, tasmin)
 
@@ -408,6 +411,7 @@ def fire_weather_indexes(
     ----------
     Y. Wang, K.R. Anderson, and R.M. Suddaby, INFORMATION REPORT NOR-X-424, 2015.
     """
+    # TODO: start_up_mode and shut_down_mode not implemented.
     tas = convert_units_to(tas, "C")
     pr = convert_units_to(pr, "mm/day")
     ws = convert_units_to(ws, "km/h")
@@ -490,6 +494,7 @@ def drought_code(
     ----------
     Y. Wang, K.R. Anderson, and R.M. Suddaby, INFORMATION REPORT NOR-X-424, 2015.
     """
+    # TODO: shut_down_mode not implemented.
     tas = convert_units_to(tas, "C")
     pr = convert_units_to(pr, "mm/day")
     if snd is not None:
@@ -803,10 +808,9 @@ def precip_accumulation(
     The following would compute for each grid cell of file `pr_day.nc` the total
     precipitation at the seasonal frequency, ie DJF, MAM, JJA, SON, DJF, etc.:
 
-    >>> import xarray as xr  # doctest: +SKIP
-    >>> from xclim.indices import precip_accumulation  # doctest: +SKIP
-    >>> pr_day = xr.open_dataset('pr_day.nc').pr  # doctest: +SKIP
-    >>> prcp_tot_seasonal = precip_accumulation(pr_day, freq="QS-DEC")  # doctest: +SKIP
+    >>> from xclim.indices import precip_accumulation
+    >>> pr_day = xr.open_dataset(path_to_pr_file).pr
+    >>> prcp_tot_seasonal = precip_accumulation(pr_day, freq="QS-DEC")
     """
     if phase in ["liquid", "solid"]:
         frz = convert_units_to("0 degC", tas)
@@ -914,11 +918,10 @@ def days_over_precip_thresh(
 
     Examples
     --------
-    >>> import xarray as xr  # doctest: +SKIP
-    >>> from xclim.indices import days_over_precip_thresh  # doctest: +SKIP
-    >>> pr = xr.open_dataset(path_to_pr_file).pr  # doctest: +SKIP
-    >>> p75 = pr.quantile(.75, dim="time", keep_attrs=True)  # doctest: +SKIP
-    >>> r75p = days_over_precip_thresh(pr, p75)  # doctest: +SKIP
+    >>> from xclim.indices import days_over_precip_thresh
+    >>> pr = xr.open_dataset(path_to_pr_file).pr
+    >>> p75 = pr.quantile(.75, dim="time", keep_attrs=True)
+    >>> r75p = days_over_precip_thresh(pr, p75)
     """
     per = convert_units_to(per, pr)
     thresh = convert_units_to(thresh, pr)
@@ -1010,12 +1013,11 @@ def tg90p(
 
     Examples
     --------
-    >>> import xarray as xr  # doctest: +SKIP
-    >>> from xclim.core.calendar import percentile_doy  # doctest: +SKIP
-    >>> from xclim.indices import tg90p  # doctest: +SKIP
-    >>> tas = xr.open_dataset("temperature_data.nc").tas  # doctest: +SKIP
-    >>> t90 = percentile_doy(tas, per=0.9)  # doctest: +SKIP
-    >>> hot_days = tg90p(tas, t90)  # doctest: +SKIP
+    >>> from xclim.core.calendar import percentile_doy
+    >>> from xclim.indices import tg90p
+    >>> tas = xr.open_dataset(path_to_tas_file).tas
+    >>> t90 = percentile_doy(tas, per=0.9)
+    >>> hot_days = tg90p(tas, t90)
     """
     t90 = convert_units_to(t90, tas)
 
@@ -1056,12 +1058,11 @@ def tg10p(
 
     Examples
     --------
-    >>> import xarray as xr  # doctest: +SKIP
-    >>> from xclim.core.calendar import percentile_doy  # doctest: +SKIP
-    >>> from xclim.indices import tg10p  # doctest: +SKIP
-    >>> tas = xr.open_dataset("temperature_data.nc").tas  # doctest: +SKIP
-    >>> t10 = percentile_doy(tas, per=0.1)  # doctest: +SKIP
-    >>> cold_days = tg10p(tas, t10)  # doctest: +SKIP
+    >>> from xclim.core.calendar import percentile_doy
+    >>> from xclim.indices import tg10p
+    >>> tas = xr.open_dataset(path_to_tas_file).tas
+    >>> t10 = percentile_doy(tas, per=0.1)
+    >>> cold_days = tg10p(tas, t10)
     """
     t10 = convert_units_to(t10, tas)
 
@@ -1102,12 +1103,11 @@ def tn90p(
 
     Examples
     --------
-    >>> import xarray as xr  # doctest: +SKIP
-    >>> from xclim.core.calendar import percentile_doy  # doctest: +SKIP
-    >>> from xclim.indices import tn90p  # doctest: +SKIP
-    >>> tas = xr.open_dataset("temperature_data.nc").tas  # doctest: +SKIP
-    >>> t90 = percentile_doy(tas, per=0.9)  # doctest: +SKIP
-    >>> hot_days = tn90p(tas, t90)  # doctest: +SKIP
+    >>> from xclim.core.calendar import percentile_doy
+    >>> from xclim.indices import tn90p
+    >>> tas = xr.open_dataset(path_to_tas_file).tas
+    >>> t90 = percentile_doy(tas, per=0.9)
+    >>> hot_days = tn90p(tas, t90)
     """
     t90 = convert_units_to(t90, tasmin)
 
@@ -1148,12 +1148,11 @@ def tn10p(
 
     Examples
     --------
-    >>> import xarray as xr  # doctest: +SKIP
-    >>> from xclim.core.calendar import percentile_doy  # doctest: +SKIP
-    >>> from xclim.indices import tn10p  # doctest: +SKIP
-    >>> tas = xr.open_dataset("temperature_data.nc").tas  # doctest: +SKIP
-    >>> t10 = percentile_doy(tas, per=0.1)  # doctest: +SKIP
-    >>> cold_days = tn10p(tas, t10)  # doctest: +SKIP
+    >>> from xclim.core.calendar import percentile_doy
+    >>> from xclim.indices import tn10p
+    >>> tas = xr.open_dataset(path_to_tas_file).tas
+    >>> t10 = percentile_doy(tas, per=0.1)
+    >>> cold_days = tn10p(tas, t10)
     """
     t10 = convert_units_to(t10, tasmin)
 
@@ -1194,12 +1193,11 @@ def tx90p(
 
     Examples
     --------
-    >>> import xarray as xr  # doctest: +SKIP
-    >>> from xclim.core.calendar import percentile_doy  # doctest: +SKIP
-    >>> from xclim.indices import tx90p  # doctest: +SKIP
-    >>> tas = xr.open_dataset("temperature_data.nc").tas  # doctest: +SKIP
-    >>> t90 = percentile_doy(tas, per=0.9)  # doctest: +SKIP
-    >>> hot_days = tx90p(tas, t90)  # doctest: +SKIP
+    >>> from xclim.core.calendar import percentile_doy
+    >>> from xclim.indices import tx90p
+    >>> tas = xr.open_dataset(path_to_tas_file).tas
+    >>> t90 = percentile_doy(tas, per=0.9)
+    >>> hot_days = tx90p(tas, t90)
     """
     t90 = convert_units_to(t90, tasmax)
 
@@ -1240,12 +1238,11 @@ def tx10p(
 
     Examples
     --------
-    >>> import xarray as xr  # doctest: +SKIP
-    >>> from xclim.core.calendar import percentile_doy  # doctest: +SKIP
-    >>> from xclim.indices import tx10p  # doctest: +SKIP
-    >>> tas = xr.open_dataset("temperature_data.nc").tas  # doctest: +SKIP
-    >>> t10 = percentile_doy(tas, per=0.1)  # doctest: +SKIP
-    >>> cold_days = tx10p(tas, t10)  # doctest: +SKIP
+    >>> from xclim.core.calendar import percentile_doy
+    >>> from xclim.indices import tx10p
+    >>> tas = xr.open_dataset(path_to_tas_file).tas
+    >>> t10 = percentile_doy(tas, per=0.1)
+    >>> cold_days = tx10p(tas, t10)
     """
     t10 = convert_units_to(t10, tasmax)
 

--- a/xclim/indices/_simple.py
+++ b/xclim/indices/_simple.py
@@ -93,10 +93,9 @@ def tg_mean(tas: xarray.DataArray, freq: str = "YS"):
     The following would compute for each grid cell of file `tas.day.nc` the mean temperature
     at the seasonal frequency, ie DJF, MAM, JJA, SON, DJF, etc.:
 
-    >>> import xarray as xr  # doctest: +SKIP
-    >>> from xclim.indices import tg_mean  # doctest: +SKIP
-    >>> t = xr.open_dataset(path_to_tas_file).tas  # doctest: +SKIP
-    >>> tg = tg_mean(t, freq="QS-DEC")  # doctest: +SKIP
+    >>> from xclim.indices import tg_mean
+    >>> t = xr.open_dataset(path_to_tas_file).tas
+    >>> tg = tg_mean(t, freq="QS-DEC")
     """
     arr = tas.resample(time=freq) if freq else tas
     return arr.mean(dim="time", keep_attrs=True)
@@ -502,12 +501,12 @@ def max_1day_precipitation_amount(pr: xarray.DataArray, freq: str = "YS"):
 
     Examples
     --------
-    >>> import xarray as xr  # doctest: +SKIP
-    >>> from xclim.indices import max_1day_precipitation_amount  # doctest: +SKIP
+    >>> from xclim.indices import max_1day_precipitation_amount
+
     # The following would compute for each grid cell the highest 1-day total
     # at an annual frequency:
-    >>> pr = xr.open_dataset(path_to_pr_file).pr  # doctest: +SKIP
-    >>> rx1day = max_1day_precipitation_amount(pr, freq="YS")  # doctest: +SKIP
+    >>> pr = xr.open_dataset(path_to_pr_file).pr
+    >>> rx1day = max_1day_precipitation_amount(pr, freq="YS")
     """
     out = pr.resample(time=freq).max(dim="time", keep_attrs=True)
     return convert_units_to(out, "mm/day", "hydro")
@@ -536,12 +535,12 @@ def max_n_day_precipitation_amount(pr, window: int = 1, freq: str = "YS"):
 
     Examples
     --------
-    >>> import xarray as xr  # doctest: +SKIP
-    >>> from xclim.indices import max_n_day_precipitation_amount  # doctest: +SKIP
+    >>> from xclim.indices import max_n_day_precipitation_amount
+
     # The following would compute for each grid cell the highest 5-day total precipitation
     #at an annual frequency:
-    >>> pr = xr.open_dataset(path_to_pr_file).pr  # doctest: +SKIP
-    >>> out = max_n_day_precipitation_amount(pr, window=5, freq="YS")  # doctest: +SKIP
+    >>> pr = xr.open_dataset(path_to_pr_file).pr
+    >>> out = max_n_day_precipitation_amount(pr, window=5, freq="YS")
     """
     # Rolling sum of the values
     arr = pr.rolling(time=window).sum(allow_lazy=True, skipna=False)

--- a/xclim/indices/_threshold.py
+++ b/xclim/indices/_threshold.py
@@ -125,10 +125,9 @@ def daily_pr_intensity(pr, thresh: str = "1 mm/day", freq: str = "YS"):
     precipitation fallen over days with precipitation >= 5 mm at seasonal
     frequency, ie DJF, MAM, JJA, SON, DJF, etc.:
 
-    >>> import xarray as xr  # doctest: +SKIP
-    >>> from xclim.indices import daily_pr_intensity  # doctest: +SKIP
-    >>> pr = xr.open_dataset(path_to_pr_file).pr  # doctest: +SKIP
-    >>> daily_int = daily_pr_intensity(pr, thresh='5 mm/day', freq="QS-DEC")  # doctest: +SKIP
+    >>> from xclim.indices import daily_pr_intensity
+    >>> pr = xr.open_dataset(path_to_pr_file).pr
+    >>> daily_int = daily_pr_intensity(pr, thresh='5 mm/day', freq="QS-DEC")
     """
     t = convert_units_to(thresh, pr, "hydro")
 
@@ -441,13 +440,14 @@ def growing_season_length(
 
     Examples
     --------
-    >>> import xarray as xr  # doctest: +SKIP
-    >>> from xclim.indices import growing_season_length  # doctest: +SKIP
-    >>> tas = xr.open_dataset("tas.nc").tas  # doctest: +SKIP
+    >>> from xclim.indices import growing_season_length
+    >>> tas = xr.open_dataset(path_to_tas_file).tas
+
     # For the Northern Hemisphere:
-    >>> gsl_nh = growing_season_length(tas, mid_date='07-01', freq='AS-Jan')  # doctest: +SKIP
+    >>> gsl_nh = growing_season_length(tas, mid_date='07-01', freq='AS')
+
     # If working in the Southern Hemisphere, one can use:
-    >>> gsl_sh = growing_season_length(tas, mid_date='01-01', freq='AS-Jul')  # doctest: +SKIP
+    >>> gsl_sh = growing_season_length(tas, mid_date='01-01', freq='AS-JUL')
     """
     thresh = convert_units_to(thresh, tas)
     cond = tas >= thresh
@@ -894,10 +894,9 @@ def wetdays(pr: xarray.DataArray, thresh: str = "1.0 mm/day", freq: str = "YS"):
     The following would compute for each grid cell of file `pr.day.nc` the number days
     with precipitation over 5 mm at the seasonal frequency, ie DJF, MAM, JJA, SON, DJF, etc.:
 
-    >>> import xarray as xr  # doctest: +SKIP
-    >>> from xclim.indices import wetdays  # doctest: +SKIP
-    >>> pr = xr.open_dataset('pr.day.nc').pr  # doctest: +SKIP
-    >>> wd = wetdays(pr, pr_min=5., freq="QS-DEC")  # doctest: +SKIP
+    >>> from xclim.indices import wetdays
+    >>> pr = xr.open_dataset(path_to_pr_file).pr
+    >>> wd = wetdays(pr, thresh="5 mm/day", freq="QS-DEC")
     """
     thresh = convert_units_to(thresh, pr, "hydro")
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #506 
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [x] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->

This PR re-enables the doctests that were previously skipped with #507. Minor updates to API calls have been made in order for examples to be synonymous with functions (_the reason for doctests_, one could say). With these changes, all `Examples` in the library are called and evaluated. 

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->

No. `xdoctests` was already a required testing dependency and functional codes have not been touched.

* **Other information**:

Two tests are presently being troublesome:
- `tests/indices/_multivariate.py::cold_spell_duration_index`, as written, is hanging (this could be due to the need for more bunk tasmin data).
- `tests/ensembles.py::kmeans_reduce_ensemble` is giving some esoteric TypeError traceback that I can't make sense of. 
- `tests/subset.py` are all being skipped, as this module is being deprecated very soon.