### PR TITLE
Update black in pre-commit hooks, reformat code base, remove python-pandoc

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     -   id: pyupgrade
         language_version: python3
 -   repo: https://github.com/kynan/nbstripout
-    rev: 0.3.7
+    rev: 0.3.9
     hooks:
     -   id: nbstripout
         language_version: python3
@@ -25,7 +25,7 @@ repos:
     -   id: debug-statements
         language_version: python3
 -   repo: https://github.com/ambv/black
-    rev: 19.10b0
+    rev: 20.8b1
     hooks:
     -   id: black
         language_version: python3
@@ -42,13 +42,13 @@ repos:
 #    -   id: autopep8
 #        args: ['--global-config=setup.cfg','--in-place']
 -   repo: https://github.com/timothycrosley/isort
-    rev: 5.2.2
+    rev: 5.4.2
     hooks:
     -   id: isort
         language_version: python3
         args: ['--profile', 'black']
 -   repo: https://github.com/pycqa/pydocstyle
-    rev: 5.0.2
+    rev: 5.1.0
     hooks:
     -   id: pydocstyle
         args: ['--convention=numpy', '--match="(?!test_).*\.py"']

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,8 @@ Breaking changes
 ~~~~~~~~~~~~~~~~
 * `xclim.subset` has been deprecated and now relies on `clisops` to perform specialized spatio-temporal subsetting.
   Install with `pip install xclim[gis]` in order to retain the same functionality.
+* The python library `pandoc` is no longer listed as a docs build requirement. Documentation still requires a current
+  version of `pandoc` binaries installed at system-level.
 
 New features and enhancements
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -26,6 +26,7 @@ Nothing yet.
 Internal changes
 ~~~~~~~~~~~~~~~~
 * `xclim.subset` now attempts to load and expose the functions of `clisops.core.subset`. This is an API workaround preserving backwards compatibility.
+* Code styling now conforms to the latest release of black (v0.20.8).
 
 
 0.19.0 (2020-08-18)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.19.2-beta
+current_version = 0.19.3-beta
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+).(?P<patch>\d+)(\-(?P<release>[a-z]+))?

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ docs_requirements = [
     "sphinx",
     "sphinx-rtd-theme",
     "nbsphinx",
-    "pandoc",
     "ipython",
     "ipykernel",
     "jupyter_client",

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ URL = "https://github.com/Ouranosinc/xclim"
 AUTHOR = "Travis Logan"
 AUTHOR_EMAIL = "logan.travis@ouranos.ca"
 REQUIRES_PYTHON = ">=3.6.0"
-VERSION = "0.19.2-beta"
+VERSION = "0.19.3-beta"
 LICENSE = "Apache Software License 2.0"
 
 with open("README.rst") as readme_file:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -210,7 +210,10 @@ def rh_series():
             coords=[coords],
             dims="time",
             name="rh",
-            attrs={"standard_name": "relative humidity", "units": "%",},
+            attrs={
+                "standard_name": "relative humidity",
+                "units": "%",
+            },
         )
 
     return _rh_series
@@ -225,7 +228,10 @@ def ws_series():
             coords=[coords],
             dims="time",
             name="ws",
-            attrs={"standard_name": "wind speed", "units": "km h-1",},
+            attrs={
+                "standard_name": "wind speed",
+                "units": "km h-1",
+            },
         )
 
     return _ws_series
@@ -240,7 +246,10 @@ def huss_series():
             coords=[coords],
             dims="time",
             name="huss",
-            attrs={"standard_name": "specific_humidity", "units": "",},
+            attrs={
+                "standard_name": "specific_humidity",
+                "units": "",
+            },
         )
 
     return _huss_series

