### PR TITLE
sdba - Fix from_string constructor

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,8 +2,16 @@
 History
 =======
 
-0.25.0 2021-03-31)
-------------------
+0.26.0 (unreleased)
+-------------------
+
+Bug fixes
+~~~~~~~~~
+* Fix the `from_string` object creation in sdba.
+
+
+0.25.0 (2021-03-31)
+-------------------
 
 Announcements
 ~~~~~~~~~~~~~

--- a/xclim/sdba/base.py
+++ b/xclim/sdba/base.py
@@ -21,7 +21,7 @@ class Parametrizable(dict):
     @classmethod
     def _get_subclasses(cls):
         """Return a dict of all the subclasses of the current class and recursively for those subclasses."""
-        subcls = {}
+        subcls = {cls.__name__: cls}
         for sub in cls.__subclasses__():
             subcls[sub.__name__] = sub
             subcls.update(sub._get_subclasses())

--- a/xclim/testing/tests/test_sdba/test_base.py
+++ b/xclim/testing/tests/test_sdba/test_base.py
@@ -5,6 +5,10 @@ import xarray as xr
 from xclim.sdba.base import Grouper, Parametrizable
 
 
+class ATestSubClass(Parametrizable):
+    pass
+
+
 def test_param_class():
     gr = Grouper(group="time.month")
     in_params = dict(
@@ -14,14 +18,16 @@ def test_param_class():
 
     assert obj.parameters == in_params
 
-    repr(obj).startswith(
-        "ParametrizableClass(anint=4, abool=True, astring='a string', adict={'key': 'val'}, "
+    assert repr(obj).startswith(
+        "Parametrizable(anint=4, abool=True, astring='a string', adict={'key': 'val'}, "
         "group=Grouper(dim='time',"
     )
 
     s = str(obj)
     obj2 = Parametrizable.from_string(s)
     assert obj.parameters == obj2.parameters
+
+    assert "ATestSubClass" in Parametrizable._get_subclasses()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes an issue raised in slack.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (major / minor / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

## What kind of change does this PR introduce?
My misunderstanding of python's `__new__`. I though that it was executed upon class _declaration_, but it is rather called upon class _instantiation_. When `sdba.base.Parametrizable.from_string` encounter a class name, it would look in a registry populated in the `__new__`, so only when subclasses were created. Thus, in a brand new session, if the first thing you call is a `from_string` or `from_dataset`, the registry is empty because no objects have been created yet. Resulting in an error.

Rather, here we use the `__subclasses__` python method to list all subclasses (recursively). No need for instantiation.

@huard Should we change the `Indicator` class to use this instead?   The main bonus is that classes that do not have instances would still be listed in the registry (ex: Daily, Hourly, Tasmax, ...).

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
No