### PR TITLE
Add spatial analog algos from flyingpigeon

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -16,6 +16,7 @@ New features and enhancements
 * `xclim.core.calendar.convert_calendar` now accepts a `missing` argument.
 * Added `xclim.core.calendar.date_range` and `xclim.core.calendar.date_range_like` wrapping pandas' `date_range` and xarray's `cftime_range`.
 * `xclim.core.calendar.get_calendar` now accepts many different types of data, including datetime object directly.
+* New module `xclim.analog` and method `xclim.analog.spatial_analogs` to compute spatial analogs.
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -89,6 +89,12 @@ ensembles module
    :undoc-members:
    :show-inheritance:
 
+spatial analogs module
+----------------------
+
+.. automodule:: xclim.analog
+   :members:
+
 testing module
 --------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.21.1-beta
+current_version = 0.21.2-beta
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+).(?P<patch>\d+)(\-(?P<release>[a-z]+))?

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ URL = "https://github.com/Ouranosinc/xclim"
 AUTHOR = "Travis Logan"
 AUTHOR_EMAIL = "logan.travis@ouranos.ca"
 REQUIRES_PYTHON = ">=3.6.0"
-VERSION = "0.21.1-beta"
+VERSION = "0.21.2-beta"
 LICENSE = "Apache Software License 2.0"
 
 with open("README.rst") as readme_file:

--- a/tests/test_analog.py
+++ b/tests/test_analog.py
@@ -15,12 +15,12 @@ def matlab_sample(n=30):
     Climate Analogs" to compare against the functions here. The sample
     created here is identical to the sample used to drive the Matlab code.
 
-    
+
     Parameters
     ----------
     n : int
       Sample size.
-      
+
     Returns
     -------
     2D array, 2D array
@@ -247,7 +247,7 @@ class TestKLDIV:
 
         out = []
         for i in range(trials):
-            out.append(xca.kldiv(p.rvs(n), q.rvs(n), k))
+            out.append(xca.kldiv(p.rvs(n), q.rvs(n), k=k))
         out = np.array(out)
 
         # Compare with analytical value

--- a/tests/test_analog.py
+++ b/tests/test_analog.py
@@ -15,8 +15,16 @@ def matlab_sample(n=30):
     Climate Analogs" to compare against the functions here. The sample
     created here is identical to the sample used to drive the Matlab code.
 
