### PR TITLE
sdba refactor using map_blocks

### DIFF
--- a/xclim/core/utils.py
+++ b/xclim/core/utils.py
@@ -118,7 +118,7 @@ def ensure_chunk_size(da: xr.DataArray, max_iter: int = 10, **minchunks: int):
       A kwarg mapping from dimension name to minimum chunk size.
       Pass -1 to force a single chunk along that dimension.
     """
-    if not isinstance(da.data, dsk.Array):
+    if not uses_dask(da):
         return da
 
     all_chunks = dict(zip(da.dims, da.chunks))
@@ -150,6 +150,16 @@ def ensure_chunk_size(da: xr.DataArray, max_iter: int = 10, **minchunks: int):
     if chunking:
         return da.chunk(chunks=chunking)
     return da
+
+
+def uses_dask(da):
+    if isinstance(da, xr.DataArray) and isinstance(da.data, dsk.Array):
+        return True
+    if isinstance(da, xr.Dataset) and any(
+        isinstance(var.data, dsk.Array) for var in da.variables.values()
+    ):
+        return True
+    return False
 
 
 def _calc_perc(arr, p=[50]):

--- a/xclim/sdba/_qm.py
+++ b/xclim/sdba/_qm.py
@@ -3,20 +3,18 @@ Quantile Mapping algorithms.
 
 This file defines the different QM steps, to be wrapped into the Adjustment objects.
 """
-import numpy as np
 import xarray as xr
 
-import xclim.sdba.nbutils as nbu
-import xclim.sdba.utils as u
-
+from . import nbutils as nbu
+from . import utils as u
 from .base import map_blocks, map_groups
 
 
 @map_groups(
     af=["<PROP>", "quantiles"], hist_q=["<PROP>", "quantiles"], scaling=["<PROP>"]
 )
-def dqm_train(ds, *, dim="time", kind="+", quantiles=None):
-    """DQM: Train step: Element on one group of a 1D timeseries"""
+def dqm_train(ds, *, dim, kind, quantiles):
+    """DQM: Train step on one group."""
     refn = u.apply_correction(ds.ref, u.invert(ds.ref.mean(dim), kind), kind)
     histn = u.apply_correction(ds.hist, u.invert(ds.hist.mean(dim), kind), kind)
 
@@ -31,16 +29,23 @@ def dqm_train(ds, *, dim="time", kind="+", quantiles=None):
     return xr.Dataset(data_vars=dict(af=af, hist_q=hist_q, scaling=scaling))
 
 
-def dqm_train_main(ref, hist, group, nquantiles=15, kind="+"):
-    """DQM: Train step: Entry point."""
-    quantiles = np.array(u.equally_spaced_nodes(nquantiles, eps=1e-6), dtype="float32")
-    ds = xr.Dataset({"ref": ref, "hist": hist})
-    return dqm_train(ds, group=group, quantiles=quantiles, kind=kind)
+@map_groups(
+    af=["<PROP>", "quantiles"],
+    hist_q=["<PROP>", "quantiles"],
+)
+def eqm_train(ds, *, dim, kind, quantiles):
+    """EQM: Train step on one group."""
+    ref_q = nbu.quantile(ds.ref, quantiles, dim)
+    hist_q = nbu.quantile(ds.hist, quantiles, dim)
+
+    af = u.get_correction(hist_q, ref_q, kind)
+
+    return xr.Dataset(data_vars=dict(af=af, hist_q=hist_q))
 
 
 @map_blocks(refvar="sim", scen=["<DIM>"])
-def dqm_adjust(ds, *, group, interp="nearest", extrapolation="constant", kind="+"):
-    """DQM: Adjust step: Atomic on a 1D timeseries."""
+def qm_adjust(ds, *, group, interp, extrapolation, kind):
+    """QM (DQM and EQM): Adjust step on one block."""
     af, hist_q = u.extrapolate_qm(ds.af, ds.hist_q, method=extrapolation)
     af = u.interp_on_quantiles(ds.sim, hist_q, af, group=group, method=interp)
 
