### PR TITLE
Change sign_frac to simpler pos_frac

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -43,6 +43,7 @@ Ensembles module
 
 .. autofunction:: xclim.ensembles.change_significance
 .. autofunction:: xclim.ensembles.robustness_coefficient
+
 Indicator tools
 ===============
 

--- a/xclim/ensembles/_robustness.py
+++ b/xclim/ensembles/_robustness.py
@@ -68,8 +68,8 @@ def change_significance(
     pos_frac
       The fraction of members showing significant change that show a positive change ]0, 1].
       Null values are returned where no members show significant change.
-      The number of members agreeing on significant change and its sign is
-      thus max(pos_frac, 1 - pos_frac). Same type as  `fut`.
+      The fraction of members agreeing on both significant change and its sign is
+      thus max(pos_frac, 1 - pos_frac) * change_frac. Same type as  `fut`.
 
     Notes
     -----

--- a/xclim/ensembles/_robustness.py
+++ b/xclim/ensembles/_robustness.py
@@ -62,14 +62,24 @@ def change_significance(
     -------
     change_frac
       The fraction of members that show significant change [0, 1].
-      Passing `test=None` yields change_frac = 1 everywhere
-      except where any of `ref` or `fut` was NaN.
-      Same type as `fut`.
+      Passing `test=None` yields change_frac = 1 everywhere. Same type as `fut`.
     pos_frac
       The fraction of members showing significant change that show a positive change ]0, 1].
       Null values are returned where no members show significant change.
-      The fraction of members agreeing on both significant change and its sign is
-      thus max(pos_frac, 1 - pos_frac) * change_frac. Same type as  `fut`.
+
+      The table below shows the coefficient needed to retrieve the number of members
+      that have the indicated characteristics, by multiplying it to the total
+      number of members (`fut.realization.size`).
+
+      +-----------------+------------------------------+------------------------+
+      |                 | Significant change           | Non significant change |
+      +-----------------+------------------------------+------------------------+
+      | Any direction   | change_frac                  | 1 - change_frac        |
+      +-----------------+------------------------------+------------------------+
+      | Positive change | pos_frac * change_frac       | N.A.                   |
+      +-----------------+------------------------------+                        |
+      | Negative change | (1 - pos_frac) * change_frac |                        |
+      +-----------------+------------------------------+------------------------+
 
     Notes
     -----
@@ -95,8 +105,8 @@ def change_significance(
     .. [tebaldi2011] Tebaldi C., Arblaster, J.M. and Knutti, R. (2011) Mapping model agreement on future climate projections. GRL. doi:10.1029/2011GL049863
 
 
-    Example:
-    --------
+    Example
+    -------
     This example computes the mean temperature in an ensemble and compares two time
     periods, qualifying significant change through a single sample T-test.
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->

Sorry sorry sorry... I merged the previous PR too early, there was another change discussed with @RondeauG  that wasn't implemented yet. Changing the `sign_frac` output of `change_significance` to `pos_frac`. So fraction of members showing a _positive_ change. This carries more information as it keeps the sign of change! Thus, a user could compute the old `sign_frac`, fraction of significant members agreeing on the sign as : `max(pos_frac, 1 - pos_frac`). 

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
Yes, but no.

* **Other information**:
