### PR TITLE
New indicators for orphan indices

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,11 @@ History
 0.24.0 (unreleased)
 -------------------
 
+New indicators
+~~~~~~~~~~~~~~
+* `days_over_precip_thresh`, `fraction_over_precip_thresh`, `liquid_precip_ratio`, `warm_spell_duration_index`,  all from eponymous indices.
+* `maximum_consecutive_warm_days` from indice `maximum_consecutive_tx_days`)
+
 Breaking changes
 ~~~~~~~~~~~~~~~~
 * Numerous changes to `xclim.core.calendar.percentile_doy`:

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -18,10 +18,10 @@ Breaking changes
     * `per` argument is now expected to between 0-100 (not 0-1).
     * input data must have a daily (or coarser) time frequency.
 
-* Change in unit handling paradigm for indices, which as a result will lead to some indices returning values with different units. Note that related `Indicator` objects remain unchanged and will return units consistent with CF Convention. If you are concerned with code stability, please use `Indicator` objects. The change was necessary to resolve inconsistencies with xarray's `keep_attrs=True` context.
+* Change in unit handling paradigm for indices, many indices will have different output units than before.
 
-    * Indice functions now return output units that preserve consistency with input units. That is, feeding inputs in Celsius will yield outputs in Celsius instead of casting to Kelvin. In all cases the dimensionality is preserved.
-    * Indice functions now accept non-daily data, but daily frequency is assumed by default if the frequency cannot be inferred.
+    * Indice functions are now more flexible : output units may change for different input units, but the dimensionality is consistent.
+    * Indice functions now accept non-daily data, but daily is assumed if the frequency cannot be inferred.
 
 * Removed the explicitly-installed `netCDF4` python library from the base installation, as this is never explicitly used (now only installed in the `docs` recipe for sdba documented example).
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -18,10 +18,10 @@ Breaking changes
     * `per` argument is now expected to between 0-100 (not 0-1).
     * input data must have a daily (or coarser) time frequency.
 
-* Change in unit handling paradigm for indices, many indices will have different output units than before.
+* Change in unit handling paradigm for indices, which as a result will lead to some indices returning values with different units. Note that related `Indicator` objects remain unchanged and will return units consistent with CF Convention. If you are concerned with code stability, please use `Indicator` objects. The change was necessary to resolve inconsistencies with xarray's `keep_attrs=True` context.
 
-    * Indice functions are now more flexible : output units may change for different input units, but the dimensionality is consistent.
-    * Indice functions now accept non-daily data, but daily is assumed if the frequency cannot be inferred.
+    * Indice functions now return output units that preserve consistency with input units. That is, feeding inputs in Celsius will yield outputs in Celsius instead of casting to Kelvin. In all cases the dimensionality is preserved.
+    * Indice functions now accept non-daily data, but daily frequency is assumed by default if the frequency cannot be inferred.
 
 * Removed the explicitly-installed `netCDF4` python library from the base installation, as this is never explicitly used (now only installed in the `docs` recipe for sdba documented example).
 

--- a/xclim/indicators/atmos/_precip.py
+++ b/xclim/indicators/atmos/_precip.py
@@ -24,6 +24,9 @@ __all__ = [
     "fire_weather_indexes",
     "last_snowfall",
     "first_snowfall",
+    "days_over_precip_thresh",
+    "fraction_over_precip_thresh",
+    "liquid_precip_ratio",
 ]
 
 
@@ -275,4 +278,34 @@ first_snowfall = Prsn(
     description="{freq} first day where the solid precipitation flux exceeded {thresh}",
     units="",
     compute=indices.first_snowfall,
+)
+
+
+days_over_precip_thresh = Pr(
+    identifier="days_over_precip_thresh",
+    standard_name="number_of_days_with_lwe_thickness_of_precipitation_amount_above_threshold",
+    description="{freq} number of days with precipitation above a daily percentile. Only days with at least {thresh} are counted.",
+    units="days",
+    cell_methods="time: sum over days",
+    compute=indices.days_over_precip_thresh,
+)
+
+
+fraction_over_precip_thresh = Pr(
+    identifier="fraction_over_precip_thresh",
+    description="{freq} fraction of total precipitation due to days with precipitation above a daily percentile. Only days with at least {thresh} are included in the total.",
+    units="",
+    cell_methods="",
+    compute=indices.fraction_over_precip_thresh,
+)
+
+
+liquid_precip_ratio = PrTasx(
+    identifier="liquid_precip_ratio",
+    description="{freq} ratio of rainfall to total precipitation. Rainfall is estimated as precipitation on days where temperature is above {thresh}.",
+    abstract="The ratio of total liquid precipitation over the total precipitation. Liquid precipitation is approximated from total precipitation on days where temperature is above a threshold.",
+    units="",
+    compute=wrapped_partial(
+        indices.liquid_precip_ratio, suggested={"tas": _empty}, prsn=None
+    ),
 )