@@ -49,8 +54,8 @@ def dqm_adjust(ds, *, group, interp="nearest", extrapolation="constant", kind="+
 
 
 @map_blocks(refvar="sim", sim=["<DIM>"])
-def dqm_scale_sim(ds, *, group, interp="nearest", kind="+"):
-    """DQM: Sim preprocessing: Atomic a 1D timeseries."""
+def dqm_scale_sim(ds, *, group, interp, kind):
+    """DQM: Sim preprocessing on one block"""
     sim = u.apply_correction(
         ds.sim,
         u.broadcast(
@@ -64,35 +69,15 @@ def dqm_scale_sim(ds, *, group, interp="nearest", kind="+"):
     return sim.rename("sim").to_dataset()
 
 
-@map_groups(main_only=True, trend=["<DIM>"])
-def polydetrend_get_trend(da, *, dim, deg):
-    """Polydetrend, atomic func on 1 group of a 1D timeseries."""
-    pfc = da.polyfit(dim=dim, deg=deg)
-    trend = xr.polyval(coord=da[dim], coeffs=pfc.polyfit_coefficients)
-    return trend.rename("trend").to_dataset()
+@map_blocks(refvar="sim", scen=["<DIM>"])
+def qdm_adjust(ds, *, group, interp, extrapolation, kind):
+    """QDM: Adjust process on one block."""
+    af, _ = u.extrapolate_qm(ds.af, ds.hist_q, method=extrapolation)
 
+    sim_q = group.apply(u.rank, ds.sim, main_only=True, pct=True)
+    sel = {dim: sim_q[dim] for dim in set(af.dims).intersection(set(sim_q.dims))}
+    sel["quantiles"] = sim_q
+    af = u.broadcast(af, ds.sim, group=group, interp=interp, sel=sel)
 
-def dqm_adjust_main(
-    ds, sim, group, kind="+", interp="nearest", extrapolation="constant"
-):
-    """DQM: Adjust step: Main."""
-
-    scaled_sim = dqm_scale_sim(
-        xr.Dataset({"scaling": ds.scaling, "sim": sim}),
-        group=group,
-        kind=kind,
-        interp=interp,
-    ).sim
-
-    trend = polydetrend_get_trend(scaled_sim, group=group, deg=1).trend
-    sim_detrended = u.apply_correction(scaled_sim, u.invert(trend, kind), kind)
-
-    scen = dqm_adjust(
-        xr.Dataset({"af": ds.af, "hist_q": ds.hist_q, "sim": sim_detrended}),
-        group=group,
-        interp=interp,
-        extrapolation=extrapolation,
-        kind=kind,
-    ).scen
-
-    return u.apply_correction(scen, trend, kind)
+    scen = u.apply_correction(ds.sim, af, kind)
+    return scen.rename("scen").to_dataset()

--- a/xclim/sdba/_qm.py
+++ b/xclim/sdba/_qm.py
@@ -1,0 +1,276 @@
+"""
+Quantile Mapping algorithms.
+
+This file defines the different QM steps, to be wrapped into the Adjustment objects.
+"""
+import dask.array as da
+import numpy as np
+import xarray as xr
+from boltons.funcutils import wraps
+
+import xclim.sdba.nbutils as nbu
+import xclim.sdba.utils as u
+
+
+def duck_empty(dims, sizes, chunks=None):
+    """Return an empty DataArray based on a numpy or dask backend, depending on the chunks argument."""
+    shape = [sizes[dim] for dim in dims]
+    if chunks:
+        chnks = [chunks.get(dim, (sizes[dim],)) for dim in dims]
+        content = da.empty(shape, chunks=chnks)
+    else:
+        content = np.empty(shape)
+    return xr.DataArray(content, dims=dims)
+
+
+def groupize(**outvars):
+    """Decorator for declaring functions acting on single groups and wrapping them into a map_blocks.
+
+    A "group" kwarg is injected in the function.
+    It is assumed that `group.dim` is the only dimension touched, and some other dimensions might be added.
+
+    Arguments to the decorator are mappings from variable name in the output to its *new* dimensions.
+    Dimension order is not preserved.
+    The placeholders "<PROP>" and "<DIM>" can be used to signify `group.prop` and `group.dim` respectively.
+    """
+
+    def _decorator(func):
+        def _map_blocks_and_groupby(ds, group, **kwargs):
+            # TODO : What if they are not alignable? (i.e. different calendars)
+            ds = ds.unify_chunks()
+
+            if any(isinstance(var.data, da.Array) for var in ds.data_vars.values()):
+                # Use dask if any of the input is dask-backed.
+                if len(ds.chunks[group.dim]) > 1:
+                    raise ValueError(
+                        f"The dimension over which we group cannot be chunked ({group.dim} as chunks {ds.chunks[group.dim]})."
+                    )
+                chunks = dict(ds.chunks)
+            else:
+                chunks = None
+
+            # Make template
+
+            # TODO : What if variables do not have the same dimensions?
+            # Base dims are untouched by func, we also keep the order
+            # "reference" object for dimension handling
+            ref = list(ds.data_vars.values())[0]
+            base_dims = [d for d in ref.dims if d != group.dim]
+            alldims = set()
+            alldims.update(*[set(dims) for dims in outvars.values()])
+            alldims = base_dims + list(
+                alldims
+            )  # Ensure the untouched dimensions are first.
+
+            coords = {}
+            for i in range(len(alldims)):
+                dim = alldims[i]
+                if dim == "<PROP>":
+                    alldims[i] = group.prop
+                    coords[group.prop] = group.get_coordinate(ds=ds)
+                elif dim == "<DIM>":
+                    alldims[i] = group.dim
+                    coords[group.dim] = ds[group.dim]
+                elif dim in ds:
+                    coords[dim] = ds[dim]
+                elif dim in kwargs:
+                    coords[dim] = xr.DataArray(kwargs[dim], dims=(dim,), name=dim)
+                else:
+                    raise ValueError(
+                        f"This function adds the {dim} dimension, its coordinate must be provided as a keyword argument."
+                    )
+
+            placeholders = {"<PROP>": group.prop, "<DIM>": group.dim}
+            sizes = {name: crd.size for name, crd in coords.items()}
+
+            tmpl = xr.Dataset(coords=coords)
+            for var, dims in outvars.items():
+                dims = base_dims + [placeholders.get(dim, dim) for dim in dims]
+                tmpl[var] = duck_empty(dims, sizes, chunks)
+            tmpl = tmpl.transpose(*alldims)  # To be sure.
+
+            def _apply_on_group(dsblock, **kwargs):
+                return group.apply(func, dsblock, **kwargs).transpose(*alldims)
+
+            return ds.map_blocks(_apply_on_group, template=tmpl, kwargs=kwargs)
+
+        return _map_blocks_and_groupby
+
+    return _decorator
+
+
+@groupize(
+    af=["<PROP>", "quantiles"], hist_q=["<PROP>", "quantiles"], scaling=["<PROP>"]
+)
+def dqm_train(ds, *, dim="time", kind="+", quantiles=None):
+    """DQM: Train step: Element on one group of a 1D timeseries"""
+    refn = u.apply_correction(ds.ref, u.invert(ds.ref.mean(dim), kind), kind)
+    histn = u.apply_correction(ds.hist, u.invert(ds.hist.mean(dim), kind), kind)
+
+    ref_q = nbu.quantile(refn, quantiles, dim)
+    hist_q = nbu.quantile(histn, quantiles, dim)
+
+    af = u.get_correction(hist_q, ref_q, kind)
+    mu_ref = ds.ref.mean(dim)
+    mu_hist = ds.hist.mean(dim)
+    scaling = u.get_correction(mu_hist, mu_ref, kind=kind)
+
+    return xr.Dataset(data_vars=dict(af=af, hist_q=hist_q, scaling=scaling))
+
+
+def dqm_train_main(ref, hist, group, nquantiles=15, kind="+"):
+    """DQM: Train step: Entry point."""
+    quantiles = np.array(u.equally_spaced_nodes(nquantiles, eps=1e-6), dtype="float32")
+    ds = xr.merge((ref, hist))
+    return dqm_train(ds, group, quantiles=quantiles, kind=kind)
+
+
+# def dqm_adjust_1d(
+#     af,
+#     hist_q,
+#     sim,
+#     group,
+#     time,
+#     coords,
+#     dims,
+#     interp="nearest",
+#     extrapolation="constant",
+#     kind="+",
+# ):
+#     """DQM: Adjust step: Atomic on a 1D timeseries."""
+#     prop = group.prop
+#     dim = group.dim  # noqa
+#     for d, s in zip(dims, af.shape):
+#         coords[d] = np.arange(s)
+#     af = xr.DataArray(af, dims=(*dims, prop, "quantiles"), coords=coords)
+#     hist_q = xr.DataArray(hist_q, dims=(*dims, prop, "quantiles"), coords=coords)
+#     sim = xr.DataArray(
+#         sim,
+#         dims=(*dims, "time"),
+#         coords={crd: val for crd, val in coords.items() if crd in dims},
+#     )
+#     sim["time"] = time
+
+#     af, hist_q = u.extrapolate_qm(af, hist_q, method=extrapolation)
+#     af = u.interp_on_quantiles(sim, hist_q, af, group=group, method="linear")
+
+#     scen = u.apply_correction(sim, af, kind)
+#     return scen.values
+
+
+# def dqm_prepare_sim(
+#     sim,
+#     scaling,
+#     *,
+#     group,
+#     other_dims,
+#     core_dims,
+#     coords,
+#     out_dims,
+#     interp="linear",
+#     kind="+",
+# ):
+#     """DQM: Sim preprocessing: Atomic a 1D timeseries."""
+#     sim, scaling = reconstruct_xr(
+#         sim, scaling, other_dims=other_dims, core_dims=core_dims, coords=coords
+#     )
+#     out = u.apply_correction(
+#         sim,
+#         u.broadcast(
+#             scaling,
+#             sim,
+#             group=group,
+#             interp=interp if group.prop != "dayofyear" else "nearest",
+#         ),
+#         kind,
+#     )
+#     return deconstruct_xr(out, other_dims=other_dims, out_dims=out_dims)
+
+
+# def polydetrend_get_trend_group(da, dim, deg):
+#     """Polydetrend, atomic func on 1 group of a 1D timeseries."""
+#     pfc = da.polyfit(dim=dim, deg=deg)
+#     return xr.polyval(coord=da[dim], coeffs=pfc.polyfit_coefficients)
+
+
+# def polydetrend_get_trend_1d(da, deg, group, coord, dims):
+#     """Polydetrend, wrapper for a 1D timeseries."""
+#     da = xr.DataArray(da, dims=(*dims, group.dim), coords={group.dim: coord})
+#     out = group.apply(polydetrend_get_trend_group, da, main_only=True, deg=deg)
+#     out.transpose(..., group.dim)
+#     return out.values
+
+
+# def polydetrend_get_trend(da, group, deg=1):
+#     """Polydetrend, main."""
+#     dims = list(da.dims)
+#     dims.remove(group.dim)
+#     trend = xr.apply_ufunc(
+#         polydetrend_get_trend_1d,
+#         da,
+#         kwargs={"group": group, "deg": deg, "coord": da[group.dim], "dims": dims},
+#         input_core_dims=[[group.dim]],
+#         output_core_dims=[[group.dim]],
+#         output_dtypes=[da.dtype],
+#         dask_gufunc_kwargs=dict(
+#             meta=(np.ndarray((), dtype=da.dtype),),
+#         ),
+#         dask="parallelized",
+#     )
+#     return trend
+
+
+# def dqm_adjust(ds, sim, group, **kwargs):
+#     """DQM: Adjust step: Main."""
+#     dim = group.dim
+#     prop = group.prop
+#     dims = list(sim.dims)
+#     dims.remove(dim)
+
+#     sim = xr.apply_ufunc(
+#         dqm_prepare_sim,
+#         sim,
+#         ds.scaling,
+#         kwargs={
+#             "coords": {prop: ds[prop].values, dim: sim[dim].values},
+#             "group": group,
+#             "other_dims": dims,
+#             "core_dims": [[dim], [prop]],
+#             "out_dims": OrderedDict([("sim", [dim])]),
+#             **kwargs,
+#         },
+#         input_core_dims=[[dim], [prop]],
+#         output_core_dim=[[dim]],
+#         output_dtypes=[sim.dtype],
+#         dask_gufunc_kwargs=dict(
+#             meta=(np.ndarray((), dtype=sim.dtype),),
+#         ),
+#         dask="parallelized",
+#     )
+
+#     kind = kwargs.get("kind", "+")
+#     trend = polydetrend_get_trend(sim, group, deg=kwargs.pop("detrend", 1))
+#     sim_detrended = u.apply_correction(sim, u.invert(trend, kind), kind)
+
+#     scen = xr.apply_ufunc(
+#         dqm_adjust_1d,
+#         ds.af,
+#         ds.hist_q,
+#         sim_detrended,
+#         kwargs={
+#             "coords": {prop: ds[prop].values, "quantiles": ds.quantiles.values},
+#             "time": sim[dim],
+#             "group": group,
+#             "dims": dims,
+#             **kwargs,
+#         },
+#         input_core_dims=[[prop, "quantiles"], [prop, "quantiles"], [dim]],
+#         output_core_dims=[[dim]],
+#         output_dtypes=[sim.dtype],
+#         dask_gufunc_kwargs=dict(
+#             meta=(np.ndarray((), dtype=sim.dtype),),
+#         ),
+#         dask="parallelized",
+#     )
+
+#     return u.apply_correction(scen, trend, kind)

--- a/xclim/sdba/_qm.py
+++ b/xclim/sdba/_qm.py
@@ -3,103 +3,16 @@ Quantile Mapping algorithms.
 
 This file defines the different QM steps, to be wrapped into the Adjustment objects.
 """
-import dask.array as da
 import numpy as np
 import xarray as xr
-from boltons.funcutils import wraps
 
 import xclim.sdba.nbutils as nbu
 import xclim.sdba.utils as u
 
-
-def duck_empty(dims, sizes, chunks=None):
-    """Return an empty DataArray based on a numpy or dask backend, depending on the chunks argument."""
-    shape = [sizes[dim] for dim in dims]
-    if chunks:
-        chnks = [chunks.get(dim, (sizes[dim],)) for dim in dims]
-        content = da.empty(shape, chunks=chnks)
-    else:
-        content = np.empty(shape)
-    return xr.DataArray(content, dims=dims)
+from .base import map_blocks, map_groups
 
 
-def groupize(**outvars):
-    """Decorator for declaring functions acting on single groups and wrapping them into a map_blocks.
-
-    A "group" kwarg is injected in the function.
-    It is assumed that `group.dim` is the only dimension touched, and some other dimensions might be added.
-
-    Arguments to the decorator are mappings from variable name in the output to its *new* dimensions.
-    Dimension order is not preserved.
-    The placeholders "<PROP>" and "<DIM>" can be used to signify `group.prop` and `group.dim` respectively.
-    """
-
-    def _decorator(func):
-        def _map_blocks_and_groupby(ds, group, **kwargs):
-            # TODO : What if they are not alignable? (i.e. different calendars)
-            ds = ds.unify_chunks()
-
-            if any(isinstance(var.data, da.Array) for var in ds.data_vars.values()):
-                # Use dask if any of the input is dask-backed.
-                if len(ds.chunks[group.dim]) > 1:
-                    raise ValueError(
-                        f"The dimension over which we group cannot be chunked ({group.dim} as chunks {ds.chunks[group.dim]})."
-                    )
-                chunks = dict(ds.chunks)
-            else:
-                chunks = None
-
-            # Make template
-
-            # TODO : What if variables do not have the same dimensions?
-            # Base dims are untouched by func, we also keep the order
-            # "reference" object for dimension handling
-            ref = list(ds.data_vars.values())[0]
-            base_dims = [d for d in ref.dims if d != group.dim]
-            alldims = set()
-            alldims.update(*[set(dims) for dims in outvars.values()])
-            alldims = base_dims + list(
-                alldims
-            )  # Ensure the untouched dimensions are first.
-
-            coords = {}
-            for i in range(len(alldims)):
-                dim = alldims[i]
-                if dim == "<PROP>":
-                    alldims[i] = group.prop
-                    coords[group.prop] = group.get_coordinate(ds=ds)
-                elif dim == "<DIM>":
-                    alldims[i] = group.dim
-                    coords[group.dim] = ds[group.dim]
-                elif dim in ds:
-                    coords[dim] = ds[dim]
-                elif dim in kwargs:
-                    coords[dim] = xr.DataArray(kwargs[dim], dims=(dim,), name=dim)
-                else:
-                    raise ValueError(
-                        f"This function adds the {dim} dimension, its coordinate must be provided as a keyword argument."
-                    )
-
-            placeholders = {"<PROP>": group.prop, "<DIM>": group.dim}
-            sizes = {name: crd.size for name, crd in coords.items()}
-
-            tmpl = xr.Dataset(coords=coords)
-            for var, dims in outvars.items():
-                dims = base_dims + [placeholders.get(dim, dim) for dim in dims]
-                tmpl[var] = duck_empty(dims, sizes, chunks)
-            tmpl = tmpl.transpose(*alldims)  # To be sure.
-
-            def _apply_on_group(dsblock, **kwargs):
-                return group.apply(func, dsblock, **kwargs).transpose(*alldims)
-
-            return ds.map_blocks(_apply_on_group, template=tmpl, kwargs=kwargs)
-
-        return _map_blocks_and_groupby
-
-    return _decorator
-
-
-@groupize(
+@map_groups(
     af=["<PROP>", "quantiles"], hist_q=["<PROP>", "quantiles"], scaling=["<PROP>"]
 )
 def dqm_train(ds, *, dim="time", kind="+", quantiles=None):
@@ -121,156 +34,65 @@ def dqm_train(ds, *, dim="time", kind="+", quantiles=None):
 def dqm_train_main(ref, hist, group, nquantiles=15, kind="+"):
     """DQM: Train step: Entry point."""
     quantiles = np.array(u.equally_spaced_nodes(nquantiles, eps=1e-6), dtype="float32")
-    ds = xr.merge((ref, hist))
-    return dqm_train(ds, group, quantiles=quantiles, kind=kind)
+    ds = xr.Dataset({"ref": ref, "hist": hist})
+    return dqm_train(ds, group=group, quantiles=quantiles, kind=kind)
 
 
-# def dqm_adjust_1d(
-#     af,
-#     hist_q,
-#     sim,
-#     group,
-#     time,
-#     coords,
-#     dims,
-#     interp="nearest",
-#     extrapolation="constant",
-#     kind="+",
-# ):
-#     """DQM: Adjust step: Atomic on a 1D timeseries."""
-#     prop = group.prop
-#     dim = group.dim  # noqa
-#     for d, s in zip(dims, af.shape):
-#         coords[d] = np.arange(s)
-#     af = xr.DataArray(af, dims=(*dims, prop, "quantiles"), coords=coords)
-#     hist_q = xr.DataArray(hist_q, dims=(*dims, prop, "quantiles"), coords=coords)
-#     sim = xr.DataArray(
-#         sim,
-#         dims=(*dims, "time"),
-#         coords={crd: val for crd, val in coords.items() if crd in dims},
-#     )
-#     sim["time"] = time
+@map_blocks(refvar="sim", scen=["<DIM>"])
+def dqm_adjust(ds, *, group, interp="nearest", extrapolation="constant", kind="+"):
+    """DQM: Adjust step: Atomic on a 1D timeseries."""
+    af, hist_q = u.extrapolate_qm(ds.af, ds.hist_q, method=extrapolation)
+    af = u.interp_on_quantiles(ds.sim, hist_q, af, group=group, method=interp)
 
-#     af, hist_q = u.extrapolate_qm(af, hist_q, method=extrapolation)
-#     af = u.interp_on_quantiles(sim, hist_q, af, group=group, method="linear")
-
-#     scen = u.apply_correction(sim, af, kind)
-#     return scen.values
+    scen = u.apply_correction(ds.sim, af, kind).rename("scen")
+    return scen.to_dataset()
 
 
-# def dqm_prepare_sim(
-#     sim,
-#     scaling,
-#     *,
-#     group,
-#     other_dims,
-#     core_dims,
-#     coords,
-#     out_dims,
-#     interp="linear",
-#     kind="+",
-# ):
-#     """DQM: Sim preprocessing: Atomic a 1D timeseries."""
-#     sim, scaling = reconstruct_xr(
-#         sim, scaling, other_dims=other_dims, core_dims=core_dims, coords=coords
-#     )
-#     out = u.apply_correction(
-#         sim,
-#         u.broadcast(
-#             scaling,
-#             sim,
-#             group=group,
-#             interp=interp if group.prop != "dayofyear" else "nearest",
-#         ),
-#         kind,
-#     )
-#     return deconstruct_xr(out, other_dims=other_dims, out_dims=out_dims)
+@map_blocks(refvar="sim", sim=["<DIM>"])
+def dqm_scale_sim(ds, *, group, interp="nearest", kind="+"):
+    """DQM: Sim preprocessing: Atomic a 1D timeseries."""
+    sim = u.apply_correction(
+        ds.sim,
+        u.broadcast(
+            ds.scaling,
+            ds.sim,
+            group=group,
+            interp=interp if group.prop != "dayofyear" else "nearest",
+        ),
+        kind,
+    )
+    return sim.rename("sim").to_dataset()
 
 
-# def polydetrend_get_trend_group(da, dim, deg):
-#     """Polydetrend, atomic func on 1 group of a 1D timeseries."""
-#     pfc = da.polyfit(dim=dim, deg=deg)
-#     return xr.polyval(coord=da[dim], coeffs=pfc.polyfit_coefficients)
+@map_groups(main_only=True, trend=["<DIM>"])
+def polydetrend_get_trend(da, *, dim, deg):
+    """Polydetrend, atomic func on 1 group of a 1D timeseries."""
+    pfc = da.polyfit(dim=dim, deg=deg)
+    trend = xr.polyval(coord=da[dim], coeffs=pfc.polyfit_coefficients)
+    return trend.rename("trend").to_dataset()
 
 
-# def polydetrend_get_trend_1d(da, deg, group, coord, dims):
-#     """Polydetrend, wrapper for a 1D timeseries."""
-#     da = xr.DataArray(da, dims=(*dims, group.dim), coords={group.dim: coord})
-#     out = group.apply(polydetrend_get_trend_group, da, main_only=True, deg=deg)
-#     out.transpose(..., group.dim)
-#     return out.values
+def dqm_adjust_main(
+    ds, sim, group, kind="+", interp="nearest", extrapolation="constant"
+):
+    """DQM: Adjust step: Main."""
 
+    scaled_sim = dqm_scale_sim(
+        xr.Dataset({"scaling": ds.scaling, "sim": sim}),
+        group=group,
+        kind=kind,
+        interp=interp,
+    ).sim
 
-# def polydetrend_get_trend(da, group, deg=1):
-#     """Polydetrend, main."""
-#     dims = list(da.dims)
-#     dims.remove(group.dim)
-#     trend = xr.apply_ufunc(
-#         polydetrend_get_trend_1d,
-#         da,
-#         kwargs={"group": group, "deg": deg, "coord": da[group.dim], "dims": dims},
-#         input_core_dims=[[group.dim]],
-#         output_core_dims=[[group.dim]],
-#         output_dtypes=[da.dtype],
-#         dask_gufunc_kwargs=dict(
-#             meta=(np.ndarray((), dtype=da.dtype),),
-#         ),
-#         dask="parallelized",
-#     )
-#     return trend
+    trend = polydetrend_get_trend(scaled_sim, group=group, deg=1).trend
+    sim_detrended = u.apply_correction(scaled_sim, u.invert(trend, kind), kind)
 
+    scen = dqm_adjust(
+        xr.Dataset({"af": ds.af, "hist_q": ds.hist_q, "sim": sim_detrended}),
+        group=group,
+        interp=interp,
+        extrapolation=extrapolation,
+        kind=kind,
+    ).scen
 
-# def dqm_adjust(ds, sim, group, **kwargs):
-#     """DQM: Adjust step: Main."""
-#     dim = group.dim
-#     prop = group.prop
-#     dims = list(sim.dims)
-#     dims.remove(dim)
-
-#     sim = xr.apply_ufunc(
-#         dqm_prepare_sim,
-#         sim,
-#         ds.scaling,
-#         kwargs={
-#             "coords": {prop: ds[prop].values, dim: sim[dim].values},
-#             "group": group,
-#             "other_dims": dims,
-#             "core_dims": [[dim], [prop]],
-#             "out_dims": OrderedDict([("sim", [dim])]),
-#             **kwargs,
-#         },
-#         input_core_dims=[[dim], [prop]],
-#         output_core_dim=[[dim]],
-#         output_dtypes=[sim.dtype],
-#         dask_gufunc_kwargs=dict(
-#             meta=(np.ndarray((), dtype=sim.dtype),),
-#         ),
-#         dask="parallelized",
-#     )
-
-#     kind = kwargs.get("kind", "+")
-#     trend = polydetrend_get_trend(sim, group, deg=kwargs.pop("detrend", 1))
-#     sim_detrended = u.apply_correction(sim, u.invert(trend, kind), kind)
-
-#     scen = xr.apply_ufunc(
-#         dqm_adjust_1d,
-#         ds.af,
-#         ds.hist_q,
-#         sim_detrended,
-#         kwargs={
-#             "coords": {prop: ds[prop].values, "quantiles": ds.quantiles.values},
-#             "time": sim[dim],
-#             "group": group,
-#             "dims": dims,
-#             **kwargs,
-#         },
-#         input_core_dims=[[prop, "quantiles"], [prop, "quantiles"], [dim]],
-#         output_core_dims=[[dim]],
-#         output_dtypes=[sim.dtype],
-#         dask_gufunc_kwargs=dict(
-#             meta=(np.ndarray((), dtype=sim.dtype),),
-#         ),
-#         dask="parallelized",
-#     )
-
-#     return u.apply_correction(scen, trend, kind)
+    return u.apply_correction(scen, trend, kind)

--- a/xclim/sdba/detrending.py
+++ b/xclim/sdba/detrending.py
@@ -3,7 +3,7 @@ from typing import Union
 
 import xarray as xr
 
-from .base import Grouper, Parametrizable, parse_group
+from .base import Grouper, Parametrizable, map_groups, parse_group
 from .loess import loess_smoothing
 from .utils import ADDITIVE, apply_correction, invert
 
@@ -14,14 +14,17 @@ class BaseDetrend(Parametrizable):
     Defines three methods:
 
     fit(da)      : Compute trend from da and return a new _fitted_ Detrend object.
-    get_trend(da): Return the fitted trend along da's coordinate.
     detrend(da)  : Return detrended array.
     retrend(da)  : Puts trend back on da.
 
-    * Subclasses should implement _fit() and _get_trend(). Both will be called in a `group.apply()`.
-    `_fit()` is called with the dataarray and str `dim` that indicates the fitting dimension,
-        it should return a dataset that will be set as `.fitds`.
-    `_get_trend()` is called with .fitds broadcasted on the main dim of the input DataArray.
+    A fitted Detrend object is unique to the trend coordinate of the object used in `fit`, (usually 'time').
+    The computed trend is stored in `Detrend.trend`.
+
+    * Subclasses should implement _get_trend_group() or _get_trend().
+    The first will be called in a `group.apply(..., main_only=True)`, and should return a single DataArray.
+    The second allows the use of functions wrapped in `map_groups` and should also return a single DataArray.
+
+    The subclasses may reimplement `_detrend` and `_retrend`.
     """
 
     @parse_group
@@ -38,50 +41,50 @@ class BaseDetrend(Parametrizable):
         kind : {'*', '+'}
             The way the trend is removed or added, either additive or multiplicative.
         """
-        self.__fitted = False
         super().__init__(group=group, kind=kind, **kwargs)
+        self.__fitted = False
 
     def fit(self, da: xr.DataArray):
         """Extract the trend of a DataArray along a specific dimension.
 
-        Returns a new object storing the fit data that can be used for detrending and retrending.
+        Returns a new object that can be used for detrending and retrending. Fitted objects are unique to the fitted coordinate used.
         """
         new = self.copy()
-        new._set_ds(new.group.apply(new._fit, da, main_only=True))
-        new.__fitted = True
+        new._set_trend(new._get_trend(da))
         return new
 
-    def get_trend(self, da: xr.DataArray):
-        """Get the trend computed from the fit, along the self.group.dim as found on da.
+    def _get_trend(self, da: xr.DataArray):
+        """Computes the trend, along the self.group.dim as found on da.
 
         If da is a DataArray (and has a "dtype" attribute), the trend is casted to have the same dtype.
+
+        This method applies `_get_trend_group` with `self.group`.
         """
         out = self.group.apply(
-            self._get_trend,
-            {self.group.dim: da[self.group.dim], **self.ds.data_vars},
+            self._get_trend_group,
+            da,
             main_only=True,
         )
         if hasattr(da, "dtype"):
             out = out.astype(da.dtype)
-        return out
+        return out.rename("trend")
 
     def detrend(self, da: xr.DataArray):
         """Remove the previously fitted trend from a DataArray."""
         if not self.__fitted:
             raise ValueError("You must call fit() before detrending.")
-        trend = self.get_trend(da)
-        return self._detrend(da, trend)
+        return self._detrend(da, self.trend)
 
     def retrend(self, da: xr.DataArray):
-        """Replace the previously fitted trend on a DataArray."""
+        """Put the previously fitted trend back on a DataArray."""
         if not self.__fitted:
             raise ValueError("You must call fit() before retrending")
-        trend = self.get_trend(da)
-        return self._retrend(da, trend)
+        return self._retrend(da, self.trend)
 
-    def _set_ds(self, ds):
-        self.ds = ds
-        self.ds.attrs["fit_params"] = str(self)
+    def _set_trend(self, trend):
+        self.__fitted = True
+        self.trend = trend
+        self.trend.attrs["fit_params"] = str(self)
 
     def _detrend(self, da, trend):
         # Remove trend from series
@@ -91,17 +94,24 @@ class BaseDetrend(Parametrizable):
         # Add trend to series
         return apply_correction(da, trend, self.kind)
 
-    def _get_trend(self, grpd, dim="time"):
+    def _get_trend_group(self, grpd, dim="time"):
         raise NotImplementedError
 
-    def _fit(self, da):
-        raise NotImplementedError
+    @property
+    def fitted(self):
+        return self.__fitted
+
+    def __repr__(self):
+        rep = super().__repr__()
+        if not self.fitted:
+            return f"<{rep} | unfitted>"
+        return rep
 
 
 class NoDetrend(BaseDetrend):
     """Convenience class for polymorphism. Does nothing."""
 
-    def _fit(self, da, dim=None):
+    def _get_trend_group(self, da, dim=None):
         return da.isel({dim: 0})
 
     def _detrend(self, da, trend):
@@ -114,13 +124,13 @@ class NoDetrend(BaseDetrend):
 class MeanDetrend(BaseDetrend):
     """Simple detrending removing only the mean from the data, quite similar to normalizing."""
 
-    def _fit(self, da, dim="time"):
-        mean = da.mean(dim=dim)
-        mean.name = "mean"
-        return mean
+    def _get_trend(self, da):
+        return _meandetrend_get_trend(da, **self)
 
-    def _get_trend(self, grpd, dim="time"):
-        return grpd.mean
+
+@map_groups(main_only=True, trend=["<DIM>"])
+def _meandetrend_get_trend(da, *, dim, kind):
+    return da.mean(dim).rename("trend").to_dataset()
 
 
 class PolyDetrend(BaseDetrend):
@@ -146,19 +156,21 @@ class PolyDetrend(BaseDetrend):
             group=group, kind=kind, degree=degree, preserve_mean=preserve_mean
         )
 
-    def _fit(self, da, dim="time"):
-        return da.polyfit(dim=dim, deg=self.degree)
-
-    def _get_trend(self, grpd, dim="time"):
+    def _get_trend(self, da):
         # Estimate trend over da
-        trend = xr.polyval(coord=grpd[dim], coeffs=grpd.polyfit_coefficients)
+        trend = _polydetrend_get_trend(da, **self)
+        return trend.trend
 
-        if self.preserve_mean:
-            trend = apply_correction(
-                trend, invert(trend.mean(dim=dim), self.kind), self.kind
-            )
 
-        return trend
+@map_groups(main_only=True, trend=["<DIM>"])
+def _polydetrend_get_trend(da, *, dim, degree, preserve_mean, kind):
+    """Polydetrend, atomic func on 1 group."""
+    pfc = da.polyfit(dim=dim, deg=degree)
+    trend = xr.polyval(coord=da[dim], coeffs=pfc.polyfit_coefficients)
+
+    if preserve_mean:
+        trend = apply_correction(trend, invert(trend.mean(dim=dim), kind), kind)
+    return trend.rename("trend").to_dataset()
 
 
 class LoessDetrend(BaseDetrend):
@@ -200,29 +212,13 @@ class LoessDetrend(BaseDetrend):
     ):
         super().__init__(group=group, kind=kind, f=f, niter=niter, d=0, weights=weights)
 
-    def _fit(self, da, dim="time"):
+    def _get_trend_group(self, da, *, dim):
         trend = loess_smoothing(
             da,
-            dim=self.group.dim,
+            dim=dim,
             f=self.f,
             niter=self.niter,
             d=self.d,
             weights=self.weights,
         )
-        trend.name = "trend"
-        return trend.to_dataset()
-
-    def get_trend(self, da: xr.DataArray):
-        """Get the trend computed from the fit, along the self.group.dim as found on da.
-
-        If da is a DataArray (and has a "dtype" attribute), the trend is casted to have the same dtype.
-        """
-        # Check if we need to interpolate
-        if da[self.group.dim].equals(self.ds[self.group.dim]):
-            out = self.ds.trend
-        else:
-            out = self.ds.trend.interp(coords={self.group.dim: da[self.group.dim]})
-
-        if hasattr(da, "dtype"):
-            out = out.astype(da.dtype)
-        return out
+        return trend

--- a/xclim/sdba/nbutils.py
+++ b/xclim/sdba/nbutils.py
@@ -1,0 +1,67 @@
+"""Numba-accelerated utils."""
+import numpy as np
+import xarray as xr
+from numba import float32, float64, guvectorize, jit  # , int32, int64
+
+
+@guvectorize(
+    [(float32[:], float32, float32[:]), (float64[:], float64, float64[:])],
+    "(n),()->()",
+    nopython=True,
+)
+def _vecquantiles(arr, rnk, res):
+    res[0] = np.nanquantile(arr, rnk)
+
+
+def vecquantiles(da, rnk, dims):
+    tem = xr.core.utils.get_temp_dimname(da.dims, "temporal")
+    da = da.stack({tem: dims})
+    da = da.transpose(*rnk.dims, tem)
+
+    res = xr.DataArray(
+        _vecquantiles(da.values, rnk.values),
+        dims=rnk.dims,
+        coords=rnk.coords,
+        attrs=da.attrs,
+    )
+    return res
+
+
+@guvectorize(
+    [(float32[:], float32[:]), (float64[:], float64[:])], "(n)->(n)", nopython=True
+)
+def _rank(arr, out):
+    out[:] = np.argsort(np.argsort(arr))
+
+
+def rank(da):
+    return da.copy(data=_rank(da.values))
+
+
+@jit(
+    [
+        float32[:, :](float32[:, :], float32[:]),
+        float64[:, :](float64[:, :], float32[:]),
+    ],
+    nopython=True,
+)
+def _quantile(arr, q):
+    out = np.empty((arr.shape[0], q.size), dtype=arr.dtype)
+    for index in range(out.shape[0]):
+        out[index] = np.nanquantile(arr[index], q)
+    return out
+
+
+def quantile(da, q, dims):
+    spa = xr.core.utils.get_temp_dimname(da.dims, "spatial")
+    tem = xr.core.utils.get_temp_dimname(da.dims, "temporal")
+    da = da.stack({spa: set(da.dims) - set(dims), tem: dims})
+    da = da.transpose(spa, tem)
+
+    res = xr.DataArray(
+        _quantile(da.values, q),
+        dims=(spa, "quantiles"),
+        coords={spa: da[spa], "quantiles": q},
+        attrs=da.attrs,
+    )
+    return res.unstack(spa)

--- a/xclim/sdba/nbutils.py
+++ b/xclim/sdba/nbutils.py
@@ -13,8 +13,13 @@ def _vecquantiles(arr, rnk, res):
     res[0] = np.nanquantile(arr, rnk)
 
 
-def vecquantiles(da, rnk, dims):
+def vecquantiles(da, rnk, dim):
+    """For when the quantile (rnk) is different for each point.
+
+    da and rnk must share all dimensions but dim.
+    """
     tem = xr.core.utils.get_temp_dimname(da.dims, "temporal")
+    dims = [dim] if isinstance(dim, str) else dim
     da = da.stack({tem: dims})
     da = da.transpose(*rnk.dims, tem)
 
@@ -27,41 +32,62 @@ def vecquantiles(da, rnk, dims):
     return res
 
 
-@guvectorize(
-    [(float32[:], float32[:]), (float64[:], float64[:])], "(n)->(n)", nopython=True
-)
-def _rank(arr, out):
-    out[:] = np.argsort(np.argsort(arr))
-
-
-def rank(da):
-    return da.copy(data=_rank(da.values))
-
-
 @jit(
     [
         float32[:, :](float32[:, :], float32[:]),
-        float64[:, :](float64[:, :], float32[:]),
+        float64[:, :](float64[:, :], float64[:]),
+        float32[:](float32[:], float32[:]),
+        float64[:](float64[:], float64[:]),
     ],
     nopython=True,
 )
 def _quantile(arr, q):
-    out = np.empty((arr.shape[0], q.size), dtype=arr.dtype)
-    for index in range(out.shape[0]):
-        out[index] = np.nanquantile(arr[index], q)
+    if arr.ndim == 1:
+        out = np.empty((q.size,), dtype=arr.dtype)
+        out[:] = np.nanquantile(arr, q)
+    else:
+        out = np.empty((arr.shape[0], q.size), dtype=arr.dtype)
+        for index in range(out.shape[0]):
+            out[index] = np.nanquantile(arr[index], q)
     return out
 
 
-def quantile(da, q, dims):
-    spa = xr.core.utils.get_temp_dimname(da.dims, "spatial")
-    tem = xr.core.utils.get_temp_dimname(da.dims, "temporal")
-    da = da.stack({spa: set(da.dims) - set(dims), tem: dims})
-    da = da.transpose(spa, tem)
+def quantile(da, q, dim):
+    """Compute the quantiles from a fixed list "q" """
+    # We have two cases :
+    # - When all dims are processed : we stack them and use _quantile1d
+    # - When the quantiles are vectorized over some dims, these are also stacked and then _quantile2D is used.
+    # All this stacking is so we can cover all ND+1D cases with one numba function.
 
-    res = xr.DataArray(
-        _quantile(da.values, q),
-        dims=(spa, "quantiles"),
-        coords={spa: da[spa], "quantiles": q},
-        attrs=da.attrs,
-    )
-    return res.unstack(spa)
+    # Stack the dims and send to the last position
+    # This is in case there are more than one
+    dims = [dim] if isinstance(dim, str) else dim
+    tem = xr.core.utils.get_temp_dimname(da.dims, "temporal")
+    da = da.stack({tem: dims})
+
+    # So we cut in half the definitions to declare in numba
+    if not hasattr(q, "dtype") or q.dtype != da.dtype:
+        q = np.array(q, dtype=da.dtype)
+
+    if len(da.dims) > 1:
+        # There are some extra dims
+        extra = xr.core.utils.get_temp_dimname(da.dims, "extra")
+        da = da.stack({extra: set(da.dims) - {tem}})
+        da = da.transpose(..., tem)
+        res = xr.DataArray(
+            _quantile(da.values, q),
+            dims=(extra, "quantiles"),
+            coords={extra: da[extra], "quantiles": q},
+            attrs=da.attrs,
+        ).unstack(extra)
+
+    else:
+        # All dims are processed
+        res = xr.DataArray(
+            _quantile(da.values, q),
+            dims=("quantiles"),
+            coords={"quantiles": q},
+            attrs=da.attrs,
+        )
+
+    return res

--- a/xclim/testing/tests/test_sdba/test_utils.py
+++ b/xclim/testing/tests/test_sdba/test_utils.py
@@ -32,7 +32,7 @@ def test_map_cdf(series):
         y_value=yd.ppf(q),
         group="time",
     )
-    np.testing.assert_allclose(x_value, xd.ppf(q), 3)
+    np.testing.assert_allclose(x_value, [xd.ppf(q)], 0.1)
 
     # Scalar
     q = 0.5
@@ -42,7 +42,7 @@ def test_map_cdf(series):
         y_value=yd.ppf(q),
         group="time",
     )
-    np.testing.assert_allclose(x_value, xd.ppf(q), 3)
+    np.testing.assert_allclose(x_value, [[xd.ppf(q)]], 0.1)
 
 
 def test_equally_spaced_nodes():
@@ -110,13 +110,9 @@ def test_interp_on_quantiles(shape, group, method):
         xr.testing.assert_equal(fut_corr.isnull(), fut == 1000)
 
 
-@pytest.mark.parametrize("use_dask", [True, False])
-def test_rank(use_dask):
+def test_rank():
     arr = np.random.random_sample(size=(10, 10, 1000))
     da = xr.DataArray(arr, dims=("x", "y", "time"))
-
-    if use_dask:
-        da = da.chunk({"x": 1})
 
     ranks = u.rank(da, dim="time", pct=False)
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #652
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (major / minor / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
Moves most of the adjustment code to standalone functions that are wrapped in `map_blocks` call through a fancy-but-complex decorator. Also adds some numba-accelerated utilities.

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
Yes. The API itself hasn't changed, but there are some notable differences.


In the following I try to summarize the changes. 

- Adjustment objects in `xclim/sdba/adjustment.py` act more like pipelines : the computation functions are in `_qm.py`. Same for Detrend objects. The code is currently in a hybrid state, it is not clear to me if we want to keep that or not.
- When we have a group of operations that acts on a A) a single dask block or B) on a single group in a single block, I strongly recommend writing a single function and wrapping it with A) `xclim.sdba.base.map_blocks` or B) `map_groups`. The second inserts a  `Grouper.apply(...)` call in the `map_blocks` call.

