### PR TITLE
Better quantity string parsing

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -36,6 +36,7 @@ Internal changes
 * With the help of the `mypy` library, added several typing fixes to better identify inputs/outputs, and reduce object type mutations.
 * Fixed some doctests in `ensembles` and `set_options`.
 * `clisops` v0.4.0+ is now an optional requirements for non-Windows builds.
+* New `xclim.core.units.str2pint` method to convert quantity strings to quantity objects. Main improvement is to make "3 degC days" a valid string that converts to "3 K days".
 
 
 0.21.0 (2020-10-23)

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -9,6 +9,7 @@ from xclim.core.units import (
     convert_units_to,
     pint2cfunits,
     pint_multiply,
+    str2pint,
     units,
     units2pint,
 )
@@ -79,6 +80,10 @@ class TestConvertUnitsTo:
         out = convert_units_to(pr, "mm/day")
         assert isinstance(out.data, dsk.Array)
 
+    def test_offset_confusion(self):
+        out = convert_units_to("10 degC days", "K days")
+        assert out == 10
+
 
 class TestUnitConversion:
     def test_pint2cfunits(self):
@@ -100,7 +105,7 @@ class TestUnitConversion:
         assert str(u) == "meter ** 3 / second"
         assert pint2cfunits(u) == "m^3 s-1"
 
-        u = units2pint("2 kg m-2 s-1")
+        u = units2pint("kg m-2 s-1")
         assert (str(u)) == "kilogram / meter ** 2 / second"
 
         u = units2pint("%")
@@ -117,6 +122,13 @@ class TestUnitConversion:
         out = pint_multiply(a, 1 * units.days)
         assert out[0] == 1 * 60 * 60 * 24
         assert out.units == "kg m-2"
+
+    def test_str2pint(self):
+        Q_ = units.Quantity
+        assert str2pint("-0.78 m") == Q_(-0.78, units="meter")
+        assert str2pint("m kg/s") == Q_(1, units="meter kilogram/second")
+        assert str2pint("11.8 degC days") == Q_(11.8, units="delta_degree_Celsius days")
+        assert str2pint("nan m^2 K^-3").units == Q_(1, units="m²/K³").units
 
 
 class TestCheckUnits:


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #606
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
Adds a `xc.core.units.str2pint` function that parses string into `pint.Quantity`, but instead of parsing them as _expressions_, it splits the magnitude and the units, casting the first to a float and parsing the second with pint's `parse_units`. This matches more closely what a user expects when writing things like "3 degC days". AFAIU, we meant quantity 3 of unit "degree­­·days" and not "3 times 1 degreeC times 1 day", which is what `parse_expression` does.

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
`units2pint` now _always_ returns a `pint.Unit` object and doesn't accept string with magnitudes (`units2pint('2 m')` doesn't work anymore). For the sake of polymorphism, `str2pint` also accepts strings without magnitudes (it catches them when the float can't be cast), but then returns a `pint.Quantity` of magnitude 1.