-    :param n:
-    :return:
+    
+    Parameters
+    ----------
+    n : int
+      Sample size.
+      
+    Returns
+    -------
+    2D array, 2D array
+       Synthetic samples (3, n)
     """
 
     z = 1.0 * (np.arange(n) + 1) / n - 0.5

--- a/tests/test_analog.py
+++ b/tests/test_analog.py
@@ -54,8 +54,8 @@ def test_randn():
 def test_spatial_analogs(method):
     if method == "skezely_rizzo":
         pytest.skip("Method not implemented.")
-    diss = open_dataset("SpatialAnalogs/dissimilarity", branch="spatial_analogs")
-    data = open_dataset("SpatialAnalogs/indicators", branch="spatial_analogs")
+    diss = open_dataset("SpatialAnalogs/dissimilarity")
+    data = open_dataset("SpatialAnalogs/indicators")
 
     target = data.sel(lat=46.1875, lon=-72.1875, time=slice("1970", "1990"))
     candidates = data.sel(time=slice("1970", "1990"))
@@ -66,8 +66,8 @@ def test_spatial_analogs(method):
 
 
 def test_spatial_analogs_multidim():
-    diss = open_dataset("SpatialAnalogs/dissimilarity", branch="spatial_analogs")
-    data = open_dataset("SpatialAnalogs/indicators", branch="spatial_analogs")
+    diss = open_dataset("SpatialAnalogs/dissimilarity")
+    data = open_dataset("SpatialAnalogs/indicators")
 
     targets = data.sel(
         lat=slice(46, 47), lon=slice(-73, -72), time=slice("1970", "1990")

--- a/tests/test_analog.py
+++ b/tests/test_analog.py
@@ -1,0 +1,286 @@
+# Tests taken from flyingpigeon on Nov 2020
+import numpy as np
+import pytest
+from numpy.testing import assert_almost_equal
+from scipy import integrate, stats
+
+import xclim.analog as xca
+from xclim.testing import open_dataset
+
+
+def matlab_sample(n=30):
+    """
+    In some of the following tests I'm using Matlab code written by Patrick
+    Grenier for the paper "An Assessment of Six Dissimilarity Metrics for
+    Climate Analogs" to compare against the functions here. The sample
+    created here is identical to the sample used to drive the Matlab code.
+
+    :param n:
+    :return:
+    """
+
+    z = 1.0 * (np.arange(n) + 1) / n - 0.5
+
+    x = np.vstack([z * 2 + 30, z * 3 + 40, z]).T
+
+    y = np.vstack([z * 2.2 + 31, z[::-1] * 2.8 + 38, z * 1.1]).T
+
+    return x, y
+
+
+def randn(mean, std, shape):
+    """Return a random normal sample with exact mean and standard deviation."""
+    r = np.random.randn(*shape)
+    r1 = r / r.std(0, ddof=1) * np.array(std)
+    return r1 - r1.mean(0) + np.array(mean)
+
+
+def test_randn():
+    mu, std = [2, 3], [1, 2]
+    r = randn(mu, std, [10, 2])
+    assert_almost_equal(r.mean(0), mu)
+    assert_almost_equal(r.std(0, ddof=1), std)
+
+
+@pytest.mark.parametrize("method", xca.metrics.keys())
+def test_spatial_analogs(method):
+    if method == "skezely_rizzo":
+        pytest.skip("Method not implemented.")
+    diss = open_dataset("SpatialAnalogs/dissimilarity", branch="spatial_analogs")
+    data = open_dataset("SpatialAnalogs/indicators", branch="spatial_analogs")
+
+    target = data.sel(lat=46.1875, lon=-72.1875, time=slice("1970", "1990"))
+    candidates = data.sel(time=slice("1970", "1990"))
+
+    out = xca.spatial_analogs(target, candidates, method=method)
+
+    np.testing.assert_allclose(diss[method], out, rtol=1e-3, atol=1e-3)
+
+
+def test_spatial_analogs_multidim():
+    diss = open_dataset("SpatialAnalogs/dissimilarity", branch="spatial_analogs")
+    data = open_dataset("SpatialAnalogs/indicators", branch="spatial_analogs")
+
+    targets = data.sel(
+        lat=slice(46, 47), lon=slice(-73, -72), time=slice("1970", "1990")
+    )
+    targets = targets.stack(locations=["lat", "lon"])
+    candidates = data.sel(time=slice("1970", "1990"))
+
+    out = xca.spatial_analogs(targets, candidates, method="seuclidean")
+    assert out.dims == ("locations", "lat", "lon")
+
+    np.testing.assert_array_almost_equal(
+        diss.seuclidean, out.sel(locations=(46.1875, -72.1875)), 5
+    )
+    assert out.attrs["indices"] == "meantemp,totalpr"
+
+
+class TestSEuclidean:
+    def test_simple(self):
+        d = 2
+        n, m = 25, 30
+
+        x = randn(0, 1, (n, d))
+        y = randn([1, 2], 1, (m, d))
+        dm = xca.seuclidean(x, y)
+        assert_almost_equal(dm, np.hypot(1, 2), 2)
+
+        # Variance of the candidate sample does not affect answer.
+        x = randn(0, 1, (n, d))
+        y = randn([1, 2], 2, (m, d))
+        dm = xca.seuclidean(x, y)
+        assert_almost_equal(dm, np.hypot(1, 2), 2)
+
+    def test_compare_with_matlab(self):
+        x, y = matlab_sample()
+        dm = xca.seuclidean(x, y)
+        assert_almost_equal(dm, 2.8463, 4)
+
+
+class TestNN:
+    def test_simple(self):
+        d = 2
+        n, m = 200, 200
+        np.random.seed(1)
+        x = np.random.randn(n, d)
+        y = np.random.randn(m, d)
+
+        # Almost identical samples
+        dm = xca.nearest_neighbor(x + 0.001, x)
+        assert_almost_equal(dm, 0, 2)
+
+        # Same distribution but mixed
+        dm = xca.nearest_neighbor(x, y)
+        assert_almost_equal(dm, 0.5, 1)
+
+        # Two completely different distributions
+        dm = xca.nearest_neighbor(x + 10, y)
+        assert_almost_equal(dm, 1, 2)
+
+    def test_compare_with_matlab(self):
+        x, y = matlab_sample()
+        dm = xca.nearest_neighbor(x, y)
+        assert_almost_equal(dm, 1, 4)
+
+
+class TestZAE:
+    def test_simple(self):
+        d = 2
+        n = 200
+        # m = 200
+        x = np.random.randn(n, d)
+        # y = np.random.randn(m, d)
+
+        # Almost identical samples
+        dm = xca.zech_aslan(x + 0.001, x)
+        assert dm < 0
+
+    def test_compare_with_matlab(self):
+        x, y = matlab_sample()
+        dm = xca.zech_aslan(x, y)
+        assert_almost_equal(dm, 0.77802, 4)
+
+
+class TestFR:
+    def test_simple(self):
+        # Over these 7 points, there are 2 with edges within the same sample.
+        # [1,2]-[2,2] & [3,2]-[4,2]
+        # |
+        # |   x
+        # | o o x x
+        # | x  o
+        # |_ _ _ _ _ _ _
+        x = np.array([[1, 2], [2, 2], [3, 1]])
+        y = np.array([[1, 1], [2, 4], [3, 2], [4, 2]])
+
+        dm = xca.friedman_rafsky(x, y)
+        assert_almost_equal(dm, 2.0 / 7, 3)
+
+    def test_compare_with_matlab(self):
+        x, y = matlab_sample()
+        dm = xca.friedman_rafsky(x, y)
+        assert_almost_equal(dm, 0.96667, 4)
+
+
+class TestKS:
+    def test_1D_ks_2samp(self):
+        # Compare with scipy.stats.ks_2samp
+        x = np.random.randn(50) + 1
+        y = np.random.randn(50)
+        s, p = stats.ks_2samp(x, y)
+        dm = xca.kolmogorov_smirnov(x, y)
+        assert_almost_equal(dm, s, 3)
+
+    def test_compare_with_matlab(self):
+        x, y = matlab_sample()
+        dm = xca.kolmogorov_smirnov(x, y)
+        assert_almost_equal(dm, 0.96667, 4)
+
+
+def analytical_KLDiv(p, q):
+    """Return the Kullback-Leibler divergence between two distributions.
+
+    Parameters
+    ----------
+    p, q : scipy.frozen_rv
+      Scipy frozen distribution instances, e.g. stats.norm(0,1)
+
+    Returns
+    -------
+    out : float
+      The Kullback-Leibler divergence computed by numerically integrating
+      p(x)*log(p(x)/q(x)).
+    """
+
+    def func(x):
+        return p.pdf(x) * np.log(p.pdf(x) / q.pdf(x))
+
+    a = 1e-5
+    return integrate.quad(func, max(p.ppf(a), q.ppf(a)), min(p.isf(a), q.isf(a)))[0]
+
+
+@pytest.mark.slow
+class TestKLDIV:
+    #
+    def test_against_analytic(self):
+        p = stats.norm(2, 1)
+        q = stats.norm(2.6, 1.4)
+
+        ra = analytical_KLDiv(p, q)
+
+        N = 10000
+        np.random.seed(2)
+        # x, y = p.rvs(N), q.rvs(N)
+
+        re = xca.kldiv(p.rvs(N), q.rvs(N))
+
+        assert_almost_equal(re, ra, 1)
+
+    def accuracy_vs_kth(self, n=100, trials=100):
+        """Evalute the accuracy of the algorithm as a function of k.
+
+        Parameters
+        ----------
+        N : int
+          Number of random samples.
+        trials : int
+          Number of independent drawing experiments.
+
+        Returns
+        -------
+        (err, stddev) The mean error and standard deviation around the
+        analytical value for different values of k from 1 to 15.
+        """
+        p = stats.norm(0, 1)
+        q = stats.norm(0.2, 0.9)
+
+        k = np.arange(1, 16)
+
+        out = []
+        for i in range(trials):
+            out.append(xca.kldiv(p.rvs(n), q.rvs(n), k))
+        out = np.array(out)
+
+        # Compare with analytical value
+        err = out - analytical_KLDiv(p, q)
+
+        # Return mean and standard deviation
+        return err.mean(0), err.std(0)
+
+    #
+    def test_accuracy(self):
+        m, _ = self.accuracy_vs_kth(n=500, trials=500)
+        assert_almost_equal(np.mean(m[0:2]), 0, 2)
+
+    #
+    def test_different_sample_size(self):
+        p = stats.norm(2, 1)
+        q = stats.norm(2.6, 1.4)
+
+        ra = analytical_KLDiv(p, q)
+
+        n = 6000
+        # Same sample size for x and y
+        re = [xca.kldiv(p.rvs(n), q.rvs(n)) for i in range(30)]
+        assert_almost_equal(np.mean(re), ra, 2)
+
+        # Different sample sizes
+        re = [xca.kldiv(p.rvs(n * 2), q.rvs(n)) for i in range(30)]
+        assert_almost_equal(np.mean(re), ra, 2)
+
+        re = [xca.kldiv(p.rvs(n), q.rvs(n * 2)) for i in range(30)]
+        assert_almost_equal(np.mean(re), ra, 2)
+
+    #
+    def test_mvnormal(self):
+        """Compare the results to the figure 2 in the paper."""
+        from numpy.random import multivariate_normal, normal
+
+        n = 30000
+        p = normal(0, 1, size=(n, 2))
+        np.random.seed(1)
+        q = multivariate_normal([0.5, -0.5], [[0.5, 0.1], [0.1, 0.3]], size=n)
+
+        assert_almost_equal(xca.kldiv(p, q), 1.39, 1)
+        assert_almost_equal(xca.kldiv(q, p), 0.62, 1)

--- a/xclim/__init__.py
+++ b/xclim/__init__.py
@@ -6,4 +6,4 @@ from xclim.indicators import ICCLIM, anuclim, atmos, icclim, land, seaIce
 
 __author__ = """Travis Logan"""
 __email__ = "logan.travis@ouranos.ca"
-__version__ = "0.21.1-beta"
+__version__ = "0.21.2-beta"

--- a/xclim/analog.py
+++ b/xclim/analog.py
@@ -1,0 +1,545 @@
+# -*- encoding: utf8 -*-
+"""
+===============
+Spatial analogs
+===============
+
+Spatial analogues are maps showing which areas have a present-day climate that is analogous
+to the future climate of a given place. This type of map can be useful for climate adaptation
+to see how well regions are coping today under specific climate conditions. For example,
+officials from a city located in a temperate region that may be expecting more heatwaves in
+the future can learn from the experience of another city where heatwaves are a common occurrence,
+leading to more proactive intervention plans to better deal with new climate conditions.
+
+Spatial analogues are estimated by comparing the distribution of climate indices computed at
+the target location over the future period with the distribution of the same climate indices
+computed over a reference period for multiple candidate regions. A number of methodological
+choices thus enter the computation:
+
+    - Climate indices of interest,
+    - Metrics measuring the difference between both distributions,
+    - Reference data from which to compute the base indices,
+    - A future climate scenario to compute the target indices.
+
+The climate indices chosen to compute the spatial analogues are usually annual values of
+indices relevant to the intended audience of these maps. For example, in the case of the
+wine grape industry, the climate indices examined could include the length of the frost-free
+season, growing degree-days, annual winter minimum temperature andand annual number of
+very cold days [Roy2017].
+
+
+Methods to compute the (dis)similarity between samples
+------------------------------------------------------
+
+This module implements five of the six methods described in [Grenier20131]_ to measure
+the dissimilarity between two samples. Some of these algorithms can be used to
+test whether or not two samples have been drawn from the same distribution.
+Here, they are used to find areas with analog climate conditions to a target
+climate.
+
+Methods available
+~~~~~~~~~~~~~~~~~
+ * Standardized Euclidean distance
+ * Nearest Neighbour distance
+ * Zech-Aslan energy statistic
+ * Friedman-Rafsky runs statistic
+ * Kolmogorov-Smirnov statistic
+ * Kullback-Leibler divergence
+
+All methods accept arrays, the first is the reference (shape (n, D)) and
+the second is the candidate (shape (m, D)). Where the climate indicators
+vary along D and the distribution dimension along n or m. All methods output
+a single float.
+
+
+.. rubric:: References
+
+.. [Roy2017] Roy, P., Grenier, P., Barriault, E. et al. Climatic Change (2017) 143: 43. `<doi:10.1007/s10584-017-1960-x>`_
+.. [Grenier2013]  Grenier, P., A.-C. Parent, D. Huard, F. Anctil, and D. Chaumont, 2013: An assessment of six dissimilarity metrics for climate analogs. J. Appl. Meteor. Climatol., 52, 733–752, `<doi:10.1175/JAMC-D-12-0170.1>`_
+"""
+from typing import Sequence, Union
+
+import numpy as np
+import xarray as xr
+
+# Code adapted from flyingpigeon.dissimilarity, Nov 2020.
+from numba import jit
+from scipy import spatial
+from scipy.spatial import cKDTree as KDTree
+
+# TODO: Szekely, G, Rizzo, M (2014) Energy statistics: A class of statistics
+# based on distances. J Stat Planning & Inference 143: 1249-1272
+
+# TODO: Hellinger distance
+metrics = {}
+
+
+def spatial_analogs(
+    target: xr.Dataset,
+    candidates: xr.Dataset,
+    dist_dim: Union[str, Sequence[str]] = "time",
+    method: str = "kldiv",
+    **kwargs,
+):
+    """Compute dissimilarity statistics between target points and candidate points.
+
+    Spatial analogs based on the comparison of climate indices. The algorithm compares
+    the distribution of the reference indices with the distribution of spatially
+    distributed candidate indices and returns a value measuring the dissimilarity
+    between both distributions over the candidate grid.
+
+    Parameters
+    ----------
+    target : xr.Dataset
+        Dataset of the target indices. Only indice variables should be included in the
+        dataset's `data_vars`. They should have only the dimension(s) `dist_dim `in common with `candidates`.
+    candidates : xr.Dataset
+        Dataset of the candidate indices. Only indice variables should be included in
+        the dataset's `data_vars`.
+    dist_dim : Union[str, Sequence[Union[str, Sequence[str]]]]
+        The dimension(s) over which the *distributions* are constructed.
+    method : {'seuclidean', 'nearest_neighbor', 'zech_aslan', 'kolmogorov_smirnov', 'friedman_rafsky', 'kldiv'}
+        Which method to use when computing the dissimilarity statistic.
+    **kwargs
+        Any other parameter passed directly to the dissimilarity method.
+
+    Returns
+    -------
+    xr.DataArray
+        The dissimilarity statistic over the union of candidates' and target's dimensions.
+    """
+    if isinstance(dist_dim, str):
+        dist_dim = [dist_dim]
+
+    # Create the target DataArray:
+    target = xr.concat(
+        target.data_vars.values(),
+        xr.DataArray(list(target.data_vars.keys()), dims=("indices",), name="indices"),
+    )
+    target = target.stack(dist=dist_dim)
+
+    # Create the target DataArray:
+    candidates = xr.concat(
+        candidates.data_vars.values(),
+        xr.DataArray(
+            list(candidates.data_vars.keys()), dims=("indices",), name="indices"
+        ),
+    )
+    candidates = candidates.stack(dist=dist_dim)
+
+    try:
+        metric = metrics[method]
+    except KeyError:
+        raise ValueError(
+            f"Method {method} is not implemented. Available methods are : {','.join(metrics.keys())}."
+        )
+
+    # Compute dissimilarity
+    diss = xr.apply_ufunc(
+        metric,
+        target,
+        candidates,
+        input_core_dims=[("dist", "indices"), ("dist", "indices")],
+        output_core_dims=[()],
+        vectorize=True,
+        dask="parallelized",
+        output_dtypes=[float],
+    )
+    diss.name = "dissimilarity"
+    diss.attrs.update(
+        long_name=f"Dissimilarity between target and candidates, using metric {method}."
+    )
+
+    return diss
+
+
+# ---------------------------------------------------------------------------- #
+# -------------------------- Utility functions ------------------------------- #
+# ---------------------------------------------------------------------------- #
+
+
+def standardize(x, y):
+    """
+    deviation.
+
+    Parameters
+    ----------
+    x, y : ndarray
+        Arrays to be compared.
+
+    Returns
+    -------
+    x, y : ndarray
+        Standardized arrays.
+    """
+    s = np.sqrt(x.std(0, ddof=1) * y.std(0, ddof=1))
+    return x / s, y / s
+
+
+def register_metric(func):
+    metrics[func.__name__] = func
+    return func
+
+
+# ---------------------------------------------------------------------------- #
+# ------------------------ Dissimilarity metrics ----------------------------- #
+# ---------------------------------------------------------------------------- #
+
+
+@register_metric
+@jit
+def seuclidean(x, y):
+    """
+    Compute the Euclidean distance between the mean of a multivariate
+    candidate sample with respect to the mean of a reference sample.
+
+    Parameters
+    ----------
+    x : ndarray (n,d)
+        Reference sample.
+    y : ndarray (m,d)
+        Candidate sample.
+
+    Returns
+    -------
+    float
+        Standardized Euclidean Distance between the mean of the samples
+        ranging from 0 to infinity.
+
+    Notes
+    -----
+    This metric considers neither the information from individual points nor
+    the standard deviation of the candidate distribution.
+
+    References
+    ----------
+    Veloz et al. (2011) Identifying climatic analogs for Wisconsin under
+    21st-century climate-change scenarios. Climatic Change,
+    DOI 10.1007/s10584-011-0261-z.
+    """
+    mx = x.mean(axis=0)
+    my = y.mean(axis=0)
+
+    return spatial.distance.seuclidean(mx, my, x.var(axis=0, ddof=1))
+
+
+@register_metric
+@jit
+def nearest_neighbor(x, y):
+    """
+    Compute a dissimilarity metric based on the number of points in the
+    pooled sample whose nearest neighbor belongs to the same distribution.
+
+    Parameters
+    ----------
+    x : ndarray (n,d)
+        Reference sample.
+    y : ndarray (m,d)
+        Candidate sample.
+
+    Returns
+    -------
+    float
+        Nearest-Neighbor dissimilarity metric ranging from 0 to 1.
+
+    References
+    ----------
+    Henze N. (1988) A Multivariate two-sample test based on the number of
+    nearest neighbor type coincidences. Ann. of Stat., Vol. 16, No.2, 772-783.
+    """
+    x, y = standardize(x, y)
+
+    nx, _ = x.shape
+
+    # Pool the samples and find the nearest neighbours
+    xy = np.vstack([x, y])
+    tree = KDTree(xy)
+    _, ind = tree.query(xy, k=2, eps=0, p=2, n_jobs=2)
+
+    # Identify points whose neighbors are from the same sample
+    same = ~np.logical_xor(*(ind < nx).T)
+
+    return same.mean()
+
+
+@register_metric
+@jit
+def zech_aslan(x, y):
+    """
+    Compute the Zech-Aslan energy distance dissimimilarity metric based on an
+    analogy with the energy of a cloud of electrical charges.
+
+    Parameters
+    ----------
+    x : ndarray (n,d)
+        Reference sample.
+    y : ndarray (m,d)
+        Candidate sample.
+
+    Returns
+    -------
+    float
+        Zech-Aslan dissimilarity metric ranging from -infinity to infinity.
+
+    References
+    ----------
+    Zech G. and Aslan B. (2003) A Multivariate two-sample test based on the
+    concept of minimum energy. PHYStat2003, SLAC, Stanford, CA, Sep 8-11.
+    Aslan B. and Zech G. (2008) A new class of binning-free, multivariate
+    goodness-of-fit tests: the energy tests. arXiV:hep-ex/0203010v5.
+    """
+    nx, d = x.shape
+    ny, d = y.shape
+
+    v = (x.std(axis=0, ddof=1) * y.std(axis=0, ddof=1)).astype(np.double)
+
+    dx = spatial.distance.pdist(x, "seuclidean", V=v)
+    dy = spatial.distance.pdist(y, "seuclidean", V=v)
+    dxy = spatial.distance.cdist(x, y, "seuclidean", V=v)
+
+    phix = -np.log(dx).sum() / nx / (nx - 1)
+    phiy = -np.log(dy).sum() / ny / (ny - 1)
+    phixy = np.log(dxy).sum() / nx / ny
+    return phix + phiy + phixy
+
+
+@register_metric
+def skezely_rizzo(x, y):
+    """
+    Compute the Skezely-Rizzo energy distance dissimimilarity metric
+    based on an analogy with the energy of a cloud of electrical charges.
+
+    Parameters
+    ----------
+    x : ndarray (n,d)
+        Reference sample.
+    y : ndarray (m,d)
+        Candidate sample.
+
+    Returns
+    -------
+    float
+        Skezely-Rizzo dissimilarity metric ranging from -infinity to infinity.
+
+    References
+    ----------
+    TODO
+    """
+    raise NotImplementedError
+    # nx, d = x.shape
+    # ny, d = y.shape
+    #
+    # v = x.std(0, ddof=1) * y.std(0, ddof=1)
+    #
+    # dx = spatial.distance.pdist(x, 'seuclidean', V=v)
+    # dy = spatial.distance.pdist(y, 'seuclidean', V=v)
+    # dxy = spatial.distance.cdist(x, y, 'seuclidean', V=v)
+    #
+    # phix = -np.log(dx).sum() / nx / (nx - 1)
+    # phiy = -np.log(dy).sum() / ny / (ny - 1)
+    # phixy = np.log(dxy).sum() / nx / ny
+
+    # z = dxy.sum() * 2. / (nx*ny) - (1./nx**2) *
+
+    # z = (2 / (n * m)) * sum(dxy(:)) - (1 / (n ^ 2)) * sum(2 * dx) - (1 /
+    #  (m ^ 2)) * sum(2 * dy);
+    # z = ((n * m) / (n + m)) * z;
+
+
+@register_metric
+@jit
+def friedman_rafsky(x, y):
+    """
+    Compute a dissimilarity metric based on the Friedman-Rafsky runs statistics.
+
+    The algorithm builds a minimal spanning tree (the subset of edges
+    connecting all points that minimizes the total edge length) then counts
+    the edges linking points from the same distribution.
+
+    Parameters
+    ----------
+    x : ndarray (n,d)
+        Reference sample.
+    y : ndarray (m,d)
+        Candidate sample.
+
+    Returns
+    -------
+    float
+        Friedman-Rafsky dissimilarity metric ranging from 0 to (m+n-1)/(m+n).
+
+    References
+    ----------
+    Friedman J.H. and Rafsky L.C. (1979) Multivariate generaliations of the
+    Wald-Wolfowitz and Smirnov two-sample tests. Annals of Stat. Vol.7,
+    No. 4, 697-717.
+    """
+    from scipy.sparse.csgraph import minimum_spanning_tree
+    from sklearn import neighbors
+
+    nx, _ = x.shape
+    ny, _ = y.shape
+    n = nx + ny
+
+    xy = np.vstack([x, y])
+
+    # Compute the NNs and the minimum spanning tree
+    g = neighbors.kneighbors_graph(xy, n_neighbors=n - 1, mode="distance")
+    mst = minimum_spanning_tree(g, overwrite=True)
+    edges = np.array(mst.nonzero()).T
+
+    # Number of points whose neighbor is from the other sample
+    diff = np.logical_xor(*(edges < nx).T).sum()
+
+    return 1.0 - (1.0 + diff) / n
+
+
+@register_metric
+@jit
+def kolmogorov_smirnov(x, y):
+    """
+    Compute the Kolmogorov-Smirnov statistic applied to two multivariate
+    samples as described by Fasano and Franceschini.
+
+    Parameters
+    ----------
+    x : ndarray (n,d)
+        Reference sample.
+    y : ndarray (m,d)
+        Candidate sample.
+
+    Returns
+    -------
+    float
+        Kolmogorov-Smirnov dissimilarity metric ranging from 0 to 1.
+
+    References
+    ----------
+    Fasano G. and Francheschini A. (1987) A multidimensional version
+    of the Kolmogorov-Smirnov test. Monthly Notices of the Royal
+    Astronomical Society, vol. 225, pp. 155-170.
+    """
+
+    def pivot(x, y):
+        nx, d = x.shape
+        ny, d = y.shape
+
+        # Multiplicating factor converting d-dim booleans to a unique integer.
+        mf = (2 ** np.arange(d)).reshape(1, d, 1)
+        minlength = 2 ** d
+
+        # Assign a unique integer according on whether or not x[i] <= sample
+        ix = ((x.T <= np.atleast_3d(x)) * mf).sum(1)
+        iy = ((x.T <= np.atleast_3d(y)) * mf).sum(1)
+
+        # Count the number of samples in each quadrant
+        cx = 1.0 * np.apply_along_axis(np.bincount, 0, ix, minlength=minlength) / nx
+        cy = 1.0 * np.apply_along_axis(np.bincount, 0, iy, minlength=minlength) / ny
+
+        # This is from https://github.com/syrte/ndtest/blob/master/ndtest.py
+        # D = cx - cy
+        # D[0,:] -= 1. / nx # I don't understand this...
+        # dmin, dmax = -D.min(), D.max() + .1 / nx
+
+        return np.max(np.abs(cx - cy))
+
+    return max(pivot(x, y), pivot(y, x))
+
+
+@register_metric
+@jit
+def kldiv(x, y, k=1):
+    """
+    Compute the Kullback-Leibler divergence between two multivariate samples.
+
+    .. math
+        D(P||Q) = "\"frac{d}{n} "\"sum_i^n "\"log{"\"frac{r_k(x_i)}{s_k(x_i)}} + "\"log{"\"frac{m}{n-1}}
+
+    where r_k(x_i) and s_k(x_i) are, respectively, the euclidean distance
+    to the kth neighbour of x_i in the x array (excepting x_i) and
+    in the y array.
+
+    Parameters
+    ----------
+    x : ndarray (n,d)
+        Samples from distribution P, which typically represents the true
+        distribution (reference).
+    y : ndarray (m,d)
+        Samples from distribution Q, which typically represents the
+        approximate distribution (candidate)
+    k : int or sequence
+        The kth neighbours to look for when estimating the density of the
+        distributions. Defaults to 1, which can be noisy.
+
+    Returns
+    -------
+    out : float or sequence
+        The estimated Kullback-Leibler divergence D(P||Q) computed from
+        the distances to the kth neighbour.
+
+    Notes
+    -----
+    In information theory, the Kullback–Leibler divergence is a non-symmetric
+    measure of the difference between two probability distributions P and Q,
+    where P is the "true" distribution and Q an approximation. This nuance is
+    important because D(P||Q) is not equal to D(Q||P).
+
+    For probability distributions P and Q of a continuous random variable,
+    the K–L  divergence is defined as:
+
+        D_{KL}(P||Q) = "\"int p(x) "\"log{p()/q(x)} dx
+
+    This formula assumes we have a representation of the probability
+    densities p(x) and q(x).  In many cases, we only have samples from the
+    distribution, and most methods first estimate the densities from the
+    samples and then proceed to compute the K-L divergence. In Perez-Cruz,
+    the authors propose an algorithm to estimate the K-L divergence directly
+    from the sample using an empirical CDF. Even though the CDFs do not
+    converge to their true values, the paper proves that the K-L divergence
+    almost surely does converge to its true value.
+
+    References
+    ----------
+    Kullback-Leibler Divergence Estimation of Continuous Distributions (2008).
+    Fernando Pérez-Cruz.
+    """
+
+    mk = np.iterable(k)
+    ka = np.atleast_1d(k)
+
+    nx, d = x.shape
+    ny, d = y.shape
+
+    # Limit the number of dimensions to 10, too slow otherwise.
+    if d > 10:
+        raise ValueError("Too many dimensions: {}.".format(d))
+
+    # Not enough data to draw conclusions.
+    if nx < 5 or ny < 5:
+        return np.nan
+
+    # Build a KD tree representation of the samples.
+    xtree = KDTree(x)
+    ytree = KDTree(y)
+
+    # Get the k'th nearest neighbour from each points in x for both x and y.
+    # We get the values for K + 1 to make sure the output is a 2D array.
+    kmax = max(ka) + 1
+    r, _ = xtree.query(x, k=kmax, eps=0, p=2, n_jobs=2)
+    s, _ = ytree.query(x, k=kmax, eps=0, p=2, n_jobs=2)
+
+    # There is a mistake in the paper. In Eq. 14, the right side misses a
+    # negative sign on the first term of the right hand side.
+    out = []
+    for ki in ka:
+        # The 0th nearest neighbour of x[i] in x is x[i] itself.
+        # Hence we take the k'th + 1, which in 0-based indexing is given by
+        # index k.
+        out.append(
+            -np.log(r[:, ki] / s[:, ki - 1]).sum() * d / nx + np.log(ny / (nx - 1.0))
+        )
+
+    if mk:
+        return out
+    else:
+        return out[0]

--- a/xclim/analog.py
+++ b/xclim/analog.py
@@ -183,7 +183,6 @@ def metric(func):
     All metric functions accept 2D inputs. This reshape 1D inputs to (n, 1) and (m, 1).
     All metric functions are invalid when any non-finite values are present in the inputs.
     """
