### PR TITLE
Glob-like patterns in AttrFormatter and french nouns

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -33,6 +33,7 @@ New features and enhancements
 * New `wind_vector_from_speed` indicator. Also the `wind_speed_from_vector` now also returns the wind from direction.
 * New `sdba.processing.jitter_over_thresh` for variables with a upper bound.
 * Added `tg_min` and `tg_max` to the list of available `Indicators` under `atmos`.
+* `core.formatting.AttrFormatter` (and thus, locale dictionaries) can now use glob-like pattern for matching values to translate.
 
 Bug fixes
 ~~~~~~~~~

--- a/tests/test_locales.py
+++ b/tests/test_locales.py
@@ -16,7 +16,7 @@ from xclim.locales import generate_local_dict
 esperanto = (
     "eo",
     {
-        "attrs_mapping": {"modifiers": ["adj"], "YS": ["jara"], "MS": ["monata"]},
+        "attrs_mapping": {"modifiers": ["adj"], "AS-*": ["jara"], "MS": ["monata"]},
         "TG_MEAN": {
             "long_name": "Meza ciutaga averaga temperaturo",
             "title": "Meza ciutaga averaga temperaturo",
@@ -29,7 +29,7 @@ russian = (
     {
         "attrs_mapping": {
             "modifiers": ["nn", "nf"],
-            "YS": ["годовое", "годовая"],
+            "AS-*": ["годовое", "годовая"],
             "MS": ["месячный", "месячная"],
         },
         "TG_MEAN": {
@@ -99,8 +99,8 @@ def test_local_attrs_multi(tmp_path):
 
 def test_local_formatter():
     fmt = xloc.get_local_formatter(russian)
-    assert fmt.format("{freq:nn}", freq="YS") == "годовое"
-    assert fmt.format("{freq:nf}", freq="YS") == "годовая"
+    assert fmt.format("{freq:nn}", freq="AS-JUL") == "годовое"
+    assert fmt.format("{freq:nf}", freq="AS-DEC") == "годовая"
 
 
 def test_indicator_output(tas_series):

--- a/xclim/core/formatting.py
+++ b/xclim/core/formatting.py
@@ -53,7 +53,7 @@ class AttrFormatter(string.Formatter):
 
         >>> fmt = AttrFormatter({'nice': ['beau', 'belle'], 'evil' : ['méchant', 'méchante']}, ['m', 'f'])
         >>> fmt.format("Le chien est {adj1:m}, l'oie est {adj2:f}", adj1='nice', adj2='evil')
-        'Le chien est beau, l'oie est méchante'
+        "Le chien est beau, l'oie est méchante"
 
         The base values may be given using unix shell-like patterns:
         >>> fmt = AttrFormatter({'AS-*': ['annuel', 'annuelle'], 'MS' : ['mensuel', 'mensuelle']}, ['m', 'f'])

--- a/xclim/core/formatting.py
+++ b/xclim/core/formatting.py
@@ -7,6 +7,7 @@ Formatting utilities for indicators
 import datetime as dt
 import re
 import string
+from glob.fnmatch import fnmatch
 from typing import Mapping, Optional, Sequence, Union
 
 import xarray as xr
@@ -54,24 +55,32 @@ class AttrFormatter(string.Formatter):
         >>> fmt.format("Le chien est {adj1:m}, l'oie est {adj2:f}", adj1='nice', adj2='evil')
         "Le chien est beau, l'oie est méchante"
         """
-        if value in self.mapping and not format_spec:
-            return self.mapping[value][0]
+        baseval = self._match_value(value)
+        if baseval is not None and not format_spec:
+            return self.mapping[baseval][0]
 
         if format_spec in self.modifiers:
-            if value in self.mapping:
-                return self.mapping[value][self.modifiers.index(format_spec)]
+            if baseval is not None:
+                return self.mapping[baseval][self.modifiers.index(format_spec)]
             raise ValueError(
                 f"No known mapping for string '{value}' with modifier '{format_spec}'"
             )
         return super().format_field(value, format_spec)
+
+    def _match_value(self, value):
+        for mapval in self.mapping.values():
+            if fnmatch(value, mapval):
+                return mapval
+        return None
 
 
 # Tag mappings between keyword arguments and long-form text.
 default_formatter = AttrFormatter(
     {
         "YS": ["annual", "years"],
+        "AS-*": ["annual", "years"],
         "MS": ["monthly", "months"],
-        "QS-DEC": ["seasonal", "seasons"],
+        "QS-*": ["seasonal", "seasons"],
         "DJF": ["winter"],
         "MAM": ["spring"],
         "JJA": ["summer"],

--- a/xclim/core/formatting.py
+++ b/xclim/core/formatting.py
@@ -73,9 +73,10 @@ class AttrFormatter(string.Formatter):
         return super().format_field(value, format_spec)
 
     def _match_value(self, value):
-        for mapval in self.mapping.values():
-            if fnmatch(value, mapval):
-                return mapval
+        if isinstance(value, str):
+            for mapval in self.mapping.keys():
+                if fnmatch(value, mapval):
+                    return mapval
         return None
 
 

--- a/xclim/core/formatting.py
+++ b/xclim/core/formatting.py
@@ -40,7 +40,7 @@ class AttrFormatter(string.Formatter):
     def format_field(self, value, format_spec):
         """Format a value given a formatting spec.
 
-        If `format_spec` is in this Formatter's modifiers, the correspong variation
+        If `format_spec` is in this Formatter's modifiers, the corresponding variation
         of value is given. If `format_spec` is not specified but `value` is in the
         mapping, the first variation is returned.
 
@@ -54,6 +54,11 @@ class AttrFormatter(string.Formatter):
         >>> fmt = AttrFormatter({'nice': ['beau', 'belle'], 'evil' : ['méchant', 'méchante']}, ['m', 'f'])
         >>> fmt.format("Le chien est {adj1:m}, l'oie est {adj2:f}", adj1='nice', adj2='evil')
         "Le chien est beau, l'oie est méchante"
+
+        The base values may be given using unix shell-like patterns:
+        >>> fmt = AttrFormatter({'AS-*': ['annuel', 'annuelle'], 'MS' : ['mensuel', 'mensuelle']}, ['m', 'f'])
+        >>> fmt.format("La moyenne {freq:f} est faite sur un échantillon {src_timestep:m}", freq='AS-JUL', src_timestep='MS')
+        "La moyenne annuelle est faite sur un échantillon mensuel"
         """
         baseval = self._match_value(value)
         if baseval is not None and not format_spec:

--- a/xclim/core/formatting.py
+++ b/xclim/core/formatting.py
@@ -53,12 +53,12 @@ class AttrFormatter(string.Formatter):
 
         >>> fmt = AttrFormatter({'nice': ['beau', 'belle'], 'evil' : ['méchant', 'méchante']}, ['m', 'f'])
         >>> fmt.format("Le chien est {adj1:m}, l'oie est {adj2:f}", adj1='nice', adj2='evil')
-        "Le chien est beau, l'oie est méchante"
+        'Le chien est beau, l'oie est méchante'
 
         The base values may be given using unix shell-like patterns:
         >>> fmt = AttrFormatter({'AS-*': ['annuel', 'annuelle'], 'MS' : ['mensuel', 'mensuelle']}, ['m', 'f'])
         >>> fmt.format("La moyenne {freq:f} est faite sur un échantillon {src_timestep:m}", freq='AS-JUL', src_timestep='MS')
-        "La moyenne annuelle est faite sur un échantillon mensuel"
+        'La moyenne annuelle est faite sur un échantillon mensuel'
         """
         baseval = self._match_value(value)
         if baseval is not None and not format_spec:

--- a/xclim/core/locales.py
+++ b/xclim/core/locales.py
@@ -16,6 +16,7 @@ These files are expected to be defined as in this example for french:
         "attrs_mapping" : {
             "modifiers": ["", "f", "mpl", "fpl"],
             "YS" : ["annuel", "annuelle", "annuels", "annuelles"],
+            "AS-*" : ["annuel", "annuelle", "annuels", "annuelles"],
             ... and so on for other frequent parameters translation...
         },
           "DTRVAR": {

--- a/xclim/locales/__init__.py
+++ b/xclim/locales/__init__.py
@@ -1,7 +1,6 @@
 """Locales and language support module."""
 from xclim.core.formatting import default_formatter
 from xclim.core.locales import TRANSLATABLE_ATTRS, get_best_locale, get_local_dict
-from xclim.indicators.atmos import tg_mean
 
 
 def generate_local_dict(locale: str, init_english: bool = False):

--- a/xclim/locales/fr.json
+++ b/xclim/locales/fr.json
@@ -4,55 +4,70 @@
       "m",
       "f",
       "mpl",
-      "fpl"
+      "fpl",
+      "nom",
     ],
     "YS": [
       "annuel",
       "annuelle",
       "annuels",
-      "annuelles"
+      "annuelles",
+      "années",
+    ],
+    "AS-*": [
+      "annuel",
+      "annuelle",
+      "annuels",
+      "annuelles",
+      "années",
     ],
     "MS": [
       "mensuel",
       "mensuelle",
       "mensuels",
-      "mensuelles"
+      "mensuelles",
+      "mois",
     ],
-    "QS-DEC": [
+    "QS-*": [
       "saisonnier",
       "saisonnière",
       "saisonniers",
-      "saisonnières"
+      "saisonnières",
+      "saisons",
     ],
     "DJF": [
       "hivernal",
       "hivernale",
       "hivernaux",
-      "hivernales"
+      "hivernales",
+      "hivers",
     ],
     "MAM": [
       "printanier",
       "printanière",
       "printaniers",
-      "printanières"
+      "printanières",
+      "printemps",
     ],
     "JJA": [
       "estival",
       "estivale",
       "estivaux",
-      "estivales"
+      "estivales",
+      "étés",
     ],
     "SON": [
       "automnal",
       "automnale",
       "automnaux",
-      "automnales"
+      "automnales",
+      "automnes",
     ],
     "norm": [
       "normal",
       "normale",
       "normaux",
-      "normales"
+      "normales",
     ],
     "m1": [
       "janvier"

--- a/xclim/locales/fr.json
+++ b/xclim/locales/fr.json
@@ -5,69 +5,69 @@
       "f",
       "mpl",
       "fpl",
-      "nom",
+      "nom"
     ],
     "YS": [
       "annuel",
       "annuelle",
       "annuels",
       "annuelles",
-      "années",
+      "années"
     ],
     "AS-*": [
       "annuel",
       "annuelle",
       "annuels",
       "annuelles",
-      "années",
+      "années"
     ],
     "MS": [
       "mensuel",
       "mensuelle",
       "mensuels",
       "mensuelles",
-      "mois",
+      "mois"
     ],
     "QS-*": [
       "saisonnier",
       "saisonnière",
       "saisonniers",
       "saisonnières",
-      "saisons",
+      "saisons"
     ],
     "DJF": [
       "hivernal",
       "hivernale",
       "hivernaux",
       "hivernales",
-      "hivers",
+      "hivers"
     ],
     "MAM": [
       "printanier",
       "printanière",
       "printaniers",
       "printanières",
-      "printemps",
+      "printemps"
     ],
     "JJA": [
       "estival",
       "estivale",
       "estivaux",
       "estivales",
-      "étés",
+      "étés"
     ],
     "SON": [
       "automnal",
       "automnale",
       "automnaux",
       "automnales",
-      "automnes",
+      "automnes"
     ],
     "norm": [
       "normal",
       "normale",
       "normaux",
-      "normales",
+      "normales"
     ],
     "m1": [
       "janvier"


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes an issue raised in slack.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
Values to format, in `core.formatting.AttrFormatter` can now include glob-like patterns. Example : `"QS-*`" that translates to "seasonal".

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
No

* **Other information**:
Also added the plural nouns in french. I don't think we're using them, but they exist in the english formatter.