### PR TITLE
Multiple fixes on calendar tools

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,7 @@ History
 =======
 0.22.0 (unreleased)
 -------------------
+
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
@@ -12,12 +13,16 @@ New indicators
 New features and enhancements
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * add unique titles to atmos calculations employing wrapped_partials
+* `xclim.core.calendar.convert_calendar` now accepts a `missing` argument.
+* Added `xclim.core.calendar.date_range` wrapping pandas' `date_range` and xarray's `cftime_range`.
 
 Bug fixes
 ~~~~~~~~~
+* Fixed bug that prevented the use of `xclim.core.missing.MissingBase` and subclasses with an indexer and a cftime datetime coordinate.
 
 Internal changes
 ~~~~~~~~~~~~~~~~~
+* Passing `align_on` to `xclim.core.calendar.convert_calendar` without using '360_day' calendars will not raise a warning anymore.
 
 0.21.0 (2020-10-23)
 -------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -15,6 +15,7 @@ New features and enhancements
 * add unique titles to atmos calculations employing wrapped_partials
 * `xclim.core.calendar.convert_calendar` now accepts a `missing` argument.
 * Added `xclim.core.calendar.date_range` wrapping pandas' `date_range` and xarray's `cftime_range`.
+* `xclim.core.calendar.get_calendar` now accepts many different types of data, including datetime object directly.
 
 Bug fixes
 ~~~~~~~~~

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -14,7 +14,7 @@ New features and enhancements
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * add unique titles to atmos calculations employing wrapped_partials
 * `xclim.core.calendar.convert_calendar` now accepts a `missing` argument.