--- a/tests/test_atmos.py
+++ b/tests/test_atmos.py
@@ -41,7 +41,9 @@ def test_saturation_vapor_pressure(tas_series):
     tas = tas_series(np.array([-20, -10, -1, 10, 20, 25, 30, 40, 60]) + K2C)
     e_sat_exp = [103, 260, 563, 1228, 2339, 3169, 4247, 7385, 19947]
     e_sat = atmos.saturation_vapor_pressure(
-        tas=tas, method="sonntag90", ice_thresh="0 degC",
+        tas=tas,
+        method="sonntag90",
+        ice_thresh="0 degC",
     )
     np.testing.assert_allclose(e_sat, e_sat_exp, atol=0.5, rtol=0.005)
     assert e_sat.name == "e_sat"
@@ -54,7 +56,11 @@ def test_relative_humidity(tas_series, rh_series, huss_series, ps_series):
     huss = huss_series([0.003, 0.001] + [0.005] * 7)
 
     rh = atmos.relative_humidity(
-        tas=tas, huss=huss, ps=ps, method="sonntag90", ice_thresh="0 degC",
+        tas=tas,
+        huss=huss,
+        ps=ps,
+        method="sonntag90",
+        ice_thresh="0 degC",
     )
     np.testing.assert_allclose(rh, rh_exp, atol=0.5, rtol=0.005)
     assert rh.name == "rh"
@@ -69,7 +75,11 @@ def test_specific_humidity(tas_series, rh_series, huss_series, ps_series):
     )
 
     huss = atmos.specific_humidity(
-        tas=tas, rh=rh, ps=ps, method="sonntag90", ice_thresh="0 degC",
+        tas=tas,
+        rh=rh,
+        ps=ps,
+        method="sonntag90",
+        ice_thresh="0 degC",
     )
     np.testing.assert_allclose(huss, huss_exp, atol=1e-4, rtol=0.05)
     assert huss.name == "huss"

--- a/tests/test_fwi.py
+++ b/tests/test_fwi.py
@@ -156,13 +156,22 @@ def test_fire_weather_ufunc_errors(tas_series, pr_series, rh_series, ws_series):
     # Test invalid combination
     with pytest.raises(TypeError):
         fire_weather_ufunc(
-            tas=tas, pr=pr, rh=rh, ws=ws, lat=lat, dc0=DC0, indexes=["DC", "ISI"],
+            tas=tas,
+            pr=pr,
+            rh=rh,
+            ws=ws,
+            lat=lat,
+            dc0=DC0,
+            indexes=["DC", "ISI"],
         )
 
     # Test missing arguments
     with pytest.raises(TypeError):
         fire_weather_ufunc(
-            tas=tas, pr=pr, dc0=DC0, indexes=["DC"],  # lat=lat,
+            tas=tas,
+            pr=pr,
+            dc0=DC0,
+            indexes=["DC"],  # lat=lat,
         )
 
     with pytest.raises(TypeError):
@@ -190,7 +199,12 @@ def test_fire_weather_ufunc_errors(tas_series, pr_series, rh_series, ws_series):
 
     # Test output is complete
     out = fire_weather_ufunc(
-        tas=tas, pr=pr, lat=lat, dc0=DC0, indexes=["DC"], start_date="2017-03-03",
+        tas=tas,
+        pr=pr,
+        lat=lat,
+        dc0=DC0,
+        indexes=["DC"],
+        start_date="2017-03-03",
     )
 
     assert len(out.keys()) == 1

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -1533,7 +1533,9 @@ def test_saturation_vapor_pressure(tas_series, method, ice_thresh, exp0):
     e_sat_exp = exp0 + [1228, 2339, 3169, 4247, 7385, 19947]
 
     e_sat = xci.saturation_vapor_pressure(
-        tas=tas, method=method, ice_thresh=ice_thresh,
+        tas=tas,
+        method=method,
+        ice_thresh=ice_thresh,
     )
     np.testing.assert_allclose(e_sat, e_sat_exp, atol=0.5, rtol=0.005)
 

--- a/tests/test_run_length.py
+++ b/tests/test_run_length.py
@@ -79,7 +79,12 @@ class TestLongestRun:
 
         # n-dim version versus ufunc
         da3d = xr.open_dataset(self.nc_pr).pr[:, 40:50, 50:68] * 0
