### PR TITLE
Use python 3.7 on ReadTheDoc

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.7
       - name: Install tox
         run: pip install tox
       - name: Run lint

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,7 @@ build:
   image: latest
 
 python:
-  version: 3.6
+  version: 3.7
   install:
     - method: pip
       path: .


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR should fix the RTD failures in #655.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (major / minor / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
Bumps the python version to 3.7 for RTD.

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
No, on the contrary, many of xclim dependencies are dropping support for python 3.6.

* **Other information**:
Still, I don't know why this happened, but this seems to fix the timeouts on RTD.