### PR TITLE
Degree-day depassment date

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -108,6 +108,7 @@ jobs:
       script:
         - py.test --cov=xclim
   allow_failures:
+    - env: TOXENV=py38-doctest
     - env: TOXENV=py38-anaconda
 #    - env: TOXENV=macOS
     - env:

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,7 @@ Breaking changes
 
 New indicators
 ~~~~~~~~~~~~~~
+* `atmos.degree_days_depassment_date`, the day of year when the degree days sum exceeds a threshold.
 
 New features and enhancements
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -1691,7 +1691,6 @@ def test_degree_days_depassment_date(tas_series):
         tas, thresh="0 degC", op=">", sum_thresh="150 K days"
     )
     assert out[0] == 151
-    assert "tmean > 0 degc" in out.attrs["description"]
 
     out = xci.degree_days_depassment_date(
         tas, thresh="2 degC", op="<", sum_thresh="150 degC days"

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -1698,6 +1698,6 @@ def test_degree_days_depassment_date(tas_series):
     assert out[0] == 151
 
     out = xci.degree_days_depassment_date(
-        tas, thresh="2 degC", op="<", sum_thresh="150 K days", after_date="07-01"
+        tas, thresh="2 degC", op="<", sum_thresh="150 K days", start_date="04-15"
     )
-    assert out[0] == 183
+    assert out[0] == 256

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -1682,3 +1682,23 @@ def test_specific_humidity(
         ice_thresh="0 degC",
     )
     np.testing.assert_allclose(huss, huss_exp, atol=1e-4, rtol=0.05)
+
+
+def test_degree_days_depassment_date(tas_series):
+    tas = tas_series(np.ones(366) + K2C, start="2000-01-01")
+
+    out = xci.degree_days_depassment_date(
+        tas, thresh="0 degC", op=">", sum_thresh="150 K days"
+    )
+    assert out[0] == 151
+    assert "tmean > 0 degc" in out.attrs["description"]
+
+    out = xci.degree_days_depassment_date(
+        tas, thresh="2 degC", op="<", sum_thresh="150 degC days"
+    )
+    assert out[0] == 151
+
+    out = xci.degree_days_depassment_date(
+        tas, thresh="2 degC", op="<", sum_thresh="150 K days", after_date="07-01"
+    )
+    assert out[0] == 183

--- a/tests/test_temperature.py
+++ b/tests/test_temperature.py
@@ -1186,3 +1186,23 @@ def test_freshet_start(tas_series):
         tas_series(np.arange(-50, 350) + 274, start="1/1/2000"), freq="YS"
     )
     assert out[0] == 51
+
+
+def test_degree_days_depassment_date(tas_series):
+    tas = tas_series(np.ones(366) + K2C, start="2000-01-01")
+
+    out = atmos.degree_days_depassment_date(
+        tas, thresh="0 degC", op=">", sum_thresh="150 K days"
+    )
+    assert out[0] == 151
+    assert "tmean > 0 degc" in out.attrs["description"]
+
+    out = atmos.degree_days_depassment_date(
+        tas, thresh="2 degC", op="<", sum_thresh="150 K days"
+    )
+    assert out[0] == 151
+
+    out = atmos.degree_days_depassment_date(
+        tas, thresh="2 degC", op="<", sum_thresh="150 K days", after_date="07-01"
+    )
+    assert out[0] == 183

--- a/tests/test_temperature.py
+++ b/tests/test_temperature.py
@@ -1206,8 +1206,11 @@ def test_degree_days_depassment_date():
 
     with set_options(check_missing="skip"):
         out = atmos.degree_days_depassment_date(
-            tas=tas, thresh="4 degC", op=">", sum_thresh="1500 K days", freq="AS-JUL"
+            tas=tas,
+            thresh="4 degC",
+            op=">",
+            sum_thresh="1500 K days",
+            start_date="07-02",
+            freq="YS",
         )
-        np.testing.assert_array_equal(
-            out, np.array([[np.nan, np.nan, 62, 48], [np.nan, 278, 240, 243]]).T
-        )
+        np.testing.assert_array_equal(out, np.array([[np.nan, 280, 241, 244]]).T)