--- a/xclim/indicators/atmos/_temperature.py
+++ b/xclim/indicators/atmos/_temperature.py
@@ -54,6 +54,8 @@ __all__ = [
     "growing_season_end",
     "tropical_nights",
     "degree_days_exceedance_date",
+    "warm_spell_duration_index",
+    "maximum_consecutive_warm_days",
 ]
 
 
@@ -644,4 +646,24 @@ degree_days_exceedance_date = Tas(
     " exceeds {sum_thresh}, the cumulative sum starts on {after_date}.",
     cell_methods="",
     compute=indices.degree_days_exceedance_date,
+)
+
+
+warm_spell_duration_index = Tasmax(
+    identifier="warm_spell_duration_index",
+    description="{freq} total number of days within spells of at least {window} days with tmax above the 90th daily percentile.",
+    units="days",
+    standard_name="number_of_days_with_air_temperature_above_threshold",
+    cell_methods="time: sum over days",
+    compute=indices.warm_spell_duration_index,
+)
+
+
+maximum_consecutive_warm_days = Tasmax(
+    identifier="maximum_consecutive_warm_days",
+    description="{freq} longest spell of consecutive days with Tmax above {thresh}.",
+    units="days",
+    standard_name="spell_length_of_days_with_air_temperature_above_threshold",
+    cell_methods="time: maximum over days",
+    compute=indices.maximum_consecutive_tx_days,
 )

--- a/xclim/indices/_multivariate.py
+++ b/xclim/indices/_multivariate.py
@@ -1341,7 +1341,7 @@ def warm_spell_duration_index(
 ) -> xarray.DataArray:
     r"""Warm spell duration index.
 
-    Number of days with at least six consecutive days where the daily maximum temperature is above the 90th
+    Number of days inside spells of a minimum number of consecutive days where the daily maximum temperature is above the 90th
     percentile. The 90th percentile should be computed for a 5-day moving window, centered on each calendar day in the
     1961-1990 period.
 
@@ -1359,8 +1359,7 @@ def warm_spell_duration_index(
     Returns
     -------
     xarray.DataArray, [time]
-      Count of days with at least six consecutive days where the daily maximum temperature is above the 90th
-      percentile [days].
+      Warm spell duration index
 
     Examples
     --------
@@ -1380,8 +1379,10 @@ def warm_spell_duration_index(
     precipitation, J. Geophys. Res., 111, D05109, doi: 10.1029/2005JD006290.
 
     """
+    thresh = convert_units_to(tx90, tasmax)
+
     # Create time series out of doy values.
-    thresh = resample_doy(tx90, tasmax)
+    thresh = resample_doy(thresh, tasmax)
 
     above = tasmax > thresh
 

--- a/xclim/indices/_threshold.py
+++ b/xclim/indices/_threshold.py
@@ -1322,7 +1322,7 @@ def maximum_consecutive_frost_free_days(
 def maximum_consecutive_tx_days(
     tasmax: xarray.DataArray, thresh: str = "25 degC", freq: str = "YS"
 ):
-    r"""Maximum number of consecutive summer days (Tx > 25℃).
+    r"""Maximum number of consecutive summer days.
 
     Return the maximum number of consecutive days within the period where
     the maximum temperature is above a certain threshold.

--- a/xclim/locales/__init__.py
+++ b/xclim/locales/__init__.py
@@ -52,7 +52,6 @@ def generate_local_dict(locale: str, init_english: bool = False):
             ):
                 if init_english:
                     eng_attr = var_attrs.get(translatable_attr)
-                    print(translatable_attr, eng_attr)
                     if not isinstance(eng_attr, str):
                         eng_attr = ""
                 ind_attrs.setdefault(f"{translatable_attr}", eng_attr)

