### PR TITLE
Docstring fixes

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,10 @@ New indicators
 ~~~~~~~~~~~~~~
 * `atmos.corn_heat_units` computes the daily temperature-based index for corn growth.
 
+Internal Changes
+~~~~~~~~~~~~~~~~
+* Added and adjusted typing in call signatures and docstrings, with grammar fixes, for many `xclim.indices` operations.
+
 0.26.1 (2021-05-04)
 -------------------
 * Bug fix release adding `ExtremeValues` to publicly exposed bias-adjustment methods.

--- a/xclim/indices/_anuclim.py
+++ b/xclim/indices/_anuclim.py
@@ -433,6 +433,7 @@ def prcptot(
     return pram.resample(time=freq).sum(dim="time", keep_attrs=True)
 
 
+# FIXME: src_timestep is not used here.
 @declare_units(pr="[precipitation]")
 def prcptot_wetdry_period(
     pr: xarray.DataArray, *, op: str, src_timestep: str, freq: str = "YS"
@@ -481,7 +482,7 @@ def _anuclim_coeff_var(arr: xarray.DataArray) -> xarray.DataArray:
 
 
 def _from_other_arg(
-    criteria: xarray.DataArray, output: xarray.DataArray, op, freq
+    criteria: xarray.DataArray, output: xarray.DataArray, op, freq: str
 ) -> xarray.DataArray:
     """Pick values from output based on operation returning an index from criteria.
 

--- a/xclim/indices/_conversion.py
+++ b/xclim/indices/_conversion.py
@@ -117,9 +117,9 @@ def sfcwind_2_uas_vas(
     Returns
     -------
     uas : xr.DataArray, [m s-1]
-      Eastward wind velocity
+      Eastward wind velocity.
     vas : xr.DataArray, [m s-1]
-      Northward wind velocity
+      Northward wind velocity.
 
     """
     # Converts the wind speed to m s-1
@@ -147,14 +147,14 @@ def sfcwind_2_uas_vas(
 
 @declare_units(tas="[temperature]", ice_thresh="[temperature]")
 def saturation_vapor_pressure(
-    tas: xr.DataArray, ice_thresh: str = None, method: str = "sonntag90"
+    tas: xr.DataArray, ice_thresh: str = None, method: str = "sonntag90"  # noqa
 ) -> xr.DataArray:
     """Saturation vapor pressure from temperature.
 
     Parameters
     ----------
     tas : xr.DataArray
-      Temperature array
+      Temperature array.
     ice_thresh : str
       Threshold temperature under which to switch to equations in reference to ice instead of water.
       If None (default) everything is computed with reference to water.
@@ -164,7 +164,7 @@ def saturation_vapor_pressure(
     Returns
     -------
     xarray.DataArray, [Pa]
-      Saturation vapor pressure
+      Saturation vapor pressure.
 
     Notes
     -----
@@ -279,13 +279,13 @@ def relative_humidity(
     Parameters
     ----------
     tas : xr.DataArray
-      Temperature array
+      Temperature array.
     dtas : xr.DataArray
-      Dewpoint temperature, if specified, overrides huss and ps.
+      Dewpoint temperature (if specified, overrides huss and ps).
     huss : xr.DataArray
-      Specific Humidity
+      Specific Humidity.
     ps : xr.DataArray
-      Air Pressure
+      Air Pressure.
     ice_thresh : str
       Threshold temperature under which to switch to equations in reference to ice instead of water.
       If None (default) everything is computed with reference to water. Does nothing if 'method' is "bohren98".
@@ -293,12 +293,12 @@ def relative_humidity(
       Which method to use, see notes of this function and of `saturation_vapor_pressure`.
     invalid_values : {"clip", "mask", None}
       What to do with values outside the 0-100 range. If "clip" (default), clips everything to 0 - 100,
-      if "mask", replaces values outside the range by np.nan, and if `None` , does nothing.
+      if "mask", replaces values outside the range by np.nan, and if `None`, does nothing.
 
     Returns
     -------
     xr.DataArray, [%]
-      Relative humidity
+      Relative humidity.
 
     Notes
     -----
@@ -393,10 +393,11 @@ def specific_humidity(
     Parameters
     ----------
     tas : xr.DataArray
-      Temperature array
+      Temperature.
     rh : xr.DataArrsay
+      Relative Humidity.
     ps : xr.DataArray
-      Air Pressure
+      Air Pressure.
     ice_thresh : str
       Threshold temperature under which to switch to equations in reference to ice instead of water.
       If None (default) everything is computed with reference to water.
@@ -411,7 +412,7 @@ def specific_humidity(
     Returns
     -------
     xarray.DataArray, [dimensionless]
-      Specific humidity
+      Specific humidity.
 
     Notes
     -----
@@ -459,7 +460,7 @@ def snowfall_approximation(
     tas: xr.DataArray,
     thresh: str = "0 degC",
     method: str = "binary",
-):
+) -> xr.DataArray:
     """Snowfall approximation from total precipitation and temperature.
 
     Solid precipitation estimated from precipitation and temperature according to a given method.
@@ -469,7 +470,7 @@ def snowfall_approximation(
     pr : xarray.DataArray
       Mean daily precipitation flux.
     tas : xarray.DataArray, optional
-      Mean, maximum or minimum daily temperature.
+      Mean, maximum, or minimum daily temperature.
     thresh : str,
       Threshold temperature, used by method "binary".
     method : {"binary"}
@@ -478,7 +479,7 @@ def snowfall_approximation(
     Returns
     -------
     xarray.DataArray, [same units as pr]
-      Solid precipitation flux
+      Solid precipitation flux.
 
     Notes
     -----
@@ -505,7 +506,7 @@ def rain_approximation(
     tas: xr.DataArray,
     thresh: str = "0 degC",
     method: str = "binary",
-):
+) -> xr.DataArray:
     """Rainfall approximation from total precipitation and temperature.
 
     Liquid precipitation estimated from precipitation and temperature according to a given method.
@@ -516,7 +517,7 @@ def rain_approximation(
     pr : xarray.DataArray
       Mean daily precipitation flux.
     tas : xarray.DataArray, optional
-      Mean, maximum or minimum daily temperature.
+      Mean, maximum, or minimum daily temperature.
     thresh : str,
       Threshold temperature, used by method "binary".
     method : {"binary"}
@@ -525,7 +526,7 @@ def rain_approximation(
     Returns
     -------
     xarray.DataArray, [same units as pr]
-      Liquid precipitation rate
+      Liquid precipitation rate.
 
     Notes
     -----

--- a/xclim/indices/_hydrology.py
+++ b/xclim/indices/_hydrology.py
@@ -2,7 +2,7 @@ import numpy as np
 import xarray
 
 from xclim.core.calendar import get_calendar
-from xclim.core.units import declare_units, rate2amount, to_agg_units
+from xclim.core.units import declare_units, rate2amount
 
 from . import generic
 
@@ -150,7 +150,10 @@ def snow_melt_we_max(
     freq : str
       Resampling frequency.
 
-    The maximum snow melt over a given number of days for each period. [mass/area]
+    Returns
+    -------
+    xarray.DataArray
+      The maximum snow melt over a given number of days for each period. [mass/area].
     """
 
     # Compute change in SWE. Set melt as a positive change.
@@ -187,7 +190,7 @@ def melt_and_precip_max(
     Returns
     -------
     xarray.DataArray
-      The maximum snow melt plus precipitation over a given number of days for each period. [mass/area]
+      The maximum snow melt plus precipitation over a given number of days for each period. [mass/area].
     """
 
     # Compute change in SWE. Set melt as a positive change.

--- a/xclim/indices/_multivariate.py
+++ b/xclim/indices/_multivariate.py
@@ -242,7 +242,7 @@ def daily_temperature_range(
 
     Returns
     -------
-    xarray.DataArray, [same as tasmin]
+    xarray.DataArray, [same units as tasmin]
       The average variation in daily temperature range for the given time period.
 
     Notes
@@ -283,7 +283,7 @@ def daily_temperature_range_variability(
 
     Returns
     -------
-    xarray.DataArray, [same as tasmin]
+    xarray.DataArray, [same units as tasmin]
       The average day-to-day variation in daily temperature range for the given time period.
 
     Notes
@@ -323,7 +323,7 @@ def extreme_temperature_range(
 
     Returns
     -------
-    xarray.DataArray, [same as tasmin]
+    xarray.DataArray, [same units as tasmin]
       Extreme intra-period temperature range for the given time period.
 
     Notes
@@ -383,7 +383,7 @@ def heat_wave_frequency(
     Returns
     -------
     xarray.DataArray, [dimensionless]
-      Number of heatwave at the wanted frequency
+      Number of heatwave at the requested frequency.
 
     Notes
     -----
@@ -452,7 +452,7 @@ def heat_wave_max_length(
     Returns
     -------
     xarray.DataArray, [time]
-      Maximum length of heatwave at the wanted frequency
+      Maximum length of heatwave at the requested frequency.
 
     Notes
     -----
@@ -519,7 +519,7 @@ def heat_wave_total_length(
     Returns
     -------
     xarray.DataArray, [time]
-      Total length of heatwave at the wanted frequency
+      Total length of heatwave at the requested frequency.
 
     Notes
     -----
@@ -567,7 +567,7 @@ def liquid_precip_ratio(
     Returns
     -------
     xarray.DataArray, [dimensionless]
-      Ratio of rainfall to total precipitation
+      Ratio of rainfall to total precipitation.
 
     Notes
     -----
@@ -684,7 +684,7 @@ def rain_on_frozen_ground_days(
     Returns
     -------
     xarray.DataArray, [time]
-      The number of rain on frozen ground events per period
+      The number of rain on frozen ground events per period.
 
     Notes
     -----
@@ -796,7 +796,7 @@ def days_over_precip_thresh(
     Returns
     -------
     xarray.DataArray, [time]
-      Count of days with daily precipitation above the given percentile [days]
+      Count of days with daily precipitation above the given percentile [days].
 
     Examples
     --------
@@ -886,7 +886,7 @@ def tg90p(
     Returns
     -------
     xarray.DataArray, [time]
-      Count of days with daily mean temperature below the 10th percentile [days]
+      Count of days with daily mean temperature below the 10th percentile [days].
 
     Notes
     -----
@@ -930,7 +930,7 @@ def tg10p(
     Returns
     -------
     xarray.DataArray, [time]
-      Count of days with daily mean temperature below the 10th percentile [days]
+      Count of days with daily mean temperature below the 10th percentile [days].
 
     Notes
     -----
@@ -974,7 +974,7 @@ def tn90p(
     Returns
     -------
     xarray.DataArray, [time]
-      Count of days with daily minimum temperature below the 10th percentile [days]
+      Count of days with daily minimum temperature below the 10th percentile [days].
 
     Notes
     -----
@@ -1018,7 +1018,7 @@ def tn10p(
     Returns
     -------
     xarray.DataArray, [time]
-      Count of days with daily minimum temperature below the 10th percentile [days]
+      Count of days with daily minimum temperature below the 10th percentile [days].
 
     Notes
     -----
@@ -1062,7 +1062,7 @@ def tx90p(
     Returns
     -------
     xarray.DataArray, [time]
-      Count of days with daily maximum temperature below the 10th percentile [days]
+      Count of days with daily maximum temperature below the 10th percentile [days].
 
     Notes
     -----
@@ -1106,7 +1106,7 @@ def tx10p(
     Returns
     -------
     xarray.DataArray, [time]
-      Count of days with daily maximum temperature below the 10th percentile [days]
+      Count of days with daily maximum temperature below the 10th percentile [days].
 
     Notes
     -----
@@ -1163,9 +1163,7 @@ def tx_tn_days_above(
     Returns
     -------
     xarray.DataArray, [time]
-      the number of days with tasmin > thresh_tasmin and
-      tasmax > thresh_tasamax per period
-
+      the number of days with tasmin > thresh_tasmin and tasmax > thresh_tasmax per period.
 
     Notes
     -----
@@ -1216,7 +1214,7 @@ def warm_spell_duration_index(
     Returns
     -------
     xarray.DataArray, [time]
-      Warm spell duration index
+      Warm spell duration index.
 
     Examples
     --------
@@ -1276,7 +1274,7 @@ def winter_rain_ratio(
     Returns
     -------
     xarray.DataArray
-      Ratio of rainfall to total precipitation during winter months (DJF)
+      Ratio of rainfall to total precipitation during winter months (DJF).
     """
     ratio = liquid_precip_ratio(pr, prsn, tas, freq=freq)
     winter = ratio.indexes["time"].month == 12

--- a/xclim/indices/_simple.py
+++ b/xclim/indices/_simple.py
@@ -31,7 +31,7 @@ __all__ = [
 
 
 @declare_units(tas="[temperature]")
-def tg_max(tas: xarray.DataArray, freq: str = "YS"):
+def tg_max(tas: xarray.DataArray, freq: str = "YS") -> xarray.DataArray:
     r"""Highest mean temperature.
 
     The maximum of daily mean temperature.
@@ -61,7 +61,7 @@ def tg_max(tas: xarray.DataArray, freq: str = "YS"):
 
 
 @declare_units(tas="[temperature]")
-def tg_mean(tas: xarray.DataArray, freq: str = "YS"):
+def tg_mean(tas: xarray.DataArray, freq: str = "YS") -> xarray.DataArray:
     r"""Mean of daily average temperature.
 
     Resample the original daily mean temperature series by taking the mean over each period.
@@ -101,7 +101,7 @@ def tg_mean(tas: xarray.DataArray, freq: str = "YS"):
 
 
 @declare_units(tas="[temperature]")
-def tg_min(tas: xarray.DataArray, freq: str = "YS"):
+def tg_min(tas: xarray.DataArray, freq: str = "YS") -> xarray.DataArray:
     r"""Lowest mean temperature.
 
     Minimum of daily mean temperature.
@@ -131,7 +131,7 @@ def tg_min(tas: xarray.DataArray, freq: str = "YS"):
 
 
 @declare_units(tasmin="[temperature]")
-def tn_max(tasmin: xarray.DataArray, freq: str = "YS"):
+def tn_max(tasmin: xarray.DataArray, freq: str = "YS") -> xarray.DataArray:
     r"""Highest minimum temperature.
 
     The maximum of daily minimum temperature.
@@ -161,7 +161,7 @@ def tn_max(tasmin: xarray.DataArray, freq: str = "YS"):
 
 
 @declare_units(tasmin="[temperature]")
-def tn_mean(tasmin: xarray.DataArray, freq: str = "YS"):
+def tn_mean(tasmin: xarray.DataArray, freq: str = "YS") -> xarray.DataArray:
     r"""Mean minimum temperature.
 
     Mean of daily minimum temperature.
@@ -192,7 +192,7 @@ def tn_mean(tasmin: xarray.DataArray, freq: str = "YS"):
 
 
 @declare_units(tasmin="[temperature]")
-def tn_min(tasmin: xarray.DataArray, freq: str = "YS"):
+def tn_min(tasmin: xarray.DataArray, freq: str = "YS") -> xarray.DataArray:
     r"""Lowest minimum temperature.
 
     Minimum of daily minimum temperature.
@@ -222,7 +222,7 @@ def tn_min(tasmin: xarray.DataArray, freq: str = "YS"):
 
 
 @declare_units(tasmax="[temperature]")
-def tx_max(tasmax: xarray.DataArray, freq: str = "YS"):
+def tx_max(tasmax: xarray.DataArray, freq: str = "YS") -> xarray.DataArray:
     r"""Highest max temperature.
 
     The maximum value of daily maximum temperature.
@@ -252,7 +252,7 @@ def tx_max(tasmax: xarray.DataArray, freq: str = "YS"):
 
 
 @declare_units(tasmax="[temperature]")
-def tx_mean(tasmax: xarray.DataArray, freq: str = "YS"):
+def tx_mean(tasmax: xarray.DataArray, freq: str = "YS") -> xarray.DataArray:
     r"""Mean max temperature.
 
     The mean of daily maximum temperature.
@@ -283,7 +283,7 @@ def tx_mean(tasmax: xarray.DataArray, freq: str = "YS"):
 
 
 @declare_units(tasmax="[temperature]")
-def tx_min(tasmax: xarray.DataArray, freq: str = "YS"):
+def tx_min(tasmax: xarray.DataArray, freq: str = "YS") -> xarray.DataArray:
     r"""Lowest max temperature.
 
     The minimum of daily maximum temperature.
@@ -313,7 +313,9 @@ def tx_min(tasmax: xarray.DataArray, freq: str = "YS"):
 
 
 @declare_units(tasmin="[temperature]", thresh="[temperature]")
-def frost_days(tasmin: xarray.DataArray, thresh: str = "0 degC", freq: str = "YS"):
+def frost_days(
+    tasmin: xarray.DataArray, thresh: str = "0 degC", freq: str = "YS"
+) -> xarray.DataArray:
     r"""Frost days index.
 
     Number of days where daily minimum temperatures are below 0℃.
@@ -349,7 +351,7 @@ def frost_days(tasmin: xarray.DataArray, thresh: str = "0 degC", freq: str = "YS
 @declare_units(tasmax="[temperature]", thresh="[temperature]")
 def ice_days(
     tasmax: xarray.DataArray, thresh: str = "0 degC", freq: str = "YS"
-):  # noqa: D401
+) -> xarray.DataArray:  # noqa: D401
     r"""Number of ice/freezing days.
 
     Number of days where daily maximum temperatures are below 0℃.
@@ -383,7 +385,9 @@ def ice_days(
 
 
 @declare_units(pr="[precipitation]")
-def max_1day_precipitation_amount(pr: xarray.DataArray, freq: str = "YS"):
+def max_1day_precipitation_amount(
+    pr: xarray.DataArray, freq: str = "YS"
+) -> xarray.DataArray:
     r"""Highest 1-day precipitation amount for a period (frequency).
 
     Resample the original daily total precipitation temperature series by taking the max over each period.
@@ -423,7 +427,7 @@ def max_1day_precipitation_amount(pr: xarray.DataArray, freq: str = "YS"):
 @declare_units(pr="[precipitation]")
 def max_n_day_precipitation_amount(
     pr: xarray.DataArray, window: int = 1, freq: str = "YS"
-):
+) -> xarray.DataArray:
     r"""Highest precipitation amount cumulated over a n-day moving window.
 
     Calculate the n-day rolling sum of the original daily total precipitation series
@@ -462,7 +466,9 @@ def max_n_day_precipitation_amount(
 
 
 @declare_units(pr="[precipitation]")
-def max_pr_intensity(pr: xarray.DataArray, window: int = 1, freq: str = "YS"):
+def max_pr_intensity(
+    pr: xarray.DataArray, window: int = 1, freq: str = "YS"
+) -> xarray.DataArray:
     r"""Highest precipitation intensity over a n-hour moving window.
 
     Calculate the n-hour rolling average of the original hourly total precipitation series

--- a/xclim/indices/_threshold.py
+++ b/xclim/indices/_threshold.py
@@ -72,7 +72,7 @@ def cold_spell_days(
     thresh: str = "-10 degC",
     window: int = 5,
     freq: str = "AS-JUL",
-):
+) -> xarray.DataArray:
     r"""Cold spell days.
 
     The number of days that are part of cold spell events, defined as a sequence of consecutive days with mean daily
@@ -120,7 +120,7 @@ def cold_spell_frequency(
     thresh: str = "-10 degC",
     window: int = 5,
     freq: str = "AS-JUL",
-):
+) -> xarray.DataArray:
     r"""Cold spell frequency.
 
     The number of cold spell events, defined as a sequence of consecutive days with mean daily
@@ -247,7 +247,7 @@ def continuous_snow_cover_start(
 @declare_units(pr="[precipitation]", thresh="[precipitation]")
 def daily_pr_intensity(
     pr: xarray.DataArray, thresh: str = "1 mm/day", freq: str = "YS"
-):
+) -> xarray.DataArray:
     r"""Average daily precipitation intensity.
 
     Return the average precipitation over wet days.
@@ -307,7 +307,9 @@ def daily_pr_intensity(
 
 
 @declare_units(pr="[precipitation]", thresh="[precipitation]")
-def dry_days(pr: xarray.DataArray, thresh: str = "0.2 mm/d", freq: str = "YS"):
+def dry_days(
+    pr: xarray.DataArray, thresh: str = "0.2 mm/d", freq: str = "YS"
+) -> xarray.DataArray:
     r"""Dry days.
 
     The number of days with daily precipitation below threshold.
@@ -344,7 +346,7 @@ def dry_days(pr: xarray.DataArray, thresh: str = "0.2 mm/d", freq: str = "YS"):
 @declare_units(pr="[precipitation]", thresh="[precipitation]")
 def maximum_consecutive_wet_days(
     pr: xarray.DataArray, thresh: str = "1 mm/day", freq: str = "YS"
-):
+) -> xarray.DataArray:
     r"""Consecutive wet days.
 
     Returns the maximum number of consecutive wet days.
@@ -389,7 +391,7 @@ def maximum_consecutive_wet_days(
 @declare_units(tas="[temperature]", thresh="[temperature]")
 def cooling_degree_days(
     tas: xarray.DataArray, thresh: str = "18 degC", freq: str = "YS"
-):
+) -> xarray.DataArray:
     r"""Cooling degree days.
 
     Sum of degree days above the temperature threshold at which spaces are cooled.
@@ -429,7 +431,7 @@ def cooling_degree_days(
 @declare_units(tas="[temperature]", thresh="[temperature]")
 def freshet_start(
     tas: xarray.DataArray, thresh: str = "0 degC", window: int = 5, freq: str = "YS"
-):
+) -> xarray.DataArray:
     r"""First day consistently exceeding threshold temperature.
 
     Returns first day of period where a temperature threshold is exceeded
@@ -474,7 +476,7 @@ def freshet_start(
 @declare_units(tas="[temperature]", thresh="[temperature]")
 def growing_degree_days(
     tas: xarray.DataArray, thresh: str = "4.0 degC", freq: str = "YS"
-):
+) -> xarray.DataArray:
     r"""Growing degree-days over threshold temperature value.
 
     The sum of degree-days over the threshold temperature.
@@ -514,7 +516,7 @@ def growing_season_end(
     mid_date: DayOfYearStr = "07-01",
     window: int = 5,
     freq: str = "YS",
-):
+) -> xarray.DataArray:
     r"""End of the growing season.
 
     Day of the year of the start of a sequence of days with a temperature consistently
@@ -561,7 +563,7 @@ def growing_season_length(
     window: int = 6,
     mid_date: DayOfYearStr = "07-01",
     freq: str = "YS",
-):
+) -> xarray.DataArray:
     r"""Growing season length.
 
     The number of days between the first occurrence of at least six consecutive days
@@ -635,7 +637,7 @@ def frost_season_length(
     mid_date: Optional[DayOfYearStr] = "01-01",
     thresh: str = "0.0 degC",
     freq: str = "AS-JUL",
-):
+) -> xarray.DataArray:
     r"""Frost season length.
 
     The number of days between the first occurrence of at least N (def: 5) consecutive days
@@ -708,7 +710,7 @@ def last_spring_frost(
     before_date: DayOfYearStr = "07-01",
     window: int = 1,
     freq: str = "YS",
-):
+) -> xarray.DataArray:
     r"""Last day of temperatures inferior to a threshold temperature.
 
     Returns last day of period where a temperature is inferior to a threshold
@@ -731,7 +733,7 @@ def last_spring_frost(
     -------
     xarray.DataArray, [dimensionless]
       Day of the year when temperature is inferior to a threshold over a given number of days for the first time.
-      If there is no such day, return np.nan.
+      If there is no such day, returns np.nan.
     """
     thresh = convert_units_to(thresh, tas)
     cond = tas < thresh
@@ -754,7 +756,7 @@ def first_day_below(
     after_date: DayOfYearStr = "07-01",
     window: int = 1,
     freq: str = "YS",
-):
+) -> xarray.DataArray:
     r"""First day of temperatures inferior to a threshold temperature.
 
     Returns first day of period where a temperature is inferior to a threshold
@@ -779,7 +781,7 @@ def first_day_below(
     -------
     xarray.DataArray, [dimensionless]
       Day of the year when minimum temperature is inferior to a threshold over a given number of days for the first time.
-      If there is no such day, return np.nan.
+      If there is no such day, returns np.nan.
     """
     thresh = convert_units_to(thresh, tasmin)
     cond = tasmin < thresh
@@ -802,7 +804,7 @@ def first_day_above(
     after_date: DayOfYearStr = "01-01",
     window: int = 1,
     freq: str = "YS",
-):
+) -> xarray.DataArray:
     r"""First day of temperatures superior to a threshold temperature.
 
     Returns first day of period where a temperature is superior to a threshold
@@ -827,7 +829,7 @@ def first_day_above(
     -------
     xarray.DataArray, [dimensionless]
       Day of the year when minimum temperature is superior to a threshold over a given number of days for the first time.
-      If there is no such day, return np.nan.
+      If there is no such day, returns np.nan.
     """
     thresh = convert_units_to(thresh, tasmin)
     cond = tasmin > thresh
@@ -848,7 +850,7 @@ def first_snowfall(
     prsn: xarray.DataArray,
     thresh: str = "0.5 mm/day",
     freq: str = "AS-JUL",
-):
+) -> xarray.DataArray:
     r"""First day with solid precipitation above a threshold.
 
     Returns the first day of a period where the solid precipitation exceeds a threshold.
@@ -866,8 +868,8 @@ def first_snowfall(
     Returns
     -------
     xarray.DataArray, [dimensionless]
-      First day of the year when the solid precipitation  is superior to a threshold,
-      If there is no such day, return np.nan.
+      First day of the year when the solid precipitation is superior to a threshold.
+      If there is no such day, returns np.nan.
 
     References
     ----------
@@ -892,7 +894,7 @@ def last_snowfall(
     prsn: xarray.DataArray,
     thresh: str = "0.5 mm/day",
     freq: str = "AS-JUL",
-):
+) -> xarray.DataArray:
     r"""Last day with solid precipitation above a threshold.
 
     Returns the last day of a period where the solid precipitation exceeds a threshold.
@@ -910,8 +912,8 @@ def last_snowfall(
     Returns
     -------
     xarray.DataArray, [dimensionless]
-      Last day of the year when the solid precipitation is superior to a threshold,
-      If there is no such day, return np.nan.
+      Last day of the year when the solid precipitation is superior to a threshold.
+      If there is no such day, returns np.nan.
 
     References
     ----------
@@ -937,7 +939,7 @@ def days_with_snow(
     low: str = "0 kg m-2 s-1",
     high: str = "1E6 kg m-2 s-1",
     freq: str = "AS-JUL",
-):
+) -> xarray.DataArray:
     r"""Days with snow.
 
     Return the number of days where snowfall is within low and high thresholds.
@@ -976,7 +978,7 @@ def heat_wave_index(
     thresh: str = "25.0 degC",
     window: int = 5,
     freq: str = "YS",
-):
+) -> xarray.DataArray:
     """Heat wave index.
 
     Number of days that are part of a heatwave, defined as five or more consecutive days over 25℃.
@@ -1008,7 +1010,7 @@ def heat_wave_index(
 @declare_units(tas="[temperature]", thresh="[temperature]")
 def heating_degree_days(
     tas: xarray.DataArray, thresh: str = "17.0 degC", freq: str = "YS"
-):
+) -> xarray.DataArray:
     r"""Heating degree days.
 
     Sum of degree days below the temperature threshold at which spaces are heated.
@@ -1187,8 +1189,8 @@ def snow_cover_duration(
 @declare_units(tasmin="[temperature]", thresh="[temperature]")
 def tn_days_below(
     tasmin: xarray.DataArray, thresh: str = "-10.0 degC", freq: str = "YS"
-):  # noqa: D401
-    """Number of days with tmin below a threshold.
+) -> xarray.DataArray:  # noqa: D401
+    """Number of days with tasmin below a threshold.
 
     Number of days where daily minimum temperature is below a threshold.
 
@@ -1204,7 +1206,7 @@ def tn_days_below(
     Returns
     -------
     xarray.DataArray, [time]
-      Number of days Tmin < threshold.
+      The number of days with tasmin < threshold per period.
 
     Notes
     -----
@@ -1223,7 +1225,7 @@ def tn_days_below(
 @declare_units(tasmax="[temperature]", thresh="[temperature]")
 def tx_days_above(
     tasmax: xarray.DataArray, thresh: str = "25.0 degC", freq: str = "YS"
-):  # noqa: D401
+) -> xarray.DataArray:  # noqa: D401
     """Number of summer days.
 
     Number of days where daily maximum temperature exceed a threshold.
@@ -1240,7 +1242,7 @@ def tx_days_above(
     Returns
     -------
     xarray.DataArray, [time]
-      Number of summer days.
+      Number of summer days (number of days with tasmax > threshold per period).
 
     Notes
     -----
@@ -1259,7 +1261,7 @@ def tx_days_above(
 @declare_units(tasmax="[temperature]", thresh="[temperature]")
 def warm_day_frequency(
     tasmax: xarray.DataArray, thresh: str = "30 degC", freq: str = "YS"
-):
+) -> xarray.DataArray:
     """Frequency of extreme warm days.
 
     Return the number of days with tasmax > thresh per period
@@ -1276,7 +1278,7 @@ def warm_day_frequency(
     Returns
     -------
     xarray.DataArray, [time]
-      Number of days exceeding threshold.
+      Number of days with tasmax > threshold per period.
 
     Notes
     -----
@@ -1296,7 +1298,7 @@ def warm_day_frequency(
 @declare_units(tasmin="[temperature]", thresh="[temperature]")
 def warm_night_frequency(
     tasmin: xarray.DataArray, thresh: str = "22 degC", freq: str = "YS"
-):
+) -> xarray.DataArray:
     """Frequency of extreme warm nights.
 
     Return the number of days with tasmin > thresh per period
@@ -1313,7 +1315,7 @@ def warm_night_frequency(
     Returns
     -------
     xarray.DataArray, [time]
-      The number of days with tasmin > thresh per period
+      Number of days with tasmin > threshold per period.
     """
     thresh = convert_units_to(thresh, tasmin)
     events = threshold_count(tasmin, ">", thresh, freq)
@@ -1321,7 +1323,9 @@ def warm_night_frequency(
 
 
 @declare_units(pr="[precipitation]", thresh="[precipitation]")
-def wetdays(pr: xarray.DataArray, thresh: str = "1.0 mm/day", freq: str = "YS"):
+def wetdays(
+    pr: xarray.DataArray, thresh: str = "1.0 mm/day", freq: str = "YS"
+) -> xarray.DataArray:
     """Wet days.
 
     Return the total number of days during period with precipitation over threshold.
@@ -1338,7 +1342,7 @@ def wetdays(pr: xarray.DataArray, thresh: str = "1.0 mm/day", freq: str = "YS"):
     Returns
     -------
     xarray.DataArray, [time]
-      The number of wet days for each period [day]
+      The number of wet days for each period [day].
 
     Examples
     --------
@@ -1360,7 +1364,7 @@ def maximum_consecutive_frost_days(
     tasmin: xarray.DataArray,
     thresh: str = "0.0 degC",
     freq: str = "AS-JUL",
-):
+) -> xarray.DataArray:
     r"""Maximum number of consecutive frost days (Tn < 0℃).
 
     The maximum number of consecutive days within the period where the
@@ -1379,7 +1383,7 @@ def maximum_consecutive_frost_days(
     Returns
     -------
     xarray.DataArray, [time]
-      The maximum number of consecutive frost days.
+      The maximum number of consecutive frost days (tasmin < threshold per period).
 
     Notes
     -----
@@ -1404,7 +1408,7 @@ def maximum_consecutive_frost_days(
 @declare_units(pr="[precipitation]", thresh="[precipitation]")
 def maximum_consecutive_dry_days(
     pr: xarray.DataArray, thresh: str = "1 mm/day", freq: str = "YS"
-):
+) -> xarray.DataArray:
     r"""Maximum number of consecutive dry days.
 
     Return the maximum number of consecutive days within the period where precipitation
@@ -1422,7 +1426,7 @@ def maximum_consecutive_dry_days(
     Returns
     -------
     xarray.DataArray, [time]
-      The maximum number of consecutive dry days.
+      The maximum number of consecutive dry days (precipitation < threshold per period).
 
     Notes
     -----
@@ -1447,7 +1451,7 @@ def maximum_consecutive_dry_days(
 @declare_units(tasmin="[temperature]", thresh="[temperature]")
 def maximum_consecutive_frost_free_days(
     tasmin: xarray.DataArray, thresh: str = "0 degC", freq: str = "YS"
-):
+) -> xarray.DataArray:
     r"""Maximum number of consecutive frost free days (Tn > 0℃).
 
     Return the maximum number of consecutive days within the period where the
@@ -1465,7 +1469,7 @@ def maximum_consecutive_frost_free_days(
     Returns
     -------
     xarray.DataArray, [time]
-      The maximum number of consecutive frost free days.
+      The maximum number of consecutive frost free days (tasmin > threshold per period).
 
     Notes
     -----
@@ -1490,7 +1494,7 @@ def maximum_consecutive_frost_free_days(
 @declare_units(tasmax="[temperature]", thresh="[temperature]")
 def maximum_consecutive_tx_days(
     tasmax: xarray.DataArray, thresh: str = "25 degC", freq: str = "YS"
-):
+) -> xarray.DataArray:
     r"""Maximum number of consecutive summer days.
 
     Return the maximum number of consecutive days within the period where
@@ -1508,7 +1512,7 @@ def maximum_consecutive_tx_days(
     Returns
     -------
     xarray.DataArray, [time]
-      The maximum number of consecutive summer days.
+      The maximum number of consecutive summer days (tasmax > threshold per period).
 
     Notes
     -----
@@ -1531,7 +1535,9 @@ def maximum_consecutive_tx_days(
 
 
 @declare_units(sic="[]", area="[area]", thresh="[]")
-def sea_ice_area(sic: xarray.DataArray, area: xarray.DataArray, thresh: str = "15 pct"):
+def sea_ice_area(
+    sic: xarray.DataArray, area: xarray.DataArray, thresh: str = "15 pct"
+) -> xarray.DataArray:
     """Total sea ice area.
 
     Sea ice area measures the total sea ice covered area where sea ice concentration is above a threshold,
@@ -1549,7 +1555,7 @@ def sea_ice_area(sic: xarray.DataArray, area: xarray.DataArray, thresh: str = "1
     Returns
     -------
     xarray.DataArray, [length]^2
-        Sea ice area
+      Sea ice area.
 
     Notes
     -----
@@ -1571,7 +1577,7 @@ def sea_ice_area(sic: xarray.DataArray, area: xarray.DataArray, thresh: str = "1
 @declare_units(sic="[]", area="[area]", thresh="[]")
 def sea_ice_extent(
     sic: xarray.DataArray, area: xarray.DataArray, thresh: str = "15 pct"
-):
+) -> xarray.DataArray:
     """Total sea ice extent.
 
     Sea ice extent measures the *ice-covered* area, where a region is considered ice-covered if its sea ice
@@ -1589,7 +1595,7 @@ def sea_ice_extent(
     Returns
     -------
     xarray.DataArray, [length]^2
-        Sea ice extent
+      Sea ice extent.
 
     Notes
     -----
@@ -1611,7 +1617,7 @@ def tropical_nights(
     tasmin: xarray.DataArray,
     thresh: str = "20.0 degC",
     freq: str = "YS",
-):
+) -> xarray.DataArray:
     """Tropical nights.
 
     The number of days with minimum daily temperature above threshold.
@@ -1652,7 +1658,7 @@ def degree_days_exceedance_date(
     op: str = ">",
     after_date: DayOfYearStr = None,
     freq: str = "YS",
-):
+) -> xarray.DataArray:
     r"""Degree days exceedance date.
 
     Day of year when the sum of degree days exceeds a threshold. Degree days are
@@ -1678,7 +1684,7 @@ def degree_days_exceedance_date(
     Returns
     -------
     xarray.DataArray, [dimensionless]
-      Degree days exceedance date
+      Degree-days exceedance date.
 
     Notes
     -----
@@ -1726,9 +1732,10 @@ def degree_days_exceedance_date(
 
 
 @declare_units(snd="[length]", thresh="[length]")
-def winter_storm(snd: xarray.DataArray, thresh: str = "25 cm", freq="AS-JUL"):
-    """
-    Days with snowfall over threshold.
+def winter_storm(
+    snd: xarray.DataArray, thresh: str = "25 cm", freq: str = "AS-JUL"
+) -> xarray.DataArray:
+    """Days with snowfall over threshold.
 
     Number of days with snowfall accumulation greater or equal to threshold.
 

--- a/xclim/indices/generic.py
+++ b/xclim/indices/generic.py
@@ -88,7 +88,7 @@ def select_resample_op(da: xr.DataArray, op: str, freq: str = "YS", **indexer):
     return r.map(op)
 
 
-def doymax(da: xr.DataArray):
+def doymax(da: xr.DataArray) -> xr.DataArray:
     """Return the day of year of the maximum value."""
     i = da.argmax(dim="time")
     out = da.time.dt.dayofyear[i]
@@ -96,7 +96,7 @@ def doymax(da: xr.DataArray):
     return out
 
 
-def doymin(da: xr.DataArray):
+def doymin(da: xr.DataArray) -> xr.DataArray:
     """Return the day of year of the minimum value."""
     i = da.argmin(dim="time")
     out = da.time.dt.dayofyear[i]
@@ -104,7 +104,7 @@ def doymin(da: xr.DataArray):
     return out
 
 
-def default_freq(**indexer):
+def default_freq(**indexer) -> str:
     """Return the default frequency."""
     freq = "AS-JAN"
     if indexer:
@@ -302,7 +302,7 @@ def daily_downsampler(da: xr.DataArray, freq: str = "YS") -> xr.DataArray:
 
 def count_level_crossings(
     low_data: xr.DataArray, high_data: xr.DataArray, threshold: str, freq: str
-):
+) -> xr.DataArray:
     """Calculate the number of times low_data is below threshold while high_data is above threshold.
 
     First, the threshold is transformed to the same standard_name and units as the input data,
@@ -318,6 +318,10 @@ def count_level_crossings(
       Quantity.
     freq: str
       Resampling frequency.
+
+    Returns
+    -------
+    xarray.DataArray
     """
     # Convert units to low_data
     high_data = convert_units_to(high_data, low_data)
@@ -330,7 +334,9 @@ def count_level_crossings(
     return to_agg_units(out, low_data, "count", dim="time")
 
 
-def count_occurrences(data: xr.DataArray, threshold: str, condition: str, freq: str):
+def count_occurrences(
+    data: xr.DataArray, threshold: str, condition: str, freq: str
+) -> xr.DataArray:
     """Calculate the number of times some condition is met.
 
     First, the threshold is transformed to the same standard_name and units as the input data.
@@ -347,6 +353,10 @@ def count_occurrences(data: xr.DataArray, threshold: str, condition: str, freq: 
       Operator.
     freq: str
       Resampling frequency.
+
+    Returns
+    -------
+    xarray.DataArray
     """
     threshold = convert_units_to(threshold, data)
 
@@ -358,7 +368,7 @@ def count_occurrences(data: xr.DataArray, threshold: str, condition: str, freq: 
 
 def diurnal_temperature_range(
     low_data: xr.DataArray, high_data: xr.DataArray, freq: str
-):
+) -> xr.DataArray:
     """Calculate the average diurnal temperature range.
 
     Parameters
@@ -369,6 +379,10 @@ def diurnal_temperature_range(
       Highest daily temperature (tasmax).
     freq: str
       Resampling frequency.
+
+    Returns
+    -------
+    xarray.DataArray
     """
     high_data = convert_units_to(high_data, low_data)
 
@@ -380,7 +394,9 @@ def diurnal_temperature_range(
     return out
 
 
-def first_occurence(data: xr.DataArray, threshold: str, condition: str, freq: str):
+def first_occurence(
+    data: xr.DataArray, threshold: str, condition: str, freq: str
+) -> xr.DataArray:
     """Calculate the first time some condition is met.
 
     First, the threshold is transformed to the same standard_name and units as the input data.
@@ -396,6 +412,10 @@ def first_occurence(data: xr.DataArray, threshold: str, condition: str, freq: st
       Operator
     freq : str
       Resampling frequency.
+
+    Returns
+    -------
+    xarray.DataArray
     """
     threshold = convert_units_to(threshold, data)
 
@@ -411,7 +431,9 @@ def first_occurence(data: xr.DataArray, threshold: str, condition: str, freq: st
     return out
 
 
-def last_occurence(data: xr.DataArray, threshold: str, condition: str, freq: str):
+def last_occurence(
+    data: xr.DataArray, threshold: str, condition: str, freq: str
+) -> xr.DataArray:
     """Calculate the last time some condition is met.
 
     First, the threshold is transformed to the same standard_name and units as the input data.
@@ -427,6 +449,10 @@ def last_occurence(data: xr.DataArray, threshold: str, condition: str, freq: str
       Operator
     freq : str
       Resampling frequency.
+
+    Returns
+    -------
+    xarray.DataArray
     """
     threshold = convert_units_to(threshold, data)
 
@@ -444,7 +470,7 @@ def last_occurence(data: xr.DataArray, threshold: str, condition: str, freq: str
 
 def spell_length(
     data: xr.DataArray, threshold: str, condition: str, reducer: str, freq: str
-):
+) -> xr.DataArray:
     """Calculate statistics on lengths of spells.
 
     First, the threshold is transformed to the same standard_name and units as the input data.
@@ -462,6 +488,10 @@ def spell_length(
       Reducer.
     freq : str
       Resampling frequency.
+
+    Returns
+    -------
+    xarray.DataArray
     """
     threshold = convert_units_to(threshold, data)
 
@@ -475,7 +505,7 @@ def spell_length(
     return to_agg_units(out, data, "count")
 
 
-def statistics(data: xr.DataArray, reducer: str, freq: str):
+def statistics(data: xr.DataArray, reducer: str, freq: str) -> xr.DataArray:
     """Calculate a simple statistic of the data.
 
     Parameters
@@ -485,6 +515,10 @@ def statistics(data: xr.DataArray, reducer: str, freq: str):
       Reducer.
     freq : str
       Resampling frequency.
+
+    Returns
+    -------
+    xarray.DataArray
     """
     out = getattr(data.resample(time=freq), reducer)()
     out.attrs["units"] = data.attrs["units"]
@@ -493,7 +527,7 @@ def statistics(data: xr.DataArray, reducer: str, freq: str):
 
 def thresholded_statistics(
     data: xr.DataArray, threshold: str, condition: str, reducer: str, freq: str
-):
+) -> xr.DataArray:
     """Calculate a simple statistic of the data for which some condition is met.
 
     First, the threshold is transformed to the same standard_name and units as the input data.
@@ -511,6 +545,10 @@ def thresholded_statistics(
       Reducer.
     freq : str
       Resampling frequency.
+
+    Returns
+    -------
+    xarray.DataArray
     """
     threshold = convert_units_to(threshold, data)
 
@@ -521,7 +559,9 @@ def thresholded_statistics(
     return out
 
 
-def temperature_sum(data: xr.DataArray, threshold: str, condition: str, freq: str):
+def temperature_sum(
+    data: xr.DataArray, threshold: str, condition: str, freq: str
+) -> xr.DataArray:
     """Calculate the temperature sum above/below a threshold.
 
     First, the threshold is transformed to the same standard_name and units as the input data.
@@ -538,6 +578,10 @@ def temperature_sum(data: xr.DataArray, threshold: str, condition: str, freq: st
       Operator
     freq : str
       Resampling frequency.
+
+    Returns
+    -------
+    xarray.DataArray
     """
     threshold = convert_units_to(threshold, data)
 
@@ -551,7 +595,7 @@ def temperature_sum(data: xr.DataArray, threshold: str, condition: str, freq: st
 
 def interday_diurnal_temperature_range(
     low_data: xr.DataArray, high_data: xr.DataArray, freq: str
-):
+) -> xr.DataArray:
     """Calculate the average absolute day-to-day difference in diurnal temperature range.
 
     Parameters
@@ -562,6 +606,10 @@ def interday_diurnal_temperature_range(
       Highest daily temperature (tasmax).
     freq: str
       Resampling frequency.
+
+    Returns
+    -------
+    xarray.DataArray
     """
     high_data = convert_units_to(high_data, low_data)
 
@@ -575,7 +623,7 @@ def interday_diurnal_temperature_range(
 
 def extreme_temperature_range(
     low_data: xr.DataArray, high_data: xr.DataArray, freq: str
-):
+) -> xr.DataArray:
     """Calculate the extreme temperature range as the maximum of daily maximum temperature minus the minimum of daily minimum temperature.
 
     Parameters
@@ -586,6 +634,10 @@ def extreme_temperature_range(
       Highest daily temperature (tasmax).
     freq: str
       Resampling frequency.
+
+    Returns
+    -------
+    xarray.DataArray
     """
     high_data = convert_units_to(high_data, low_data)
 

--- a/xclim/indices/run_length.py
+++ b/xclim/indices/run_length.py
@@ -12,6 +12,7 @@ from typing import Optional, Sequence, Tuple, Union
 from warnings import warn
 
 import numpy as np
+import xarray
 import xarray as xr
 from dask import array as dsk
 
@@ -26,7 +27,7 @@ def get_npts(da: xr.DataArray) -> int:
     Parameters
     ----------
     da : xarray.DataArray
-      N-dimensional input array
+      N-dimensional input array.
 
     Returns
     -------
@@ -114,7 +115,7 @@ def rle_statistics(
     Parameters
     ----------
     da : xr.DataArray
-      N-dimensional array (boolean)
+      N-dimensional array (boolean).
     reducer: str
       Name of the reducing function.
     dim : str
@@ -179,7 +180,7 @@ def windowed_run_events(
     Parameters
     ----------
     da: xr.DataArray
-      Input N-dimensional DataArray (boolean)
+      Input N-dimensional DataArray (boolean).
     window : int
       Minimum run length.
     dim : str
@@ -230,7 +231,7 @@ def windowed_run_count(
     Returns
     -------
     xr.DataArray
-      Total number of true values part of a consecutive runs of at least `window` long.
+      Total number of `True` values part of a consecutive runs of at least `window` long.
     """
     if ufunc_1dim == "auto":
         npts = get_npts(da)
@@ -256,7 +257,7 @@ def first_run(
     Parameters
     ----------
     da : xr.DataArray
-      Input N-dimensional DataArray (boolean)
+      Input N-dimensional DataArray (boolean).
     window : int
       Minimum duration of consecutive run to accumulate values.
     dim : str
@@ -273,7 +274,8 @@ def first_run(
     Returns
     -------
     xr.DataArray
-      Index (or coordinate if `coord` is not False) of first item in first valid run. Returns np.nan if there are no valid run.
+      Index (or coordinate if `coord` is not False) of first item in first valid run.
+      Returns np.nan if there are no valid runs.
     """
     if ufunc_1dim == "auto":
         if isinstance(da.data, dsk.Array) and len(da.chunks[da.dims.index(dim)]) > 1:
@@ -322,7 +324,7 @@ def last_run(
     Parameters
     ----------
     da : xr.DataArray
-      Input N-dimensional DataArray (boolean)
+      Input N-dimensional DataArray (boolean).
     window : int
       Minimum duration of consecutive run to accumulate values.
     dim : str
@@ -339,7 +341,8 @@ def last_run(
     Returns
     -------
     xr.DataArray
-      Index (or coordinate if `coord` is not False) of last item in last valid run. Returns np.nan if there are no valid run.
+      Index (or coordinate if `coord` is not False) of last item in last valid run.
+      Returns np.nan if there are no valid runs.
     """
     reversed_da = da.sortby(dim, ascending=False)
     out = first_run(
@@ -421,7 +424,7 @@ def keep_longest_run(da: xr.DataArray, dim: str = "time") -> xr.DataArray:
     Parameters
     ----------
     da : xr.DataArray
-      Boolean array
+      Boolean array.
     dim : str
       Dimension along which to check for the longest run.
 
@@ -458,7 +461,7 @@ def season(
     Parameters
     ----------
     da : xr.DataArray
-      Input N-dimensional DataArray (boolean)
+      Input N-dimensional DataArray (boolean).
     window : int
       Minimum duration of consecutive values to start and end the season.
     date: DayOfYearStr, optional
@@ -575,7 +578,7 @@ def season_length(
     Parameters
     ----------
     da : xr.DataArray
-      Input N-dimensional DataArray (boolean)
+      Input N-dimensional DataArray (boolean).
     window : int
       Minimum duration of consecutive values to start and end the season.
     date: DayOfYearStr, optional
@@ -616,7 +619,7 @@ def run_end_after_date(
     Parameters
     ----------
     da : xr.DataArray
-      Input N-dimensional DataArray (boolean)
+      Input N-dimensional DataArray (boolean).
     window : int
       Minimum duration of consecutive run to accumulate values.
     date : str
@@ -631,7 +634,8 @@ def run_end_after_date(
     Returns
     -------
     xr.DataArray
-      Index (or coordinate if `coord` is not False) of last item in last valid run. Returns np.nan if there are no valid run.
+      Index (or coordinate if `coord` is not False) of last item in last valid run.
+      Returns np.nan if there are no valid runs.
     """
     mid_idx = index_of_date(da[dim], date, max_idxs=1, default=0)
     if mid_idx.size == 0:  # The date is not within the group. Happens at boundaries.
@@ -668,7 +672,7 @@ def first_run_after_date(
     Parameters
     ----------
     da : xr.DataArray
-      Input N-dimensional DataArray (boolean)
+      Input N-dimensional DataArray (boolean).
     window : int
       Minimum duration of consecutive run to accumulate values.
     date : DayOfYearStr
@@ -683,7 +687,8 @@ def first_run_after_date(
     Returns
     -------
     xr.DataArray
-      Index (or coordinate if `coord` is not False) of first item in the first valid run. Returns np.nan if there are no valid run.
+      Index (or coordinate if `coord` is not False) of first item in the first valid run.
+      Returns np.nan if there are no valid runs.
     """
     mid_idx = index_of_date(da.time, date, max_idxs=1, default=0)
     if mid_idx.size == 0:  # The date is not within the group. Happens at boundaries.
@@ -709,7 +714,7 @@ def last_run_before_date(
     Parameters
     ----------
     da : xr.DataArray
-      Input N-dimensional DataArray (boolean)
+      Input N-dimensional DataArray (boolean).
     window : int
       Minimum duration of consecutive run to accumulate values.
     date : DayOfYearStr
@@ -724,7 +729,8 @@ def last_run_before_date(
     Returns
     -------
     xr.DataArray
-      Index (or coordinate if `coord` is not False) of last item in last valid run. Returns np.nan if there are no valid run.
+      Index (or coordinate if `coord` is not False) of last item in last valid run.
+      Returns np.nan if there are no valid runs.
     """
     mid_idx = index_of_date(da.time, date, default=-1)
 
@@ -748,11 +754,11 @@ def rle_1d(
     Returns
     -------
     values : np.array
-      The values taken by arr over each run
+      The values taken by arr over each run.
     run lengths : np.array
-      The length of each run
+      The length of each run.
     start position : np.array
-      The starting index of each run
+      The starting index of each run.
 
     Examples
     --------
@@ -783,14 +789,15 @@ def first_run_1d(arr: Sequence[Union[int, float]], window: int) -> int:
     Parameters
     ----------
     arr : Sequence[Union[int, float]]
-      Input array
+      Input array.
     window : int
       Minimum duration of consecutive run to accumulate values.
 
     Returns
     -------
     int
-      Index of first item in first valid run. Returns np.nan if there are no valid run.
+      Index of first item in first valid run.
+      Returns np.nan if there are no valid runs.
     """
     v, rl, pos = rle_1d(arr)
     ind = np.where(v * rl >= window, pos, np.inf).min()
@@ -807,6 +814,8 @@ def statistics_run_1d(arr: Sequence[bool], reducer: str) -> int:
     ----------
     arr : Sequence[bool]
       Input array (bool)
+    reducer: {'min', 'max', 'mean', 'sum'}
+      Reducing function name.
 
     Returns
     -------
@@ -826,7 +835,7 @@ def windowed_run_count_1d(arr: Sequence[bool], window: int) -> int:
     Parameters
     ----------
     arr : Sequence[bool]
-      Input array (bool)
+      Input array (bool).
     window : int
       Minimum duration of consecutive run to accumulate values.
 
@@ -839,19 +848,19 @@ def windowed_run_count_1d(arr: Sequence[bool], window: int) -> int:
     return np.where(v * rl >= window, rl, 0).sum()
 
 
-def windowed_run_events_1d(arr: Sequence[bool], window: int):
+def windowed_run_events_1d(arr: Sequence[bool], window: int) -> xarray.DataArray:
     """Return the number of runs of a minimum length.
 
     Parameters
     ----------
     arr : Sequence[bool]
-      Input array (bool)
+      Input array (bool).
     window : int
       Minimum run length.
 
     Returns
     -------
-    func
+    xarray.DataArray
       Number of distinct runs of a minimum length.
     """
     v, rl, pos = rle_1d(arr)
@@ -864,13 +873,13 @@ def windowed_run_count_ufunc(x: Sequence[bool], window: int) -> xr.DataArray:
     Parameters
     ----------
     x : Sequence[bool]
-      Input array (bool)
+      Input array (bool).
     window : int
       Minimum duration of consecutive run to accumulate values.
 
     Returns
     -------
-    out : func
+    xarray.DataArray
       A function operating along the time dimension of a dask-array.
     """
     return xr.apply_ufunc(
@@ -891,13 +900,13 @@ def windowed_run_events_ufunc(x: Sequence[bool], window: int) -> xr.DataArray:
     Parameters
     ----------
     x : Sequence[bool]
-      Input array (bool)
+      Input array (bool).
     window : int
-      Minimum run length
+      Minimum run length.
 
     Returns
     -------
-    out : func
+    xarray.DataArray
       A function operating along the time dimension of a dask-array.
     """
     return xr.apply_ufunc(
@@ -926,7 +935,7 @@ def statistics_run_ufunc(
 
     Returns
     -------
-    out : func
+    xarray.DataArray
       A function operating along the time dimension of a dask-array.
     """
     return xr.apply_ufunc(
@@ -951,13 +960,15 @@ def first_run_ufunc(
     Parameters
     ----------
     x : Union[xr.DataArray, Sequence[bool]]
-      Input array (bool)
+      Input array (bool).
     window : int
-    dim: Optional[str]
+      Minimum run length.
+    dim : str
+      Dimension along which to index (default: "time").
 
     Returns
     -------
-    out : func
+    xarray.DataArray
       A function operating along the time dimension of a dask-array.
     """
     ind = xr.apply_ufunc(
@@ -994,7 +1005,7 @@ def lazy_indexing(
     Returns
     -------
     xr.DataArray
-      Values of `da` at indices `index`
+      Values of `da` at indices `index`.
     """
     if da.ndim == 1:
         # Case where da is 1D and index is N-D
@@ -1076,7 +1087,7 @@ def index_of_date(
 
     Returns
     -------
-    ndarray
+    numpy.ndarray
       1D array of integers, indexes of `date` in `time`.
     """
     if date is None:

--- a/xclim/indices/stats.py
+++ b/xclim/indices/stats.py
@@ -1,6 +1,6 @@
 """Statistic-related functions. See the `frequency_analysis` notebook for examples."""
 
-from typing import Optional, Sequence, Union
+from typing import Dict, Optional, Sequence, Tuple, Union
 
 import dask.array
 import numpy as np
@@ -87,6 +87,8 @@ def fit(
     method : {"ML", "PWM"}
       Fitting method, either maximum likelihood (ML) or probability weighted moments (PWM), also called L-Moments.
       The PWM method is usually more robust to outliers.
+    dim : str
+      The dimension upon which to perform the indexing (default: "time").
     **fitkwargs
       Other arguments passed directly to :py:func:`_fitstart` and to the distribution's `fit`.
 
@@ -158,10 +160,11 @@ def parametric_quantile(p: xr.DataArray, q: Union[int, Sequence]) -> xr.DataArra
     Parameters
     ----------
     p : xr.DataArray
-      Distribution parameters returned by the `fit` function. The array should have dimension `dparams` storing the
-      distribution parameters, and attribute `scipy_dist`, storing the name of the distribution.
+      Distribution parameters returned by the `fit` function.
+      The array should have dimension `dparams` storing the distribution parameters,
+      and attribute `scipy_dist`, storing the name of the distribution.
     q : Union[float, Sequence]
-      Quantile to compute, which must be between 0 and 1 inclusive.
+      Quantile to compute, which must be between `0` and `1`, inclusive.
 
     Returns
     -------
@@ -218,7 +221,7 @@ def parametric_quantile(p: xr.DataArray, q: Union[int, Sequence]) -> xr.DataArra
 
 def fa(
     da: xr.DataArray, t: Union[int, Sequence], dist: str = "norm", mode: str = "max"
-):
+) -> xr.DataArray:
     """Return the value corresponding to the given return period.
 
     Parameters
@@ -270,7 +273,7 @@ def frequency_analysis(
     window: int = 1,
     freq: Optional[str] = None,
     **indexer,
-):
+) -> xr.DataArray:
     """Return the value corresponding to a return period.
 
     Parameters
@@ -343,7 +346,7 @@ def get_lm3_dist(dist):
     return getattr(lmoments3.distr, _lm3_dist_map[dist])
 
 
-def _fit_start(x, dist, **fitkwargs):
+def _fit_start(x, dist, **fitkwargs) -> Tuple[Tuple, Dict]:
     """Return initial values for distribution parameters.
 
     Providing the ML fit method initial values can help the optimizer find the global optimum.
@@ -355,6 +358,10 @@ def _fit_start(x, dist, **fitkwargs):
     dist : str
       Name of the univariate distribution, such as beta, expon, genextreme, gamma, gumbel_r, lognorm, norm
       (see scipy.stats). Only `genextreme` and `weibull_exp` distributions are supported.
+
+    Returns
+    -------
+    tuple, dict
 
     References
     ----------
@@ -392,7 +399,7 @@ def _fit_start(x, dist, **fitkwargs):
 
 def _dist_method_1D(
     params: Sequence[float], arg=None, *, dist: str, function: str, **kwargs
-):
+) -> xr.DataArray:
     """Statistical function for given argument on given distribution initialized with params.
 
     See :ref:`scipy:scipy.stats.rv_continuous` for a available functions and their arguments.
@@ -426,7 +433,7 @@ def dist_method(
     fit_params: xr.DataArray,
     arg: Optional[xr.DataArray] = None,
     **kwargs,
-):
+) -> xr.DataArray:
     """Vectorized statistical function for given argument on given distribution initialized with params.
 
     See :ref:`scipy:scipy.stats.rv_continuous` for a available functions and their arguments.


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (major / minor / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->

I noticed a malformed docstring in the documentation (https://xclim.readthedocs.io/en/latest/indices.html?highlight=snow#xclim.indices.snow_melt_we_max) and upon inspection, found many inconsistencies throughout the indices.

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->

No, but `prcptot_wetdry_period` has a `src_timestep` keyword that does nothing. It **should** be removed (breaking change). Also, `first_occurence` and `last_occurence` are misspelled ("occurrence"). 

* **Other information**:

I'm a fan of the [Oxford comma](https://en.wikipedia.org/wiki/Serial_comma). Do we have strong feelings about this?
