### PR TITLE
Add TX, TN, and TG days above and below

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,9 +5,14 @@ History
 0.27.0 (unreleased)
 -------------------
 
+Breaking changes
+~~~~~~~~~~~~~~~~
+* The `tropical_nights` indice is being deprecated in favour of `tn_days_above` with `thresh="20 degC"`. The indicator remains valid, now wrapping this new indice.
+
 New indicators
 ~~~~~~~~~~~~~~
 * `atmos.corn_heat_units` computes the daily temperature-based index for corn growth.
+* New indices and indicators for `tx_days_below`, `tg_days_above`, `tg_days_below`, and `tn_days_above`.
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.26.1
+current_version = 0.26.2-beta
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+).(?P<patch>\d+)(\-(?P<release>[a-z]+))?

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ URL = "https://github.com/Ouranosinc/xclim"
 AUTHOR = "Travis Logan"
 AUTHOR_EMAIL = "logan.travis@ouranos.ca"
 REQUIRES_PYTHON = ">=3.7.0"
-VERSION = "0.26.1"
+VERSION = "0.26.2-beta"
 LICENSE = "Apache Software License 2.0"
 
 with open("README.rst") as readme_file:

--- a/xclim/__init__.py
+++ b/xclim/__init__.py
@@ -9,7 +9,7 @@ from xclim.indicators import atmos, land, seaIce  # noqa
 
 __author__ = """Travis Logan"""
 __email__ = "logan.travis@ouranos.ca"
-__version__ = "0.26.1"
+__version__ = "0.26.2-beta"
 
 
 # Virtual modules creation:

--- a/xclim/data/fr.json
+++ b/xclim/data/fr.json
@@ -192,6 +192,13 @@
     "comment": "",
     "abstract": "L'indice de sécheresse fait partie du système canadien des Indices Forêt-Météo. C'est un code numérique estimant la teneur en humidité moyenne de couches organiques."
   },
+  "TN_DAYS_ABOVE": {
+    "long_name": "Nombre de jours avec Tmin > {thresh}",
+    "description": "Nombre {freq:m} de jours où la température journalière minimale est au-dessus de {thresh}",
+    "title": "Nombre de jours avec tmin au-dessus d'un certain seuil",
+    "comment": "",
+    "abstract": "Nombre de jours où la température journalière minimale est au-dessus d'un seuil."
+  },
   "TN_DAYS_BELOW": {
     "long_name": "Nombre de jours avec Tmin < {thresh}",
     "description": "Nombre {freq:m} de jours où la température journalière minimale est sous {thresh}",
@@ -199,12 +206,33 @@
     "comment": "",
     "abstract": "Nombre de jours où la température journalière minimale est sous un seuil."
   },
