### PR TITLE
Add pooch to doctests build

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -40,6 +40,7 @@ deps =
     pylint
     pytest
     xdoctest
+    pooch
 setenv = PYTEST_ADDOPTS = "--color=yes"
 commands =
     - mypy xclim


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #706 
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (major / minor / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
Turns out the `doctests` tox environment does not install dependencies from the `docs` extra, contrary to what I believed. Thus, adding `pooch` to the special dependencies of the `doctests` run was needed. xarray's API hopefully remained the same with the new method, except for the deprecation of `file_md5_checksum` that we fixed earlier.

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
No