-    metrics[func.__name__] = func
 
     @wraps(func)
     def _metric_overhead(x, y, **kwargs):
@@ -204,6 +203,7 @@ def metric(func):
 
         return func(x, y, **kwargs)
 
+    metrics[func.__name__] = _metric_overhead
     return _metric_overhead
 
 
@@ -400,7 +400,6 @@ def friedman_rafsky(x, y):
     n = nx + ny
 
     xy = np.vstack([x, y])
-
     # Compute the NNs and the minimum spanning tree
     g = neighbors.kneighbors_graph(xy, n_neighbors=n - 1, mode="distance")
     mst = minimum_spanning_tree(g, overwrite=True)
@@ -463,7 +462,7 @@ def kolmogorov_smirnov(x, y):
 
 
 @metric
-def kldiv(x, y, k=1):
+def kldiv(x, y, *, k=1):
     r"""
     Compute the Kullback-Leibler divergence between two multivariate samples.
 

--- a/xclim/analog.py
+++ b/xclim/analog.py
@@ -148,6 +148,7 @@ def spatial_analogs(
     diss.attrs.update(
         long_name=f"Dissimilarity between target and candidates, using metric {method}.",
         indices=",".join(target.indices.values),
+        metric=method,
     )
 
     return diss
@@ -160,7 +161,7 @@ def spatial_analogs(
 
 def standardize(x, y):
     """
