### PR TITLE
is_dayofyear attribute changed to int

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -14,6 +14,7 @@ New features and enhancements
 * On-the-fly generation of cfchecks with `xc.core.cfchecks.generate_cfcheck`, for a few known variables only.
 * New `xc.indices.run_length.rle_statistics` for min, max, mean, std (etc) statistics on run lengths.
 * New virtual submodule `cf`, with CF standard indices defined in `clix-meta <https://github.com/clix-meta/clix-meta>`_.
+* Indices returning day-of-year data add 2 new attributes to the output: `is_dayofyear` (=1) and `calendar`.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/xclim/core/calendar.py
+++ b/xclim/core/calendar.py
@@ -976,5 +976,5 @@ def days_since_to_doy(
     out.attrs.update(
         {k: v for k, v in da.attrs.items() if k not in ["units", "calendar"]}
     )
-    out.attrs.update(calendar=calendar, is_dayofyear=True)
+    out.attrs.update(calendar=calendar, is_dayofyear=1)
     return convert_calendar(out, base_calendar).rename(da.name)

--- a/xclim/indices/_hydrology.py
+++ b/xclim/indices/_hydrology.py
@@ -123,7 +123,7 @@ def snd_max_doy(snd: xarray.DataArray, freq: str = "AS-JUL") -> xarray.DataArray
 
     # Compute doymax. Will return first time step if all snow depths are 0.
     out = generic.select_resample_op(snd, op=generic.doymax, freq=freq)
-    out.attrs.update(units="", is_dayofyear=True, calendar=get_calendar(snd))
+    out.attrs.update(units="", is_dayofyear=1, calendar=get_calendar(snd))
 
     # Mask arrays that miss at least one non-null snd.
     return out.where(~valid)

--- a/xclim/indices/_threshold.py
+++ b/xclim/indices/_threshold.py
@@ -193,7 +193,7 @@ def continuous_snow_cover_end(
         .map(rl.season, window=window, dim="time", coord="dayofyear")
         .end
     )
-    out.attrs.update(units="", is_dayofyear=True, calendar=get_calendar(snd))
+    out.attrs.update(units="", is_dayofyear=1, calendar=get_calendar(snd))
     return out
 
 
@@ -240,7 +240,7 @@ def continuous_snow_cover_start(
         )
         .start
     )
-    out.attrs.update(units="", is_dayofyear=True, calendar=get_calendar(snd))
+    out.attrs.update(units="", is_dayofyear=1, calendar=get_calendar(snd))
     return out
 
 
@@ -467,7 +467,7 @@ def freshet_start(
     thresh = convert_units_to(thresh, tas)
     over = tas > thresh
     out = over.resample(time=freq).map(rl.first_run, window=window, coord="dayofyear")
-    out.attrs.update(units="", is_dayofyear=True, calendar=get_calendar(tas))
+    out.attrs.update(units="", is_dayofyear=1, calendar=get_calendar(tas))
     return out
 
 
@@ -550,7 +550,7 @@ def growing_season_end(
         dim="time",
         coord="dayofyear",
     )
-    out.attrs.update(units="", is_dayofyear=True, calendar=get_calendar(tas))
+    out.attrs.update(units="", is_dayofyear=1, calendar=get_calendar(tas))
     return out
 
 
@@ -743,7 +743,7 @@ def last_spring_frost(
         dim="time",
         coord="dayofyear",
     )
-    out.attrs.update(units="", is_dayofyear=True, calendar=get_calendar(tas))
+    out.attrs.update(units="", is_dayofyear=1, calendar=get_calendar(tas))
     return out
 
 
@@ -791,7 +791,7 @@ def first_day_below(
         dim="time",
         coord="dayofyear",
     )
-    out.attrs.update(units="", is_dayofyear=True, calendar=get_calendar(tasmin))
+    out.attrs.update(units="", is_dayofyear=1, calendar=get_calendar(tasmin))
     return out
 
 
@@ -839,7 +839,7 @@ def first_day_above(
         dim="time",
         coord="dayofyear",
     )
-    out.attrs.update(units="", is_dayofyear=True, calendar=get_calendar(tasmin))
+    out.attrs.update(units="", is_dayofyear=1, calendar=get_calendar(tasmin))
     return out
 
 
@@ -883,7 +883,7 @@ def first_snowfall(
         dim="time",
         coord="dayofyear",
     )
-    out.attrs.update(units="", is_dayofyear=True, calendar=get_calendar(prsn))
+    out.attrs.update(units="", is_dayofyear=1, calendar=get_calendar(prsn))
     return out
 
 
@@ -1721,7 +1721,7 @@ def degree_days_exceedance_date(
         )
 
     out = c.clip(0).resample(time=freq).map(_exceedance_date)
-    out.attrs.update(units="", is_dayofyear=True, calendar=get_calendar(tas))
+    out.attrs.update(units="", is_dayofyear=1, calendar=get_calendar(tas))
     return out
 
 

--- a/xclim/indices/generic.py
+++ b/xclim/indices/generic.py
@@ -92,7 +92,7 @@ def doymax(da: xr.DataArray):
     """Return the day of year of the maximum value."""
     i = da.argmax(dim="time")
     out = da.time.dt.dayofyear[i]
-    out.attrs.update(units="", is_dayofyear=True, calendar=get_calendar(da))
+    out.attrs.update(units="", is_dayofyear=1, calendar=get_calendar(da))
     return out
 
 
@@ -100,7 +100,7 @@ def doymin(da: xr.DataArray):
     """Return the day of year of the minimum value."""
     i = da.argmin(dim="time")
     out = da.time.dt.dayofyear[i]
-    out.attrs.update(units="", is_dayofyear=True, calendar=get_calendar(da))
+    out.attrs.update(units="", is_dayofyear=1, calendar=get_calendar(da))
     return out
 
 

--- a/xclim/testing/tests/test_calendar.py
+++ b/xclim/testing/tests/test_calendar.py
@@ -388,7 +388,7 @@ def test_doy_to_days_since():
         [190, 360, 3],
         dims=("time",),
         coords={"time": time},
-        attrs={"is_dayofyear": True, "calendar": "default"},
+        attrs={"is_dayofyear": 1, "calendar": "default"},
     )
 
     out = doy_to_days_since(da)
@@ -420,7 +420,7 @@ def test_doy_to_days_since():
         dims=("time",),
         coords={"time": time},
         name="da",
-        attrs={"is_dayofyear": True, "calendar": "default"},
+        attrs={"is_dayofyear": 1, "calendar": "default"},
     )
 
     out = doy_to_days_since(da, start="01-02")
@@ -437,7 +437,7 @@ def test_doy_to_days_since():
         dims=("time",),
         coords={"time": time},
         name="da",
-        attrs={"is_dayofyear": True, "calendar": "default"},
+        attrs={"is_dayofyear": 1, "calendar": "default"},
     )
 
     out = doy_to_days_since(da)

--- a/xclim/testing/tests/test_generic.py
+++ b/xclim/testing/tests/test_generic.py
@@ -141,4 +141,4 @@ def test_doyminmax(q_series):
         for attr in ["units", "is_dayofyear", "calendar"]:
             assert attr in da.attrs.keys()
         assert da.attrs["units"] == ""
-        assert da.attrs["is_dayofyear"]
+        assert da.attrs["is_dayofyear"] == 1

--- a/xclim/testing/tests/test_indices.py
+++ b/xclim/testing/tests/test_indices.py
@@ -286,7 +286,7 @@ class TestLastSpringFrost:
         for attr in ["units", "is_dayofyear", "calendar"]:
             assert attr in lsf.attrs.keys()
         assert lsf.attrs["units"] == ""
