### PR TITLE
Rename history to xclim_history

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -15,6 +15,7 @@ Breaking changes
 * A clean-up and harmonization of the indicators metadata has changed some of the indicator identifiers, long_names, abstracts and titles. `xclim.atmos.drought_code` and `fire_weather_indexes` now have indentifiers "dc" and "fwi" (lowercase version of the previous identifiers).
 * `xc.indices.run_length.run_length_with_dates` becomes `xc.indices.run_length.season_length`. Its argument `date` is now optional and the default changes from "07-01" to `None`.
 * `xc.indices.consecutive_frost_days` becomes `xc.indices.maximum_consecutive_frost_days`.
+* Changed the `history` indicator output attribute to `xclim_history` in order to respect CF conventions.
 
 New indicators
 ~~~~~~~~~~~~~~

--- a/tests/test_ensembles.py
+++ b/tests/test_ensembles.py
@@ -141,7 +141,7 @@ class TestEnsembleStats:
 
         out2 = ensembles.ensemble_percentiles(ens, values=(25, 75))
         assert np.all(out2["tg_mean_p75"] > out2["tg_mean_p25"])
-        assert "Computation of the percentiles on" in out1.attrs["history"]
+        assert "Computation of the percentiles on" in out1.attrs["xclim_history"]
 
         out3 = ensembles.ensemble_percentiles(ens, split=False)
         xr.testing.assert_equal(
@@ -197,7 +197,7 @@ class TestEnsembleStats:
         np.testing.assert_array_equal(
             ens["tg_mean"][:, 0, 5, 5].min(dim="realization"), out1.tg_mean_min[0, 5, 5]
         )
-        assert "Computation of statistics on" in out1.attrs["history"]
+        assert "Computation of statistics on" in out1.attrs["xclim_history"]
 
 
 class TestEnsembleReduction:

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -87,9 +87,9 @@ def test_attrs(tas_series):
     ind = UniIndTemp()
     txm = ind(a, thresh=5, freq="YS")
     assert txm.cell_methods == "time: mean within days time: mean within years"
-    assert f"{dt.datetime.now():%Y-%m-%d %H}" in txm.attrs["history"]
-    assert "tmin(da, thresh=5, freq='YS')" in txm.attrs["history"]
-    assert f"xclim version: {__version__}." in txm.attrs["history"]
+    assert f"{dt.datetime.now():%Y-%m-%d %H}" in txm.attrs["xclim_history"]
+    assert "tmin(da, thresh=5, freq='YS')" in txm.attrs["xclim_history"]
+    assert f"xclim version: {__version__}." in txm.attrs["xclim_history"]
     assert txm.name == "tmin5"
 
 
@@ -212,7 +212,7 @@ def test_json(pr_series):
         "keywords",
         "abstract",
         "parameters",
-        "history",
+        "xclim_history",
         "references",
         "notes",
         "outputs",

--- a/tests/test_sdba/test_adjustment.py
+++ b/tests/test_sdba/test_adjustment.py
@@ -44,8 +44,8 @@ class TestLoci:
         p = loci.adjust(sim)
         np.testing.assert_array_almost_equal(p, ref, dec)
 
-        assert "history" in p.attrs
-        assert "Bias-adjusted with LOCI(" in p.attrs["history"]
+        assert "xclim_history" in p.attrs
+        assert "Bias-adjusted with LOCI(" in p.attrs["xclim_history"]
 
 
 class TestScaling:

--- a/xclim/core/formatting.py
+++ b/xclim/core/formatting.py
@@ -249,7 +249,7 @@ def update_history(
         "history",
         *inputs_list,
         new_line="\n",
-        missing_str="<No available history>",
+        missing_str="",
         **inputs_kws,
     )
     if len(merged_history) > 0 and not merged_history.endswith("\n"):

--- a/xclim/core/indicator.py
+++ b/xclim/core/indicator.py
@@ -396,7 +396,7 @@ class Indicator(IndicatorRegistrar):
     def update_attrs(cls, ba, das, attrs, var_id=None, names=None):
         """Format attributes with the run-time values of `compute` call parameters.
 
-        Cell methods and history attributes are updated, adding to existing values. The language of the string is
+        Cell methods and xclim_history attributes are updated, adding to existing values. The language of the string is
         taken from the `OPTIONS` configuration dictionary.
 
         Parameters
@@ -409,7 +409,7 @@ class Indicator(IndicatorRegistrar):
           The attributes to format and update.
         var_id : str
           The identifier to use when requesting the attributes translations.
-          Defaults to the class name (for the translations) or the `identifier` field of the class (for the history attribute).
+          Defaults to the class name (for the translations) or the `identifier` field of the class (for the xclim_history attribute).
           If given, the identifier will be converted to uppercase to get the translation attributes.
           This is meant for multi-outputs indicators.
         names : Sequence[str]
@@ -418,7 +418,7 @@ class Indicator(IndicatorRegistrar):
         Returns
         -------
         dict
-          Attributes with {} expressions replaced by call argument values. With updated `cell_methods` and `history`.
+          Attributes with {} expressions replaced by call argument values. With updated `cell_methods` and `xclim_history`.
           `cell_methods` is not added is `names` is given and those not contain `cell_methods`.
         """
         args = ba.arguments
@@ -455,7 +455,7 @@ class Indicator(IndicatorRegistrar):
             if "cell_methods" in out:
                 attrs["cell_methods"] += " " + out.pop("cell_methods")
 
-        attrs["history"] = update_history(
+        attrs["xclim_history"] = update_history(
             f"{var_id or cls.identifier}{ba.signature.replace(parameters=cp.values())}",
             new_name=out.get("var_name"),
             **das,

--- a/xclim/ensembles.py
+++ b/xclim/ensembles.py
@@ -143,7 +143,7 @@ def ensemble_mean_std_max_min(ens: xr.Dataset) -> xr.Dataset:
                     + vv.split("_")[-1]
                     + " of ensemble"
                 )
-    ds_out.attrs["history"] = update_history(
+    ds_out.attrs["xclim_history"] = update_history(
         f"Computation of statistics on {ens.realization.size} ensemble members.", ds_out
     )
     return ds_out
@@ -207,7 +207,7 @@ def ensemble_percentiles(
             ]
         )
         out.attrs.update(ens.attrs)
-        out.attrs["history"] = update_history(
+        out.attrs["xclim_history"] = update_history(
             f"Computation of the percentiles on {ens.realization.size} ensemble members.",
             ens,
         )
@@ -262,7 +262,7 @@ def ensemble_percentiles(
             out[p] = perc
             out = out.rename(name_dict={p: f"{ens.name}_p{int(p):02d}"})
 
-    out.attrs["history"] = update_history(
+    out.attrs["xclim_history"] = update_history(
         f"Computation of the percentiles on {ens.realization.size} ensemble members.",
         ens,
     )

--- a/xclim/indices/generic.py
+++ b/xclim/indices/generic.py
@@ -186,7 +186,7 @@ def fit(da: xr.DataArray, dist: str = "norm", method="ML"):
     out.attrs["estimator"] = method_name[method].capitalize()
     out.attrs["scipy_dist"] = dist
     out.attrs["units"] = ""
-    out.attrs["history"] = update_history(
+    out.attrs["xclim_history"] = update_history(
         f"Estimate distribution parameters by {method_name[method]} method.",
         new_name="fit",
         data=da,
@@ -252,7 +252,7 @@ def parametric_quantile(p: xr.DataArray, q: Union[int, Sequence]):
     ).strip()
     out.attrs["units"] = p.attrs["original_units"]
 
-    out.attrs["history"] = update_history(
+    out.attrs["xclim_history"] = update_history(
         "Compute parametric quantiles from distribution parameters",
         new_name="parametric_quantile",
         parameters=p,

--- a/xclim/sdba/adjustment.py
+++ b/xclim/sdba/adjustment.py
@@ -123,7 +123,7 @@ class BaseAdjustment(Parametrizable):
 
         scen = self._adjust(sim, **kwargs)
         params = ", ".join([f"{k}={repr(v)}" for k, v in kwargs.items()])
-        scen.attrs["history"] = update_history(
+        scen.attrs["xclim_history"] = update_history(
             f"Bias-adjusted with {str(self)}.adjust(sim, {params})", sim
         )
         return scen


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR is step forward for #368
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
Changes the `history` attribute that Indicators assign to their output to `xclim_history`.  Also removed the `<No available history>` placeholder strings, an empty string is used instead.

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
Yes.

* **Other information**:
Right now we are constructing this history string from all the `history` attributes of the input variables. Which doesn't make sense in regards to CF conventions and. from now on, is not coherent with our own attribute name. As long as #558 is not implemented, I don't see any solutions...