--- a/xclim/locales/fr.json
+++ b/xclim/locales/fr.json
@@ -711,8 +711,8 @@
   },
   "FRACTION_OVER_PRECIP_THRESH": {
     "title": "Fraction des jours pluvieux où la précipitation est au-dessus d'un percentile quotidien.",
-    "abstract": "Fraction des jours pluvieux d'une période où la précipitation est au-dessus d'un percentile quotidien. La référence est le nombre jours où la précipitation est au-dessus d'un seuil fixe.",
-    "description": "Fraction {freq:f} des jours pluvieux où la précipitation au-dessus d'un percentile quotidien. La référence est le nombre jours où la précipitation est au-dessus d'un seuil fixe.",
+    "abstract": "Fraction des jours pluvieux d'une période où la précipitation est au-dessus d'un percentile quotidien. La référence est le nombre de jours où la précipitation est au-dessus d'un seuil fixe.",
+    "description": "Fraction {freq:f} des jours pluvieux où la précipitation est au-dessus d'un percentile quotidien. La référence est le nombre jours où la précipitation est au-dessus d'un seuil fixe.",
     "long_name": "Fraction des jours pluvieux où la précipitation est au-dessus d'un percentile quotidien."
   },
   "LIQUID_PRECIP_RATIO": {
@@ -722,7 +722,7 @@
     "long_name": "Fraction liquide de la précipitation totale."
   },
   "WARM_SPELL_DURATION_INDEX": {
-    "title": "Indice de durée des vaques de chaleur.",
+    "title": "Indice de durée des vagues de chaleur.",
     "abstract": "Nombre de jours faisant partie de vagues d'une longueur minimale où la température maximale quotidienne excède le 90e percentile. Le 90e percentile des températures devrait être calculé avec une fenêtre mobile de 5 jours.",
     "description": "Nombre {freq:m} total de jours faisant parties de vagues de chaleur d'au moins {window} jours consécutifs où tmax est au-dessus du 90e percentile.",
     "long_name": "Indice de durée des vagues de chaleur."

--- a/xclim/locales/fr.json
+++ b/xclim/locales/fr.json
@@ -702,5 +702,35 @@
     "description": "Premier jour {freq:m} où la précipitation solide excède {thresh}.",
     "title": "Premier jour avec une précipitation solide au-dessus d'un seuil",
     "abstract": "Premier jour d'une période où la précipitation solide excède un certain seuil."
+  },
+  "DAYS_OVER_PRECIP_THRESH": {
+    "title": "Nombre de jours pluvieux où la précipitation est au-dessus d'un percentile quotidien.",
+    "abstract": "Nombre de jours d'une période où la précipitation est au-dessus d'un percentile quotidien et d'un seuil fixe.",
+    "description": "Nombre {freq:m} de jours où la précipitation au-dessus d'un percentile quotidien. Seuls les jours avec au moins {thresh} sont comptés.",
+    "long_name": "Nombre de jours pluvieux où la précipitation est au-dessus d'un percentile quotidien."
+  },
+  "FRACTION_OVER_PRECIP_THRESH": {
+    "title": "Fraction des jours pluvieux où la précipitation est au-dessus d'un percentile quotidien.",
+    "abstract": "Fraction des jours pluvieux d'une période où la précipitation est au-dessus d'un percentile quotidien. La référence est le nombre jours où la précipitation est au-dessus d'un seuil fixe.",
+    "description": "Fraction {freq:f} des jours pluvieux où la précipitation au-dessus d'un percentile quotidien. La référence est le nombre jours où la précipitation est au-dessus d'un seuil fixe.",
+    "long_name": "Fraction des jours pluvieux où la précipitation est au-dessus d'un percentile quotidien."
+  },
+  "LIQUID_PRECIP_RATIO": {
+    "title": "Fraction liquide de la précipitation totale.",
+    "abstract": "Le ratio entre la précipitation liquide et la précipitation totale. La précipitation liquide est approximée par la précipitation lorsque la température est au-dessus d'un seuil.",
+    "description": "Le ratio {freq:m} entre la précipitation liquide et la précipitation totale. La précipitation liquide est approximée par la précipitation lorsque la température est au-dessus de {thresh}.",
+    "long_name": "Fraction liquide de la précipitation totale."
+  },
+  "WARM_SPELL_DURATION_INDEX": {
+    "title": "Indice de durée des vaques de chaleur.",
+    "abstract": "Nombre de jours faisant partie de vagues d'une longueur minimale où la température maximale quotidienne excède le 90e percentile. Le 90e percentile des températures devrait être calculé avec une fenêtre mobile de 5 jours.",
+    "description": "Nombre {freq:m} total de jours faisant parties de vagues de chaleur d'au moins {window} jours consécutifs où tmax est au-dessus du 90e percentile.",
+    "long_name": "Indice de durée des vagues de chaleur."
+  },
+  "MAXIMUM_CONSECUTIVE_WARM_DAYS": {
+    "title": "Nombre maximal de jours chauds consécutifs.",
+    "abstract": "Nombre maximal de jours consecutifs où la température maximale quotidienne excède un certain seuil.",
+    "description": "Nombre {freq:m} maximal de jours chauds consécutifs (Tmax > {thresh}).",
+    "long_name": "Nombre maximal de jours chauds consécutifs."
   }
 }

--- a/xclim/testing/tests/test_precip.py
+++ b/xclim/testing/tests/test_precip.py
@@ -6,6 +6,7 @@ import pytest
 import xarray as xr
 
 from xclim import atmos, set_options
+from xclim.core.calendar import percentile_doy
 from xclim.testing import open_dataset
 
 K2C = 273.15
@@ -368,3 +369,52 @@ class TestSnowfallDate:
                 ]
             ),
         )
+
+
+def test_days_over_precip_thresh():
+    pr = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc").pr
+    per = percentile_doy(pr, window=5, per=80)
+
+    out1 = atmos.days_over_precip_thresh(pr, per)
+    np.testing.assert_array_equal(out1[1, :, 0], np.array([87, 63, 74, 79]))
+
+    out2 = atmos.days_over_precip_thresh(pr, per, thresh="2 mm/d")
+    np.testing.assert_array_equal(out2[1, :, 0], np.array([87, 63, 71, 79]))
+
+    assert "only days with at least 2 mm/d are counted." in out2.description
+
+
+def test_fraction_over_precip_thresh():
+    pr = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc").pr
+    per = percentile_doy(pr, window=5, per=80)
+
+    out = atmos.fraction_over_precip_thresh(pr, per)
+    np.testing.assert_allclose(
+        out[1, :, 0], np.array([0.832, 0.785, 0.776, 0.815]), atol=0.001
+    )
+
+    out = atmos.fraction_over_precip_thresh(pr, per, thresh="0.002 m/d")
+    np.testing.assert_allclose(
+        out[1, :, 0], np.array([0.853, 0.818, 0.803, 0.840]), atol=0.001
+    )
+
+    assert "only days with at least 0.002 m/d are included" in out.description
+
+
+def test_liquid_precip_ratio():
+    ds = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc")
+
+    out = atmos.liquid_precip_ratio(pr=ds.pr, tas=ds.tas, thresh="0 degC", freq="YS")
+    np.testing.assert_allclose(
+        out[:, 0], np.array([0.919, 0.805, 0.525, 0.740, 0.993]), atol=1e3
+    )
+
+    with set_options(cf_compliance="raise"):
+        # Test if tasmax is allowed
+        out = atmos.liquid_precip_ratio(
+            pr=ds.pr, tas=ds.tasmax, thresh="33 degF", freq="YS"
+        )
+        np.testing.assert_allclose(
+            out[:, 0], np.array([0.975, 0.921, 0.547, 0.794, 0.999]), atol=1e3
+        )
+        assert "where temperature is above 33 degf." in out.description

--- a/xclim/testing/tests/test_temperature.py
+++ b/xclim/testing/tests/test_temperature.py
@@ -1215,3 +1215,27 @@ def test_degree_days_exceedance_date():
             freq="YS",
         )
         np.testing.assert_array_equal(out, np.array([[np.nan, 280, 241, 244]]).T)
+
+
+def test_warm_spell_duration_index():
+    tasmax = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc").tasmax
+    tx90 = percentile_doy(tasmax, window=5, per=90)
+
+    out = atmos.warm_spell_duration_index(
+        tasmax=tasmax, tx90=tx90, window=3, freq="AS-JUL"
+    )
+    np.testing.assert_array_equal(out[0, :, 0], np.array([np.nan, 3, 0, 0, np.nan]))
+    assert (
+        "Annual total number of days within spells of at least 3 days"
+        in out.description
+    )
+
+
+def test_maximum_consecutive_warm_days():
+    tasmax = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc").tasmax
+    out = atmos.maximum_consecutive_warm_days(tasmax)
+    np.testing.assert_array_equal(out[1, :], np.array([13, 21, 6, 10]))
+    assert (
+        "Annual longest spell of consecutive days with tmax above 25 degc."
+        in out.description
+    )


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #647
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (major / minor / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
Creates indicators for 5 indices. Only 2 indices without indicators remain (warm_day_frequency and warm_night_frequency), but these will be deprecated soon.

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
No.

* **Other information**:
There were small docstring fixes and a `convert_units_to` added to `warm_spell_duration_index`.