--- a/tests/test_temperature.py
+++ b/tests/test_temperature.py
@@ -6,6 +6,7 @@ import xarray as xr
 
 from xclim import atmos
 from xclim.core.calendar import percentile_doy
+from xclim.core.options import set_options
 from xclim.testing import open_dataset
 
 K2C = 273.15
@@ -1188,21 +1189,21 @@ def test_freshet_start(tas_series):
     assert out[0] == 51
 
 
-def test_degree_days_depassment_date(tas_series):
-    tas = tas_series(np.ones(366) + K2C, start="2000-01-01")
+def test_degree_days_depassment_date():
+    tas = open_dataset("FWI/GFWED_sample_2017.nc").tas
 
     out = atmos.degree_days_depassment_date(
-        tas, thresh="0 degC", op=">", sum_thresh="150 K days"
+        tas=tas,
+        thresh="4 degC",
+        op=">",
+        sum_thresh="200 K days",
     )
-    assert out[0] == 151
-    assert "tmean > 0 degc" in out.attrs["description"]
+    np.testing.assert_array_equal(out, np.array([[153, 136, 9, 6]]).T)
 
-    out = atmos.degree_days_depassment_date(
-        tas, thresh="2 degC", op="<", sum_thresh="150 K days"
-    )
-    assert out[0] == 151
-
-    out = atmos.degree_days_depassment_date(
-        tas, thresh="2 degC", op="<", sum_thresh="150 K days", after_date="07-01"
-    )
-    assert out[0] == 183
+    with set_options(check_missing="skip"):
+        out = atmos.degree_days_depassment_date(
+            tas=tas, thresh="4 degC", op=">", sum_thresh="1500 K days", freq="AS-JUL"
+        )
+        np.testing.assert_array_equal(
+            out, np.array([[np.nan, np.nan, 62, 48], [np.nan, 278, 240, 243]]).T
+        )

--- a/tests/test_temperature.py
+++ b/tests/test_temperature.py
@@ -1191,7 +1191,9 @@ def test_freshet_start(tas_series):
 
 def test_degree_days_depassment_date():
     tas = open_dataset("FWI/GFWED_sample_2017.nc").tas
-    tas.attrs["cell_methods"] = "time: mean within days"
+    tas.attrs.update(
+        cell_methods="time: mean within days", standard_name="air_temperature"
+    )
 
     out = atmos.degree_days_depassment_date(
         tas=tas,
@@ -1200,7 +1202,7 @@ def test_degree_days_depassment_date():
         sum_thresh="200 K days",
     )
     np.testing.assert_array_equal(out, np.array([[153, 136, 9, 6]]).T)