-    deviation.
+    Standardize x and y by the square root of the product of their standard deviation.
 
     Parameters
     ----------
@@ -176,58 +177,34 @@ def standardize(x, y):
     return x / s, y / s
 
 
-def reshape_sample(x, y):
+def metric(func):
+    """Register a metric function in the `metrics` mapping and add some preparation/checking code.
+
+    All metric functions accept 2D inputs. This reshape 1D inputs to (n, 1) and (m, 1).
+    All metric functions are invalid when any non-finite values are present in the inputs.
     """
-    Reshape the input arrays to conform to the conventions used in the
-    dissimilarity metrics.
-
-    Parameters
-    ----------
-    x, y : array_like
-      Arrays to be compared.
-
-    Returns
-    -------
-    x, y : array_like
-      Arrays of shape (n,d) and (m,d), where `n` and `m` are the number of
-      samples and `d` is the dimension.
-
-    Raises
-    ------
-    AssertionError
-        If x and y have different dimensions.
-    """
-    x = np.atleast_2d(x)
-    y = np.atleast_2d(y)
-
-    # If array is 1D, flip it.
-    if x.shape[0] == 1:
-        x = x.T
-    if y.shape[0] == 1:
-        y = y.T
-
-    if x.shape[1] != y.shape[1]:
-        raise AttributeError("Shape mismatch")
-
-    return x, y
-
-
-def register_metric(func):
-    """Register a metric function in the `metrics` mapping."""
     metrics[func.__name__] = func
-    return func
-
-
-def drop_when_nan(func):
-    """Return NaN if any value in the two inputs is NaN."""
 
     @wraps(func)
-    def _drop_when_nan(x, y, **kwargs):
+    def _metric_overhead(x, y, **kwargs):
         if np.any(np.isnan(x)) or np.any(np.isnan(y)):
             return np.NaN
+
+        x = np.atleast_2d(x)
+        y = np.atleast_2d(y)
+
+        # If array is 1D, flip it.
+        if x.shape[0] == 1:
+            x = x.T
+        if y.shape[0] == 1:
+            y = y.T
+
+        if x.shape[1] != y.shape[1]:
+            raise AttributeError("Shape mismatch")
+
         return func(x, y, **kwargs)
 
-    return _drop_when_nan
+    return _metric_overhead
 
 
 # ---------------------------------------------------------------------------- #
@@ -235,8 +212,7 @@ def drop_when_nan(func):
 # ---------------------------------------------------------------------------- #
 
 
-@register_metric
-@drop_when_nan
+@metric
 def seuclidean(x, y):
     """
     Compute the Euclidean distance between the mean of a multivariate candidate sample with respect to the mean of a reference sample.
