### PR TITLE
Speed up and clean up tests

### DIFF
--- a/.github/CONTRIBUTING.rst
+++ b/.github/CONTRIBUTING.rst
@@ -165,7 +165,10 @@ Tips
 
 To run a subset of tests::
 
-$ pytest tests.test_xclim
+# For running only a test file:
+$ pytest tests/test_xclim.py
+# or to skip all slow tests:
+$ pytest -m "not slow"
 
 To run all conventions tests at once::
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -27,6 +27,7 @@ Bug fixes
 Internal changes
 ~~~~~~~~~~~~~~~~
 * `core.cfchecks.check_valid` now accepts a sequence of strings as its `expected` argument.
+* Clean up in the tests to speed up testing. Addition of a marker to exclude slow tests when needed.
 
 
 0.22.0 (2020-12-07)

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,8 @@ filterwarnings =
 testpaths = tests tests/test_sdba
 usefixtures = xdoctest_namespace
 doctest_optionflags = NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL NUMBER ELLIPSIS
+markers =
+	slow: marks tests as slow (deselect with '-m "not slow"')
 
 [tool:pylint]
 ignore = docs,tests

--- a/tests/test_analog.py
+++ b/tests/test_analog.py
@@ -50,6 +50,7 @@ def test_randn():
     assert_almost_equal(r.std(0, ddof=1), std)
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("method", xca.metrics.keys())
 def test_spatial_analogs(method):
     if method == "skezely_rizzo":
@@ -65,6 +66,7 @@ def test_spatial_analogs(method):
     np.testing.assert_allclose(diss[method], out, rtol=1e-3, atol=1e-3)
 
 
+@pytest.mark.slow
 def test_spatial_analogs_multidim():
     diss = open_dataset("SpatialAnalogs/dissimilarity")
     data = open_dataset("SpatialAnalogs/indicators")

--- a/tests/test_ensembles.py
+++ b/tests/test_ensembles.py
@@ -296,19 +296,6 @@ class TestEnsembleReduction:
         assert ids == [4, 5, 7, 10, 11, 12, 13]
         assert len(ids) == 7
 
-        sample_weights = np.ones(ds.data.shape[0])
-        # try zero weights
-        sample_weights[[6, 18, 22]] = 0
-        [ids, cluster, fig_data] = ensembles.kmeans_reduce_ensemble(
-            data=ds.data,
-            method={"rsq_optimize": None},
-            random_state=42,
-            make_graph=False,
-            sample_weights=sample_weights,
-        )
-        assert ids == [4, 5, 7, 10, 12, 13]
-        assert len(ids) == 6
-
     def test_kmeans_variweights(self):
         pytest.importorskip("sklearn", minversion="0.22")
         ds = open_dataset(self.nc_file)
@@ -327,19 +314,7 @@ class TestEnsembleReduction:
         assert ids == [1, 3, 8, 10, 13, 14, 16, 19, 20]
         assert len(ids) == 9
 
-        # using RSQ optimize
-        [ids, cluster, fig_data] = ensembles.kmeans_reduce_ensemble(
-            data=ds.data,
-            method={"rsq_optimize": None},
-            random_state=42,
-            make_graph=False,
-            variable_weights=var_weights,
-        )
-
-        assert ids == [2, 4, 8, 13, 14, 22]
-        assert len(ids) == 6
-
-        # try zero weights
+        # using RSQ optimize and try zero weights
         var_weights = np.ones(ds.data.shape[1])
         var_weights[[1, 4]] = 0
 

--- a/tests/test_ensembles.py
+++ b/tests/test_ensembles.py
@@ -210,6 +210,7 @@ class TestEnsembleStats:
         assert "Computation of statistics on" in out1.attrs["xclim_history"]
 
 
+@pytest.mark.slow
 class TestEnsembleReduction:
     nc_file = os.path.join("EnsembleReduce", "TestEnsReduceCriteria.nc")
 

--- a/tests/test_ensembles.py
+++ b/tests/test_ensembles.py
@@ -349,20 +349,6 @@ class TestEnsembleReduction:
             if np.sum(cluster == cluster[i]) > 1:
                 assert i not in ids
 
