### PR TITLE
Reduce number of simultaneous Travis CI jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,14 @@ branches:
 jobs:
   fast_finish: true
   include:
-    - env:
-        - TOXENV=docs
-      name: "Documentation"
-      python: 3.6
-      addons:
-        apt:
-          packages:
-            - pandoc
+#    - env:
+#        - TOXENV=docs
+#      name: "Documentation"
+#      python: 3.6
+#      addons:
+#        apt:
+#          packages:
+#            - pandoc
     - env: TOXENV=black
       name: "Black, Flake8, Numpy-like Docstring compliance, and linting"
       python: 3.6
@@ -31,7 +31,7 @@ jobs:
             - libspatialindex-dev
             - libnetcdf-dev
             - libhdf5-dev
-    - if: branch = master
+    - if: type = push
       env: TOXENV=py38-macOS
       name: "Python3.8 (macOS)"
       os: osx
@@ -66,7 +66,7 @@ jobs:
         apt:
           packages:
             - libspatialindex-dev
-    - if: branch = master
+    - if: type = push
       env: TOXENV=py36-bottleneck
       name: "Python3.6 (Linux + bottleneck@master)"
       python: 3.6
@@ -74,7 +74,7 @@ jobs:
         apt:
           packages:
             - libspatialindex-dev
-    - if: branch = master
+    - if: type = push
       env: TOXENV=py38-anaconda
       name: "Python3.8 (Linux + Anaconda)"
       python: 3.8
@@ -96,7 +96,7 @@ jobs:
           - pip install -e .[dev]
       script:
           - py.test --cov=xclim
-    - if: branch = master
+    - if: type = push
       env:
         - TOXENV=py37-windows
         - DESIRED_PYTHON=3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,8 @@ jobs:
     - env: TOXENV=py36-nosubset-lm3
       name: "Python3.6 (Linux + lmoments3@master) (no subsetting)"
       python: 3.6
-    - env: TOXENV=py36-xarray
+    - if: type = push
+      env: TOXENV=py36-xarray
       name: "Python3.6 (Linux + xarray@master + cftime@master)"
       python: 3.6
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,17 +20,10 @@ jobs:
           packages:
             - pandoc
     - env: TOXENV=black
-      name: "Black, Flake8, and Numpy-like Docstring compliance"
+      name: "Black, Flake8, Numpy-like Docstring compliance, and linting"
       python: 3.6
-    - env: TOXENV=doctests
-      name: "Linting suggestions and Doctests"
-      python: 3.6
-      addons:
-        apt:
-          packages:
-            - libspatialindex-dev
-    - env: TOXENV=py38
-      name: "Python3.8 (Linux)"
+    - env: TOXENV=py38-doctest
+      name: "Python3.8 (Linux) + doctests"
       python: 3.8
       addons:
         apt:
@@ -38,7 +31,8 @@ jobs:
             - libspatialindex-dev
             - libnetcdf-dev
             - libhdf5-dev
-    - env: TOXENV=py38-macOS
+    - if: branch = master
+      env: TOXENV=py38-macOS
       name: "Python3.8 (macOS)"
       os: osx
       language: shell
@@ -72,14 +66,16 @@ jobs:
         apt:
           packages:
             - libspatialindex-dev
-    - env: TOXENV=py36-bottleneck
+    - if: branch = master
+      env: TOXENV=py36-bottleneck
       name: "Python3.6 (Linux + bottleneck@master)"
       python: 3.6
       addons:
         apt:
           packages:
             - libspatialindex-dev
-    - env: TOXENV=py38-anaconda
+    - if: branch = master
+      env: TOXENV=py38-anaconda
       name: "Python3.8 (Linux + Anaconda)"
       python: 3.8
       before_install:
@@ -100,7 +96,8 @@ jobs:
           - pip install -e .[dev]
       script:
           - py.test --cov=xclim