@@ -265,14 +241,13 @@ def seuclidean(x, y):
     21st-century climate-change scenarios. Climatic Change,
     DOI 10.1007/s10584-011-0261-z.
     """
-    x, y = reshape_sample(x, y)
     mx = x.mean(axis=0)
     my = y.mean(axis=0)
 
     return spatial.distance.seuclidean(mx, my, x.var(axis=0, ddof=1))
 
 
-@register_metric
+@metric
 def nearest_neighbor(x, y):
     """
     Compute a dissimilarity metric based on the number of points in the pooled sample whose nearest neighbor belongs to the same distribution.
@@ -294,7 +269,6 @@ def nearest_neighbor(x, y):
     Henze N. (1988) A Multivariate two-sample test based on the number of
     nearest neighbor type coincidences. Ann. of Stat., Vol. 16, No.2, 772-783.
     """
-    x, y = reshape_sample(x, y)
     x, y = standardize(x, y)
 
     nx, _ = x.shape
@@ -310,7 +284,7 @@ def nearest_neighbor(x, y):
     return same.mean()
 
 
-@register_metric
+@metric
 def zech_aslan(x, y):
     """
     Compute the Zech-Aslan energy distance dissimimilarity metric based on an analogy with the energy of a cloud of electrical charges.
@@ -334,7 +308,6 @@ def zech_aslan(x, y):
     Aslan B. and Zech G. (2008) A new class of binning-free, multivariate
     goodness-of-fit tests: the energy tests. arXiV:hep-ex/0203010v5.
     """
-    x, y = reshape_sample(x, y)
     nx, d = x.shape
     ny, d = y.shape
 
@@ -350,7 +323,7 @@ def zech_aslan(x, y):
     return phix + phiy + phixy
 
 
-@register_metric
+@metric
 def skezely_rizzo(x, y):
     """
     Compute the Skezely-Rizzo energy distance dissimimilarity metric based on an analogy with the energy of a cloud of electrical charges.