-        model_weights = np.ones(ds.data.shape[0])
-        model_weights[[0, 3, 4, 6, 7, 10, 11, 12, 13]] = 0
-        [ids, cluster, fig_data] = ensembles.kmeans_reduce_ensemble(
-            data=ds.data,
-            method={"n_clusters": 9},
-            random_state=42,
-            make_graph=False,
-            model_weights=model_weights,
-        )
-        for i in np.where(model_weights == 0)[0]:
-            # as long as the cluster has more than one member the models w/ weight==0 should not be present
-            if np.sum(cluster == cluster[i]) > 1:
-                assert i not in ids
-
     @pytest.mark.skipif(
         "matplotlib.pyplot" not in sys.modules, reason="matplotlib.pyplot is required"
     )

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 # Tests for the Indicator objects
 import gc
-from inspect import _empty
 from typing import Union
 
 import dask
@@ -390,9 +389,9 @@ def test_update_history():
 
 
 def test_input_dataset():
-    dsx = open_dataset("NRCANdaily/nrcan_canada_daily_tasmax_1990")
-    dsn = open_dataset("NRCANdaily/nrcan_canada_daily_tasmin_1990")
-    ds = xr.merge([dsx, dsn])
+    ds = open_dataset(
+        "ERA5/daily_surface_cancities_1990-1993.nc", branch="add-main-testdataset"
+    )
 
     # Use defaults
     out = xclim.atmos.daily_temperature_range(freq="YS", ds=ds)
@@ -405,5 +404,6 @@ def test_input_dataset():
     out = xclim.atmos.daily_temperature_range(tasmax=ds.tasmax, freq="YS", ds=ds)
 
     # Inexistent variable:
+    dsx = ds.drop_vars("tasmin")
     with pytest.raises(MissingVariableError):
         out = xclim.atmos.daily_temperature_range(freq="YS", ds=dsx)  # noqa

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -389,9 +389,7 @@ def test_update_history():
 
 
 def test_input_dataset():
-    ds = open_dataset(
-        "ERA5/daily_surface_cancities_1990-1993.nc", branch="add-main-testdataset"
-    )
+    ds = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc")
 
     # Use defaults
     out = xclim.atmos.daily_temperature_range(freq="YS", ds=ds)

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -825,23 +825,12 @@ class TestTGXN10p:
         assert out[5] == 5
 
     def test_doy_interpolation(self):
-        pytest.importorskip("xarray", "0.11.4")
-
         # Just a smoke test
-        fn_clim = os.path.join(
-            "CanESM2_365day",
-            "tasmin_day_CanESM2_rcp85_r1i1p1_na10kgrid_qm-moving-50bins-detrend_2095.nc",
-        )
-        fn = os.path.join(
-            "HadGEM2-CC_360day",
-            "tasmin_day_HadGEM2-CC_rcp85_r1i1p1_na10kgrid_qm-moving-50bins-detrend_2095.nc",
-        )
-
-        with open_dataset(fn_clim) as ds:
-            t10 = percentile_doy(ds.tasmin.isel(lat=0, lon=0), per=0.1)
-
-        with open_dataset(fn) as ds:
-            xci.tn10p(ds.tasmin.isel(lat=0, lon=0), t10, freq="MS")
+        with open_dataset(
+            "ERA5/daily_surface_cancities_1990-1993.nc", branch="add-main-testdataset"
+        ) as ds:
+            t10 = percentile_doy(ds.tasmin, per=0.1)
+            xci.tn10p(ds.tasmin, t10, freq="MS")
 
 
 class TestTGXN90p:
@@ -1459,30 +1448,18 @@ class TestWinterRainRatio:
 
 # I'd like to parametrize some of these tests so we don't have to write individual tests for each indicator.
 class TestTG:
-    @staticmethod
-    @pytest.fixture(scope="session")
-    def cmip3_day_tas():
-        # xr.set_options(enable_cftimeindex=False)
+    @pytest.mark.parametrize(
+        "ind,exp",
+        [(xci.tg_mean, 283.1391), (xci.tg_min, 266.1117), (xci.tg_max, 292.1250)],
+    )
+    def test_simple(self, ind, exp):
         ds = open_dataset(
-            os.path.join("cmip3", "tas.sresb1.giss_model_e_r.run1.atm.da.nc")
+            "ERA5/daily_surface_cancities_1990-1993.nc", branch="add-main-testdataset"
         )