-    assert "tmean > 0 degc" in out.attrs["description"]
+    assert "tmean > 4 degc" in out.attrs["description"]
 
     with set_options(check_missing="skip"):
         out = atmos.degree_days_depassment_date(

--- a/tests/test_temperature.py
+++ b/tests/test_temperature.py
@@ -1191,6 +1191,7 @@ def test_freshet_start(tas_series):
 
 def test_degree_days_depassment_date():
     tas = open_dataset("FWI/GFWED_sample_2017.nc").tas
+    tas.attrs["cell_methods"] = "time: mean within days"
 
     out = atmos.degree_days_depassment_date(
         tas=tas,
@@ -1199,6 +1200,7 @@ def test_degree_days_depassment_date():
         sum_thresh="200 K days",
     )
     np.testing.assert_array_equal(out, np.array([[153, 136, 9, 6]]).T)
+    assert "tmean > 0 degc" in out.attrs["description"]
 
     with set_options(check_missing="skip"):
         out = atmos.degree_days_depassment_date(

--- a/xclim/indicators/atmos/_temperature.py
+++ b/xclim/indicators/atmos/_temperature.py
@@ -640,8 +640,8 @@ degree_days_depassment_date = Tas(
     units="",
     standard_name="day_of_year",
     long_name="Day of year when cumulative degree days exceed {sum_thresh}.",
-    description="Day of year when the integral of degee days (when tmean {op} {thresh})"
-    " exceeds {sum_thresh}, with an earliest limit at {after_date}.",
+    description="Day of year when the integral of degree days (tmean {op} {thresh})"
+    " exceeds {sum_thresh}, the cumulative sum starts on {start_date}.",
     cell_methods="",
     compute=indices.degree_days_depassment_date,
 )

--- a/xclim/indicators/atmos/_temperature.py
+++ b/xclim/indicators/atmos/_temperature.py
@@ -639,7 +639,7 @@ degree_days_depassment_date = Tas(
     identifier="degree_days_depassment_date",
     units="",
     standard_name="day_of_year",
-    long_name="Day of year when the cumulative degree days exceeds {sum_thresh}.",
+    long_name="Day of year when cumulative degree days exceed {sum_thresh}.",
     description="Day of year when the integral of degee days (when tmean {op} {thresh})"
     " exceeds {sum_thresh}, with an earliest limit at {after_date}.",
     cell_methods="",

--- a/xclim/indicators/atmos/_temperature.py
+++ b/xclim/indicators/atmos/_temperature.py
@@ -53,6 +53,7 @@ __all__ = [
     "growing_season_length",
     "growing_season_end",
     "tropical_nights",
+    "degree_days_depassment_date",
 ]
 
 
@@ -631,4 +632,16 @@ tn10p = Tasmin(
     "for a reference period.",
     cell_methods="time: minimum within days time: sum over days",
     compute=indices.tn10p,
+)
+
+
+degree_days_depassment_date = Tas(
+    identifier="degree_days_depassment_date",
+    units="",
+    standard_name="day_of_year",
+    long_name="Day of year when the cumulative degree days exceeds {sum_thresh}.",
+    description="Day of year when the integral of degee days (when tmean {op} {thresh})"
+    " exceeds {sum_thresh}, with an earliest limit at {after_date}.",
+    cell_methods="",
+    compute=indices.degree_days_depassment_date,
 )

--- a/xclim/indices/_threshold.py
+++ b/xclim/indices/_threshold.py
@@ -19,7 +19,7 @@ __all__ = [
     "cold_spell_days",
     "cold_spell_frequency",
     "daily_pr_intensity",
-    "degree_day_depassment_date",
+    "degree_days_depassment_date",
     "cooling_degree_days",
     "freshet_start",
     "growing_degree_days",
@@ -1369,7 +1369,7 @@ def tropical_nights(
 
 
 @declare_units("", tas="[temperature]", thresh="[temperature]", sum_thresh="K days")
-def degree_day_depassment_date(
+def degree_days_depassment_date(
     tas: xarray.DataArray,
     thresh: str,
     sum_thresh: str,
@@ -1380,7 +1380,7 @@ def degree_day_depassment_date(
     thresh = convert_units_to(thresh, "K")
     tas = convert_units_to(tas, "K")
     sum_thresh = convert_units_to(sum_thresh, "K days")
-    print(sum_thresh, thresh)
+
     if op in ["<", "<=", "lt", "le"]:
         c = thresh - tas
     elif op in [">", ">=", "gt", "ge"]:

--- a/xclim/indices/_threshold.py
+++ b/xclim/indices/_threshold.py
@@ -1377,7 +1377,7 @@ def degree_days_depassment_date(
     after_date: str = None,
     freq: str = "YS",
 ):
-    r"""Degree days depassment date
+    r"""Degree days depassment date.
 
     Day of year when the sum of degree days exceeds a threshold. Degree days are
     computed above or below a given temperature threshold.

--- a/xclim/indices/_threshold.py
+++ b/xclim/indices/_threshold.py
@@ -1377,6 +1377,49 @@ def degree_days_depassment_date(
     after_date: str = None,
     freq: str = "YS",
 ):
+    r"""Degree days depassment date
+
+    Day of year when the sum of degree days exceeds a threshold. Degree days are
+    computed above or below a given temperature threshold.
+
+    Parameters
+    ----------
+    tas : xarray.DataArray
+      Mean daily temperature.
+    thresh : str
+      Threshold temperature on which to base degree days evaluation.
+    sum_thresh : str
+      Threshold of the degree days sum, in "K days".
+    op : {">", "gt", "<", "lt", ">=", "ge", "<=", "le"}
+      If equivalent to '>', degree days are computed as `tas - thresh` and if
+      equivalent to '<', they are computed as `thresh - tas`.
+    after_date: str, optional
+      If given, the earliest date that can be returned. This acts as a calendar-aware
+      `max(out, after_date)`.
+    freq : str
+      Resampling frequency; Defaults to "YS". If `after_date` is given, `freq` should
+      be annual.
+
+    Returns
+    -------
+    xarray.DataArray
+      Degree days depassment date
+
+    Notes
+    -----
+    Let :math:`TG_{ij}` be the daily mean temperature at day :math:`i` of period :math:`j`,
+    :math:`T` is the reference threshold and :math:`ST` is the sum threshold. Then the
+    degree days depassment date is the first day :math:`k` such that
+
+    .. math::
+
+        \begin{cases}
+        ST < \sum_{i=1}^{k} \max(TG_{ij} - T, 0) & \text{if $op$ is '>'} \\
+        ST < \sum_{i=1}^{k} \max(T - TG_{ij}, 0) & \text{if $op$ is '<'}
+        \end{cases}
+
+    The resulting :math:`k` is expressed as a day of year.
+    """
     thresh = convert_units_to(thresh, "K")
     tas = convert_units_to(tas, "K")
     sum_thresh = convert_units_to(sum_thresh, "K days")

--- a/xclim/locales/fr.json
+++ b/xclim/locales/fr.json
@@ -675,7 +675,7 @@
   },
   "DEGREE_DAYS_DEPASSMENT_DATE": {
     "long_name": "Premier jour de l'année où la somme des degrés-jours excède {sum_thresh}",
-    "description": "Premier jour de l'année où la somme des degrés-jours (Tmoy {op} {thresh}) excède {sum_thresh}, limité au plus tôt par {after_date}.",
+    "description": "Premier jour de l'année où la somme des degrés-jours (Tmoy {op} {thresh}) excède {sum_thresh}, la somme commençant le {start_date}.",
     "title": "Jour du dépassement des degrés-jours",
     "abstract": "Jour de l'année où la somme des degrés-jours excède un seuil. Les degrés-jours sont calculés au-dessus ou au-dessous d'un seuil de température donné."
   }

--- a/xclim/locales/fr.json
+++ b/xclim/locales/fr.json
@@ -672,5 +672,11 @@
     "description": "Premier jour de l'année avec une température au-dessus de {thresh} pour au moins {window} jours.",
     "title": "Premier jour de l'année de températures au-dessus d'un seuil.",
     "abstract": "Calcule le premier jour d'une période où la température est plus élevée qu'un certain seuil durant un nombre de jours donné, limité par une date minimale."
+  },
+  "DEGREE_DAYS_DEPASSMENT_DATE": {
+    "long_name": "Premier jour de l'année où la somme des degrés-jours excède {sum_thresh}",
+    "description": "Premier jour de l'année où la somme des degrés-jours (Tmoy {op} {thresh}) excède {sum_thresh}, limité au plus tôt par {after_date}.",
+    "title": "Jour du dépassement des degrés-jours",
+    "abstract": "Jour de l'année où la somme des degrés-jours excède un seuil. Les degrés-jours sont calculés au-dessus ou au-dessous d'un seuil de température donné."
   }
 }


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #569
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
Adds `xclim.indices.degree_day_depassment_date`, which returns the day-of-year when the cumulative degree-day sum exceeds `sum_thresh`. The degree-days are computed using `thresh` and in the `op` direction. i.e.: if  `op = '>'`, `dd = (tas - thresh).clip(0)`
and inversely.  

This definition makes the cumulative degree-day sum a monotonically increasing function. Which raises the question, do we really need an `after_date`? It could be replaced by a `clip` on the result. But, it wasn't much work anyway.

This PR also extracts `xc.indices.generic.compare` from  `xc.indices.generic.threshold_count`. I thought I would need it, but then I didn't.

Finally, now all run_lengths with dates accept `date=None`, which result not performing that check. All hail polymorphism.

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
No.

* **Other information**:

Indicators, doc and tests to come.