@@ -392,8 +365,7 @@ def skezely_rizzo(x, y):
     # z = ((n * m) / (n + m)) * z;
 
 
-@register_metric
-@drop_when_nan
+@metric
 def friedman_rafsky(x, y):
     """
     Compute a dissimilarity metric based on the Friedman-Rafsky runs statistics.
@@ -423,7 +395,6 @@ def friedman_rafsky(x, y):
     from scipy.sparse.csgraph import minimum_spanning_tree
     from sklearn import neighbors
 
-    x, y = reshape_sample(x, y)
     nx, _ = x.shape
     ny, _ = y.shape
     n = nx + ny
@@ -441,7 +412,7 @@ def friedman_rafsky(x, y):
     return 1.0 - (1.0 + diff) / n
 
 
-@register_metric
+@metric
 def kolmogorov_smirnov(x, y):
     """
     Compute the Kolmogorov-Smirnov statistic applied to two multivariate samples as described by Fasano and Franceschini.
@@ -464,7 +435,6 @@ def kolmogorov_smirnov(x, y):
     of the Kolmogorov-Smirnov test. Monthly Notices of the Royal
     Astronomical Society, vol. 225, pp. 155-170.
     """
-    x, y = reshape_sample(x, y)
 
     def pivot(x, y):
         nx, d = x.shape
@@ -492,7 +462,7 @@ def kolmogorov_smirnov(x, y):
     return max(pivot(x, y), pivot(y, x))
 
 
-@register_metric
+@metric
 def kldiv(x, y, k=1):
     r"""
     Compute the Kullback-Leibler divergence between two multivariate samples.
