### PR TITLE
DDED : Change start_date to after_date

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@ History
 Breaking changes
 ~~~~~~~~~~~~~~~~
 * Renamed indicator `atmos.degree_days_depassment_date` to `atmos.degree_days_exceedance_date`.
+* In `degree_days_exceedance_date` : renamed argument `start_date` to `after_date`.
 * Added cfchecks for Pr+Tas-based indicators.
 
 New indicators

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -1676,7 +1676,7 @@ def test_degree_days_exceedance_date(tas_series):
     assert out[0] == 151
 
     out = xci.degree_days_exceedance_date(
-        tas, thresh="2 degC", op="<", sum_thresh="150 K days", start_date="04-15"
+        tas, thresh="2 degC", op="<", sum_thresh="150 K days", after_date="04-15"
     )
     assert out[0] == 256
 

--- a/tests/test_temperature.py
+++ b/tests/test_temperature.py
@@ -1210,7 +1210,7 @@ def test_degree_days_exceedance_date():
             thresh="4 degC",
             op=">",
             sum_thresh="1500 K days",
-            start_date="07-02",
+            after_date="07-02",
             freq="YS",
         )
         np.testing.assert_array_equal(out, np.array([[np.nan, 280, 241, 244]]).T)

--- a/xclim/indicators/atmos/_temperature.py
+++ b/xclim/indicators/atmos/_temperature.py
@@ -641,7 +641,7 @@ degree_days_exceedance_date = Tas(
     standard_name="day_of_year",
     long_name="Day of year when cumulative degree days exceed {sum_thresh}.",
     description="Day of year when the integral of degree days (tmean {op} {thresh})"
-    " exceeds {sum_thresh}, the cumulative sum starts on {start_date}.",
+    " exceeds {sum_thresh}, the cumulative sum starts on {after_date}.",
     cell_methods="",
     compute=indices.degree_days_exceedance_date,
 )

--- a/xclim/indices/_threshold.py
+++ b/xclim/indices/_threshold.py
@@ -1453,7 +1453,7 @@ def degree_days_exceedance_date(
     thresh: str,
     sum_thresh: str,
     op: str = ">",
-    start_date: str = None,
+    after_date: str = None,
     freq: str = "YS",
 ):
     r"""Degree days exceedance date.
@@ -1472,7 +1472,7 @@ def degree_days_exceedance_date(
     op : {">", "gt", "<", "lt", ">=", "ge", "<=", "le"}
       If equivalent to '>', degree days are computed as `tas - thresh` and if
       equivalent to '<', they are computed as `thresh - tas`.
-    start_date: str, optional
+    after_date: str, optional
       Date at which to start the cumulative sum. In "mm-dd" format, defaults to the
       start of the sampling period.
     freq : str
@@ -1509,7 +1509,7 @@ def degree_days_exceedance_date(
         c = tas - thresh
 
     def _exceedance_date(grp):
-        strt_idx = rl.index_of_date(grp.time, start_date, max_idxs=1, default=0)
+        strt_idx = rl.index_of_date(grp.time, after_date, max_idxs=1, default=0)
         if (
             strt_idx.size == 0
         ):  # The date is not within the group. Happens at boundaries.


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #623
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (major / minor / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->

In `atmos.degree_days_exceedance_date`, changes the `start_date` argument to `after_date`. This will avoid name collisions in `finch`, when also requesting time subsetting in a WPS call.

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
Yes.