-        da3d[0:10,] = da3d[0:10,] + 1
+        da3d[0:10,] = (
+            da3d[
+                0:10,
+            ]
+            + 1
+        )
         da3d = da3d == 1
         lt_orig = da3d.resample(time="M").map(rl.longest_run_ufunc)
         # override 'auto' usage of ufunc for small number of gridpoints
@@ -102,7 +107,12 @@ class TestLongestRun:
 
         # n-dim version versus ufunc
         da3d = xr.open_dataset(self.nc_pr).pr[:, 40:50, 50:68] * 0
-        da3d[-10:,] = da3d[-10:,] + 1
+        da3d[-10:,] = (
+            da3d[
+                -10:,
+            ]
+            + 1
+        )
         da3d = da3d == 1
         lt_orig = da3d.resample(time="M").map(rl.longest_run_ufunc)
         lt_Ndim = da3d.resample(time="M").map(
@@ -144,7 +154,12 @@ class TestLongestRun:
 
         # n-dim version versus ufunc
         da3d = xr.open_dataset(self.nc_pr).pr[:, 40:50, 50:68] * 0 + 1
-        da3d[35,] = da3d[35,] + 1
+        da3d[35,] = (
+            da3d[
+                35,
+            ]
+            + 1
+        )
         da3d = da3d == 1
         lt_orig = da3d.resample(time="M").map(rl.longest_run_ufunc)
         lt_Ndim = da3d.resample(time="M").map(
@@ -269,7 +284,12 @@ class TestRunsWithDates:
         if use_dask:
             runs = runs.chunk({"time": 10, "dim0": 1})
 
-        out = rl.run_length_with_date(runs, window=1, dim="time", date=date,)
+        out = rl.run_length_with_date(
+            runs,
+            window=1,
+            dim="time",
+            date=date,
+        )
         np.testing.assert_array_equal(np.mean(out.load()), expected)
 
     @pytest.mark.parametrize(

--- a/tests/test_run_length.py
+++ b/tests/test_run_length.py
@@ -79,12 +79,7 @@ class TestLongestRun:
 
         # n-dim version versus ufunc
         da3d = xr.open_dataset(self.nc_pr).pr[:, 40:50, 50:68] * 0
-        da3d[0:10,] = (
-            da3d[
-                0:10,
-            ]
-            + 1
-        )
+        da3d[0:10] = da3d[0:10] + 1
         da3d = da3d == 1
         lt_orig = da3d.resample(time="M").map(rl.longest_run_ufunc)
         # override 'auto' usage of ufunc for small number of gridpoints
@@ -107,12 +102,7 @@ class TestLongestRun:
 
         # n-dim version versus ufunc
         da3d = xr.open_dataset(self.nc_pr).pr[:, 40:50, 50:68] * 0
-        da3d[-10:,] = (
-            da3d[
-                -10:,
-            ]
-            + 1
-        )
+        da3d[-10:] = da3d[-10:] + 1
         da3d = da3d == 1
         lt_orig = da3d.resample(time="M").map(rl.longest_run_ufunc)
         lt_Ndim = da3d.resample(time="M").map(
@@ -154,12 +144,7 @@ class TestLongestRun:
 
         # n-dim version versus ufunc
         da3d = xr.open_dataset(self.nc_pr).pr[:, 40:50, 50:68] * 0 + 1
-        da3d[35,] = (
-            da3d[
-                35,
-            ]
-            + 1
-        )
+        da3d[35] = da3d[35] + 1
         da3d = da3d == 1
         lt_orig = da3d.resample(time="M").map(rl.longest_run_ufunc)
         lt_Ndim = da3d.resample(time="M").map(

--- a/tests/test_sdba/conftest.py
+++ b/tests/test_sdba/conftest.py
@@ -80,7 +80,10 @@ def make_qm():
             a = a[0]
 
         return xr.DataArray(
-            a, dims=dims, coords=coords, attrs={"group": group, "window": 1},
+            a,
+            dims=dims,
+            coords=coords,
+            attrs={"group": group, "window": 1},
         )
 
     return _make_qm

--- a/tests/test_sdba/test_adjustment.py
+++ b/tests/test_sdba/test_adjustment.py
@@ -113,7 +113,11 @@ class TestDQM:
         hist = sim = series(x, name)
         ref = series(y, name)
 
-        DQM = DetrendedQuantileMapping(kind=kind, group="time", nquantiles=50,)
+        DQM = DetrendedQuantileMapping(
+            kind=kind,
+            group="time",
+            nquantiles=50,
+        )
         DQM.train(ref, hist)
         p = DQM.adjust(sim, interp="linear")
 
@@ -227,7 +231,11 @@ class TestQDM:
         hist = sim = series(x, name)
         ref = series(y, name)
 
-        QDM = QuantileDeltaMapping(kind=kind, group="time", nquantiles=10,)
+        QDM = QuantileDeltaMapping(
+            kind=kind,
+            group="time",
+            nquantiles=10,
+        )
         QDM.train(ref, hist)
         p = QDM.adjust(sim, interp="linear")
 
@@ -342,7 +350,11 @@ class TestQM:
         # Test train
         hist = sim = series(x, name)
         ref = series(y, name)
-        QM = EmpiricalQuantileMapping(kind=kind, group="time", nquantiles=50,)
+        QM = EmpiricalQuantileMapping(
+            kind=kind,
+            group="time",
+            nquantiles=50,
+        )
         QM.train(ref, hist)
         p = QM.adjust(sim, interp="linear")
 

--- a/tests/test_sdba/utils.py
+++ b/tests/test_sdba/utils.py
@@ -32,7 +32,11 @@ def series(values, name, start="2000-01-01"):
         }
 
     return xr.DataArray(
-        values, coords=coords, dims=list(coords.keys()), name=name, attrs=attrs,
+        values,
+        coords=coords,
+        dims=list(coords.keys()),
+        name=name,
+        attrs=attrs,
     )
 
 

--- a/tests/test_subset.py
+++ b/tests/test_subset.py
@@ -95,7 +95,9 @@ class TestSubsetTime:
 
         with pytest.warns(None) as record:
             subset.subset_time(
-                da, start_date=2050, end_date=2055,
+                da,
+                start_date=2050,
+                end_date=2055,
             )
         assert (
             'start_date and end_date require dates in (type: str) using formats of "%Y", "%Y-%m" or "%Y-%m-%d".'

--- a/tox.ini
+++ b/tox.ini
@@ -26,8 +26,6 @@ deps =
     black
     pydocstyle
 commands =
-    ; Error codes D205 and D400 will be properly ignored in pydocstyle>=5.0.3. Remove this pip install then.
-    pip install git+https://github.com/PyCQA/pydocstyle.git@master#egg=pydocstyle
     pydocstyle --convention=numpy xclim
     flake8 xclim tests
     black --check --target-version py36 xclim tests
@@ -46,6 +44,7 @@ deps =
     pylint
     pytest
     xdoctest
+setenv = PYTEST_ADDOPTS = "--color=yes"
 commands =
     pylint --rcfile=setup.cfg --exit-zero xclim
     pytest --rootdir tests/ --xdoctest xclim
@@ -56,6 +55,7 @@ extras = dev
 [testenv]
 setenv =
     HOME = {envtmpdir}
+    PYTEST_ADDOPTS = "--color=yes"
     PYTHONPATH = {toxinidir}
     COV_CORE_SOURCE=
 passenv = CI TRAVIS TRAVIS_* LD_LIBRARY_PATH
@@ -77,5 +77,5 @@ commands =
     py36-bottleneck: pip install hypothesis
     py36-bottleneck: pip install git+https://github.com/pydata/bottleneck.git@master#egg=bottleneck
     py36-nosubset-lm3: pip install git+https://github.com/OpenHydrology/lmoments3.git@develop#egg=lmoments3
-    py.test --cov xclim --basetemp={envtmpdir}
+    pytest --cov xclim --basetemp={envtmpdir}
     - coveralls

--- a/xclim/__init__.py
+++ b/xclim/__init__.py
@@ -6,4 +6,4 @@ from xclim.indicators import ICCLIM, anuclim, atmos, land, seaIce
 
 __author__ = """Travis Logan"""
 __email__ = "logan.travis@ouranos.ca"
-__version__ = "0.19.2-beta"
+__version__ = "0.19.3-beta"

--- a/xclim/core/calendar.py
+++ b/xclim/core/calendar.py
@@ -218,7 +218,9 @@ def convert_calendar(
 
 
 def interp_calendar(
-    source: Union[xr.DataArray, xr.Dataset], target: xr.DataArray, dim: str = "time",
+    source: Union[xr.DataArray, xr.Dataset],
+    target: xr.DataArray,
+    dim: str = "time",
 ) -> xr.DataArray:
     """Interpolates a DataArray/Dataset to another calendar based on decimal year measure.
 

--- a/xclim/core/formatting.py
+++ b/xclim/core/formatting.py
@@ -19,7 +19,9 @@ class AttrFormatter(string.Formatter):
     """
 
     def __init__(
-        self, mapping: Mapping[str, Sequence[str]], modifiers: Sequence[str],
+        self,
+        mapping: Mapping[str, Sequence[str]],
+        modifiers: Sequence[str],
     ):
         """Initialize the formatter.
 

--- a/xclim/core/indicator.py
+++ b/xclim/core/indicator.py
@@ -480,7 +480,10 @@ class Indicator:
 
         def _translate(var_id, var_attrs, names):
             attrs = get_local_attrs(
-                var_id, locale, names=names, append_locale_name=False,
+                var_id,
+                locale,
+                names=names,
+                append_locale_name=False,
             )
             if fill_missing:
                 for name in names:

--- a/xclim/ensembles.py
+++ b/xclim/ensembles.py
@@ -331,7 +331,9 @@ def _ens_align_datasets(
 
             cal = get_calendar(time)
             ds = convert_calendar(
-                ds, calendar, align_on="date" if "360_day" in [cal, calendar] else None,
+                ds,
+                calendar,
+                align_on="date" if "360_day" in [cal, calendar] else None,
             )
 
         ds_all.append(ds)

--- a/xclim/indicators/atmos/_conversion.py
+++ b/xclim/indicators/atmos/_conversion.py
@@ -79,7 +79,10 @@ relative_humidity_from_dewpoint = Converter(
         else ""
     ),
     compute=wrapped_partial(
-        indices.relative_humidity, huss=None, ps=None, invalid_values="mask",
+        indices.relative_humidity,
+        huss=None,
+        ps=None,
+        invalid_values="mask",
     ),
 )
 

--- a/xclim/indices/_anuclim.py
+++ b/xclim/indices/_anuclim.py
@@ -138,7 +138,9 @@ def temperature_seasonality(tas: xarray.DataArray):
 
 
 @declare_units("percent", pr="[precipitation]")
-def precip_seasonality(pr: xarray.DataArray,):
+def precip_seasonality(
+    pr: xarray.DataArray,
+):
     r"""ANUCLIM Precipitation Seasonality (C of V).
 
     The annual precipitation Coefficient of Variation (C of V) expressed in percent. Calculated as the standard deviation
@@ -191,7 +193,10 @@ def precip_seasonality(pr: xarray.DataArray,):
 
 @declare_units("[temperature]", tas="[temperature]")
 def tg_mean_warmcold_quarter(
-    tas: xarray.DataArray, op: str = None, input_freq: str = None, freq: str = "YS",
+    tas: xarray.DataArray,
+    op: str = None,
+    input_freq: str = None,
+    freq: str = "YS",
 ):
     r"""ANUCLIM Mean temperature of warmest/coldest quarter.
 

--- a/xclim/indices/_conversion.py
+++ b/xclim/indices/_conversion.py
@@ -377,7 +377,11 @@ def relative_humidity(
 
 
 @declare_units(
-    "", tas="[temperature]", rh="[]", ps="[pressure]", ice_thresh="[temperature]",
+    "",
+    tas="[temperature]",
+    rh="[]",
+    ps="[pressure]",
+    ice_thresh="[temperature]",
 )
 def specific_humidity(
     tas: xr.DataArray,

--- a/xclim/indices/_threshold.py
+++ b/xclim/indices/_threshold.py
@@ -453,7 +453,10 @@ def growing_season_length(
     cond = tas >= thresh
 
     return cond.resample(time=freq).map(
-        rl.run_length_with_date, window=window, date=mid_date, dim="time",
+        rl.run_length_with_date,
+        window=window,
+        date=mid_date,
+        dim="time",
     )
 
 
@@ -616,7 +619,9 @@ def heating_degree_days(
 
 
 @declare_units(
-    "days", tasmax="[temperature]", thresh_tasmax="[temperature]",
+    "days",
+    tasmax="[temperature]",
+    thresh_tasmax="[temperature]",
 )
 def hot_spell_max_length(
     tasmax: xarray.DataArray,
@@ -676,7 +681,9 @@ def hot_spell_max_length(
 
 
 @declare_units(
-    "", tasmax="[temperature]", thresh_tasmax="[temperature]",
+    "",
+    tasmax="[temperature]",
+    thresh_tasmax="[temperature]",
 )
 def hot_spell_frequency(
     tasmax: xarray.DataArray,
@@ -1107,7 +1114,9 @@ def sea_ice_extent(sic, area, thresh: str = "15 pct"):
 
 @declare_units("days", tasmin="[temperature]", thresh="[temperature]")
 def tropical_nights(
-    tasmin: xarray.DataArray, thresh: str = "20.0 degC", freq: str = "YS",
+    tasmin: xarray.DataArray,
+    thresh: str = "20.0 degC",
+    freq: str = "YS",
 ):
     r"""Tropical nights.
 

--- a/xclim/indices/fwi.py
+++ b/xclim/indices/fwi.py
@@ -673,7 +673,8 @@ def fire_weather_ufunc(
     if "ISI" in indexes:
         indexes.update({"FFMC"})
     indexes = sorted(
-        list(indexes), key=["DC", "DMC", "FFMC", "ISI", "BUI", "FWI", "DSR"].index,
+        list(indexes),
+        key=["DC", "DMC", "FFMC", "ISI", "BUI", "FWI", "DSR"].index,
     )
 
     if start_date is not None:

--- a/xclim/indices/run_length.py
+++ b/xclim/indices/run_length.py
@@ -311,7 +311,10 @@ def last_run(
 
 
 def run_length_with_date(
-    da: xr.DataArray, window: int, date: str = "07-01", dim: str = "time",
+    da: xr.DataArray,
+    window: int,
+    date: str = "07-01",
+    dim: str = "time",
 ) -> xr.DataArray:
     """Return the length of the longest consecutive run of True values found to be semi-continuous before and after a given date.
 
@@ -342,7 +345,9 @@ def run_length_with_date(
         return xr.full_like(da.isel(time=0), np.nan, float).drop_vars("time")
 
     end = first_run(
-        (~da).where(da.time >= da.time[mid_index][0]), window=window, dim=dim,
+        (~da).where(da.time >= da.time[mid_index][0]),
+        window=window,
+        dim=dim,
     )
     beg = first_run(da, window=window, dim=dim)
     sl = end - beg
@@ -439,7 +444,10 @@ def first_run_after_date(
         return xr.full_like(da.isel(time=0), np.nan, float).drop_vars("time")
 
     return first_run(
-        da.where(da.time >= da.time[mid_idx][0]), window=window, dim=dim, coord=coord,
+        da.where(da.time >= da.time[mid_idx][0]),
+        window=window,
+        dim=dim,
+        coord=coord,
     )
 
 
@@ -680,7 +688,11 @@ def longest_run_ufunc(x: Sequence[bool]) -> xr.apply_ufunc:
     )
 
 
-def first_run_ufunc(x: xr.DataArray, window: int, dim: str = "time",) -> xr.apply_ufunc:
+def first_run_ufunc(
+    x: xr.DataArray,
+    window: int,
+    dim: str = "time",
+) -> xr.apply_ufunc:
     """Dask-parallel version of first_run_1d, ie: the first entry in array of consecutive true values.
 
     Parameters

--- a/xclim/sdba/adjustment.py
+++ b/xclim/sdba/adjustment.py
@@ -52,7 +52,9 @@ class BaseAdjustment(Parametrizable):
         super().__init__(**kwargs)
 
     def train(
-        self, ref: DataArray, hist: DataArray,
+        self,
+        ref: DataArray,
+        hist: DataArray,
     ):
         """Train the adjustment object. Refer to the class documentation for the algorithm details.
 
@@ -186,7 +188,9 @@ class EmpiricalQuantileMapping(BaseAdjustment):
         group: Union[str, Grouper] = "time",
     ):
         super().__init__(
-            nquantiles=nquantiles, kind=kind, group=group,
+            nquantiles=nquantiles,
+            kind=kind,
+            group=group,
         )
 
     def _train(self, ref, hist):
@@ -281,7 +285,9 @@ class DetrendedQuantileMapping(EmpiricalQuantileMapping):
         norm_window: int = 1,
     ):
         super().__init__(
-            nquantiles=nquantiles, kind=kind, group=group,
+            nquantiles=nquantiles,
+            kind=kind,
+            group=group,
         )
         self["norm_group"] = Grouper("time.dayofyear", window=norm_window)
 

--- a/xclim/sdba/processing.py
+++ b/xclim/sdba/processing.py
@@ -103,14 +103,17 @@ def adapt_freq(
 
         # Get the percentile rank of each value in sim.
         # da.rank() doesn't work with dask arrays.
-        rank = xr.apply_ufunc(
-            lambda da: np.argsort(np.argsort(da, axis=-1), axis=-1),
-            sim,
-            input_core_dims=[dim],
-            output_core_dims=[dim],
-            dask="parallelized",
-            output_dtypes=[sim.dtype],
-        ) / sim.notnull().sum(dim=dim)
+        rank = (
+            xr.apply_ufunc(
+                lambda da: np.argsort(np.argsort(da, axis=-1), axis=-1),
+                sim,
+                input_core_dims=[dim],
+                output_core_dims=[dim],
+                dask="parallelized",
+                output_dtypes=[sim.dtype],
+            )
+            / sim.notnull().sum(dim=dim)
+        )
 
         # Frequency-adapted sim
         sim_ad = sim.where(
@@ -210,5 +213,7 @@ def normalize(
         return group.apply(_normalize_group, x)
 
     return apply_correction(
-        x, broadcast(invert(norm, kind), x, group=group, interp="nearest"), kind,
+        x,
+        broadcast(invert(norm, kind), x, group=group, interp="nearest"),
+        kind,
     )

--- a/xclim/sdba/utils.py
+++ b/xclim/sdba/utils.py
@@ -68,7 +68,10 @@ def map_cdf(
         )
 
     return group.apply(
-        _map_cdf_group, {"x": x, "y": y}, y_value=np.atleast_1d(y_value), skipna=skipna,
+        _map_cdf_group,
+        {"x": x, "y": y},
+        y_value=np.atleast_1d(y_value),
+        skipna=skipna,
     )
 
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [x] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->

This PR makes the xclim code sympatico with recent changes to `black` (v0.19.10 --> v0.20.8). I haven't read the patch notes in-depth (I know there are some interesting experimental features coming, but, in the interest of not messing up everyone's day, they aren't active here yet).

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->

No. Changes are minor. The convention now appears to be to split `args` and `kwargs` in call signatures vertically by default. You can still write them horizontally, but pre-commit hooks will modify to fit the standard.

* **Other information**:

You may need to perform an update to `pre-commit` if you haven't updated it in a long time. `conda update pre-commit` will do the work for you while the commit hooks will update and manage themselves.