### PR TITLE
Wind speed indicators with new multi-output options

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -25,6 +25,7 @@ New features and enhancements
 * Indicators now have a `realm` attribute. It must be given when creating indicators outside xclim.
 * Better docstring parsing for indicators: parameters description, annotation and default value are accessible in the json output and `Indicator.parameters`.
 * New command line interface `xclim` for simple indicator computing tasks.
+* New `wind_vector_from_speed` indicator. Also the `wind_speed_from_vector` now also returns the wind from direction.
 
 Bug fixes
 ~~~~~~~~~

--- a/xclim/indicators/atmos/_conversion.py
+++ b/xclim/indicators/atmos/_conversion.py
@@ -7,6 +7,7 @@ from xclim.core.utils import wrapped_partial
 __all__ = [
     "tg",
     "wind_speed_from_vector",
+    "wind_vector_from_speed",
     "saturation_vapor_pressure",
     "relative_humidity_from_dewpoint",
     "relative_humidity",
@@ -33,14 +34,34 @@ tg = Converter(
 
 
 wind_speed_from_vector = Converter(
-    identifier="sfcWind",
+    identifier="wind_speed_from_vector",
     _nvar=2,
-    units="m s-1",
-    standard_name="wind_speed",
-    description="Wind speed computed as the magnitude of the (uas, vas) vector.",
-    long_name="Near-Surface Wind Speed",
+    var_name=["sfcWind", "sfcWindfromdir"],
+    units=["m s-1", "degree"],
+    standard_name=["wind_speed", "wind_from_direction"],
+    description=[
+        "Wind speed computed as the magnitude of the (uas, vas) vector.",
+        "Wind direction computed as the angle of the (uas, vas) vector. A direction of 0° is attributed to winds with a speed under {calm_wind_thresh}.",
+    ],
+    long_name=["Near-Surface Wind Speed", "Near-Surface Wind from Direction"],
     cell_methods="",
-    compute=wrapped_partial(indices.uas_vas_2_sfcwind, return_direction=False),
+    compute=indices.uas_vas_2_sfcwind,
+)
+
+
+wind_vector_from_speed = Converter(
+    identifier="wind_vector_from_speed",
+    _nvar=2,
+    var_name=["uas", "vas"],
+    units=["m s-1", "m s-1"],
+    standard_name=["eastward_wind", "northward_wind"],
+    long_name=["Near-Surface Eastward Wind", "Near-Surface Northward Wind"],
+    description=[
+        "Eastward wind speed computed from its speed and direction of origin.",
+        "Northward wind speed computed from its speed and direction of origin.",
+    ],
+    cell_methods="",
+    compute=indices.sfcwind_2_uas_vas,
 )
 
 

--- a/xclim/indices/_conversion.py
+++ b/xclim/indices/_conversion.py
@@ -38,10 +38,10 @@ def tas(tasmin: xr.DataArray, tasmax: xr.DataArray) -> xr.DataArray:
     return tas
 
 
-@declare_units(None, check_output=False, uas="[speed]", vas="[speed]")
-def uas_vas_2_sfcwind(
-    uas: xr.DataArray = None, vas: xr.DataArray = None, return_direction: bool = True
-):
+@declare_units(
+    ["m/s", "degree"], uas="[speed]", vas="[speed]", calm_wind_thresh="[speed]"
+)
+def uas_vas_2_sfcwind(uas: xr.DataArray, vas: xr.DataArray, calm_wind_thresh="0.5 m/s"):
     """Convert eastward and northward wind components to wind speed and direction.
 
     Parameters
@@ -50,39 +50,31 @@ def uas_vas_2_sfcwind(
       Eastward wind velocity (m s-1)
     vas : xr.DataArray
       Northward wind velocity (m s-1)
-    return_direction: bool
-      If true, returns direction, else returns surface windspeed.
+    calm_wind_thresh : str
+      The threshold under which winds are considered "calm" and for which the direction
+      is set to 0. On the Beaufort scale, calm winds are defined as < 0.5 m/s.
 
     Returns
     -------
     wind : xr.DataArray
       Wind velocity (m s-1)
     windfromdir : xr.DataArray
-      Direction from which the wind blows, following the meteorological convention where 360 stands for North.
+      Direction from which the wind blows, following the meteorological convention where
+      360 stands for North and 0 for calm winds.
 
     Notes
     -----
-    Northerly winds with a velocity less than 0.5 m/s are given a wind direction of 0°,
-    while stronger winds are set to 360°.
+    Winds with a velocity less than `calm_wind_thresh` are given a wind direction of 0°,
+    while stronger notherly winds are set to 360°.
     """
     # Converts the wind speed to m s-1
     uas = convert_units_to(uas, "m/s")
     vas = convert_units_to(vas, "m/s")
+    wind_thresh = convert_units_to(calm_wind_thresh, "m/s")
 
     # Wind speed is the hypotenuse of "uas" and "vas"
     wind = np.hypot(uas, vas)
 
-    if not return_direction:
-        wind.attrs["units"] = "m s-1"
-        return wind
-
-    # TODO Attributes should be set by the indicator, but there are no multi-output indicators, so we set them anyway if return_direction is True,
-    # Add attributes to wind. This is done by copying uas' attributes and overwriting a few of them
-    wind.attrs = uas.attrs
-    wind.name = "sfcWind"
-    wind.attrs["units"] = "m s-1"
-    wind.attrs["standard_name"] = "wind_speed"
-    wind.attrs["long_name"] = "Near-Surface Wind Speed"
     # Calculate the angle
     windfromdir_math = np.degrees(np.arctan2(vas, uas))
 
@@ -92,29 +84,23 @@ def uas_vas_2_sfcwind(
     # According to the meteorological standard, calm winds must have a direction of 0°
     # while northerly winds have a direction of 360°
     # On the Beaufort scale, calm winds are defined as < 0.5 m/s
-    windfromdir = xr.where((windfromdir.round() == 0) & (wind >= 0.5), 360, windfromdir)
-    windfromdir = xr.where(wind < 0.5, 0, windfromdir)
-
-    # Add attributes to winddir. This is done by copying uas' attributes and overwriting a few of them
-    windfromdir.attrs = uas.attrs
-    windfromdir.name = "sfcWindfromdir"
-    windfromdir.attrs["standard_name"] = "wind_from_direction"
-    windfromdir.attrs["long_name"] = "Near-Surface Wind from Direction"
-    windfromdir.attrs["units"] = "degree"
+    windfromdir = xr.where(windfromdir.round() == 0, 360, windfromdir)
+    windfromdir = xr.where(wind < wind_thresh, 0, windfromdir)
 
     return wind, windfromdir
 
 
-@declare_units(None, check_output=False, wind="[speed]", windfromdir="[]")
-def sfcwind_2_uas_vas(wind: xr.DataArray = None, windfromdir: xr.DataArray = None):
+@declare_units(["m s-1", "m s-1"], sfcWind="[speed]", sfcWindfromdir="[]")
+def sfcwind_2_uas_vas(sfcWind: xr.DataArray, sfcWindfromdir: xr.DataArray):
     """Convert wind speed and direction to eastward and northward wind components.
 
     Parameters
     ----------
-    wind : xr.DataArray
+    sfcWind : xr.DataArray
       Wind velocity (m s-1)
-    windfromdir : xr.DataArray
-      Direction from which the wind blows, following the meteorological convention where 360 stands for North.
+    sfcWindfromdir : xr.DataArray
+      Direction from which the wind blows, following the meteorological convention
+      where 360 stands for North.
 
     Returns
     -------
@@ -125,10 +111,10 @@ def sfcwind_2_uas_vas(wind: xr.DataArray = None, windfromdir: xr.DataArray = Non
 
     """
     # Converts the wind speed to m s-1
-    wind = convert_units_to(wind, "m/s")
+    sfcWind = convert_units_to(sfcWind, "m/s")
 
     # Converts the wind direction from the meteorological standard to the mathematical standard
-    windfromdir_math = (-windfromdir + 270) % 360.0
+    windfromdir_math = (-sfcWindfromdir + 270) % 360.0
 
     # TODO: This commented part should allow us to resample subdaily wind, but needs to be cleaned up and put elsewhere
     # if resample is not None:
@@ -140,22 +126,8 @@ def sfcwind_2_uas_vas(wind: xr.DataArray = None, windfromdir: xr.DataArray = Non
     #     windfromdir_math = np.concatenate([[degrees(phase(sum(rect(1, radians(d)) for d in angles) / len(angles)))]
     #                                       for angles in windfromdir_math_per_day])
 
-    uas = wind * np.cos(np.radians(windfromdir_math))
-    vas = wind * np.sin(np.radians(windfromdir_math))
-
-    # Add attributes to uas and vas. This is done by copying wind' attributes and overwriting a few of them
-    uas.attrs = wind.attrs
-    uas.name = "uas"
-    uas.attrs["standard_name"] = "eastward_wind"
-    uas.attrs["long_name"] = "Near-Surface Eastward Wind"
-    wind.attrs["units"] = "m s-1"
-
-    vas.attrs = wind.attrs
-    vas.name = "vas"
-    vas.attrs["standard_name"] = "northward_wind"
-    vas.attrs["long_name"] = "Near-Surface Northward Wind"
-    wind.attrs["units"] = "m s-1"
-
+    uas = sfcWind * np.cos(np.radians(windfromdir_math))
+    vas = sfcWind * np.sin(np.radians(windfromdir_math))
     return uas, vas
 
 

--- a/xclim/indices/_conversion.py
+++ b/xclim/indices/_conversion.py
@@ -65,7 +65,7 @@ def uas_vas_2_sfcwind(uas: xr.DataArray, vas: xr.DataArray, calm_wind_thresh="0.
     Notes
     -----
     Winds with a velocity less than `calm_wind_thresh` are given a wind direction of 0°,
-    while stronger notherly winds are set to 360°.
+    while stronger northerly winds are set to 360°.
     """
     # Converts the wind speed to m s-1
     uas = convert_units_to(uas, "m/s")

--- a/xclim/locales/fr.json
+++ b/xclim/locales/fr.json
@@ -547,11 +547,29 @@
     "long_name": "Indice forêt météo",
     "description": "Évaluation numérique de l'intensité du feu."
   },
-  "SFCWIND": {
+  "WIND_SPEED_FROM_VECTOR": {
+    "title": "Vitesse et direction du vent à partir du vecteur vent.",
+    "abstract": "Calcul de la magnitude et la direction de la vitesse du vent à partir des deux composantes ouest-est et sud-nord."
+  },
+  "WIND_SPEED_FROM_VECTOR.sfcWind": {
     "long_name": "Vitesse du vent de surface",
-    "description": "Magnitude de la vitesse vent calculée à partir des deux composantes uas et vas.",
-    "title": "Magnitude de la vitesse du vent",
-    "abstract": "Calcul de la magnitude de la vitesse du vent à partir des deux composantes ouest-est et sud-nord."
+    "description": "Magnitude de la vitesse vent calculée à partir des deux composantes uas et vas."
+  },
+  "WIND_SPEED_FROM_VECTOR.sfcWindfromdir": {
+    "long_name": "Direction de provenance du vent de surface",
+    "description": "Direction de provenance du vent calculée à partir des deux composantes uas et vas. Les vents du nord ont une direction de 360° et les vents de moins de {calm_wind_thresh} ont une direction de 0°."
+  },
+  "WIND_VECTOR_FROM_SPEED": {
+    "title": "Vitesse cartésienne du vent à partir de la magnitude et direction de provenance.",
+    "abstract": "Calcul des deux composantes ouest-est et nord-sud du vent à partir de la magnitude et la direction de provenance de sa vitesse."
+  },
+  "WIND_VECTOR_FROM_SPEED.uas": {
+    "long_name": "Vent d'ouest de surface",
+    "description": "Vitesse d'ouest du vent de surface calculé à partir de la norme de sa vitesse et de sa direction de provenance."
+  },
+  "WIND_VECTOR_FROM_SPEED.vas": {
+    "long_name": "Vent du sud de surface",
+    "description": "Vitesse du sud du vent de surface calculé à partir de la norme de sa vitesse et de sa direction de provenance."
   },
   "E_SAT": {
     "long_name": "Pression de vapeur saturante",

--- a/xclim/locales/fr.json
+++ b/xclim/locales/fr.json
@@ -561,7 +561,7 @@
   },
   "WIND_SPEED_FROM_VECTOR.sfcWind": {
     "long_name": "Vitesse du vent de surface",
-    "description": "Magnitude de la vitesse vent calculée à partir des deux composantes uas et vas."
+    "description": "Magnitude de la vitesse du vent calculée à partir des deux composantes uas et vas."
   },
   "WIND_SPEED_FROM_VECTOR.sfcWindfromdir": {
     "long_name": "Direction de provenance du vent de surface",


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes an issue raised in the `try_mypy` branch.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
Adds the `wind_vector_from_speed` indicator wrapping `indices.sfcwind_2_uas_vas`. Also, the `wind_speed_from_vector` indicator now returns the "wind from direction" as a second output. 

I noted that we were hardcoding the "calm wind threshold", under which the wind direction is noted as 0°. I added that `calm_wind_thresh` arg to `indices.uas_vas_2_sfcWind` as to control this.

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->

- Changed the name of the indicator from `sfcWind` to `wind_speed_from_vector`
- `indices.uas_vas_2_sfcwind` lost its `return_direction` keyword arg. It always returns the direction.

* **Other information**:
@RondeauG If you have time, could you quickly check that my changes to the indices function are ok?