### PR TITLE
Remove allow_lazy in rolling computation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ jobs:
       name: "Python3.8 (Linux) + doctests"
       python: 3.8
       addons:
-        apt:
+
           packages:
             - libspatialindex-dev
             - libnetcdf-dev
@@ -59,8 +59,7 @@ jobs:
     - env: TOXENV=py36-nosubset-lm3
       name: "Python3.6 (Linux + lmoments3@master) (no subsetting)"
       python: 3.6
-    - if: type = push
-      env: TOXENV=py36-xarray
+    - env: TOXENV=py36-xarray
       name: "Python3.6 (Linux + xarray@master + cftime@master)"
       python: 3.6
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ jobs:
       name: "Python3.8 (Linux) + doctests"
       python: 3.8
       addons:
-
+        apt:
           packages:
             - libspatialindex-dev
             - libnetcdf-dev

--- a/xclim/indices/_anuclim.py
+++ b/xclim/indices/_anuclim.py
@@ -568,9 +568,7 @@ def _to_quarter(
             out.attrs["units"] = "mm"
 
         if tas is not None:
-            out = tas.rolling(time=window, center=False).mean(
-                allow_lazy=True, skipna=False
-            )
+            out = tas.rolling(time=window, center=False).mean(skipna=False)
             out.attrs = tas.attrs
 
     out = ensure_chunk_size(out, time=-1)

--- a/xclim/indices/_hydrology.py
+++ b/xclim/indices/_hydrology.py
@@ -44,11 +44,7 @@ def base_flow_index(q: xarray.DataArray, freq: str = "YS"):  # noqa: D401
        \mathrm{CMA}_7(q_i) = \frac{\sum_{j=i-3}^{i+3} q_j}{7}
 
     """
-    m7 = (
-        q.rolling(time=7, center=True)
-        .mean(allow_lazy=True, skipna=False)
-        .resample(time=freq)
-    )
+    m7 = q.rolling(time=7, center=True).mean(skipna=False).resample(time=freq)
     mq = q.resample(time=freq)
 
     m7m = m7.min(dim="time")

--- a/xclim/indices/_multivariate.py
+++ b/xclim/indices/_multivariate.py
@@ -896,7 +896,7 @@ def rain_on_frozen_ground_days(
         frozen = x == np.array([0, 0, 0, 0, 0, 0, 0, 1], bool)
         return frozen.all(axis=axis)
 
-    tcond = (tas > frz).rolling(time=8).reduce(func, allow_lazy=True)
+    tcond = (tas > frz).rolling(time=8).reduce(func)
     pcond = pr > t
 
     return (tcond * pcond * 1).resample(time=freq).sum(dim="time")

--- a/xclim/indices/_simple.py
+++ b/xclim/indices/_simple.py
@@ -456,7 +456,7 @@ def max_n_day_precipitation_amount(
     >>> out = max_n_day_precipitation_amount(pr, window=5, freq="YS")
     """
     # Rolling sum of the values
-    arr = pr.rolling(time=window).sum(allow_lazy=True, skipna=False)
+    arr = pr.rolling(time=window).sum(skipna=False)
     out = arr.resample(time=freq).max(dim="time", keep_attrs=True)
 
     out.attrs["units"] = pr.units
@@ -494,7 +494,7 @@ def max_pr_intensity(pr, window: int = 1, freq: str = "YS"):
     # TODO
     """
     # Rolling sum of the values
-    arr = pr.rolling(time=window).mean(allow_lazy=True, skipna=False)
+    arr = pr.rolling(time=window).mean(skipna=False)
     out = arr.resample(time=freq).max(dim="time", keep_attrs=True)
 
     out.attrs["units"] = pr.units

--- a/xclim/indices/run_length.py
+++ b/xclim/indices/run_length.py
@@ -247,7 +247,7 @@ def first_run(
         ind = xr.broadcast(i, da)[0].transpose(*da.dims)
         if isinstance(da.data, dsk.Array):
             ind = ind.chunk(da.chunks)
-        wind_sum = da.rolling(time=window).sum(allow_lazy=True, skipna=False)
+        wind_sum = da.rolling(time=window).sum(skipna=False)
         out = ind.where(wind_sum >= window).min(dim=dim) - (
             window - 1
         )  # remove window -1 as rolling result index is last element of the moving window

--- a/xclim/indices/stats.py
+++ b/xclim/indices/stats.py
@@ -286,7 +286,7 @@ def frequency_analysis(
     # Apply rolling average
     attrs = da.attrs.copy()
     if window > 1:
-        da = da.rolling(time=window).mean(allow_lazy=True, skipna=False)
+        da = da.rolling(time=window).mean(skipna=False)
         da.attrs.update(attrs)
 
     # Assign default resampling frequency if not provided


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
Remove the  `allow_lazy` kwarg from the `rolling` calls in `xclim.indices`. Passing `allow_lazy` is deprecated since xarray ~ 0.14, but it will raise an error in >= 0.16.2.

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
No.

* **Other information**:
I enabled the CI build that uses `xarray` at master so we can see if this works. We can disable it before merging.