-        assert lsf.attrs["is_dayofyear"]
+        assert lsf.attrs["is_dayofyear"] == 1
 
 
 class TestFirstDayBelow:
@@ -306,7 +306,7 @@ class TestFirstDayBelow:
         for attr in ["units", "is_dayofyear", "calendar"]:
             assert attr in fdb.attrs.keys()
         assert fdb.attrs["units"] == ""
-        assert fdb.attrs["is_dayofyear"]
+        assert fdb.attrs["is_dayofyear"] == 1
 
 
 class TestFirstDayAbove:
@@ -329,7 +329,7 @@ class TestFirstDayAbove:
         for attr in ["units", "is_dayofyear", "calendar"]:
             assert attr in fdb.attrs.keys()
         assert fdb.attrs["units"] == ""
-        assert fdb.attrs["is_dayofyear"]
+        assert fdb.attrs["is_dayofyear"] == 1
 
 
 class TestDaysOverPrecipThresh:
@@ -394,7 +394,7 @@ class TestFreshetStart:
         for attr in ["units", "is_dayofyear", "calendar"]:
             assert attr in out.attrs.keys()
         assert out.attrs["units"] == ""
-        assert out.attrs["is_dayofyear"]
+        assert out.attrs["is_dayofyear"] == 1
 
     def test_no_start(self, tas_series):
         tg = np.zeros(365) - 1
@@ -434,7 +434,7 @@ class TestGrowingSeasonEnd:
         for attr in ["units", "is_dayofyear", "calendar"]:
             assert attr in gs_end.attrs.keys()
         assert gs_end.attrs["units"] == ""
-        assert gs_end.attrs["is_dayofyear"]
+        assert gs_end.attrs["is_dayofyear"] == 1
 
 
 class TestGrowingSeasonLength:
@@ -1705,7 +1705,7 @@ def test_degree_days_exceedance_date(tas_series):
     for attr in ["units", "is_dayofyear", "calendar"]:
         assert attr in out.attrs.keys()
     assert out.attrs["units"] == ""
-    assert out.attrs["is_dayofyear"]
+    assert out.attrs["is_dayofyear"] == 1
 
 
 @pytest.mark.parametrize("method,exp", [("binary", [1, 1, 1, 1, 1, 0, 0, 0, 0, 0])])
@@ -1735,7 +1735,7 @@ def test_first_snowfall(prsn_series):
     for attr in ["units", "is_dayofyear", "calendar"]:
         assert attr in out.attrs.keys()
     assert out.attrs["units"] == ""
-    assert out.attrs["is_dayofyear"]
+    assert out.attrs["is_dayofyear"] == 1
 
 
 def test_last_snowfall(prsn_series):
@@ -1773,7 +1773,7 @@ def test_continous_snow_cover_start(snd_series):
     for attr in ["units", "is_dayofyear", "calendar"]:
         assert attr in out.attrs.keys()
     assert out.attrs["units"] == ""
-    assert out.attrs["is_dayofyear"]
+    assert out.attrs["is_dayofyear"] == 1
 
 
 def test_continuous_snow_cover_end(snd_series):
@@ -1794,7 +1794,7 @@ def test_continuous_snow_cover_end(snd_series):
     for attr in ["units", "is_dayofyear", "calendar"]:
         assert attr in out.attrs.keys()
     assert out.attrs["units"] == ""
-    assert out.attrs["is_dayofyear"]
+    assert out.attrs["is_dayofyear"] == 1
 
 
 def test_high_precip_low_temp(pr_series, tasmin_series):


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes an untested bug in #694
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (major / minor / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
Changes the recently added `is_dayofyear` attribute from a value of `True` to a value of `1`. This is because netCDF doesn't accept booleans in attributes. netCDF does accept attributes with no value, but xarray does not. Putting a value of 1 seems the unofficial but common way of doing this.

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
Not really.

* **Other information**:
