### PR TITLE
Temporary fix for cftime 1.4.0

### DIFF
--- a/xclim/core/calendar.py
+++ b/xclim/core/calendar.py
@@ -28,8 +28,19 @@ from xarray.core.resample import DataArrayResample
 
 from xclim.core.utils import _calc_perc
 
-# cftime and datetime classes to use for each calendar name
-datetime_classes = {"default": pydt.datetime, **cftime._cftime.DATE_TYPES}
+datetime_classes = {
+    "default": pydt.datetime,
+    "noleap": cftime.DatetimeNoLeap,
+    "360_day": cftime.Datetime360Day,
+    "365_day": cftime.DatetimeNoLeap,
+    "366_day": cftime.DatetimeAllLeap,
+    "gregorian": cftime.DatetimeGregorian,
+    "proleptic_gregorian": cftime.DatetimeProlepticGregorian,
+    "julian": cftime.DatetimeJulian,
+    "all_leap": cftime.DatetimeAllLeap,
+    "standard": cftime.DatetimeGregorian,
+}
+
 
 # Maximum day of year in each calendar.
 max_doy = {


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (major / minor / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
`cftime` 1.2.0 made the use of datetime subclasses optional and 1.4.0 (released yesterday) made them deprecated. They are still accessible, but `cftime._cftime.DATE_TYPES` was removed. This PR lists them explicitly instead.

Instead of `cftime.DatetimeNoLeap(*args)`, the recommended way of creating datetimes is now `cftime.datetime(*args, calendar='noleap')`. However, due to pydata/xarray#4853, xarray requires the use of the deprecated subclasses. Which is why I called this branch a "temporary" fix.

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
No.