@@ -548,7 +518,6 @@ def kldiv(x, y, k=1):
     Kullback-Leibler Divergence Estimation of Continuous Distributions (2008).
     Fernando Pérez-Cruz.
     """
-    x, y = reshape_sample(x, y)
     mk = np.iterable(k)
     ka = np.atleast_1d(k)
 

--- a/xclim/analog.py
+++ b/xclim/analog.py
@@ -57,13 +57,11 @@ a single float.
 .. [Roy2017] Roy, P., Grenier, P., Barriault, E. et al. Climatic Change (2017) 143: 43. `<doi:10.1007/s10584-017-1960-x>`_
 .. [Grenier2013]  Grenier, P., A.-C. Parent, D. Huard, F. Anctil, and D. Chaumont, 2013: An assessment of six dissimilarity metrics for climate analogs. J. Appl. Meteor. Climatol., 52, 733–752, `<doi:10.1175/JAMC-D-12-0170.1>`_
 """
+# Code adapted from flyingpigeon.dissimilarity, Nov 2020.
 from typing import Sequence, Union
 
 import numpy as np
 import xarray as xr
-
-# Code adapted from flyingpigeon.dissimilarity, Nov 2020.
-from numba import jit
 from scipy import spatial
 from scipy.spatial import cKDTree as KDTree
 
