### PR TITLE
Add a UserWarning so that users know about xclim.generic.stats

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -16,7 +16,7 @@ New features and enhancements
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * New xclim.testing.open_dataset method to read data from the remote testdata repo.
 * Added a notebook, `ensembles-advanced.ipynb`, to the documentation detailing ensemble reduction techniques and showing how to make use of built-in figure-generating commands.
-* Added a notebook, `frequency_analysis.ipynb`, with examples showcasing on frequency analysis.
+* Added a notebook, `frequency_analysis.ipynb`, with examples showcasing frequency analysis capabilities.
 
 Bug fixes
 ~~~~~~~~~

--- a/xclim/indices/generic.py
+++ b/xclim/indices/generic.py
@@ -6,10 +6,38 @@ Generic indices submodule
 
 Helper functions for common generic actions done in the computation of indices.
 """
+import warnings
+
 # Note: scipy.stats.dist.shapes: comma separated names of shape parameters
 # The other parameters, common to all distribution, are loc and scale.
 import numpy as np
 import xarray as xr
+
+from .stats import __all__
+
+__all__ = [x for x in __all__]
+
+warnings.warn(
+    f"xclim.indices.generic has been refactored in xclim v0.21.0 and has moved several functions to 'xclim.indices.stats'. "
+    f"The affected functions are as follows: `{'`, `'.join(__all__)}`. "
+    f"They have been made available here for your convenience. This functionality will change in xclim v0.22.0. "
+    f"Please update your scripts accordingly.",
+    UserWarning,
+    stacklevel=2,
+)
+
+__all__.extend(
+    [
+        "select_time",
+        "select_resample_op",
+        "doymax",
+        "doymin",
+        "default_freq",
+        "threshold_count",
+        "get_daily_events",
+        "daily_downsampler",
+    ]
+)
 
 
 def select_time(da: xr.DataArray, **indexer):

--- a/xclim/indices/stats.py
+++ b/xclim/indices/stats.py
@@ -8,7 +8,19 @@ import xarray as xr
 
 from xclim.core.formatting import update_history
 
-from .generic import default_freq, select_resample_op
+from . import generic
+
+__all__ = [
+    "fit",
+    "parametric_quantile",
+    "fa",
+    "frequency_analysis",
+    "get_dist",
+    "get_lm3_dist",
+    "_fit_start",
+    "_lm3_dist_map",
+]
+
 
 # Map the scipy distribution name to the lmoments3 name. Distributions with mismatched parameters are excluded.
 _lm3_dist_map = {
@@ -273,10 +285,10 @@ def frequency_analysis(
         da.attrs.update(attrs)
 
     # Assign default resampling frequency if not provided
-    freq = freq or default_freq(**indexer)
+    freq = freq or generic.default_freq(**indexer)
 
     # Extract the time series of min or max over the period
-    sel = select_resample_op(da, op=mode, freq=freq, **indexer)
+    sel = generic.select_resample_op(da, op=mode, freq=freq, **indexer)
 
     # Frequency analysis
     return fa(sel, t, dist, mode)


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
This adds a warning so that users using the functions now located at `xclim.indices.stats` know about the refactoring at execution and can still access affected functions through `xclim.generic.indices` temporarily. This backwards compatibility will be removed in `xclim` version 0.22.0.

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
No. Imports are not cyclical so things should work fine.

* **Other information**:
