### PR TITLE
Renamed DDDD to english DDED and fix laxy_indexing bug

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,27 @@
 History
 =======
 
+0.23.0 (unreleased)
+-------------------
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+* Renamed indicator `atmos.degree_days_depassment_date` to `atmos.degree_days_exceedance_date`.
+
+New indicators
+~~~~~~~~~~~~~~
+
+New features and enhancements
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Bug fixes
+~~~~~~~~~
+* Fixed a bug in `indices.run_length.lazy_indexing` that occured with 1D coords and 0D indexes when using the dask backend.
+
+Internal changes
+~~~~~~~~~~~~~~~~
+
+
 0.22.0 (2020-12-07)
 -------------------
 
@@ -32,7 +53,7 @@ Bug fixes
 * Various small fixes to the documentation (re-establishment of some internally and externally linked documents).
 
 Internal changes
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 * Passing `align_on` to `xclim.core.calendar.convert_calendar` without using '360_day' calendars will not raise a warning anymore.
 * Added formatting utilities for metadata attributes (`update_cell_methods`, `prefix_attrs` and `unprefix_attrs`).
 * `xclim/ensembles.py` moved to `xclim/ensembles/*.py`, splitting stats/creation, reduction  and robustness methods.

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -1684,20 +1684,20 @@ def test_specific_humidity(
     np.testing.assert_allclose(huss, huss_exp, atol=1e-4, rtol=0.05)
 
 
-def test_degree_days_depassment_date(tas_series):
+def test_degree_days_exceedance_date(tas_series):
     tas = tas_series(np.ones(366) + K2C, start="2000-01-01")
 
-    out = xci.degree_days_depassment_date(
+    out = xci.degree_days_exceedance_date(
         tas, thresh="0 degC", op=">", sum_thresh="150 K days"
     )
     assert out[0] == 151
 
-    out = xci.degree_days_depassment_date(
+    out = xci.degree_days_exceedance_date(
         tas, thresh="2 degC", op="<", sum_thresh="150 degC days"
     )
     assert out[0] == 151
 
-    out = xci.degree_days_depassment_date(
+    out = xci.degree_days_exceedance_date(
         tas, thresh="2 degC", op="<", sum_thresh="150 K days", start_date="04-15"
     )
     assert out[0] == 256

--- a/tests/test_run_length.py
+++ b/tests/test_run_length.py
@@ -438,3 +438,7 @@ def test_lazy_indexing_special_cases(use_dask):
 
     with pytest.raises(ValueError, match="more than one dimension more than index"):
         rl.lazy_indexing(a, b)
+
+    c = xr.DataArray([1], dims=("x",)).chunk()[0]
+    b["z"] = np.arange(b.z.size)
+    rl.lazy_indexing(b, c)

--- a/tests/test_temperature.py
+++ b/tests/test_temperature.py
@@ -1189,13 +1189,13 @@ def test_freshet_start(tas_series):
     assert out[0] == 51
 
 
-def test_degree_days_depassment_date():
+def test_degree_days_exceedance_date():
     tas = open_dataset("FWI/GFWED_sample_2017.nc").tas
     tas.attrs.update(
         cell_methods="time: mean within days", standard_name="air_temperature"
     )
 
-    out = atmos.degree_days_depassment_date(
+    out = atmos.degree_days_exceedance_date(
         tas=tas,
         thresh="4 degC",
         op=">",
@@ -1205,7 +1205,7 @@ def test_degree_days_depassment_date():
     assert "tmean > 4 degc" in out.attrs["description"]
 
     with set_options(check_missing="skip"):
-        out = atmos.degree_days_depassment_date(
+        out = atmos.degree_days_exceedance_date(
             tas=tas,
             thresh="4 degC",
             op=">",

--- a/xclim/indicators/atmos/_temperature.py
+++ b/xclim/indicators/atmos/_temperature.py
@@ -53,7 +53,7 @@ __all__ = [
     "growing_season_length",
     "growing_season_end",
     "tropical_nights",
-    "degree_days_depassment_date",
+    "degree_days_exceedance_date",
 ]
 
 
@@ -635,13 +635,13 @@ tn10p = Tasmin(
 )
 
 
-degree_days_depassment_date = Tas(
-    identifier="degree_days_depassment_date",
+degree_days_exceedance_date = Tas(
+    identifier="degree_days_exceedance_date",
     units="",
     standard_name="day_of_year",
     long_name="Day of year when cumulative degree days exceed {sum_thresh}.",
     description="Day of year when the integral of degree days (tmean {op} {thresh})"
     " exceeds {sum_thresh}, the cumulative sum starts on {start_date}.",
     cell_methods="",
-    compute=indices.degree_days_depassment_date,
+    compute=indices.degree_days_exceedance_date,
 )

--- a/xclim/indices/_threshold.py
+++ b/xclim/indices/_threshold.py
@@ -20,7 +20,7 @@ __all__ = [
     "cold_spell_days",
     "cold_spell_frequency",
     "daily_pr_intensity",
-    "degree_days_depassment_date",
+    "degree_days_exceedance_date",
     "cooling_degree_days",
     "freshet_start",
     "growing_degree_days",
@@ -1370,7 +1370,7 @@ def tropical_nights(
 
 
 @declare_units("", tas="[temperature]", thresh="[temperature]", sum_thresh="K days")
-def degree_days_depassment_date(
+def degree_days_exceedance_date(
     tas: xarray.DataArray,
     thresh: str,
     sum_thresh: str,
@@ -1378,7 +1378,7 @@ def degree_days_depassment_date(
     start_date: str = None,
     freq: str = "YS",
 ):
-    r"""Degree days depassment date.
+    r"""Degree days exceedance date.
 
     Day of year when the sum of degree days exceeds a threshold. Degree days are
     computed above or below a given temperature threshold.
@@ -1404,13 +1404,13 @@ def degree_days_depassment_date(
     Returns
     -------
     xarray.DataArray
-      Degree days depassment date
+      Degree days exceedance date
 
     Notes
     -----
     Let :math:`TG_{ij}` be the daily mean temperature at day :math:`i` of period :math:`j`,
     :math:`T` is the reference threshold and :math:`ST` is the sum threshold. Then, starting
-    at day :math:i_0:, the degree days depassment date is the first day :math:`k` such that
+    at day :math:i_0:, the degree days exceedance date is the first day :math:`k` such that
 
     .. math::
 
@@ -1430,7 +1430,7 @@ def degree_days_depassment_date(
     elif op in [">", ">=", "gt", "ge"]:
         c = tas - thresh
 
-    def _depassment_date(grp):
+    def _exceedance_date(grp):
         strt_idx = rl.index_of_date(grp.time, start_date, max_idxs=1, default=0)
         if (
             strt_idx.size == 0
@@ -1443,4 +1443,4 @@ def degree_days_depassment_date(
             date=None,
         )
 
-    return c.clip(0).resample(time=freq).map(_depassment_date)
+    return c.clip(0).resample(time=freq).map(_exceedance_date)

--- a/xclim/locales/fr.json
+++ b/xclim/locales/fr.json
@@ -673,7 +673,7 @@
     "title": "Premier jour de l'année de températures au-dessus d'un seuil.",
     "abstract": "Calcule le premier jour d'une période où la température est plus élevée qu'un certain seuil durant un nombre de jours donné, limité par une date minimale."
   },
-  "DEGREE_DAYS_DEPASSMENT_DATE": {
+  "DEGREE_DAYS_EXCEEDANCE_DATE": {
     "long_name": "Premier jour de l'année où la somme des degrés-jours excède {sum_thresh}",
     "description": "Premier jour de l'année où la somme des degrés-jours (Tmoy {op} {thresh}) excède {sum_thresh}, la somme commençant le {start_date}.",
     "title": "Jour du dépassement des degrés-jours",


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes an issue raised in slack.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
Two things : 
1) renames `degree_days_depassment_date` to Merriam-Webster-approved `degree_days_exceedance_date`.

2) Fix a bug in `lazy_indexing` that is related DDED, when using dask.  Specifically, the case where the coordinate array (`da`) is 1D and the indexes array is 0D (instead of N-D) wasn't covered. The workaround is simply to expand the indexes with a dummy dimension and squeeze it out after indexing.

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
Yes, an indicator has been renamed.