-* Added `xclim.core.calendar.date_range` wrapping pandas' `date_range` and xarray's `cftime_range`.
+* Added `xclim.core.calendar.date_range` and `xclim.core.calendar.date_range_like` wrapping pandas' `date_range` and xarray's `cftime_range`.
 * `xclim.core.calendar.get_calendar` now accepts many different types of data, including datetime object directly.
 
 Bug fixes

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -10,6 +10,7 @@ from xarray.coding.cftimeindex import CFTimeIndex
 from xclim.core.calendar import (
     adjust_doy_calendar,
     convert_calendar,
+    date_range,
     datetime_to_decimal_year,
     days_in_year,
     ensure_cftime_array,
@@ -43,12 +44,6 @@ def da(index):
     return xr.DataArray(
         np.arange(100.0, 100.0 + index.size), coords=[index], dims=["time"]
     )
-
-
-def date_range(*args, calendar="default", **kwargs):
-    if calendar == "default":
-        return pd.date_range(*args, **kwargs)
-    return xr.cftime_range(*args, calendar=calendar, **kwargs)
 
 
 @pytest.mark.parametrize(
@@ -200,6 +195,36 @@ def test_convert_calendar_360_days(source, target, freq, align_on):
         assert conv.size == 360 if freq == "D" else 360 * 4
     else:
         assert conv.size == 359 if freq == "D" else 359 * 4
+
+
+@pytest.mark.parametrize(
+    "source,target,freq",
+    [
+        ("standard", "noleap", "D"),
+        ("noleap", "default", "4H"),
+        ("noleap", "all_leap", "M"),
+        ("360_day", "noleap", "D"),
+        ("noleap", "360_day", "D"),
+    ],
+)
+def test_convert_calendar_missing(source, target, freq):
+    src = xr.DataArray(
+        date_range(
+            "2004-01-01",
+            "2004-12-31" if source != "360_day" else "2004-12-30",
+            freq=freq,
+            calendar=source,
+        ),
+        dims=("time",),
+        name="time",
+    )
+    da_src = xr.DataArray(
+        np.linspace(0, 1, src.size), dims=("time",), coords={"time": src}
+    )
+    out = convert_calendar(da_src, target, missing=np.nan, align_on="date")
+    assert xr.infer_freq(out.time) == freq
+    if source == "360_day":
+        assert out.time[-1].dt.day == 31
 
 
 @pytest.mark.parametrize(

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -1,5 +1,6 @@
 import os
 
+import cftime
 import numpy as np
 import pandas as pd
 import pytest
@@ -114,6 +115,19 @@ def test_get_calendar(file, cal, maxdoy):
         out_cal = get_calendar(ds)
         assert cal == out_cal
         assert max_doy[cal] == maxdoy
+
+
+@pytest.mark.parametrize(
+    "obj,cal",
+    [
+        ([pd.Timestamp.now()], "default"),
+        (pd.Timestamp.now(), "default"),
+        (cftime.DatetimeAllLeap(2000, 1, 1), "all_leap"),
+        (np.array([cftime.DatetimeNoLeap(2000, 1, 1)]), "noleap"),
+    ],
+)
+def test_get_calendar_nonxr(obj, cal):
+    assert get_calendar(obj) == cal
 
 
 @pytest.mark.parametrize(

--- a/tests/test_missing.py
+++ b/tests/test_missing.py
@@ -6,6 +6,7 @@ import pytest
 import xarray as xr
 
 from xclim.core import missing
+from xclim.core.calendar import convert_calendar
 from xclim.testing import open_dataset
 
 K2C = 273.15
@@ -73,8 +74,11 @@ class TestMissingAnyFills:
         miss = missing.missing_any(ts, freq="YS", month=[7, 8])
         np.testing.assert_equal(miss, [False])
 
-    def test_season(self, tasmin_series):
+    @pytest.mark.parametrize("calendar", ("default", "noleap", "360_day"))
+    def test_season(self, tasmin_series, calendar):
         ts = tasmin_series(np.zeros(360))
+        ts = convert_calendar(ts, calendar, missing=0, align_on="date")
+
         miss = missing.missing_any(ts, freq="YS", season="MAM")
         np.testing.assert_equal(miss, [False])
 

--- a/xclim/core/calendar.py
+++ b/xclim/core/calendar.py
@@ -6,8 +6,6 @@ Calendar handling utilities
 
 Helper function to handle dates, times and different calendars with xarray.
 """
-
-import datetime
 import datetime as pydt
 from typing import Any, Optional, Sequence, Union
 from warnings import warn
@@ -79,7 +77,7 @@ def get_calendar(obj: Any, dim: str = "time") -> str:
     obj = np.take(
         obj, 0
     )  # Take zeroth element, overcome cases when arrays or lists are passed.
-    if isinstance(obj, datetime.datetime):  # Also covers pandas Timestamp
+    if isinstance(obj, pydt.datetime):  # Also covers pandas Timestamp
         return "default"
     if isinstance(obj, cftime.datetime):
         return obj.calendar

--- a/xclim/core/calendar.py
+++ b/xclim/core/calendar.py
@@ -266,7 +266,7 @@ def interp_calendar(
 
 
 def date_range(*args, calendar="default", **kwargs):
-    """Wrapper of pd.date_range (if calendar == 'default') and xr.cftime_range (otherwise)."""
+    """Wrap pd.date_range (if calendar == 'default') or xr.cftime_range (otherwise)."""
     if calendar == "default":
         return pd.date_range(*args, **kwargs)
     return xr.cftime_range(*args, calendar=calendar, **kwargs)

--- a/xclim/core/missing.py
+++ b/xclim/core/missing.py
@@ -28,6 +28,7 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
+from xclim.core.calendar import date_range, get_calendar
 from xclim.core.options import (
     CHECK_MISSING,
     MISSING_METHODS,
@@ -140,13 +141,12 @@ class MissingBase:
 
         if indexer:
             # Create a full synthetic time series and compare the number of days with the original series.
-            t0 = str(start_time[0].date())
-            t1 = str(end_time[-1].date())
-            if isinstance(da.indexes["time"], xr.CFTimeIndex):
-                cal = da.time.encoding.get("calendar")
-                t = xr.cftime_range(t0, t1, freq=src_timestep, calendar=cal)
-            else:
-                t = pd.date_range(t0, t1, freq=src_timestep)
+            t = date_range(
+                start_time[0],
+                end_time[-1],
+                freq=src_timestep,
+                calendar=get_calendar(da),
+            )
 
             sda = xr.DataArray(data=np.ones(len(t)), coords={"time": t}, dims=("time",))
             st = generic.select_time(sda, **indexer)


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #568, fixes, #575, fixes #578, fixes #580 and fixes #582.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
Several small changes:

- `missing` argument added to `convert_calendar`
- No more warning for passing `align_on` uselessly to `convert_calendar`
- Non-failing use of `Missing` objects with  `indexer` and cftime coordinates.
- All objects I could think of can be passed to `get_calendar`. (python datetimes, pandas Timestamps, cftime datetimes and arrays or sequences of them).
- Added `365_day` and `366_day` to the understood CF datetime classes (respectively 'noleap' and 'all_leap').

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
No.

* **Other information**:
5 issues in 1 PR, my new high-score.