### PR TITLE
Parsable kind info for parameters of indicators

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -14,6 +14,7 @@ New indicators
 
 New features and enhancements
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* New `kind` entry in the `parameters` property of indicators, differenciating between [optional] variables and parameters.
 
 Bug fixes
 ~~~~~~~~~

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -54,7 +54,7 @@ def test_indicator_help(indicator, indname):
     runner = CliRunner()
     results = runner.invoke(cli, [indname, "--help"])
 
-    for name in indicator._sig.parameters.keys():
+    for name in indicator.parameters.keys():
         assert name in results.output
 
 

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -19,7 +19,7 @@ from xclim.core.formatting import (
     parse_doc,
     update_history,
 )
-from xclim.core.indicator import Daily, Indicator, registry
+from xclim.core.indicator import Daily, Indicator, InputKind, registry
 from xclim.core.units import units
 from xclim.core.utils import MissingVariableError
 from xclim.indices import tg_mean
@@ -328,9 +328,12 @@ def test_parsed_doc():
     params = xclim.atmos.drought_code.parameters
     assert params["tas"]["description"] == "Noon temperature."
     assert params["tas"]["annotation"] is Union[str, xr.DataArray]
-    assert params["tas"]["default"] is _empty
+    assert params["tas"]["kind"] is InputKind.VARIABLE
+    assert params["tas"]["default"] == "tas"
     assert params["snd"]["default"] is None
+    assert params["snd"]["kind"] is InputKind.OPTIONAL_VARIABLE
     assert params["shut_down_mode"]["annotation"] is str
+    assert params["shut_down_mode"]["kind"] is InputKind.PARAMETER
 
 
 def test_default_formatter():

--- a/xclim/core/indicator.py
+++ b/xclim/core/indicator.py
@@ -15,6 +15,7 @@ import warnings
 import weakref
 from collections import OrderedDict, defaultdict
 from copy import deepcopy
+from enum import IntEnum
 from inspect import Parameter, _empty, signature
 from typing import Any, Callable, Dict, List, Optional, Sequence, Union
 
@@ -40,6 +41,12 @@ from .utils import MissingVariableError
 # Indicators registry
 registry = {}  # Main class registry
 _indicators_registry = defaultdict(list)  # Private instance registry
+
+
+class InputKind(IntEnum):
+    VARIABLE = 0
+    OPTIONAL_VARIABLE = 1
+    PARAMETER = 2
 
 
 class IndicatorRegistrar:
@@ -246,11 +253,13 @@ class Indicator(IndicatorRegistrar):
         kwds["compute"] = compute = kwds.get("compute", None) or cls.compute
 
         sig = signature(compute)
-        # True if any of non-dataarray arguments are default.
+        # True if any of non-dataarray arguments ("parameters") are default.
         # In this case, we can't patch the variable names as default values.
         has_def = any(
             [
-                p.annotation is not DataArray and p.default is _empty
+                p.annotation is not DataArray
+                and p.default is _empty
+                and p.kind is not p.VAR_KEYWORD
                 for p in sig.parameters.values()
             ]
         )
@@ -300,9 +309,19 @@ class Indicator(IndicatorRegistrar):
         # params is a multilayer dict, we want to use a brand new one so deepcopy
         params = deepcopy(kwds.get("parameters", cls.parameters or {}))
         for name, param in kwds["_sig"].parameters.items():
-            param_doc = params.setdefault(name, {"type": "", "description": ""})
+            if name == "ds":  # Don't add ds in the parameters list
+                continue
+            param_doc = params.setdefault(name, {"description": ""})
             param_doc["default"] = param.default
             param_doc["annotation"] = param.annotation
+            if param.annotation == Union[str, DataArray]:
+                if param.default == name:
+                    param_doc["kind"] = InputKind.VARIABLE
+                else:
+                    param_doc["kind"] = InputKind.OPTIONAL_VARIABLE
+            else:
+                param_doc["kind"] = InputKind.PARAMETER
+
         for name in list(params.keys()):
             if name not in kwds["_parameters"]:
                 params.pop(name)

--- a/xclim/core/indicator.py
+++ b/xclim/core/indicator.py
@@ -44,6 +44,8 @@ _indicators_registry = defaultdict(list)  # Private instance registry
 
 
 class InputKind(IntEnum):
+    """Constants for input parameter kinds."""
+
     VARIABLE = 0
     OPTIONAL_VARIABLE = 1
     PARAMETER = 2


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #611
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
Adds a `kind` entry in the dicts of `Indicator.parameters`. The entry contains constants of the `xclim.core.indicator.InputKind` enum (VARIABLE, OPTIONAL_VARIABLE and PARAMETER). The first two are meant for variables we can take in a dataset, the latter is a string or a number given from user input.

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
Yes, I removed `ds` from the `ind.parameters` dict. 