-    - env:
+    - if: branch = master
+      env:
         - TOXENV=py37-windows
         - DESIRED_PYTHON=3.7
         - MINICONDA_PATH=$(cygpath --windows /c/miniconda)

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
-envlist = py36-nosubset-lm3, py36-xarray, py36-bottleneck, py37, py37-windows, py38, py38-anaconda, py38-macOS, black, docs, doctests
+envlist = py36-nosubset-lm3, py36-xarray, py36-bottleneck, py37, py37-windows, py38-doctest, py38-anaconda, py38-macOS, black
 requires = pip >= 20.0
 opts = -v
 
 [travis]
 python =
-    3.8: py38
+    3.8: py38-doctest
     3.8: py38-anaconda
     3.8: py38-macOS
     3.7: py37
@@ -14,8 +14,8 @@ python =
     3.6: py36-bottleneck
     3.6: py36-xarray
     3.6: black
-    3.6: docs
-    3.6: doctests
+;    3.6: docs
+
 
 [testenv:black]
 skip_install = True
@@ -25,29 +25,20 @@ deps =
     flake8
     black
     pydocstyle
+    pylint
 commands =
     pydocstyle --convention=numpy xclim
     flake8 xclim tests
     black --check --target-version py36 xclim tests
-
-[testenv:docs]
-basepython = python3.6
-extras = docs
-commands =
-    make --directory=docs clean html
-whitelist_externals =
-    make
-
-[testenv:doctests]
-basepython = python3.6
-deps =
-    pylint
-    pytest
-    xdoctest
-setenv = PYTEST_ADDOPTS = "--color=yes"
-commands =
     pylint --rcfile=setup.cfg --exit-zero xclim
-    pytest --rootdir tests/ --xdoctest xclim
+
+;[testenv:docs]
+;basepython = python3.6
+;extras = docs
+;commands =
+;    make --directory=docs clean html
+;whitelist_externals =
+;    make
 
 [testenv:py36-nosubset-lm3]
 extras = dev
@@ -77,5 +68,6 @@ commands =
     py36-bottleneck: pip install hypothesis
     py36-bottleneck: pip install git+https://github.com/pydata/bottleneck.git@master#egg=bottleneck
     py36-nosubset-lm3: pip install git+https://github.com/OpenHydrology/lmoments3.git@develop#egg=lmoments3
+    doctest: pytest --rootdir tests/ --xdoctest xclim
     pytest --cov xclim --basetemp={envtmpdir}
     - coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36-nosubset-lm3, py36-xarray, py36-bottleneck, py37, py37-windows, py38-doctest, py38-anaconda, py38-macOS, black
+envlist = py36-nosubset-lm3, py36-xarray, py36-bottleneck, py37, py37-windows, py38-doctest, py38-anaconda, py38-macOS, black, docs
 requires = pip >= 20.0
 opts = -v
 
@@ -14,8 +14,7 @@ python =
     3.6: py36-bottleneck
     3.6: py36-xarray
     3.6: black
-;    3.6: docs
-
+    3.6: docs
 
 [testenv:black]
 skip_install = True
@@ -32,13 +31,13 @@ commands =
     black --check --target-version py36 xclim tests
     pylint --rcfile=setup.cfg --exit-zero xclim
 
-;[testenv:docs]
-;basepython = python3.6
-;extras = docs
-;commands =
-;    make --directory=docs clean html
-;whitelist_externals =
-;    make
+[testenv:docs]
+basepython = python3.6
+extras = docs
+commands =
+    make --directory=docs clean html
+whitelist_externals =
+    make
 
 [testenv:py36-nosubset-lm3]
 extras = dev


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #552 
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->

Implements a few changes to reduce the number of triggered builds on xclim PRs. The `docs` build has been removed, as RtD now runs its own build service, linting has been grouped with the `black` conformance check build, doctests are now run on the `py38` build, and builds using dependencies from their `master` branches are conditionally run on our `master` at merge,

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->

No.

* **Other information**:
