### PR TITLE
Add snow indices

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,9 +8,13 @@ History
 Breaking changes
 ~~~~~~~~~~~~~~~~
 * Renamed indicator `atmos.degree_days_depassment_date` to `atmos.degree_days_exceedance_date`.
+* Added cfchecks for Pr+Tas-based indicators.
 
 New indicators
 ~~~~~~~~~~~~~~
+* `rain_approximation` and `snowfall_approximation` for computing `prlp` and `prsn` from `pr` and `tas` (or `tasmin` or `tasmax`) according to some threshold and method.
+* `solid_precip_accumulation` and `liquid_precip_accumulation` now accept a `thresh` parameter to control the binary snow/rain temperature threshold.
+* `first_snowfall` and `last_snowfall` to compute the date of first/last snowfall exceeding a threshold in a period.
 
 New features and enhancements
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -22,6 +26,7 @@ Bug fixes
 
 Internal changes
 ~~~~~~~~~~~~~~~~
+* `core.cfchecks.check_valid` now accepts a sequence of strings as its `expected` argument.
 
 
 0.22.0 (2020-12-07)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.22.1-beta
+current_version = 0.22.2-beta
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+).(?P<patch>\d+)(\-(?P<release>[a-z]+))?

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ URL = "https://github.com/Ouranosinc/xclim"
 AUTHOR = "Travis Logan"
 AUTHOR_EMAIL = "logan.travis@ouranos.ca"
 REQUIRES_PYTHON = ">=3.6.0"
-VERSION = "0.22.1-beta"
+VERSION = "0.22.2-beta"
 LICENSE = "Apache Software License 2.0"
 
 with open("README.rst") as readme_file:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,6 +92,25 @@ def pr_series():
 
 
 @pytest.fixture
+def prsn_series():
+    def _prsn_series(values, start="7/1/2000"):
+        coords = pd.date_range(start, periods=len(values), freq=pd.DateOffset(days=1))
+        return xr.DataArray(
+            values,
+            coords=[coords],
+            dims="time",
+            name="pr",
+            attrs={
+                "standard_name": "solid_precipitation_flux",
+                "cell_methods": "time: sum over day",
+                "units": "kg m-2 s-1",
+            },
+        )
+
+    return _prsn_series
+
+
+@pytest.fixture
 def pr_hr_series():
     """Return hourly time series."""
 

--- a/tests/test_atmos.py
+++ b/tests/test_atmos.py
@@ -115,3 +115,27 @@ def test_specific_humidity(tas_series, rh_series, huss_series, ps_series):
     )
     np.testing.assert_allclose(huss, huss_exp, atol=1e-4, rtol=0.05)
     assert huss.name == "huss"
+
+
+def test_snowfall_approximation(pr_series, tasmax_series):
+    pr = pr_series(np.ones(10))
+    tasmax = tasmax_series(np.arange(10) + K2C)
+
+    prsn = atmos.snowfall_approximation(
+        pr, tas=tasmax, thresh="5 degC", method="binary"
+    )
+
+    np.testing.assert_allclose(
+        prsn, [1, 1, 1, 1, 1, 0, 0, 0, 0, 0], atol=1e-5, rtol=1e-3
+    )
+
+
+def test_rain_approximation(pr_series, tas_series):
+    pr = pr_series(np.ones(10))
+    tas = tas_series(np.arange(10) + K2C)
+
+    prlp = atmos.rain_approximation(pr, tas=tas, thresh="5 degC", method="binary")
+
+    np.testing.assert_allclose(
+        prlp, [0, 0, 0, 0, 0, 1, 1, 1, 1, 1], atol=1e-5, rtol=1e-3
+    )

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -24,7 +24,12 @@ def date_range(request):
 
 
 @pytest.mark.parametrize(
-    "value,expected", [("a string", "a string"), ("a long string", "a * string")]
+    "value,expected",
+    [
+        ("a string", "a string"),
+        ("a long string", "a * string"),
+        ("a string", ["not correct", "a string"]),
+    ],
 )
 def test_check_valid_ok(value, expected):
     d = TestObj(value)
@@ -32,7 +37,12 @@ def test_check_valid_ok(value, expected):
 
 
 @pytest.mark.parametrize(
-    "value,expected", [(None, "a string"), ("a long string", "a * strings")]
+    "value,expected",
+    [
+        (None, "a string"),
+        ("a long string", "a * strings"),
+        ("a string", ["not correct", "also not correct"]),
+    ],
 )
 def test_check_valid_raise(value, expected):
     d = TestObj(value)

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -1726,3 +1726,15 @@ def test_rain_approximation(pr_series, tas_series, method, exp):
     prlp = xci.rain_approximation(pr, tas=tas, thresh="5 degC", method=method)
 
     np.testing.assert_allclose(prlp, exp, atol=1e-5, rtol=1e-3)
+
+
+def test_first_snowfall(prsn_series):
+    prsn = prsn_series(30 - abs(np.arange(366) - 180), start="01-01-2000")
+    out = xci.first_snowfall(prsn, thresh="15 kg m-2 s-1", freq="YS")
+    assert out[0] == 166
+
+
+def test_last_snowfall(prsn_series):
+    prsn = prsn_series(30 - abs(np.arange(366) - 180), start="01-01-2000")
+    out = xci.last_snowfall(prsn, thresh="15 kg m-2 s-1", freq="YS")
+    assert out[0] == 196

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -726,17 +726,22 @@ class TestPrecipAccumulation:
 
     def test_mixed_phases(self, pr_series, tas_series):
         pr = np.zeros(100)
-        pr[5:15] = 1
+        pr[5:20] = 1
         pr = pr_series(pr)
 
         tas = np.ones(100) * 280
         tas[5:10] = 270
+        tas[10:15] = 268
         tas = tas_series(tas)
 
         outsn = xci.precip_accumulation(pr, tas=tas, phase="solid", freq="M")
+        outsn2 = xci.precip_accumulation(
+            pr, tas=tas, phase="solid", thresh="269 K", freq="M"
+        )
         outrn = xci.precip_accumulation(pr, tas=tas, phase="liquid", freq="M")
 
-        np.testing.assert_array_equal(outsn[0], 5 * 3600 * 24)
+        np.testing.assert_array_equal(outsn[0], 10 * 3600 * 24)
+        np.testing.assert_array_equal(outsn2[0], 5 * 3600 * 24)
         np.testing.assert_array_equal(outrn[0], 5 * 3600 * 24)
 
 

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -1706,3 +1706,23 @@ def test_degree_days_exceedance_date(tas_series):
         tas, thresh="2 degC", op="<", sum_thresh="150 K days", start_date="04-15"
     )
     assert out[0] == 256
+
+
+@pytest.mark.parametrize("method,exp", [("binary", [1, 1, 1, 1, 1, 0, 0, 0, 0, 0])])
+def test_snowfall_approximation(pr_series, tasmax_series, method, exp):
+    pr = pr_series(np.ones(10))
+    tasmax = tasmax_series(np.arange(10) + K2C)
+
+    prsn = xci.snowfall_approximation(pr, tas=tasmax, thresh="5 degC", method=method)
+
+    np.testing.assert_allclose(prsn, exp, atol=1e-5, rtol=1e-3)
+
+
+@pytest.mark.parametrize("method,exp", [("binary", [0, 0, 0, 0, 0, 1, 1, 1, 1, 1])])
+def test_rain_approximation(pr_series, tas_series, method, exp):
+    pr = pr_series(np.ones(10))
+    tas = tas_series(np.arange(10) + K2C)
+
+    prlp = xci.rain_approximation(pr, tas=tas, thresh="5 degC", method=method)
+
+    np.testing.assert_allclose(prlp, exp, atol=1e-5, rtol=1e-3)

--- a/tests/test_precip.py
+++ b/tests/test_precip.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pytest
 import xarray as xr
 
-from xclim import atmos
+from xclim import atmos, set_options
 from xclim.testing import open_dataset
 
 K2C = 273.15
@@ -356,3 +356,42 @@ class TestMaxConsecDryDays:
         # make sure that vector with all nans gives nans whatever skipna
         assert np.isnan(out1.values[0, -1, -1])
         # assert (np.isnan(wds.values[0, -1, -1]))
+
+
+class TestSnowfallDate:
+    tasmin_file = "NRCANdaily/nrcan_canada_daily_tasmin_1990.nc"
+    pr_file = "NRCANdaily/nrcan_canada_daily_pr_1990.nc"
+
+    def get_snowfall(self):
+        dnr = xr.merge((open_dataset(self.pr_file), open_dataset(self.tasmin_file)))
+        return atmos.snowfall_approximation(
+            dnr.pr, tas=dnr.tasmin, thresh="-0.5 degC", method="binary"
+        )
+
+    def test_first_snowfall(self):
+        with set_options(check_missing="skip"):
+            fs = atmos.first_snowfall(prsn=self.get_snowfall(), thresh="0.5 mm/day")
+
+        np.testing.assert_array_equal(
+            fs[:, [0, 45, 82], [10, 105, 155]],
+            np.array(
+                [
+                    [[1, 1, 1], [1, 1, 1], [11, np.nan, np.nan]],
+                    [[254, 256, 277], [274, 292, 275], [300, np.nan, np.nan]],
+                ]
+            ),
+        )
+
+    def test_last_snowfall(self):
+        with set_options(check_missing="skip"):
+            ls = atmos.last_snowfall(prsn=self.get_snowfall(), thresh="0.5 mm/day")
+
+        np.testing.assert_array_equal(
+            ls[:, [0, 45, 82], [10, 105, 155]],
+            np.array(
+                [
+                    [[155, 151, 129], [127, 157, 110], [106, np.nan, np.nan]],
+                    [[365, 363, 363], [365.0, 364, 364], [362, np.nan, np.nan]],
+                ]
+            ),
+        )

--- a/tests/test_precip.py
+++ b/tests/test_precip.py
@@ -104,6 +104,16 @@ class TestPrecipAccumulation:
         assert "liquid" in out_liq.long_name
         assert out_sol.standard_name == "lwe_thickness_of_snowfall_amount"
 
+        # With a non-default threshold
+        out_sol = atmos.solid_precip_accumulation(
+            pr, tas=tasmin, thresh="40 degF", freq="MS"
+        )
+        out_liq = atmos.liquid_precip_accumulation(
+            pr, tas=tasmin, thresh="40 degF", freq="MS"
+        )
+
+        np.testing.assert_array_almost_equal(out_liq + out_sol, out_tot, 4)
+
 
 class TestWetDays:
     # TODO: replace by fixture

--- a/xclim/__init__.py
+++ b/xclim/__init__.py
@@ -6,4 +6,4 @@ from xclim.indicators import ICCLIM, anuclim, atmos, icclim, land, seaIce
 
 __author__ = """Travis Logan"""
 __email__ = "logan.travis@ouranos.ca"
-__version__ = "0.22.1-beta"
+__version__ = "0.22.2-beta"

--- a/xclim/core/cfchecks.py
+++ b/xclim/core/cfchecks.py
@@ -6,6 +6,7 @@ CF-Convention checking
 Utilities designed to verify the compliance of metadata with the CF-Convention.
 """
 import fnmatch
+from typing import Sequence, Union
 
 from .options import cfcheck
 from .utils import ValidationError
@@ -14,12 +15,17 @@ from .utils import ValidationError
 
 
 @cfcheck
-def check_valid(var, key, expected):
-    r"""Check that a variable's attribute has the expected value. Warn user otherwise."""
+def check_valid(var, key: str, expected: Union[str, Sequence[str]]):
+    r"""Check that a variable's attribute has on of the expected values. Warn user otherwise."""
     att = getattr(var, key, None)
     if att is None:
         raise ValidationError(f"Variable does not have a `{key}` attribute.")
-    if not fnmatch.fnmatch(att, expected):
+    if isinstance(expected, str):
+        expected = [expected]
+    for exp in expected:
+        if fnmatch.fnmatch(att, exp):
+            break
+    else:
         raise ValidationError(
             f"Variable has a non-conforming {key}. Got `{att}`, expected `{expected}`",
         )

--- a/xclim/core/cfchecks.py
+++ b/xclim/core/cfchecks.py
@@ -16,7 +16,7 @@ from .utils import ValidationError
 
 @cfcheck
 def check_valid(var, key: str, expected: Union[str, Sequence[str]]):
-    r"""Check that a variable's attribute has on of the expected values. Warn user otherwise."""
+    r"""Check that a variable's attribute has one of the expected values. Raise a ValidationError otherwise."""
     att = getattr(var, key, None)
     if att is None:
         raise ValidationError(f"Variable does not have a `{key}` attribute.")

--- a/xclim/indicators/atmos/_conversion.py
+++ b/xclim/indicators/atmos/_conversion.py
@@ -12,6 +12,8 @@ __all__ = [
     "relative_humidity_from_dewpoint",
     "relative_humidity",
     "specific_humidity",
+    "snowfall_approximation",
+    "rain_approximation",
 ]
 
 
@@ -149,4 +151,31 @@ specific_humidity = Converter(
         else ""
     ),
     compute=wrapped_partial(indices.specific_humidity, invalid_values="mask"),
+)
+
+
+snowfall_approximation = Converter(
+    identifier="prsn",
+    _nvar=2,
+    units="kg m-2 s-1",
+    standard_name="solid_precipitation_flux",
+    long_name="Solid precipitation",
+    description=(
+        "Solid precipitation estimated from total precipitation and temperature"
+        " with method {method} and threshold temperature {thresh}."
+    ),
+    compute=indices.snowfall_approximation,
+)
+
+rain_approximation = Converter(
+    identifier="prlp",
+    _nvar=2,
+    units="kg m-2 s-1",
+    standard_name="precipitation_flux",
+    long_name="Liquid precipitation",
+    description=(
+        "Liquid precipitation estimated from total precipitation and temperature"
+        " with method {method} and threshold temperature {thresh}."
+    ),
+    compute=indices.rain_approximation,
 )

--- a/xclim/indicators/atmos/_precip.py
+++ b/xclim/indicators/atmos/_precip.py
@@ -22,6 +22,8 @@ __all__ = [
     "solid_precip_accumulation",
     "drought_code",
     "fire_weather_indexes",
+    "last_snowfall",
+    "first_snowfall",
 ]
 
 
@@ -43,10 +45,14 @@ class PrTasx(Daily2D):
     def cfcheck(pr, tas):
         cfchecks.check_valid(tas, "cell_methods", "*time: * within days*")
         cfchecks.check_valid(tas, "standard_name", "air_temperature")
-        cfchecks.check_valid(pr, "standard_name", "precipitation_flux")
+        cfchecks.check_valid(
+            pr, "standard_name", ["precipitation_flux", "lwe_precipitation_rate"]
+        )
 
 
 class PrTas(Daily2D):
+    """Indicator involving pr and one of tas, tasmin or tasmax."""
+
     _nvar = 2
     context = "hydro"
 
@@ -54,10 +60,20 @@ class PrTas(Daily2D):
     def cfcheck(pr, tas):
         cfchecks.check_valid(tas, "cell_methods", "*time: mean within days*")
         cfchecks.check_valid(tas, "standard_name", "air_temperature")
-        cfchecks.check_valid(pr, "standard_name", "precipitation_flux")
+        cfchecks.check_valid(
+            pr, "standard_name", ["precipitation_flux", "lwe_precipitation_rate"]
+        )
 
 
-rain_on_frozen_ground_days = PrTas(
+class Prsn(Daily):
+    context = "hydro"
+
+    @staticmethod
+    def cfcheck(prsn):
+        cfchecks.check_valid(prsn, "standard_name", "solid_precipitation_flux")
+
+
+rain_on_frozen_ground_days = PrTasx(
     identifier="rain_frzgr",
     units="days",
     standard_name="number_of_days_with_lwe_thickness_of_"
@@ -240,4 +256,23 @@ fire_weather_indexes = Daily(
     units="",
     compute=indices.fire_weather_indexes,
     missing="skip",
+)
+
+
+last_snowfall = Prsn(
+    identifier="last_snowfall",
+    standard_name="day_of_year",
+    long_name="Date of last snowfall",
+    description="{freq} last day where the solid precipitation flux exceeded {thresh}",
+    units="",
+    compute=indices.last_snowfall,
+)
+
+first_snowfall = Prsn(
+    identifier="first_snowfall",
+    standard_name="day_of_year",
+    long_name="Date of first snowfall",
+    description="{freq} first day where the solid precipitation flux exceeded {thresh}",
+    units="",
+    compute=indices.first_snowfall,
 )

--- a/xclim/indicators/atmos/_precip.py
+++ b/xclim/indicators/atmos/_precip.py
@@ -152,7 +152,7 @@ precip_accumulation = Pr(
     compute=wrapped_partial(indices.precip_accumulation, tas=None, phase=None),
 )
 
-liquid_precip_accumulation = Pr(
+liquid_precip_accumulation = PrTas(
     title="Accumulated liquid precipitation.",
     identifier="liquidprcptot",
     units="mm",
@@ -165,7 +165,7 @@ liquid_precip_accumulation = Pr(
     ),  # _empty is added to un-optionalize the argument.
 )
 
-solid_precip_accumulation = Pr(
+solid_precip_accumulation = PrTas(
     title="Accumulated solid precipitation.",
     identifier="solidprcptot",
     units="mm",

--- a/xclim/indices/_conversion.py
+++ b/xclim/indices/_conversion.py
@@ -451,7 +451,7 @@ def snowfall_approximation(
     Parameters
     ----------
     pr : xarray.DataArray
-      Mean daily precipitation flux [Kg m-2 s-1] or [mm].
+      Mean daily precipitation flux [kg m-2 s-1] or [mm].
     tas : xarray.DataArray, optional
       Mean, maximum or minimum daily temperature.
     thresh : str,
@@ -465,7 +465,7 @@ def snowfall_approximation(
 
     - "binary" : When the given temperature is under a given threshold, precipitation
         is assumed to be solid. The method is agnostic to the type of temperature used
-        (mean, maximum or minimal).
+        (mean, maximum or minimum).
 
     """
     thresh = convert_units_to(thresh, tas)
@@ -492,7 +492,7 @@ def rain_approximation(
     Parameters
     ----------
     pr : xarray.DataArray
-      Mean daily precipitation flux [Kg m-2 s-1] or [mm].
+      Mean daily precipitation flux [kg m-2 s-1] or [mm].
     tas : xarray.DataArray, optional
       Mean, maximum or minimum daily temperature.
     thresh : str,

--- a/xclim/indices/_multivariate.py
+++ b/xclim/indices/_multivariate.py
@@ -831,7 +831,7 @@ def precip_accumulation(
 
     Examples
     --------
-    The following would compute, for each grid cell of dataset, the total
+    The following would compute, for each grid cell of a dataset, the total
     precipitation at the seasonal frequency, ie DJF, MAM, JJA, SON, DJF, etc.:
 
     >>> from xclim.indices import precip_accumulation

--- a/xclim/indices/_multivariate.py
+++ b/xclim/indices/_multivariate.py
@@ -737,7 +737,7 @@ def liquid_precip_ratio(
     r"""Ratio of rainfall to total precipitation.
 
     The ratio of total liquid precipitation over the total precipitation. If solid precipitation is not provided,
-    then it is approximated with pr, tas and thresh, using the `snowfall_approximation` indice with method 'binary'.
+    it is approximated with pr, tas and thresh, using the `snowfall_approximation` function with method 'binary'.
 
     Parameters
     ----------
@@ -794,7 +794,7 @@ def precip_accumulation(
     r"""Accumulated total (liquid and/or solid) precipitation.
 
     Resample the original daily mean precipitation flux and accumulate over each period.
-    If a daily temperature is provided, the phase keyword can be used to only sum precipitation of a certain phase.
+    If a daily temperature is provided, the `phase` keyword can be used to sum precipitation of a given phase only.
     When the temperature is under the provided threshold, precipitation is assumed to be snow, and liquid rain otherwise.
     This indice is agnostic to the type of daily temperature (tas, tasmax or tasmin) given.
 

--- a/xclim/indices/_multivariate.py
+++ b/xclim/indices/_multivariate.py
@@ -789,19 +789,20 @@ def precip_accumulation(
     r"""Accumulated total (liquid and/or solid) precipitation.
 
     Resample the original daily mean precipitation flux and accumulate over each period.
-    If the daily mean temperature is provided, the phase keyword can be used to only sum precipitation of a certain phase.
-    When the mean temperature is under the provided threshold, precipitation is assumed to be snow, and liquid rain otherwise.
+    If a daily temperature is provided, the phase keyword can be used to only sum precipitation of a certain phase.
+    When the temperature is under the provided threshold, precipitation is assumed to be snow, and liquid rain otherwise.
+    This indice is agnostic to the type of daily temperature (tas, tasmax or tasmin) given.
 
     Parameters
     ----------
     pr : xarray.DataArray
       Mean daily precipitation flux [Kg m-2 s-1] or [mm].
     tas : xarray.DataArray, optional
-      (Mean) daily temperature [℃] or [K]
+      Mean, maximum or minimum daily temperature.
     phase : str, optional,
       Which phase to consider, "liquid" or "solid", if None (default), both are considered.
     thresh : str,
-      Threshold of `tas` under which the precipication is assumed to be liquid rain.
+      Threshold of `tas` over which the precipication is assumed to be liquid rain.
     freq : str
       Resampling frequency as defined in
       http://pandas.pydata.org/pandas-docs/stable/timeseries.html#resampling. Defaults to "YS"
@@ -820,11 +821,11 @@ def precip_accumulation(
 
        PR_{ij} = \sum_{i=a}^{b} PR_i
 
-    If `phase` is "liquid", only times where the daily mean temperature :math:`T_i` is above or equal to 0 °C are considered, inversely for "solid".
+    If `phase` is "liquid", only times where the daily temperature :math:`T_i` is above or equal to a threshold are considered, inversely for "solid".
 
     Examples
     --------
-    The following would compute for each grid cell of file `pr_day.nc` the total
+    The following would compute, for each grid cell of dataset, the total
     precipitation at the seasonal frequency, ie DJF, MAM, JJA, SON, DJF, etc.:
 
     >>> from xclim.indices import precip_accumulation

--- a/xclim/indices/_multivariate.py
+++ b/xclim/indices/_multivariate.py
@@ -778,27 +778,30 @@ def liquid_precip_ratio(
     return ratio
 
 
-@declare_units("mm", pr="[precipitation]", tas="[temperature]")
+@declare_units("mm", pr="[precipitation]", tas="[temperature]", thresh="[temperature]")
 def precip_accumulation(
     pr: xarray.DataArray,
     tas: xarray.DataArray = None,
     phase: Optional[str] = None,
+    thresh: str = "0 degC",
     freq: str = "YS",
 ) -> xarray.DataArray:
     r"""Accumulated total (liquid and/or solid) precipitation.
 
     Resample the original daily mean precipitation flux and accumulate over each period.
     If the daily mean temperature is provided, the phase keyword can be used to only sum precipitation of a certain phase.
-    When the mean temperature is over 0 degC, precipitation is assumed to be liquid rain and snow otherwise.
+    When the mean temperature is under the provided threshold, precipitation is assumed to be snow, and liquid rain otherwise.
 
     Parameters
     ----------
     pr : xarray.DataArray
       Mean daily precipitation flux [Kg m-2 s-1] or [mm].
     tas : xarray.DataArray, optional
-      Mean daily temperature [℃] or [K]
+      (Mean) daily temperature [℃] or [K]
     phase : str, optional,
       Which phase to consider, "liquid" or "solid", if None (default), both are considered.
+    thresh : str,
+      Threshold of `tas` under which the precipication is assumed to be liquid rain.
     freq : str
       Resampling frequency as defined in
       http://pandas.pydata.org/pandas-docs/stable/timeseries.html#resampling. Defaults to "YS"
@@ -829,7 +832,7 @@ def precip_accumulation(
     >>> prcp_tot_seasonal = precip_accumulation(pr_day, freq="QS-DEC")
     """
     if phase in ["liquid", "solid"]:
-        frz = convert_units_to("0 degC", tas)
+        frz = convert_units_to(thresh, tas)
 
         if phase == "liquid":
             pr = pr.where(tas >= frz, 0)

--- a/xclim/indices/_threshold.py
+++ b/xclim/indices/_threshold.py
@@ -730,7 +730,7 @@ def first_snowfall(
 
     Returns the first day of a period where the solid precipitation exceeds a threshold.
 
-    WARNING: The default freq is valid for the northern hemisphere.
+    WARNING: The default `freq` is valid for the northern hemisphere.
 
     Parameters
     ----------

--- a/xclim/indices/_threshold.py
+++ b/xclim/indices/_threshold.py
@@ -30,6 +30,8 @@ __all__ = [
     "frost_season_length",
     "first_day_below",
     "first_day_above",
+    "first_snowfall",
+    "last_snowfall",
     "heat_wave_index",
     "heating_degree_days",
     "hot_spell_frequency",
@@ -713,6 +715,82 @@ def first_day_above(
         rl.first_run_after_date,
         window=window,
         date=after_date,
+        dim="time",
+        coord="dayofyear",
+    )
+
+
+@declare_units("", prsn="[precipitation]", thresh="[precipitation]")
+def first_snowfall(
+    prsn: xarray.DataArray,
+    thresh: str = "0.5 mm/day",
+    freq: str = "AS-JUL",
+):
+    r"""First day with solid precipitation above a threshold.
+
+    Returns the first day of a period where the solid precipitation exceeds a threshold.
+
+    WARNING: The default freq is valid for the northern hemisphere.
+
+    Parameters
+    ----------
+    prsn : xarray.DataArray
+      Solid precipitation flux.
+    thresh : str
+      Threshold precipitation flux on which to base evaluation. Default '0.5 mm/day'.
+    freq : str
+      Resampling frequency; Defaults to "YS".
+
+    Returns
+    -------
+    xarray.DataArray
+      First day of the year when the solid precipitation  is superior to a threshold,
+      If there is no such day, return np.nan.
+    """
+    thresh = convert_units_to(thresh, prsn)
+    cond = prsn >= thresh
+
+    return cond.resample(time=freq).map(
+        rl.first_run,
+        window=1,
+        dim="time",
+        coord="dayofyear",
+    )
+
+
+@declare_units("", prsn="[precipitation]", thresh="[precipitation]")
+def last_snowfall(
+    prsn: xarray.DataArray,
+    thresh: str = "0.5 mm/day",
+    freq: str = "AS-JUL",
+):
+    r"""Last day with solid precipitation above a threshold.
+
+    Returns the last day of a period where the solid precipitation exceeds a threshold.
+
+    WARNING: The default freq is valid for the northern hemisphere.
+
+    Parameters
+    ----------
+    prsn : xarray.DataArray
+      Solid precipitation flux.
+    thresh : str
+      Threshold precipitation flux on which to base evaluation. Default '0.5 mm/day'.
+    freq : str
+      Resampling frequency; Defaults to "YS".
+
+    Returns
+    -------
+    xarray.DataArray
+      Last day of the year when the solid precipitation is superior to a threshold,
+      If there is no such day, return np.nan.
+    """
+    thresh = convert_units_to(thresh, prsn)
+    cond = prsn >= thresh
+
+    return cond.resample(time=freq).map(
+        rl.last_run,
+        window=1,
         dim="time",
         coord="dayofyear",
     )

--- a/xclim/indices/_threshold.py
+++ b/xclim/indices/_threshold.py
@@ -739,7 +739,7 @@ def first_snowfall(
     thresh : str
       Threshold precipitation flux on which to base evaluation. Default '0.5 mm/day'.
     freq : str
-      Resampling frequency; Defaults to "YS".
+      Resampling frequency; Defaults to "AS-JUL".
 
     Returns
     -------
@@ -777,7 +777,7 @@ def last_snowfall(
     thresh : str
       Threshold precipitation flux on which to base evaluation. Default '0.5 mm/day'.
     freq : str
-      Resampling frequency; Defaults to "YS".
+      Resampling frequency; Defaults to "AS-JUL".
 
     Returns
     -------

--- a/xclim/locales/fr.json
+++ b/xclim/locales/fr.json
@@ -678,5 +678,29 @@
     "description": "Premier jour de l'année où la somme des degrés-jours (Tmoy {op} {thresh}) excède {sum_thresh}, la somme commençant le {start_date}.",
     "title": "Jour du dépassement des degrés-jours",
     "abstract": "Jour de l'année où la somme des degrés-jours excède un seuil. Les degrés-jours sont calculés au-dessus ou au-dessous d'un seuil de température donné."
+  },
+  "PRSN": {
+    "long_name": "Précipitation solide",
+    "description": "Précipitation solide estimée à partir de la précipitation totale et de la température selon la méthode {method} et le seuil de température {thresh}.",
+    "title": "Approximation de la neige",
+    "abstract": "Précipitation solide estimée à partir de la précipitation totale et de la température selon une méthode et un seuil de température donnés."
+  },
+  "PRLP": {
+    "long_name": "Précipitation liquide",
+    "description": "Précipitation liquide estimée à partir de la précipitation totale et de la température selon la méthode {method} et le seuil de température {thresh}.",
+    "title": "Approximation de la pluie",
+    "abstract": "Précipitation liquide estimée à partir de la précipitation totale et de la température selon une méthode et un seuil de température donnés."
+  },
+  "LAST_SNOWFALL": {
+    "long_name": "Date de la dernière neige",
+    "description": "Dernier jour {freq:m} où la précipitation solide excède {thresh}.",
+    "title": "Dernier jour avec une précipitation solide au-dessus d'un seuil",
+    "abstract": "Dernier jour d'une période où la précipitation solide excède un certain seuil."
+  },
+  "FIRST_SNOWFALL": {
+    "long_name": "Date de la première neige",
+    "description": "Premier jour {freq:m} où la précipitation solide excède {thresh}.",
+    "title": "Premier jour avec une précipitation solide au-dessus d'un seuil",
+    "abstract": "Premier jour d'une période où la précipitation solide excède un certain seuil."
   }
 }


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #597
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [x] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->

Generalized `indices.precip_accumulation` and related indicators so that the threshold temperature can be given and that either tas, tasmin or tasmax can be given as the "tas" argument (simple docstring changes). It now uses the new `snowfall_approximation` and  `rain_approximation` indices that convert `pr` and `tas` (again stat-agnostic) to `prsn` and `prlp`, according to a method and a threshold (default : 0 degC). Only 1 method is currently implemented (binary), but it could be extended with a polynomial (CLASS) based method, or more. Corresponding indicators have been created.

An indicator subclass `PrTasx` has been added, subclassing `Daily2D` and performing cf checks, ensuring that inputs are pr (either "precipitation_flux" or "lwe_precipitation_rate") and tas/tasmin/tasmax ("air_temperature and "time: * within days").
The `PrTas` subclass now also has the cf checks, but with stricter tas cell_methods : "time: mean within days".

To allow multiple standard_names in the PrTas cf check, `cfchecks.check_valid` has been modified to accept a list of expected values, raising an error if none of them match the value.

Added `first_snowfall` and `last_snowfall` indices and indicators. They compute the first/last date of solid precipitation exceeding a threshold within a period. Pretty straightforward.

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
Yes, cf validation is now stricter for PrTas(x) indicators.

* **Other information**:
As discussed in the issue thread, an automated xclim parser will not be able to see the possibility of passing tasmin or tasmax in the modified indicators.