-        yield ds.tas
-        ds.close()
-
-    def test_cmip3_tgmean(self, cmip3_day_tas):
-        pytest.importorskip("xarray", "0.11.4")
-        xci.tg_mean(cmip3_day_tas)
-
-    def test_cmip3_tgmin(self, cmip3_day_tas):
-        pytest.importorskip("xarray", "0.11.4")
-        xci.tg_min(cmip3_day_tas)
-
-    def test_cmip3_tgmax(self, cmip3_day_tas):
-        pytest.importorskip("xarray", "0.11.4")
-        xci.tg_max(cmip3_day_tas)
+        out = ind(ds.tas.sel(location="Victoria"))
+        np.testing.assert_almost_equal(out[0], exp, decimal=4)
 
     def test_indice_against_icclim(self, cmip3_day_tas):
-        pytest.importorskip("xarray", "0.11.4")
         from xclim import icclim
 
         ind = xci.tg_mean(cmip3_day_tas)

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -831,9 +831,7 @@ class TestTGXN10p:
 
     def test_doy_interpolation(self):
         # Just a smoke test
-        with open_dataset(
-            "ERA5/daily_surface_cancities_1990-1993.nc", branch="add-main-testdataset"
-        ) as ds:
+        with open_dataset("ERA5/daily_surface_cancities_1990-1993.nc") as ds:
             t10 = percentile_doy(ds.tasmin, per=0.1)
             xci.tn10p(ds.tasmin, t10, freq="MS")
 
@@ -1458,9 +1456,7 @@ class TestTG:
         [(xci.tg_mean, 283.1391), (xci.tg_min, 266.1117), (xci.tg_max, 292.1250)],
     )
     def test_simple(self, ind, exp):
-        ds = open_dataset(
-            "ERA5/daily_surface_cancities_1990-1993.nc", branch="add-main-testdataset"
-        )
+        ds = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc")
         out = ind(ds.tas.sel(location="Victoria"))
         np.testing.assert_almost_equal(out[0], exp, decimal=4)
 

--- a/tests/test_precip.py
+++ b/tests/test_precip.py
@@ -14,9 +14,7 @@ K2C = 273.15
 class TestRainOnFrozenGround:
     @pytest.mark.parametrize("chunks", [{"time": 366}, None])
     def test_3d_data_with_nans(self, chunks):
-        ds = open_dataset(
-            "ERA5/daily_surface_cancities_1990-1993.nc", branch="add-main-testdataset"
-        )
+        ds = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc")
 
         pr = ds.pr.copy()
         pr.values[1, 10] = np.nan

--- a/tests/test_sdba/test_adjustment.py
+++ b/tests/test_sdba/test_adjustment.py
@@ -134,14 +134,15 @@ class TestDQM:
         middle = (x > 1e-2) * (x < 0.99)
         np.testing.assert_array_almost_equal(p[middle], ref[middle], 1)
 
-        # Test with simure not equal to hist
-        ff = series(np.ones(ns) * 1.1, name)
-        sim2 = apply_correction(sim, ff, kind)
-        ref2 = apply_correction(ref, ff, kind)
+        # PB 13-01-21 : This seems the same as the next test.
+        # Test with sim not equal to hist
+        # ff = series(np.ones(ns) * 1.1, name)
+        # sim2 = apply_correction(sim, ff, kind)
+        # ref2 = apply_correction(ref, ff, kind)
 
-        p2 = DQM.adjust(sim2, interp="linear")
+        # p2 = DQM.adjust(sim2, interp="linear")
 
