### PR TITLE
Correct output for missing periods + MissingWMO with coarse frequencies.

### DIFF
--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -179,6 +179,10 @@ def test_missing(tas_series):
         m = ind(a, freq="MS")
         assert not m[0].isnull()
 
+    with xclim.set_options(check_missing="wmo"):
+        m = ind(a, freq="YS")
+        assert m[0].isnull()
+
     # With freq=None
     c = clim(a)
     assert c.isnull()

--- a/tests/test_missing.py
+++ b/tests/test_missing.py
@@ -164,6 +164,12 @@ class TestMissingPct:
         out = missing.missing_pct(pr, freq="MS", tolerance=0.01)
         np.testing.assert_array_equal(out, [True, False, True])
 
+    def test_missing_period(self, tas_series):
+        tas = tas_series(np.ones(366), start="2000-01-01")
+        tas = tas.sel(time=tas.time.dt.month.isin([1, 2, 3, 4, 12]))
+        out = missing.missing_pct(tas, freq="MS", tolerance=0.9, src_timestep="D")
+        np.testing.assert_array_equal(out, [False] * 4 + [True] * 7 + [False])
+
 
 class TestAtLeastNValid:
     def test_at_least_n_valid(self, tas_series):
@@ -180,3 +186,9 @@ class TestAtLeastNValid:
         pr = pr_hr_series(a)
         out = missing.at_least_n_valid(pr, freq="MS", n=25 * 24)
         np.testing.assert_array_equal(out, [True, False, True])
+
+    def test_missing_period(self, tas_series):
+        tas = tas_series(np.ones(366), start="2000-01-01")
+        tas = tas.sel(time=tas.time.dt.month.isin([1, 2, 3, 4, 12]))
+        out = missing.missing_pct(tas, freq="MS", tolerance=0.9, src_timestep="D")
+        np.testing.assert_array_equal(out, [False] * 4 + [True] * 7 + [False])


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #570 and fixes #572.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
1 - Add a resampling code to `MissingWMO.execute` to allow frequencies larger than 'MS'. Also small refactoring of `MissingFromContext.execute` to use the subclass's  `execute` method, and not an init-call syntax.
2 - Fix `MissingPct` and `AtLeastNValid` to correctly mark as missing cases where a whole period is absent from the input.

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
No.
