### PR TITLE
Indicator instance registration and realm attribute

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -20,6 +20,8 @@ New features and enhancements
 * New `generic.parametric_quantile` function taking parameters estimated by `generic.fit` as an input.
 * Add support for using probability weighted moments method in `generic.fit` function. Requires the
   `lmoments3` package, which is not included in dependencies because it is unmaintained. Install manually if needed.
+* Indicator instances can be retrieved through their class with the `get_instance()` class method.
+  This allows the use of `xclim.core.indicator.registry` as an instance registry.
 
 Bug fixes
 ~~~~~~~~~
@@ -29,6 +31,8 @@ Internal changes
 ~~~~~~~~~~~~~~~~
 * `xclim.subset` now attempts to load and expose the functions of `clisops.core.subset`. This is an API workaround preserving backwards compatibility.
 * Code styling now conforms to the latest release of black (v0.20.8).
+* New `IndicatorRegistrar` class that takes care of adding indicator classes and instances to the
+  appropriate registries. `Indicator` now inherits from it.
 
 
 0.19.0 (2020-08-18)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -22,6 +22,7 @@ New features and enhancements
   `lmoments3` package, which is not included in dependencies because it is unmaintained. Install manually if needed.
 * Indicator instances can be retrieved through their class with the `get_instance()` class method.
   This allows the use of `xclim.core.indicator.registry` as an instance registry.
+* Indicators now have a `realm` attribute. It must be given when creating indicators outside xclim.
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,6 +14,7 @@
 # serve to show the default.
 import os
 import sys
+import warnings
 
 import xarray as xr
 
@@ -50,7 +51,7 @@ def _get_indicators(module):
 
 def _indicator_table(realm):
     """Return a sequence of dicts storing metadata about all available indices."""
-    import inspect
+    # import inspect
 
     inds = _get_indicators(getattr(xclim, realm))
     table = {}
@@ -63,7 +64,9 @@ def _indicator_table(realm):
         try:
             table[indname] = ind.json()  # args)
         except KeyError as err:
-            print(f"{ind.identifier} could not be documented.({err})")
+            warnings.warn(
+                f"{ind.identifier} could not be documented.({err})", UserWarning
+            )
         else:
             table[indname]["function"] = f"xclim.indices.{ind.compute.__name__}"
     return table

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -23,6 +23,7 @@ from xclim.indices.generic import select_time
 
 
 class UniIndTemp(Indicator):
+    realm = "atmos"
     identifier = "tmin"
     var_name = "tmin{thresh}"
     units = "K"
@@ -39,6 +40,7 @@ class UniIndTemp(Indicator):
 
 
 class UniIndPr(Indicator):
+    realm = "atmos"
     identifier = "prmax"
     units = "mm/s"
     context = "hydro"
@@ -50,6 +52,7 @@ class UniIndPr(Indicator):
 
 
 class UniClim(Indicator):
+    realm = "atmos"
     identifier = "clim"
     units = "K"
 
@@ -60,6 +63,7 @@ class UniClim(Indicator):
 
 
 class MultiTemp(Indicator):
+    realm = "atmos"
     identifier = "minmaxtemp"
     var_name = ["tmin", "tmax"]
     units = "K"
@@ -86,6 +90,9 @@ def test_attrs(tas_series):
     assert f"xclim version: {__version__}." in txm.attrs["history"]
     assert txm.name == "tmin5"
 
+
+def test_registering():
+    UniIndTemp()
     assert "TMIN" in registry
 
     # Because this has not been instantiated, it's not in any registry.
@@ -100,8 +107,12 @@ def test_attrs(tas_series):
     class IndicatorNew(Indicator):
         _nvar = 2
 
-    IndicatorNew(identifier="i2d")
+    with pytest.raises(AttributeError):
+        IndicatorNew(identifier="i2d")
+
+    indnew = IndicatorNew(identifier="i2d", realm="atmos")
     assert "I2D" in registry
+    assert registry["I2D"].get_instance() is indnew
 
 
 def test_module():

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # Tests for the Indicator objects
+import gc
+
 import dask
 import numpy as np
 import pytest
@@ -107,12 +109,22 @@ def test_registering():
     class IndicatorNew(Indicator):
         _nvar = 2
 
-    with pytest.raises(AttributeError):
+    # Identifier must be given
+    with pytest.raises(AttributeError, match="has not been set."):
+        IndicatorNew()
+
+    # Realm must be given
+    with pytest.raises(AttributeError, match="realm must be given"):
         IndicatorNew(identifier="i2d")
 
     indnew = IndicatorNew(identifier="i2d", realm="atmos")
     assert "I2D" in registry
     assert registry["I2D"].get_instance() is indnew
+
+    del indnew
+    gc.collect()
+    with pytest.raises(ValueError, match="There is no existing instance"):
+        registry["I2D"].get_instance()
 
 
 def test_module():
@@ -148,6 +160,11 @@ def test_missing(tas_series):
 
     # By default, missing is set to "from_context", and the default missing option is "any"
     ind = UniIndTemp()
+
+    # Cannot set missing_options with "from_context"
+    with pytest.raises(ValueError, match="Cannot set `missing_options`"):
+        UniClim(missing_options={"tolerance": 0.01})
+
     clim = UniClim()
 
     # Null value

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -51,12 +51,14 @@ def test_wrapped_indicator(tas_series):
         return out
 
     ind1 = Indicator(
+        realm="atmos",
         identifier="test_ind1",
         _nvar=1,
         units="days",
         compute=wrapped_partial(indice, tas2=None),
     )
     ind2 = Indicator(
+        realm="atmos",
         identifier="test_ind2",
         _nvar=2,
         units="days",

--- a/xclim/core/indicator.py
+++ b/xclim/core/indicator.py
@@ -110,7 +110,7 @@ class IndicatorRegistrar:
     def get_instance(cls):
         """Return first found instance.
 
-        Raises ValueError is no instance exist (anymore).
+        Raises `ValueError` if no instance exists.
         """
         for inst_ref in _indicators_registry[cls]:
             inst = inst_ref()
@@ -256,7 +256,7 @@ class Indicator(IndicatorRegistrar):
             if key in kwds and callable(kwds[key]):
                 kwds[key] = staticmethod(kwds[key])
 
-        # Infer realm for official instances
+        # Infer realm for built-in xclim instances
         if cls.__module__.startswith(__package__.split(".")[0]):
             xclim_realm = cls.__module__.split(".")[2]
         else:

--- a/xclim/indicators/atmos/_precip.py
+++ b/xclim/indicators/atmos/_precip.py
@@ -166,6 +166,7 @@ drought_code = PrTas(
 fire_weather_indexes = Daily(
     _nvar=4,
     identifier="FWI",
+    realm="atmos",
     var_name=["dc", "dmc", "ffmc", "isi", "bui", "fwi"],
     standard_name=[
         "drought_code",


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
Moves all indicator registering actions to a new `IndicatorRegistrar` class (from which `Indicator` now inherits). Instances are registered by storing weakrefs in a dictionary. Classes stored in the indicator registry have a `get_instance()` method that returns the first existing instance, or raises a ValueError if none are found (either none were created, or they were all destroyed).

Also, to keep the realm info when parsing indicators through the registry, Indicators now have a `realm` attribute. It must be one of atmos, land, seaIce or ocean. Indicators declared in `xclim.indicators` need not declared, it is parsed from the module name. All other Indicators must explicitly set it (either through the parent class or a keyword, as other attributes).

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
No.

* **Other information**:
I believe packages like `finch` could be improved by parsing indicators through the registry instead of the module. It will ensure that external indicators (even if they don't exist for now) will be included.