-        np.testing.assert_array_almost_equal(p2[middle], ref2[middle], 1)
+        # np.testing.assert_array_almost_equal(p2[middle], ref2[middle], 1)
 
         # Test with actual trend in sim
         trend = series(
@@ -153,10 +154,8 @@ class TestDQM:
         np.testing.assert_array_almost_equal(p3[middle], ref3[middle], 1)
 
     @pytest.mark.parametrize("kind,name", [(ADDITIVE, "tas"), (MULTIPLICATIVE, "pr")])
-    @pytest.mark.parametrize(
-        "spatial_dims", [None, {"lat": np.arange(20), "lon": np.arange(20)}]
-    )
-    def test_mon_U(self, mon_series, series, mon_triangular, kind, name, spatial_dims):
+    @pytest.mark.parametrize("add_dims", [True, False])
+    def test_mon_U(self, mon_series, series, kind, name, add_dims):
         """
         Train on
         hist: U
@@ -164,7 +163,7 @@ class TestDQM:
 
         Predict on hist to get ref
         """
-        n = 10000
+        n = 5000
         u = np.random.rand(n)
 
         # Define distributions
@@ -183,18 +182,18 @@ class TestDQM:
         ref_t = mon_series(apply_correction(y, trend, kind), name)
         sim = series(apply_correction(x, trend, kind), name)
 
-        if spatial_dims:
-            hist = hist.expand_dims(**spatial_dims).chunk({"lat": 10})
-            sim = sim.expand_dims(**spatial_dims).chunk({"lat": 10})
-            ref_t = ref_t.expand_dims(**spatial_dims)
+        if add_dims:
+            hist = hist.expand_dims(lat=[0, 1, 2]).chunk({"lat": 1})
+            sim = sim.expand_dims(lat=[0, 1, 2]).chunk({"lat": 1})
+            ref_t = ref_t.expand_dims(lat=[0, 1, 2])
 
         DQM = DetrendedQuantileMapping(kind=kind, group="time.month", nquantiles=5)
         DQM.train(ref, hist)
         mqm = DQM.ds.af.mean(dim="quantiles")
         p = DQM.adjust(sim)
 
-        if spatial_dims:
-            mqm = mqm.isel({crd: 0 for crd in spatial_dims.keys()})
+        if add_dims:
+            mqm = mqm.isel(lat=0)
         np.testing.assert_array_almost_equal(mqm, int(kind == MULTIPLICATIVE), 1)
         np.testing.assert_allclose(p, ref_t, rtol=0.1, atol=0.5)
 

--- a/tests/test_sdba/test_adjustment.py
+++ b/tests/test_sdba/test_adjustment.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pytest
-import xarray as xr
 from scipy.stats import norm, uniform
 
 from xclim.sdba.adjustment import (
@@ -48,6 +47,7 @@ class TestLoci:
         assert "Bias-adjusted with LOCI(" in p.attrs["xclim_history"]
 
 
+@pytest.mark.slow
 class TestScaling:
     @pytest.mark.parametrize("kind,name", [(ADDITIVE, "tas"), (MULTIPLICATIVE, "pr")])
     def test_time(self, kind, name, series):
@@ -89,6 +89,7 @@ class TestScaling:
         np.testing.assert_array_almost_equal(p, ref)
 
 
+@pytest.mark.slow
 class TestDQM:
     @pytest.mark.parametrize("kind,name", [(ADDITIVE, "tas"), (MULTIPLICATIVE, "pr")])
     def test_quantiles(self, series, kind, name):
@@ -208,6 +209,7 @@ class TestDQM:
         np.testing.assert_almost_equal(p.std(), 15.0, 0)
 
 
+@pytest.mark.slow
 class TestQDM:
     @pytest.mark.parametrize("kind,name", [(ADDITIVE, "tas"), (MULTIPLICATIVE, "pr")])
     def test_quantiles(self, series, kind, name):
@@ -328,6 +330,7 @@ class TestQDM:
         np.testing.assert_almost_equal(bc_sim.std(), 16.7, 0)
 
 
+@pytest.mark.slow
 class TestQM:
     @pytest.mark.parametrize("kind,name", [(ADDITIVE, "tas"), (MULTIPLICATIVE, "pr")])
     def test_quantiles(self, series, kind, name):

--- a/tests/test_sdba/test_base.py
+++ b/tests/test_sdba/test_base.py
@@ -50,7 +50,7 @@ def test_grouper_get_index(tas_series, group, interp, val90):
 
 @pytest.mark.parametrize(
     "group,n",
-    [("time", 1), ("time.month", 12), ("time.week", 52), ("mytime.dayofyear", 366)],
+    [("time", 1), ("time.month", 12), ("time.week", 52)],
 )
 @pytest.mark.parametrize("use_dask", [True, False])
 def test_grouper_apply(tas_series, use_dask, group, n):

--- a/tests/test_sdba/test_base.py
+++ b/tests/test_sdba/test_base.py
@@ -48,6 +48,7 @@ def test_grouper_get_index(tas_series, group, interp, val90):
     assert indx[90] == val90
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "group,n",
     [("time", 1), ("time.month", 12), ("time.week", 52)],

--- a/tests/test_sdba/test_detrending.py
+++ b/tests/test_sdba/test_detrending.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from xclim.sdba.detrending import LoessDetrend, PolyDetrend
 
@@ -18,6 +19,7 @@ def test_poly_detrend(series):
     np.testing.assert_array_almost_equal(xt, x)
 
 
+@pytest.mark.slow
 def test_loess_detrend(series):
     x = series(np.arange(12 * 365.25), "tas")
     det = LoessDetrend(group="time", d=0, niter=1, f=0.2)

--- a/tests/test_sdba/test_detrending.py
+++ b/tests/test_sdba/test_detrending.py
@@ -19,12 +19,12 @@ def test_poly_detrend(series):
 
 
 def test_loess_detrend(series):
-    x = series(np.arange(20 * 365.25), "tas")
+    x = series(np.arange(12 * 365.25), "tas")
     det = LoessDetrend(group="time", d=0, niter=1, f=0.2)
     fx = det.fit(x)
     dx = fx.detrend(x)
     xt = fx.retrend(dx)
 
     # Strong boundary effects in LOESS, remove ~ f * Nx on each side.
-    np.testing.assert_array_almost_equal(dx.isel(time=slice(1500, 5800)), 0)
+    np.testing.assert_array_almost_equal(dx.isel(time=slice(880, 3500)), 0)
     np.testing.assert_array_almost_equal(xt, x)

--- a/tests/test_sdba/test_loess.py
+++ b/tests/test_sdba/test_loess.py
@@ -18,8 +18,8 @@ from xclim.testing import open_dataset
     "d,f,w,n,exp",
     [
         (0, 0.2, _tricube_weighting, 1, [-0.0698081, -0.3623449]),
-        (0, 0.2, _tricube_weighting, 2, [-0.0679962, -0.3426567]),
-        (1, 0.2, _tricube_weighting, 1, [-0.0698081, -0.8652001]),
+        # (0, 0.2, _tricube_weighting, 2, [-0.0679962, -0.3426567]),
+        # (1, 0.2, _tricube_weighting, 1, [-0.0698081, -0.8652001]),
         (1, 0.2, _tricube_weighting, 4, [-0.0691396, -0.9155697]),
         (1, 0.4, _gaussian_weighting, 2, [0.00287228, -0.4469015]),
     ],

--- a/tests/test_sdba/test_loess.py
+++ b/tests/test_sdba/test_loess.py
@@ -14,6 +14,7 @@ from xclim.sdba.loess import (
 from xclim.testing import open_dataset
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "d,f,w,n,exp",
     [
@@ -34,6 +35,7 @@ def test_loess_nb(d, f, w, n, exp):
     assert np.isclose(ys[-1], exp[1])
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("use_dask", [True, False])
 def test_loess_smoothing(use_dask):
     tas = open_dataset(

--- a/tests/test_subset.py
+++ b/tests/test_subset.py
@@ -17,6 +17,7 @@ except ImportError:
     subset = False
     gpd = False
 
+pytestmark = pytest.mark.slow
 TESTS_HOME = os.path.abspath(os.path.dirname(__file__))
 TESTS_DATA = os.path.join(TESTS_HOME, "testdata")
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38,39}, py36-nosubset-lm3, py36-xarray, py36-bottleneck, py37-windows, py38-doctest, py38-anaconda, macOS, black, docs, doctests
+envlist = py{36,37,38,39}, py36-slow, py36-nosubset-lm3, py36-xarray, py36-bottleneck, py37-windows, py38-doctest, py38-anaconda, macOS, black, docs, doctests
 requires = pip >= 20.0
 opts = -v
 
@@ -75,5 +75,6 @@ commands =
     bottleneck: pip install git+https://github.com/pydata/bottleneck.git@master#egg=bottleneck
     lm3: pip install git+https://github.com/OpenHydrology/lmoments3.git@develop#egg=lmoments3
     doctest: pytest --rootdir tests/ --xdoctest xclim
-    pytest --cov xclim --basetemp={envtmpdir}
+    pytest --cov xclim --basetemp={envtmpdir} -m "not slow"
+    slow: pytest --cov xclim --basetemp={envtmpdir} -m "slow"
     - coveralls


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes one goal of #525
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (minor / major / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
Many small changes to the tests, with a focus on the slowest ones.
- Removal of repetitive testing in the kmeans tests.
- Reduction of the number of points tested in sdba tests.
- Replacement of large datasets with 'ERA5/daily_surface_cancities_1990-1993.nc'.
- And some other minor changes.

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
No.

* **Other information**:
Pytest sumary before the PR (and with an older state of xclim, there were many PRs merged in between):
```
721 passed, 59 skipped, 1 xfailed, 185 warnings in 430.61s (0:07:10) 
```
After the changes:
```
771 passed, 22 skipped, 1 xfailed, 290 warnings in 349.14s (0:05:49)
```

So a speed up of 1m20s for now. My plan is to continue the work, mostly replacing heavy test datasets by the ERA5 one everywhere possible. 

Ouranosinc/xclim-testdata#6 will need to be merged before this PR.