### PR TITLE
Replicate subset shape tests fix from clisops

### DIFF
--- a/xclim/testing/tests/test_subset.py
+++ b/xclim/testing/tests/test_subset.py
@@ -669,14 +669,14 @@ class TestSubsetShape:
 
         # Average temperature at surface for region in January (time=0)
         np.testing.assert_array_almost_equal(
-            float(np.mean(sub.tas.isel(time=0))), 285.064453
+            float(np.mean(sub.tas.isel(time=0))), 285.064, 3
         )
         self.compare_vals(ds, sub, "tas")
 
         poly = gpd.read_file(self.meridian_multi_geojson)
         subtas = subset.subset_shape(ds.tas, poly)
         np.testing.assert_array_almost_equal(
-            float(np.mean(subtas.isel(time=0))), 281.091553
+            float(np.mean(subtas.isel(time=0))), 281.092, 3
         )
 
         assert sub.crs.prime_meridian_name == "Greenwich"
@@ -701,7 +701,7 @@ class TestSubsetShape:
 
         # Average temperature at surface for region in January (time=0)
         np.testing.assert_array_almost_equal(
-            float(np.mean(sub.tas.isel(time=0))), 276.732483
+            float(np.mean(sub.tas.isel(time=0))), 276.732, 3
         )
         # Check that no warnings are raised for meridian crossing
         assert (


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (major / minor / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
In roocs/clisops#138, I had a strange problem where some tests were failing on the first run, but not on subsequent runs. Some results were changing in the 1e-4 range. I'm applying the same test relaxation in our "test_subset.py" than in clisops'. (Commit [a391e39e](https://github.com/roocs/clisops/commit/a391e39e7d50f47bb4bacf91c94399e3031e753f) )