@@ -187,7 +185,6 @@ def register_metric(func):
 
 
 @register_metric
-@jit
 def seuclidean(x, y):
     """
     Compute the Euclidean distance between the mean of a multivariate
@@ -224,7 +221,6 @@ def seuclidean(x, y):
 
 
 @register_metric
-@jit
 def nearest_neighbor(x, y):
     """
     Compute a dissimilarity metric based on the number of points in the
@@ -263,7 +259,6 @@ def nearest_neighbor(x, y):
 
 
 @register_metric
-@jit
 def zech_aslan(x, y):
     """
     Compute the Zech-Aslan energy distance dissimimilarity metric based on an
@@ -347,7 +342,6 @@ def skezely_rizzo(x, y):
 
 
 @register_metric
-@jit
 def friedman_rafsky(x, y):
     """
     Compute a dissimilarity metric based on the Friedman-Rafsky runs statistics.
@@ -395,7 +389,6 @@ def friedman_rafsky(x, y):
 
 
 @register_metric
-@jit
 def kolmogorov_smirnov(x, y):
     """
     Compute the Kolmogorov-Smirnov statistic applied to two multivariate
@@ -447,7 +440,6 @@ def kolmogorov_smirnov(x, y):
 
 
 @register_metric
-@jit
 def kldiv(x, y, k=1):
     """
     Compute the Kullback-Leibler divergence between two multivariate samples.

--- a/xclim/analog.py
+++ b/xclim/analog.py
@@ -46,8 +46,8 @@ Methods available
  * Kolmogorov-Smirnov statistic
  * Kullback-Leibler divergence
 
-All methods accept arrays, the first is the reference (shape (n, D)) and
-the second is the candidate (shape (m, D)). Where the climate indicators
+All methods accept arrays, the first is the reference (n, D) and
+the second is the candidate (m, D). Where the climate indicators
 vary along D and the distribution dimension along n or m. All methods output
 a single float.
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #496 
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [x] `bumpversion (minor / major / patch)` has been called on this branch
- [x] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
Adapts (copies) the spatial analogues algorithms from flyingpigeon into xclim. For now, I haven't done much more then writing a `spatial_analog` function that wraps the metrics in an `apply_ufunc` call. I tried numba, but all metrics use scipy stuff that numba doesn't understand, so the current solution is to have `vectorize=True` in `apply_ufunc`.

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
No
