### PR TITLE
Allow clisops 040

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -117,7 +117,11 @@ Testing module
 Subset module
 -------------
 .. warning::
-    Subsetting is now offered via `clisops`. The functions offered by clisops
-    will be described here once the subsetting functions API is made available.
-    For now, refer to their documentation here:
-    :doc:`clisops subset examples <clisops:notebooks/subset>`
+    Subsetting is now offered via `clisops.core.subset`. The subsetting functions offered by clisops
+    are as follows:
+
+.. automodule:: <clisops:api>
+
+.. note::
+    For more information about `clisops` refer to their documentation here:
+    :doc:`clisops subset examples <clisops>`

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -120,8 +120,8 @@ Subset module
     Subsetting is now offered via `clisops.core.subset`. The subsetting functions offered by `clisops`
     are available at the following link:
 
-:ref: `clisops API <clisops:module-clisops.core.subset>`
+:doc:`CLISOPS API <clisops:api>`
 
 .. note::
     For more information about `clisops` refer to their documentation here:
-    :doc:`clisops documentation <clisops:readme>`
+    :doc:`CLISOPS documentation <clisops:readme>`

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -117,10 +117,10 @@ Testing module
 Subset module
 -------------
 .. warning::
-    Subsetting is now offered via `clisops.core.subset`. The subsetting functions offered by clisops
+    Subsetting is now offered via `clisops.core.subset`. The subsetting functions offered by `clisops`
     are available at the following link:
 
-:ref: `clisops API <clisops:api>`
+:ref: `clisops API <clisops:module-clisops.core.subset>`
 
 .. note::
     For more information about `clisops` refer to their documentation here:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -118,10 +118,10 @@ Subset module
 -------------
 .. warning::
     Subsetting is now offered via `clisops.core.subset`. The subsetting functions offered by clisops
-    are as follows:
+    are available at the following link:
 
-.. automodule:: <clisops:api>
+:ref: `clisops API <clisops:api>`
 
 .. note::
     For more information about `clisops` refer to their documentation here:
-    :doc:`clisops subset examples <clisops>`
+    :doc:`clisops documentation <clisops:readme>`

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -6,23 +6,24 @@ Installation
 
 Stable release
 --------------
-.. Warning::
-    For Windows users: xclim requires a handful of libraries `GDAL`, `PROJ`, and `libspatialindex-dev` (for `rtree` support)
-    that must be manually installed prior to installation via pip. If you wish to install these libraries,
-    they are offered through the `OSGeo4W installer`_. In the interest of streamlining installation, xclim is also
-    offered via an Anaconda package that pre-compiles these dependencies for ease of portability.
-
 To install xclim via pip, run this command in your terminal:
 
 .. code-block:: console
 
     $ pip install xclim
 
+To install xclim with spatial subsetting tools (`clisops`_), ensure you have needed system dependencies installed and run:
+
+.. code-block:: console
+
+    $ pip install xclim[gis] # or pip install xclim clisops
+
 This is the preferred method to install xclim, as it will always install the most recent stable release.
 
 If you don't have `pip`_ installed, this `Python installation guide`_ can guide
 you through the process.
 
+.. _clisops: https://clisops.readthedocs.io/en/latest/readme.html
 .. _pip: https://pip.pypa.io
 .. _Python installation guide: http://docs.python-guide.org/en/latest/starting/installation/
 .. _OSGeo4W installer: https://trac.osgeo.org/osgeo4w/
@@ -39,11 +40,10 @@ To install the xclim Anaconda binary, run this command in your terminal:
 
     $ conda install -c conda-forge xclim
 
-
 From sources
 ------------
 .. Warning::
-    For Python3.8+ users: Many of the required scientific libraries do not currently have wheels that support the latest
+    For Python3.9+ users: Many of the required scientific libraries do not currently have wheels that support the latest
     python. In order to ensure that installation of xclim doesn't fail, we suggest installing the `Cython` module
     before installing xclim in order to compile necessary libraries from source packages.
 
@@ -75,7 +75,6 @@ Alternatively, you can also install a local development copy via pip:
 
 .. _Github repo: https://github.com/Ouranosinc/xclim
 .. _tarball: https://github.com/Ouranosinc/xclim/tarball/master
-
 
 Creating a Conda environment
 ----------------------------

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ docs_requirements = [
     "distributed>=2.0",
 ]
 
-gis_requirements = ["clisops>0.4.0"]
+gis_requirements = ["clisops>=0.4.0"]
 
 dev_requirements = []
 with open("requirements_dev.txt") as dev:

--- a/xclim/analog.py
+++ b/xclim/analog.py
@@ -31,7 +31,7 @@ very cold days [Roy2017].
 Methods to compute the (dis)similarity between samples
 ------------------------------------------------------
 