+  "TG_DAYS_ABOVE": {
+    "long_name": "Nombre de jours avec Tmoy > {thresh}",
+    "description": "Nombre {freq:m} de jours où la moyenne de température journalière est au-dessus de {thresh}",
+    "title": "Nombre de jours avec tmoy au-dessus d'un certain seuil",
+    "comment": "",
+    "abstract": "Nombre de jours où la moyenne de température journalière est au-dessus d'un seuil."
+  },
+  "TG_DAYS_BELOW": {
+    "long_name": "Nombre de jours avec Tmoy < {thresh}",
+    "description": "Nombre {freq:m} de jours où la moyenne de température journalière est sous {thresh}",
+    "title": "Nombre de jours avec tmoy sous un certain seuil",
+    "comment": "",
+    "abstract": "Nombre de jours où la moyenne de température journalière est sous un seuil."
+  },
   "TX_DAYS_ABOVE": {
     "long_name": "Nombre de jours avec Tmax > {thresh}",
     "description": "Nombre {freq:m} de jours où la température journalière maximale est au-dessus de {thresh}",
     "title": "Nombre de jours avec tmax au-dessus d'un certain seuil",
     "comment": "",
     "abstract": "Nombre de jours où la température journalière maximale est au-dessus d'un seuil."
+  },
+  "TX_DAYS_BELOW": {
+    "long_name": "Nombre de jours avec Tmax < {thresh}",
+    "description": "Nombre {freq:m} de jours où la température journalière maximale est sous {thresh}",
+    "title": "Nombre de jours avec tmax sous un certain seuil",
+    "comment": "",
+    "abstract": "Nombre de jours où la température journalière maximale est sous un seuil."
   },
   "TX_TN_DAYS_ABOVE": {
     "long_name": "Nombre de jours avec Tmax > {thresh_tasmax} et Tmin > {thresh_tasmin}",

--- a/xclim/data/fr.json
+++ b/xclim/data/fr.json
@@ -208,17 +208,17 @@
   },
   "TG_DAYS_ABOVE": {
     "long_name": "Nombre de jours avec Tmoy > {thresh}",
-    "description": "Nombre {freq:m} de jours où la moyenne de température journalière est au-dessus de {thresh}",
+    "description": "Nombre {freq:m} de jours où la température journalière moyenne est au-dessus de {thresh}",
     "title": "Nombre de jours avec tmoy au-dessus d'un certain seuil",
     "comment": "",
-    "abstract": "Nombre de jours où la moyenne de température journalière est au-dessus d'un seuil."
+    "abstract": "Nombre de jours où la température journalière moyenne est au-dessus d'un seuil."
   },
   "TG_DAYS_BELOW": {
     "long_name": "Nombre de jours avec Tmoy < {thresh}",
-    "description": "Nombre {freq:m} de jours où la moyenne de température journalière est sous {thresh}",
+    "description": "Nombre {freq:m} de jours où la température journalière moyenne est sous {thresh}",
     "title": "Nombre de jours avec tmoy sous un certain seuil",
     "comment": "",
-    "abstract": "Nombre de jours où la moyenne de température journalière est sous un seuil."
+    "abstract": "Nombre de jours où la température journalière moyenne est sous un seuil."
   },
   "TX_DAYS_ABOVE": {
     "long_name": "Nombre de jours avec Tmax > {thresh}",

--- a/xclim/indicators/atmos/_temperature.py
+++ b/xclim/indicators/atmos/_temperature.py
@@ -8,8 +8,12 @@ from xclim.core.units import check_units
 from xclim.core.utils import wrapped_partial
 
 __all__ = [
+    "tn_days_above",
     "tn_days_below",
+    "tg_days_above",
+    "tg_days_below",
     "tx_days_above",
+    "tx_days_below",
     "tx_tn_days_above",
     "heat_wave_frequency",
     "heat_wave_max_length",
@@ -112,6 +116,16 @@ class TasminTasmax(Daily2D):
         check_units(tasmax, tasmin.attrs["units"])
 
 
+tn_days_above = Tasmin(
+    identifier="tn_days_above",
+    units="days",
+    standard_name="number_of_days_with_air_temperature_above_threshold",
+    long_name="Number of days with Tmin > {thresh}",
+    description="{freq} number of days where daily minimum temperature exceeds {thresh}.",
+    cell_methods="time: minimum within days time: sum over days",
+    compute=indices.tn_days_above,
+)
+
 tn_days_below = Tasmin(
     identifier="tn_days_below",
     units="days",
@@ -122,6 +136,26 @@ tn_days_below = Tasmin(
     compute=indices.tn_days_below,
 )
 
+tg_days_above = Tas(
+    identifier="tg_days_above",
+    units="days",
+    standard_name="number_of_days_with_air_temperature_above_threshold",
+    long_name="Number of days with Tavg > {thresh}",
+    description="{freq} number of days where daily mean temperature exceeds {thresh}.",
+    cell_methods="time: mean within days time: sum over days",
+    compute=indices.tg_days_above,
+)
+
+tg_days_below = Tas(
+    identifier="tg_days_below",
+    units="days",
+    standard_name="number_of_days_with_air_temperature_below_threshold",
+    long_name="Number of days with Tavg < {thresh}",
+    description="{freq} number of days where daily mean temperature is below {thresh}.",
+    cell_methods="time: mean within days time: sum over days",
+    compute=indices.tg_days_below,
+)
+
 tx_days_above = Tasmax(
     identifier="tx_days_above",
     units="days",
@@ -130,6 +164,16 @@ tx_days_above = Tasmax(
     description="{freq} number of days where daily maximum temperature exceeds {thresh}.",
     cell_methods="time: maximum within days time: sum over days",
     compute=indices.tx_days_above,
+)
+
+tx_days_below = Tasmin(
+    identifier="tx_days_below",
+    units="days",
+    standard_name="number_of_days_with_air_temperature_below_threshold",
+    long_name="Number of days with Tmax < {thresh}",
+    description="{freq} number of days where daily max temperature is below {thresh}.",
+    cell_methods="time: max within days time: sum over days",
+    compute=indices.tx_days_below,
 )
 
 tx_tn_days_above = TasminTasmax(
@@ -143,15 +187,6 @@ tx_tn_days_above = TasminTasmax(
     compute=indices.tx_tn_days_above,
 )
 
-tn_days_above = Tasmin(
-    identifier="tn_days_above",
-    units="days",
-    standard_name="number_of_days_with_air_temperature_above_threshold",
-    long_name="Number of days with Tmin > {thresh}",
-    description="{freq} number of days where daily minimum temperature exceeds {thresh}.",
-    cell_methods="time: minimum within days time: sum over days",
-    compute=indices.tn_days_above,
-)
 
 heat_wave_frequency = TasminTasmax(
     identifier="heat_wave_frequency",

--- a/xclim/indicators/atmos/_temperature.py
+++ b/xclim/indicators/atmos/_temperature.py
@@ -618,7 +618,7 @@ tropical_nights = Tasmin(
     description="{freq} number of Tropical Nights : defined as days with minimum daily temperature"
     " above {thresh}",
     cell_methods="time: minimum within days time: sum over days",
-    compute=indices.tropical_nights,
+    compute=wrapped_partial(indices.tn_days_above, thresh="20 degC"),
 )
 
 tg90p = Tas(

--- a/xclim/indicators/atmos/_temperature.py
+++ b/xclim/indicators/atmos/_temperature.py
@@ -143,6 +143,16 @@ tx_tn_days_above = TasminTasmax(
     compute=indices.tx_tn_days_above,
 )
 
+tn_days_above = Tasmin(
+    identifier="tn_days_above",
+    units="days",
+    standard_name="number_of_days_with_air_temperature_above_threshold",
+    long_name="Number of days with Tmin > {thresh}",
+    description="{freq} number of days where daily minimum temperature exceeds {thresh}.",
+    cell_methods="time: minimum within days time: sum over days",
+    compute=indices.tn_days_above,
+)
+
 heat_wave_frequency = TasminTasmax(
     identifier="heat_wave_frequency",
     units="",

--- a/xclim/indicators/atmos/_temperature.py
+++ b/xclim/indicators/atmos/_temperature.py
@@ -618,7 +618,7 @@ tropical_nights = Tasmin(
     description="{freq} number of Tropical Nights : defined as days with minimum daily temperature"
     " above {thresh}",
     cell_methods="time: minimum within days time: sum over days",
-    compute=wrapped_partial(indices.tn_days_above, thresh="20 degC"),
+    compute=wrapped_partial(indices.tn_days_above, suggested=dict(thresh="20 degC")),
 )
 
 tg90p = Tas(

--- a/xclim/indices/_threshold.py
+++ b/xclim/indices/_threshold.py
@@ -1213,11 +1213,47 @@ def tn_days_below(
 
     .. math::
 
-        TX_{ij} < Threshold [℃]
+        TN_{ij} < Threshold [℃]
     """
     thresh = convert_units_to(thresh, tasmin)
     f1 = threshold_count(tasmin, "<", thresh, freq)
     return to_agg_units(f1, tasmin, "count")
+
+
+@declare_units(tasmax="[temperature]", thresh="[temperature]")
+def tn_days_above(
+    tasmin: xarray.DataArray, thresh: str = "25.0 degC", freq: str = "YS"
+):  # noqa: D401
+    """Number of summer days.
+
+    Number of days where daily minimum temperature exceeds a threshold.
+
+    Parameters
+    ----------
+    tasmin : xarray.DataArray
+      Minimum daily temperature.
+    thresh : str
+      Threshold temperature on which to base evaluation.
+    freq : str
+      Resampling frequency.
+
+    Returns
+    -------
+    xarray.DataArray, [time]
+      umber of days Tmin > threshold.
+
+    Notes
+    -----
+    Let :math:`TN_{ij}` be the daily minimum temperature at day :math:`i` of period :math:`j`. Then
+    counted is the number of days where:
+
+    .. math::
+
+        TN_{ij} > Threshold [℃]
+    """
+    thresh = convert_units_to(thresh, tasmin)
+    f = threshold_count(tasmin, ">", thresh, freq)
+    return to_agg_units(f, tasmin, "count")
 
 
 @declare_units(tasmax="[temperature]", thresh="[temperature]")
@@ -1226,7 +1262,7 @@ def tx_days_above(
 ):  # noqa: D401
     """Number of summer days.
 
-    Number of days where daily maximum temperature exceed a threshold.
+    Number of days where daily maximum temperature exceeds a threshold.
 
     Parameters
     ----------

--- a/xclim/indices/_threshold.py
+++ b/xclim/indices/_threshold.py
@@ -1,4 +1,5 @@
 # noqa: D100
+import warnings
 from typing import Optional
 
 import numpy as np
@@ -1192,7 +1193,7 @@ def snow_cover_duration(
 
 @declare_units(tasmin="[temperature]", thresh="[temperature]")
 def tn_days_above(
-    tasmin: xarray.DataArray, thresh: str = "-10.0 degC", freq: str = "YS"
+    tasmin: xarray.DataArray, thresh: str = "20.0 degC", freq: str = "YS"
 ):  # noqa: D401
     """Number of days with tasmin above a threshold (number of tropical nights).
 
@@ -1792,10 +1793,20 @@ def tropical_nights(
     .. math::
 
         TN_{ij} > Threshold [℃]
+
+    Warnings
+    --------
+    The `tropical_nights` indicator is being deprecated in favour of `tn_days_above` with `thresh="20 degC" by default.
+    This change will be effectuated in a future version of xclim.
     """
-    thresh = convert_units_to(thresh, tasmin)
-    out = threshold_count(tasmin, ">", thresh, freq)
-    return to_agg_units(out, tasmin, "count")
+    warnings.warn(
+        "The `tropical_nights` indice is being deprecated in favour of `tn_days_above` with `thresh='20 degC'. "
+        "This indice will be removed in `xclim>=0.28.0`. Please update your scripts accordingly.",
+        UserWarning,
+        stacklevel=3,
+    )
+
+    return tn_days_above(tasmin, thresh=thresh, freq=freq)
 
 
 @declare_units(tas="[temperature]", thresh="[temperature]", sum_thresh="K days")

--- a/xclim/indices/_threshold.py
+++ b/xclim/indices/_threshold.py
@@ -1220,7 +1220,7 @@ def tn_days_below(
     return to_agg_units(f1, tasmin, "count")
 
 
-@declare_units(tasmax="[temperature]", thresh="[temperature]")
+@declare_units(tasmin="[temperature]", thresh="[temperature]")
 def tn_days_above(
     tasmin: xarray.DataArray, thresh: str = "25.0 degC", freq: str = "YS"
 ):  # noqa: D401

--- a/xclim/indices/_threshold.py
+++ b/xclim/indices/_threshold.py
@@ -1190,7 +1190,7 @@ def snow_cover_duration(
 
 @declare_units(tasmin="[temperature]", thresh="[temperature]")
 def tn_days_above(
-    tasmin: xarray.DataArray, thresh: str = "20.0 degC", freq: str = "YS"
+    tasmin: xarray.DataArray, thresh: str = "-10.0 degC", freq: str = "YS"
 ):  # noqa: D401
     """Number of days with tasmin above a threshold (number of tropical nights).
 
@@ -1226,7 +1226,7 @@ def tn_days_above(
 
 @declare_units(tasmin="[temperature]", thresh="[temperature]")
 def tn_days_below(
-    tasmin: xarray.DataArray, thresh: str = "20.0 degC", freq: str = "YS"
+    tasmin: xarray.DataArray, thresh: str = "-10.0 degC", freq: str = "YS"
 ):  # noqa: D401
     """Number of days with tasmin below a threshold.
 
@@ -1639,7 +1639,7 @@ def maximum_consecutive_frost_free_days(
 def maximum_consecutive_tx_days(
     tasmax: xarray.DataArray, thresh: str = "25 degC", freq: str = "YS"
 ):
-    r"""Maximum number of consecutive summer days.
+    r"""Maximum number of consecutive days with tasmax above a threshold (summer days).
 
     Return the maximum number of consecutive days within the period where
     the maximum temperature is above a certain threshold.
@@ -1656,7 +1656,7 @@ def maximum_consecutive_tx_days(
     Returns
     -------
     xarray.DataArray, [time]
-      The maximum number of consecutive summer days.
+      The maximum number of days with tasmax > thresh per periods (summer days).
 
     Notes
     -----

--- a/xclim/indices/_threshold.py
+++ b/xclim/indices/_threshold.py
@@ -48,8 +48,13 @@ __all__ = [
     "hot_spell_frequency",
     "hot_spell_max_length",
     "snow_cover_duration",
+    "tn_days_above",
     "tn_days_below",
+    "tg_days_above",
+    "tg_days_below",
     "tx_days_above",
+    "tx_days_below",
+    "tropical_nights",
     "warm_day_frequency",
     "warm_night_frequency",
     "wetdays",
@@ -62,7 +67,6 @@ __all__ = [
     "maximum_consecutive_wet_days",
     "sea_ice_area",
     "sea_ice_extent",
-    "tropical_nights",
 ]
 
 
@@ -1185,10 +1189,46 @@ def snow_cover_duration(
 
 
 @declare_units(tasmin="[temperature]", thresh="[temperature]")
-def tn_days_below(
-    tasmin: xarray.DataArray, thresh: str = "-10.0 degC", freq: str = "YS"
+def tn_days_above(
+    tasmin: xarray.DataArray, thresh: str = "20.0 degC", freq: str = "YS"
 ):  # noqa: D401
-    """Number of days with tmin below a threshold.
+    """Number of days with tasmin above a threshold (number of tropical nights).
+
+    Number of days where daily minimum temperature exceeds a threshold.
+
+    Parameters
+    ----------
+    tasmin : xarray.DataArray
+      Minimum daily temperature.
+    thresh : str
+      Threshold temperature on which to base evaluation.
+    freq : str
+      Resampling frequency.
+
+    Returns
+    -------
+    xarray.DataArray, [time]
+      Number of days where Tasmin > threshold.
+
+    Notes
+    -----
+    Let :math:`TN_{ij}` be the daily minimum temperature at day :math:`i` of period :math:`j`. Then
+    counted is the number of days where:
+
+    .. math::
+
+        TN_{ij} > Threshold [℃]
+    """
+    thresh = convert_units_to(thresh, tasmin)
+    f = threshold_count(tasmin, ">", thresh, freq)
+    return to_agg_units(f, tasmin, "count")
+
+
+@declare_units(tasmin="[temperature]", thresh="[temperature]")
+def tn_days_below(
+    tasmin: xarray.DataArray, thresh: str = "20.0 degC", freq: str = "YS"
+):  # noqa: D401
+    """Number of days with tasmin below a threshold.
 
     Number of days where daily minimum temperature is below a threshold.
 
@@ -1196,6 +1236,150 @@ def tn_days_below(
     ----------
     tasmin : xarray.DataArray
       Minimum daily temperature.
+    thresh : str
+      Threshold temperature on which to base evaluation.
+    freq : str
+      Resampling frequency.
+
+    Returns
+    -------
+    xarray.DataArray, [time]
+      Number of days where Tasmin < threshold.
+
+    Notes
+    -----
+    Let :math:`TN_{ij}` be the daily minimum temperature at day :math:`i` of period :math:`j`. Then
+    counted is the number of days where:
+
+    .. math::
+
+        TN_{ij} < Threshold [℃]
+    """
+    thresh = convert_units_to(thresh, tasmin)
+    f1 = threshold_count(tasmin, "<", thresh, freq)
+    return to_agg_units(f1, tasmin, "count")
+
+
+@declare_units(tas="[temperature]", thresh="[temperature]")
+def tg_days_above(
+    tas: xarray.DataArray, thresh: str = "10.0 degC", freq: str = "YS"
+):  # noqa: D401
+    """Number of days with tas above a threshold.
+
+    Number of days where daily mean temperature exceeds a threshold.
+
+    Parameters
+    ----------
+    tas : xarray.DataArray
+      Mean daily temperature.
+    thresh : str
+      Threshold temperature on which to base evaluation.
+    freq : str
+      Resampling frequency.
+
+    Returns
+    -------
+    xarray.DataArray, [time]
+      Number of days where Tas > threshold.
+
+    Notes
+    -----
+    Let :math:`TG_{ij}` be the daily mean temperature at day :math:`i` of period :math:`j`. Then
+    counted is the number of days where:
+
+    .. math::
+
+        TG_{ij} > Threshold [℃]
+    """
+    thresh = convert_units_to(thresh, tas)
+    f = threshold_count(tas, ">", thresh, freq)
+    return to_agg_units(f, tas, "count")
+
+
+@declare_units(tas="[temperature]", thresh="[temperature]")
+def tg_days_below(
+    tas: xarray.DataArray, thresh: str = "10.0 degC", freq: str = "YS"
+):  # noqa: D401
+    """Number of days with tas below a threshold.
+
+    Number of days where daily mean temperature is below a threshold.
+
+    Parameters
+    ----------
+    tas : xarray.DataArray
+      Mean daily temperature.
+    thresh : str
+      Threshold temperature on which to base evaluation.
+    freq : str
+      Resampling frequency.
+
+    Returns
+    -------
+    xarray.DataArray, [time]
+      Number of days where Tas < threshold.
+
+    Notes
+    -----
+    Let :math:`TG_{ij}` be the daily mean temperature at day :math:`i` of period :math:`j`. Then
+    counted is the number of days where:
+
+    .. math::
+
+        TG_{ij} < Threshold [℃]
+    """
+    thresh = convert_units_to(thresh, tas)
+    f1 = threshold_count(tas, "<", thresh, freq)
+    return to_agg_units(f1, tas, "count")
+
+
+@declare_units(tasmax="[temperature]", thresh="[temperature]")
+def tx_days_above(
+    tasmax: xarray.DataArray, thresh: str = "25.0 degC", freq: str = "YS"
+):  # noqa: D401
+    """Number of days with tasmax above a threshold (number of summer days).
+
+    Number of days where daily maximum temperature exceeds a threshold.
+
+    Parameters
+    ----------
+    tasmax : xarray.DataArray
+      Maximum daily temperature.
+    thresh : str
+      Threshold temperature on which to base evaluation.
+    freq : str
+      Resampling frequency.
+
+    Returns
+    -------
+    xarray.DataArray, [time]
+      Number of days where Tas < threshold.
+
+    Notes
+    -----
+    Let :math:`TX_{ij}` be the daily maximum temperature at day :math:`i` of period :math:`j`. Then
+    counted is the number of days where:
+
+    .. math::
+
+        TX_{ij} > Threshold [℃]
+    """
+    thresh = convert_units_to(thresh, tasmax)
+    f = threshold_count(tasmax, ">", thresh, freq)
+    return to_agg_units(f, tasmax, "count")
+
+
+@declare_units(tasmax="[temperature]", thresh="[temperature]")
+def tx_days_below(
+    tasmax: xarray.DataArray, thresh: str = "25.0 degC", freq: str = "YS"
+):  # noqa: D401
+    """Number of days with tmax below a threshold.
+
+    Number of days where daily maximum temperature is below a threshold.
+
+    Parameters
+    ----------
+    tasmax : xarray.DataArray
+      Maximum daily temperature.
     thresh : str
       Threshold temperature on which to base evaluation.
     freq : str
@@ -1215,81 +1399,9 @@ def tn_days_below(
 
         TN_{ij} < Threshold [℃]
     """
-    thresh = convert_units_to(thresh, tasmin)
-    f1 = threshold_count(tasmin, "<", thresh, freq)
-    return to_agg_units(f1, tasmin, "count")
-
-
-@declare_units(tasmin="[temperature]", thresh="[temperature]")
-def tn_days_above(
-    tasmin: xarray.DataArray, thresh: str = "25.0 degC", freq: str = "YS"
-):  # noqa: D401
-    """Number of summer days.
-
-    Number of days where daily minimum temperature exceeds a threshold.
-
-    Parameters
-    ----------
-    tasmin : xarray.DataArray
-      Minimum daily temperature.
-    thresh : str
-      Threshold temperature on which to base evaluation.
-    freq : str
-      Resampling frequency.
-
-    Returns
-    -------
-    xarray.DataArray, [time]
-      umber of days Tmin > threshold.
-
-    Notes
-    -----
-    Let :math:`TN_{ij}` be the daily minimum temperature at day :math:`i` of period :math:`j`. Then
-    counted is the number of days where:
-
-    .. math::
-
-        TN_{ij} > Threshold [℃]
-    """
-    thresh = convert_units_to(thresh, tasmin)
-    f = threshold_count(tasmin, ">", thresh, freq)
-    return to_agg_units(f, tasmin, "count")
-
-
-@declare_units(tasmax="[temperature]", thresh="[temperature]")
-def tx_days_above(
-    tasmax: xarray.DataArray, thresh: str = "25.0 degC", freq: str = "YS"
-):  # noqa: D401
-    """Number of summer days.
-
-    Number of days where daily maximum temperature exceeds a threshold.
-
-    Parameters
-    ----------
-    tasmax : xarray.DataArray
-      Maximum daily temperature.
-    thresh : str
-      Threshold temperature on which to base evaluation.
-    freq : str
-      Resampling frequency.
-
-    Returns
-    -------
-    xarray.DataArray, [time]
-      Number of summer days.
-
-    Notes
-    -----
-    Let :math:`TX_{ij}` be the daily maximum temperature at day :math:`i` of period :math:`j`. Then
-    counted is the number of days where:
-
-    .. math::
-
-        TX_{ij} > Threshold [℃]
-    """
     thresh = convert_units_to(thresh, tasmax)
-    f = threshold_count(tasmax, ">", thresh, freq)
-    return to_agg_units(f, tasmax, "count")
+    f1 = threshold_count(tasmax, "<", thresh, freq)
+    return to_agg_units(f1, tasmax, "count")
 
 
 @declare_units(tasmax="[temperature]", thresh="[temperature]")

--- a/xclim/indices/generic.py
+++ b/xclim/indices/generic.py
@@ -394,7 +394,7 @@ def diurnal_temperature_range(
     return out
 
 
-def first_occurence(
+def first_occurrence(
     data: xr.DataArray, threshold: str, condition: str, freq: str
 ) -> xr.DataArray:
     """Calculate the first time some condition is met.
@@ -431,7 +431,7 @@ def first_occurence(
     return out
 
 
-def last_occurence(
+def last_occurrence(
     data: xr.DataArray, threshold: str, condition: str, freq: str
 ) -> xr.DataArray:
     """Calculate the last time some condition is met.

--- a/xclim/testing/tests/test_indices.py
+++ b/xclim/testing/tests/test_indices.py
@@ -718,10 +718,10 @@ class TestTxDays:
         a[:6] -= [27, 28, 29, 30, 31, 32]  # 2 above 30
         mx = tasmax_series(a + K2C)
 
-        out = xci.tg_days_below(mx, thresh="-10 C")
+        out = xci.tx_days_below(mx, thresh="-10 C")
         np.testing.assert_array_equal(out[:1], [6])
         np.testing.assert_array_equal(out[1:], [0])
-        out = xci.tg_days_below(mx, thresh="-30 C")
+        out = xci.tx_days_below(mx, thresh="-30 C")
         np.testing.assert_array_equal(out[:1], [2])
         np.testing.assert_array_equal(out[1:], [0])
 

--- a/xclim/testing/tests/test_indices.py
+++ b/xclim/testing/tests/test_indices.py
@@ -663,7 +663,7 @@ class TestTnDays:
         a[:6] += [27, 28, 29, 30, 31, 32]  # 2 above 30
         mn = tasmin_series(a + K2C)
 
-        out = xci.tx_days_above(mn, thresh="30 C")
+        out = xci.tn_days_above(mn, thresh="30 C")
         np.testing.assert_array_equal(out[:1], [2])
         np.testing.assert_array_equal(out[1:], [0])
 

--- a/xclim/testing/tests/test_indices.py
+++ b/xclim/testing/tests/test_indices.py
@@ -657,27 +657,71 @@ class TestHotSpellMaxLength:
         np.testing.assert_allclose(hsml.values, expected)
 
 
-class TestTnDaysBelow:
-    def test_simple(self, tasmin_series):
+class TestTnDays:
+    def test_above_simple(self, tasmin_series):
+        a = np.zeros(365)
+        a[:6] += [27, 28, 29, 30, 31, 32]  # 2 above 30
+        mn = tasmin_series(a + K2C)
+
+        out = xci.tx_days_above(mn, thresh="30 C")
+        np.testing.assert_array_equal(out[:1], [2])
+        np.testing.assert_array_equal(out[1:], [0])
+
+    def test_below_simple(self, tasmin_series):
         a = np.zeros(365)
         a[:6] -= [27, 28, 29, 30, 31, 32]  # 2 above 30
-        mx = tasmin_series(a + K2C)
+        mn = tasmin_series(a + K2C)
 
-        out = xci.tn_days_below(mx, thresh="-10 C")
+        out = xci.tn_days_below(mn, thresh="-10 C")
         np.testing.assert_array_equal(out[:1], [6])
         np.testing.assert_array_equal(out[1:], [0])
-        out = xci.tn_days_below(mx, thresh="-30 C")
+        out = xci.tn_days_below(mn, thresh="-30 C")
         np.testing.assert_array_equal(out[:1], [2])
         np.testing.assert_array_equal(out[1:], [0])
 
 
-class TestTxDaysAbove:
-    def test_simple(self, tasmax_series):
+class TestTgDays:
+    def test_above_simple(self, tas_series):
+        a = np.zeros(365)
+        a[:6] += [27, 28, 29, 30, 31, 32]  # 2 above 30
+        mg = tas_series(a + K2C)
+
+        out = xci.tg_days_above(mg, thresh="30 C")
+        np.testing.assert_array_equal(out[:1], [2])
+        np.testing.assert_array_equal(out[1:], [0])
+
+    def test_below_simple(self, tas_series):
+        a = np.zeros(365)
+        a[:6] -= [27, 28, 29, 30, 31, 32]  # 2 above 30
+        mg = tas_series(a + K2C)
+
+        out = xci.tg_days_below(mg, thresh="-10 C")
+        np.testing.assert_array_equal(out[:1], [6])
+        np.testing.assert_array_equal(out[1:], [0])
+        out = xci.tg_days_below(mg, thresh="-30 C")
+        np.testing.assert_array_equal(out[:1], [2])
+        np.testing.assert_array_equal(out[1:], [0])
+
+
+class TestTxDays:
+    def test_above_simple(self, tasmax_series):
         a = np.zeros(365)
         a[:6] += [27, 28, 29, 30, 31, 32]  # 2 above 30
         mx = tasmax_series(a + K2C)
 
         out = xci.tx_days_above(mx, thresh="30 C")
+        np.testing.assert_array_equal(out[:1], [2])
+        np.testing.assert_array_equal(out[1:], [0])
+
+    def test_below_simple(self, tasmax_series):
+        a = np.zeros(365)
+        a[:6] -= [27, 28, 29, 30, 31, 32]  # 2 above 30
+        mx = tasmax_series(a + K2C)
+
+        out = xci.tg_days_below(mx, thresh="-10 C")
+        np.testing.assert_array_equal(out[:1], [6])
+        np.testing.assert_array_equal(out[1:], [0])
+        out = xci.tg_days_below(mx, thresh="-30 C")
         np.testing.assert_array_equal(out[:1], [2])
         np.testing.assert_array_equal(out[1:], [0])
 
@@ -1493,7 +1537,7 @@ class TestTG:
         np.testing.assert_almost_equal(out[0], exp, decimal=4)
 
     def test_indice_against_icclim(self, cmip3_day_tas):
-        from xclim.indicators import icclim
+        from xclim.indicators import icclim  # noqa
 
         with set_options(cf_compliance="log"):
             ind = xci.tg_mean(cmip3_day_tas)

--- a/xclim/testing/tests/test_locales.py
+++ b/xclim/testing/tests/test_locales.py
@@ -158,7 +158,7 @@ def test_xclim_translations(locale, official_indicators):
 
     if len(untranslated) > 0:
         pytest.fail(
-            f"Indicators {','.join(untranslated)} do not have translations for official locale {locale}."
+            f"Indicators {', '.join(untranslated)} do not have translations for official locale {locale}."
         )
 
 

--- a/xclim/testing/tests/test_temperature.py
+++ b/xclim/testing/tests/test_temperature.py
@@ -7,7 +7,6 @@ import xarray as xr
 from xclim import atmos
 from xclim.core.calendar import percentile_doy
 from xclim.core.options import set_options
-from xclim.core.units import convert_units_to
 from xclim.testing import open_dataset
 
 K2C = 273.15
@@ -873,8 +872,8 @@ class TestTnDaysBelow:
         tasC.values[180, 1, 0] = np.nan
         # compute with both skipna options
         thresh = 273.16 + -10
-        fd = atmos.tn_days_below(tas, freq="YS")
-        fdC = atmos.tn_days_below(tasC, freq="YS")
+        fd = atmos.tn_days_below(tas, thresh="-10 degC", freq="YS")
+        fdC = atmos.tn_days_below(tasC, thresh="-10 degC", freq="YS")
 
         x1 = tas.values[:, 0, 0]
 
@@ -919,10 +918,14 @@ class TestTxDaysAbove:
         assert np.isnan(fd.values[0, -1, -1])
 
 
-class TestTropicalNights:
+class TestTnDaysAbove:
     nc_file = os.path.join("NRCANdaily", "nrcan_canada_daily_tasmin_1990.nc")
 
-    def test_3d_data_with_nans(self):
+    @pytest.mark.parametrize(
+        "tn_indice, kwargs",
+        [("tn_days_above", dict(thresh="20 degC")), ("tropical_nights", dict())],
+    )
+    def test_3d_data_with_nans(self, tn_indice, kwargs):
         # test with 3d data
         tas = open_dataset(self.nc_file).tasmin
         tasC = open_dataset(self.nc_file).tasmin
@@ -933,8 +936,9 @@ class TestTropicalNights:
         tasC.values[180, 1, 0] = np.nan
         # compute with both skipna options
         thresh = 273.16 + 20
-        out = atmos.tropical_nights(tas, freq="YS")
-        outC = atmos.tropical_nights(tasC, freq="YS")
+
+        out = getattr(atmos, tn_indice)(tas, **kwargs, freq="YS")
+        outC = getattr(atmos, tn_indice)(tasC, **kwargs, freq="YS")
         # fds = xci.frost_days(tasmin, thresh=thresh, freq='YS', skipna=True)
 
         x1 = tas.values[:, 0, 0]
@@ -944,9 +948,7 @@ class TestTropicalNights:
         np.testing.assert_array_equal(out, outC)
 
         assert np.allclose(out1, out.values[0, 0, 0])
-
         assert np.isnan(out.values[0, 1, 0])
-
         assert np.isnan(out.values[0, -1, -1])
 
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR works towards adrressing #714 
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (major / minor / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->

This adds four "new" indicators and indices (`tx_days_below`, `tg_days_above`, `tg_days_below`, `tn_days_above`) so that we don't need to leverage an oddly-named indicator to perform a general type of indices calculation.

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->

No, but we currently have a `tropical_nights` that is programmatically identical to `tn_days_above`. It should eventually be replaced.

* **Other information**:
