### PR TITLE
Implement doy to days since and inverse

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,10 @@ History
 0.26.0 (unreleased)
 -------------------
 
+New features and enhancements
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* `core.calendar.doy_to_days_since` and `days_since_to_doy` to allow meaningful statistics on doy data.
+
 Bug fixes
 ~~~~~~~~~
 * Remove `from_string` object creation in sdba, replace with use of new dependency `jsonpickle`.

--- a/xclim/core/calendar.py
+++ b/xclim/core/calendar.py
@@ -968,7 +968,7 @@ def days_since_to_doy(
     out = dac + start_doy
     out = xr.where(out > doy_max, out - doy_max, out)
 
-    out.attrs.update(da.attrs)
-    del out.attrs["calendar"]
-    del out.attrs["units"]
+    out.attrs.update(
+        {k: v for k, v in da.attrs.items() if k not in ["units", "calendar"]}
+    )
     return convert_calendar(out, base_calendar)

--- a/xclim/core/calendar.py
+++ b/xclim/core/calendar.py
@@ -908,9 +908,9 @@ def doy_to_days_since(
     out = xr.where(dac > base_doy, dac, dac + doy_max) - start_doy
     out.attrs.update(da.attrs)
     if start is not None:
-        out.attrs.update(units=f"days since {start}")
+        out.attrs.update(units=f"days after {start}")
     else:
-        out.attrs.update(units="days since time coordinate")
+        out.attrs.update(units="days after time coordinate")
 
     out.attrs.update(calendar=calendar)
     return convert_calendar(out, base_calendar)

--- a/xclim/core/calendar.py
+++ b/xclim/core/calendar.py
@@ -910,7 +910,11 @@ def doy_to_days_since(
     if start is not None:
         out.attrs.update(units=f"days after {start}")
     else:
-        out.attrs.update(units="days after time coordinate")
+        starts = np.unique(out.time.dt.strftime("%m-%d"))
+        if len(starts) == 1:
+            out.attrs.update(units=f"days after {starts[0]}")
+        else:
+            out.attrs.update(units="days after time coordinate")
 
     out.attrs.update(calendar=calendar)
     return convert_calendar(out, base_calendar)

--- a/xclim/core/calendar.py
+++ b/xclim/core/calendar.py
@@ -916,8 +916,8 @@ def doy_to_days_since(
         else:
             out.attrs.update(units="days after time coordinate")
 
-    out.attrs.update(calendar=calendar).rename(da.name)
-    return convert_calendar(out, base_calendar)
+    out.attrs.update(calendar=calendar)
+    return convert_calendar(out, base_calendar).rename(da.name)
 
 
 def days_since_to_doy(
@@ -974,5 +974,5 @@ def days_since_to_doy(
 
     out.attrs.update(
         {k: v for k, v in da.attrs.items() if k not in ["units", "calendar"]}
-    ).rename(da.name)
-    return convert_calendar(out, base_calendar)
+    )
+    return convert_calendar(out, base_calendar).rename(da.name)

--- a/xclim/core/calendar.py
+++ b/xclim/core/calendar.py
@@ -845,7 +845,7 @@ def _doy_days_since_doys(base: xr.DataArray, start: Optional[DayOfYearStr] = Non
             vectorize=True,
         )
         start_doy = starts.dt.dayofyear
-        start_doy = start_doy.where(start_doy > base_doy, start_doy + doy_max)
+        start_doy = start_doy.where(start_doy >= base_doy, start_doy + doy_max)
     else:
         start_doy = base_doy
 
@@ -916,7 +916,7 @@ def doy_to_days_since(
         else:
             out.attrs.update(units="days after time coordinate")
 
-    out.attrs.update(calendar=calendar)
+    out.attrs.update(calendar=calendar).rename(da.name)
     return convert_calendar(out, base_calendar)
 
 
@@ -974,5 +974,5 @@ def days_since_to_doy(
 
     out.attrs.update(
         {k: v for k, v in da.attrs.items() if k not in ["units", "calendar"]}
-    )
+    ).rename(da.name)
     return convert_calendar(out, base_calendar)

--- a/xclim/testing/tests/test_calendar.py
+++ b/xclim/testing/tests/test_calendar.py
@@ -389,11 +389,17 @@ def test_doy_to_days_since():
     out = doy_to_days_since(da)
     np.testing.assert_array_equal(out, [7, 178, 186])
 
+    assert out.attrs["units"] == "days after 07-01"
+
     da2 = days_since_to_doy(out)
     xr.testing.assert_identical(da, da2)
 
+    out = doy_to_days_since(da, start="07-01")
+    np.testing.assert_array_equal(out, [7, 178, 186])
+
     # other calendar
     out = doy_to_days_since(da, calendar="noleap")
+    assert out.attrs["calendar"] == "noleap"
     np.testing.assert_array_equal(out, [8, 178, 186])
 
     da2 = days_since_to_doy(out)  # calendar read from attribute
@@ -401,12 +407,13 @@ def test_doy_to_days_since():
 
     # with start
     time = date_range("2020-12-31", "2022-12-31", freq="Y")
-    da = xr.DataArray([190, 360, 3], dims=("time",), coords={"time": time})
+    da = xr.DataArray([190, 360, 3], dims=("time",), coords={"time": time}, name="da")
 
     out = doy_to_days_since(da, start="01-02")
     np.testing.assert_array_equal(out, [188, 358, 1])
 
     da2 = days_since_to_doy(out)  # start read from attribute
+    assert da2.name == da.name
     xr.testing.assert_identical(da, da2)
 
     # finer freq
@@ -414,6 +421,7 @@ def test_doy_to_days_since():
     da = xr.DataArray([15, 33, 66], dims=("time",), coords={"time": time})
 
     out = doy_to_days_since(da)
+    assert out.attrs["units"] == "days after time coordinate"
     np.testing.assert_array_equal(out, [14, 1, 5])
 
     da2 = days_since_to_doy(out)  # start read from attribute


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #688
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (major / minor / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
Adds `xc.core.calendar.doy_to_days_since` and inverse `days_since_to_doy`. It converts between data in day of year to a number of days since a given date. By default, that date is the time coordinate of the value, but it can be changed with `start=MM-DD`. Also, passing `calendar` is possible to change the calendar in which the computation is done, otherwise the calendar of the time axis is used. In the inverse function, `start` and `calendar` can be forced, but they are read from the attributres otherwise.

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
No.