-This module implements five of the six methods described in [Grenier20131]_ to measure
+This module implements five of the six methods described in [Grenier2013]_ to measure
 the dissimilarity between two samples. Some of these algorithms can be used to
 test whether or not two samples have been drawn from the same distribution.
 Here, they are used to find areas with analog climate conditions to a target

--- a/xclim/core/calendar.py
+++ b/xclim/core/calendar.py
@@ -8,7 +8,6 @@ Helper function to handle dates, times and different calendars with xarray.
 """
 import datetime as pydt
 from typing import Any, Optional, Sequence, Union
-from warnings import warn
 
 import cftime
 import numpy as np
@@ -52,9 +51,9 @@ def get_calendar(obj: Any, dim: str = "time") -> str:
     obj : Any
       An object defining some date..
       If `obj` is an array/dataset with a datetime coordinate, use `dim` to specify its name.
-        Values must have either a datetime64 dtype or a cftime dtype.
+      Values must have either a datetime64 dtype or a cftime dtype.
       `obj`can also be a python datetime.datetime, a cftime object or a pandas Timestamp
-        or an iterable of those, in which case the calendar is inferred from the first value.
+      or an iterable of those, in which case the calendar is inferred from the first value.
     dim : str
       Name of the coordinate to check (if `obj` is a DataArray or Dataset).
 
@@ -135,30 +134,30 @@ def convert_calendar(
     If one of the source or target calendars is `360_day`, `align_on` must be specified and two options are offered.
 
     "year"
-        The dates are translated according to their rank in the year (dayofyear), ignoring their original month and day information,
-        meaning that the missing/surplus days are added/removed at regular intervals.
+      The dates are translated according to their rank in the year (dayofyear), ignoring their original month and day information,
+      meaning that the missing/surplus days are added/removed at regular intervals.
 
-        From a `360_day` to a standard calendar, the output will be missing the following dates (day of year in parenthesis):
-            To a leap year:
-                January 31st (31), March 31st (91), June 1st (153), July 31st (213), September 31st (275) and November 30th (335).
-            To a non-leap year:
-                February 6th (36), April 19th (109), July 2nd (183), September 12th (255), November 25th (329).
+      From a `360_day` to a standard calendar, the output will be missing the following dates (day of year in parenthesis):
+        To a leap year:
+          January 31st (31), March 31st (91), June 1st (153), July 31st (213), September 31st (275) and November 30th (335).
+        To a non-leap year:
+          February 6th (36), April 19th (109), July 2nd (183), September 12th (255), November 25th (329).
 
-        From standard calendar to a '360_day', the following dates in the source array will be dropped:
-            From a leap year:
-                January 31st (31), April 1st (92), June 1st (153), August 1st (214), September 31st (275), December 1st (336)
-            From a non-leap year:
-                February 6th (37), April 20th (110), July 2nd (183), September 13th (256), November 25th (329)
+      From standard calendar to a '360_day', the following dates in the source array will be dropped:
+        From a leap year:
+          January 31st (31), April 1st (92), June 1st (153), August 1st (214), September 31st (275), December 1st (336)
+        From a non-leap year:
+          February 6th (37), April 20th (110), July 2nd (183), September 13th (256), November 25th (329)
 
-        This option is best used on daily and subdaily data.
+      This option is best used on daily and subdaily data.
 
     "date"
-        The month/day information is conserved and invalid dates are dropped from the output. This means that when converting from
-        a `360_day` to a standard calendar, all 31st (Jan, March, May, July, August, October and December) will be missing as there is no equivalent
-        dates in the `360_day` and the 29th (on non-leap years) and 30th of February will be dropped as there are no equivalent dates in
-        a standard calendar.
+      The month/day information is conserved and invalid dates are dropped from the output. This means that when converting from
+      a `360_day` to a standard calendar, all 31st (Jan, March, May, July, August, October and December) will be missing as there is no equivalent
+      dates in the `360_day` and the 29th (on non-leap years) and 30th of February will be dropped as there are no equivalent dates in
+      a standard calendar.
 
-        This option is best used with data on a frequency coarser than daily.
+      This option is best used with data on a frequency coarser than daily.
     """
     cal_src = get_calendar(source, dim=dim)
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->

This undoes the pin for `clisops` above 0.4.0. The newer version of `clisops` will be fully pip-installable but in the meantime, any `clisops` will work with `xclim`, therefore we shouldn't need to pin. `pip` should not be responsible for ensuring that system-level dependencies are available for an optional python dependencies.

This also updates the docs to show users that `pip install xclim[gis]` is an allowed recipe, and attempts to use the `automodule` with `intersphinx` to load the API from `clisops` into our documentation.

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->

It shouldn't.

* **Other information**:
