### PR TITLE
Remove magic in sdba-serialization

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,7 +7,7 @@ History
 
 Bug fixes
 ~~~~~~~~~
-* Fix the `from_string` object creation in sdba.
+* Remove `from_string` object creation in sdba, replace with use of new dependency `jsonpickle`.
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/docs/notebooks/sdba-advanced.ipynb
+++ b/docs/notebooks/sdba-advanced.ipynb
@@ -198,7 +198,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The trained `QDM` exposes the training data in the `ds` attribute, we will write to disk, read it back and intialize an new object from it. Notice the `adj_params` in the dataset, that has the same value as the repr string printed just above."
+    "The trained `QDM` exposes the training data in the `ds` attribute, we will write to disk, read it back and intialize an new object from it. Notice the `adj_params` in the dataset, that has the same value as the repr string printed just above. Also, notice the `_xclim_adjustment` attribute that contains a json string so we can rebuild the adjustment object later."
    ]
   },
   {
@@ -243,6 +243,22 @@
     "QDM.set_dataset(ds)\n",
     "QDM.ds"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "QDM2.adjust(sim)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/docs/notebooks/sdba-advanced.ipynb
+++ b/docs/notebooks/sdba-advanced.ipynb
@@ -198,7 +198,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The trained `QDM` exposes the training data in the `ds` attribute, we will write to disk, read it back and intialize an new object from it. Notice the `adj_params` in the dataset, that has the same value as the repr string printed just above. Also, notice the `_xclim_adjustment` attribute that contains a json string so we can rebuild the adjustment object later."
+    "The trained `QDM` exposes the training data in the `ds` attribute, Here, we will write it to disk, read it back and initialize an new object from it. Notice the `adj_params` in the dataset, that has the same value as the repr string printed just above. Also, notice the `_xclim_adjustment` attribute that contains a json string so we can rebuild the adjustment object later."
    ]
   },
   {

--- a/environment.yml
+++ b/environment.yml
@@ -18,3 +18,4 @@ dependencies:
  - Click
  - netCDF4>=1.4
  - clisops>=0.4.0
+ - jsonpickle

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ requirements = [
     "scikit-learn>=0.21.3",
     "Click",
     "packaging>=20.0",
+    "jsonpickle",
 ]
 
 setup_requirements = ["pytest-runner", "wheel"]

--- a/xclim/sdba/base.py
+++ b/xclim/sdba/base.py
@@ -13,9 +13,10 @@ from boltons.funcutils import wraps
 class Parametrizable(dict):
     """Helper base class resembling a dictionary.
 
-    The concept of this object is that is _completely_ defined by the content of its internal dictionary.
-    When serializing and restoring this object, only members of :py:methd:`Parametrizable.parameters` are preserved.
-    Parameters passed in the init or set using item access "[ ]" are considered those stored in the internal
+    This object is _completely_ defined by the content of its internal dictionary, accessible through item access
+    (`self['attr']`) or in `self.parameters`. When serializing and restoring this object, only members of that internal
+    dict are preserved. All other attributes set directly with `self.attr = value` will not be preserved upon serialization 
+    and restoration of the object with `[json]pickle`.
     dictionary. Other variables set with `self.var = data` will be lost in the serialization process.
     This class is best serialized and restored with `jsonpickle`.
     """

--- a/xclim/sdba/base.py
+++ b/xclim/sdba/base.py
@@ -15,7 +15,7 @@ class Parametrizable(dict):
 
     This object is _completely_ defined by the content of its internal dictionary, accessible through item access
     (`self['attr']`) or in `self.parameters`. When serializing and restoring this object, only members of that internal
-    dict are preserved. All other attributes set directly with `self.attr = value` will not be preserved upon serialization 
+    dict are preserved. All other attributes set directly with `self.attr = value` will not be preserved upon serialization
     and restoration of the object with `[json]pickle`.
     dictionary. Other variables set with `self.var = data` will be lost in the serialization process.
     This class is best serialized and restored with `jsonpickle`.

--- a/xclim/sdba/base.py
+++ b/xclim/sdba/base.py
@@ -13,8 +13,11 @@ from boltons.funcutils import wraps
 class Parametrizable(dict):
     """Helper base class resembling a dictionary.
 
-    Only parameters passed in the init or set using item access "[ ]" are considered as such and returned in the
-    :py:meth:`Parametrizable.parameters` dictionary, the copy method and the class representation.
+    The concept of this object is that is _completely_ defined by the content of its internal dictionary.
+    When serializing and restoring this object, only members of :py:methd:`Parametrizable.parameters` are preserved.
+    Parameters passed in the init or set using item access "[ ]" are considered those stored in the internal
+    dictionary. Other variables set with `self.var = data` will be lost in the serialization process.
+    This class is best serialized and restored with `jsonpickle`.
     """
 
     _repr_hide_params = []

--- a/xclim/sdba/base.py
+++ b/xclim/sdba/base.py
@@ -1,10 +1,9 @@
 """Base classes."""
-import re
-from ast import literal_eval
 from inspect import signature
 from types import FunctionType
 from typing import Callable, Mapping, Optional, Sequence, Set, Union
 
+import jsonpickle
 import numpy as np
 import xarray as xr
 from boltons.funcutils import wraps
@@ -18,73 +17,15 @@ class Parametrizable(dict):
     :py:meth:`Parametrizable.parameters` dictionary, the copy method and the class representation.
     """
 
-    @classmethod
-    def _get_subclasses(cls):
-        """Return a dict of all the subclasses of the current class and recursively for those subclasses."""
-        subcls = {cls.__name__: cls}
-        for sub in cls.__subclasses__():
-            subcls[sub.__name__] = sub
-            subcls.update(sub._get_subclasses())
-        return subcls
+    _repr_hide_params = []
 
-    @classmethod
-    def from_string(cls, defstr: str):
-        """Create an instance of this object from a string.
+    def __getstate__(self):
+        """For (json)pickle, a Parametrizable should be defined by its internal dict only."""
+        return self.parameters
 
-        The string must have been created with `str(object)` where object has the same type
-        as this object. The resulting instance might be slightly different than the original one.
-
-        Parameters
-        ----------
-        defstr : str
-          String providing the definition of the object.
-
-        Examples
-        --------
-        >>> obj = Parametrizable(anint=1, anobj=Parametrizable(astr='hello world'))
-        >>> ss = str(obj)
-        >>> obj2 = Parametrizable.from_string(ss)
-        >>> obj
-        Parametrizable(anint=1, anobj=Parametrizable(astr='hello world'))
-        >>> obj2
-        Parametrizable(anint=1, anobj=Parametrizable(astr='hello world'))
-        """
-        # This method is a basic and specific un-serializer for Parametrizable objects (and children)
-        # It uses the fact that Parametrizable classes DO NOT have real attributes: only methods and what is stored in the dict
-        # This allows for creating an empty obj with new, by passing the init and filling it with the dict method "update"
-
-        # regex pattern that fully matches a string produced by Parametrizable._repr__
-        match = re.fullmatch(r"(?P<class>[A-Za-z0-9_]+)\((?P<args>.*)\)", defstr)
-        if not match:
-            raise ValueError(
-                f"Received malformed string for creating a {cls.__name__} instance. ({defstr})"
-            )
-        if match.groupdict()["class"] != cls.__name__:
-            raise ValueError(
-                f"Wrong class : constructor of {cls.__name__} received a string for {match.groupdict()['class']}"
-            )
-
-        # Get a new instance of cls but bypassing the init, basically this returns an empty dict with the methods of cls
-        obj = cls.__new__(cls)
-        params = {}
-        # regex pattern that matches each argument in the repr of a Parametrizable obj, distinguishing other Parametrizable classes (and their arguments) from python literals
-        # Iterate over the matches
-        for argmatch in re.finditer(
-            r"(?P<name>[A-Za-z0-9_]+)=(?P<vstr>((?P<vcls>[A-Za-z0-9_]+)\((.*?)\))|.+?(?=, ))",
-            match.groupdict()["args"] + ", ",
-        ):
-            dd = argmatch.groupdict()
-            if dd["vcls"] is not None:
-                # Thus we matched another Parametrizable class repr, recursively call it "from _string"
-                params[dd["name"]] = Parametrizable._get_subclasses()[
-                    dd["vcls"]
-                ].from_string(dd["vstr"])
-            else:
-                # A normal python literal
-                params[dd["name"]] = literal_eval(dd["vstr"])
-        # Update the params (Parametrizable inherits this from dict
-        obj.update(params)
-        return obj
+    def __setstate__(self, state):
+        """For (json)pickle, a Parametrizable in only defined by its internal dict."""
+        self.update(state)
 
     def __getattr__(self, attr):
         """Get attributes."""
@@ -101,25 +42,30 @@ class Parametrizable(dict):
 
     def __repr__(self):
         """Return a string representation that allows eval to recreate it."""
-        params = ", ".join([f"{k}={repr(v)}" for k, v in self.items()])
+        params = ", ".join(
+            [
+                f"{k}={repr(v)}"
+                for k, v in self.items()
+                if k not in self._repr_hide_params
+            ]
+        )
         return f"{self.__class__.__name__}({params})"
 
 
 class ParametrizableWithDataset(Parametrizable):
     """Parametrizeable class that also has a `ds` attribute storing a dataset."""
 
-    _attribute = "params"
+    _attribute = "_xclim_parameters"
 
     @classmethod
     def from_dataset(cls, ds: xr.Dataset):
         """Create an instance from a dataset.
 
-        The dataset must have a global attribute with a name corresponding to `self.__attribute`,
-        and that attribute must be the result of `str(object)` where object is of the same type as
-        this object.
+        The dataset must have a global attribute with a name corresponding to `cls._attribute`,
+        and that attribute must be the result of `jsonpickle.encode(object)` where object is
+        of the same type as this object.
         """
-        defstr = ds.attrs[cls._attribute]
-        obj = cls.from_string(defstr)
+        obj = jsonpickle.decode(ds.attrs[cls._attribute])
         obj.set_dataset(ds)
         return obj
 
@@ -129,11 +75,13 @@ class ParametrizableWithDataset(Parametrizable):
         Useful with custom object initialization or if some external processing was performed.
         """
         self.ds = ds
-        self.ds.attrs[self._attribute] = str(self)
+        self.ds.attrs[self._attribute] = jsonpickle.encode(self)
 
 
 class Grouper(Parametrizable):
     """Helper object to perform grouping actions on DataArrays and Datasets."""
+
+    _repr_hide_params = ["dim", "prop"]  # For a concise repr
 
     def __init__(
         self,

--- a/xclim/testing/tests/test_sdba/test_base.py
+++ b/xclim/testing/tests/test_sdba/test_base.py
@@ -21,7 +21,7 @@ def test_param_class():
 
     assert repr(obj).startswith(
         "Parametrizable(anint=4, abool=True, astring='a string', adict={'key': 'val'}, "
-        "group=Grouper(dim='time',"
+        "group=Grouper("
     )
 
     s = jsonpickle.encode(obj)

--- a/xclim/testing/tests/test_sdba/test_base.py
+++ b/xclim/testing/tests/test_sdba/test_base.py
@@ -1,3 +1,4 @@
+import jsonpickle
 import numpy as np
 import pytest
 import xarray as xr
@@ -23,11 +24,9 @@ def test_param_class():
         "group=Grouper(dim='time',"
     )
 
-    s = str(obj)
-    obj2 = Parametrizable.from_string(s)
+    s = jsonpickle.encode(obj)
+    obj2 = jsonpickle.decode(s)
     assert obj.parameters == obj2.parameters
-
-    assert "ATestSubClass" in Parametrizable._get_subclasses()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes issues raised in #681.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (major / minor / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
Removes magic and xclim-specific code in `xclim.sdba.base.Parametrizable` that served the serialization purpose. Instead, users are invited to use `jsonpickle` for (de)serialization of those objects. This removed the `from_string` class method. For `ParametrizableWithDataset` (adjustment objects), the `from_dataset` and  `set_dataset` methods now use the `jsonpickle` way.

Minimal magic was kept. The concept of `Parametrizable` is that it is completely defined by its dict content, so I added `__getstate__` and `__setstate__` as defined in built-in python's pickling syntax (and reused by jsonpickle).  These will ensure only members of `Parametrizable.parameters` are serialized and restored. Thus excluding `ds` for Adjustment objects : we wouldn't want the whole dataset being translated to json and added to itself!

`Adjustment.from_dataset` is kept and its use is the same as before.

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
Yes. No more `Grouper.from_string`. but I guess no one was using this.

* **Other information**:
Examples:

```python3
from xclim.sdba import Grouper, QuantileDeltaMapping
import jsonpickle

group = Grouper('time.dayofyear')

# Human-readable string representation:
repr(group)

# Machine-readable string representation:
s = jsonpickle.encode(group)
group2 = jsonpickle.decode(s)   # group2 is the same as group

QDM = QuantileDeltaMapping(nquantiles=15, group=group)
QDM.train(ref, hist)

# QDM.ds has 2 attributes:
# "_xclim_adjustment", the machine-readable string of jsonpickle.encode(QDM)
# "adj_params", the human-readable string of str(QDM)
QDM.ds.to_netcdf('training.nc')
QDM2 = QuantileDetlaMapping.from_dataset(xr.open_dataset('training.nc'))

# QDM2 is the same as QDM
```