In opposition to `xr.apply_ufunc`, `map_blocks` passes an xarray object to its children function (not a numpy array). This is what we want, because we need the coordinates (especially the "time"  one). However, instead of configuring the call and its output with keyword args, `map_blocks` wants a "template", i.e. the output dataset, but empty. Creating this is not simple, especially since I want to remove that overhead from the actual algorithm writing. Thus the two decorators. 
Both take as input a mapping from new variable name to new dimensions. See the code for examples.

Some details that might also interest users like @RondeauG :

- There is a new limitations for any input to functions wrapped by the new decorators (i.e. `ref`, `hist` and `sim`): they must have the same dimensions and be mergeable in a dataset. This means using the same calendar, for example. 
- I modified the `Grouper` object so that passing 'time' (and only for that case), groups over a dummy dimension called `group`. Before, passing 'time' acted like a passthrough : `group.apply('mean', ds)` was the exact same as `ds.mean('time')`. But, this caused generality problems downstream, so now a call to `group.apply` replaces the main dimension by the grouped dimension.



All this was in a quest for better performances and scalability. Right now, DQM without dask takes ~ half the time and with dask 20% of the time. (using two years on 1300 points, grouping by dayofyear). I'll make more tests later.

Currently, only the QM methods are transformed, will do the rest later.