### PR TITLE
Add raw modifier

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,7 @@ New features and enhancements
 * Addition of the `run_length_ufunc` option to control which run length algorithm gets run. Defaults stay the same (automatic switch dependent of the input array : the 1D version is used with non-dask arrays with less than 9000 points per slice).
 * Indicator modules built from YAML can now use custom indices. A mapping or module of them can be given to ``build_indicator_module_from_yaml`` with the ``indices`` keyword.
 * Virtual submodules now include an `iter_indicators` function to iterate over the pairs of names and indicator objects in that module.
+* The indicator string formatter now accepts a "r" modifier which passes the raw strings instead of the adjective version.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/xclim/core/formatting.py
+++ b/xclim/core/formatting.py
@@ -34,7 +34,7 @@ class AttrFormatter(string.Formatter):
         mapping : Mapping[str, Sequence[str]]
             A mapping from values to their possible variations.
         modifiers : Sequence[str]
-            The list of modifiers, must be the as long as the longest value of `mapping`. Cannot include reserver modifier 'r'.
+            The list of modifiers, must be the as long as the longest value of `mapping`. Cannot include reserved modifier 'r'.
         """
         super().__init__()
         if "r" in modifiers:
@@ -77,7 +77,7 @@ class AttrFormatter(string.Formatter):
                 f"No known mapping for string '{value}' with modifier '{format_spec}'"
             )
         elif format_spec == "r":
-            return value
+            return super().format_field(value, "")
         return super().format_field(value, format_spec)
 
     def _match_value(self, value):

--- a/xclim/core/formatting.py
+++ b/xclim/core/formatting.py
@@ -34,9 +34,11 @@ class AttrFormatter(string.Formatter):
         mapping : Mapping[str, Sequence[str]]
             A mapping from values to their possible variations.
         modifiers : Sequence[str]
-            The list of modifiers, must be the as long as the longest value of `mapping`.
+            The list of modifiers, must be the as long as the longest value of `mapping`. Cannot include reserver modifier 'r'.
         """
         super().__init__()
+        if "r" in modifiers:
+            raise ValueError("Modifier 'r' is reserved for default raw formatting.")
         self.modifiers = modifiers
         self.mapping = mapping
 
@@ -44,8 +46,8 @@ class AttrFormatter(string.Formatter):
         """Format a value given a formatting spec.
 
         If `format_spec` is in this Formatter's modifiers, the corresponding variation
-        of value is given. If `format_spec` is not specified but `value` is in the
-        mapping, the first variation is returned.
+        of value is given. If `format_spec` is 'r' (raw), the value is returned unmodified.
+        If `format_spec` is not specified but `value` is in the mapping, the first variation is returned.
 
         Examples
         --------
@@ -54,9 +56,9 @@ class AttrFormatter(string.Formatter):
         In french, the genre of the noun changes the adjective (cat = chat is masculine,
         and goose = oie is feminine) so we initialize the formatter as:
 
-        >>> fmt = AttrFormatter({'nice': ['beau', 'belle'], 'evil' : ['méchant', 'méchante']}, ['m', 'f'])
-        >>> fmt.format("Le chien est {adj1:m}, l'oie est {adj2:f}", adj1='nice', adj2='evil')
-        "Le chien est beau, l'oie est méchante"
+        >>> fmt = AttrFormatter({'nice': ['beau', 'belle'], 'evil' : ['méchant', 'méchante'], 'smart': ['intelligent', 'intelligente']}, ['m', 'f'])
+        >>> fmt.format("Le chien est {adj1:m}, l'oie est {adj2:f}, le gecko est {adj3:r}", adj1='nice', adj2='evil', adj3='smart')
+        "Le chien est beau, l'oie est méchante, le gecko est smart"
 
         The base values may be given using unix shell-like patterns:
 
@@ -74,6 +76,8 @@ class AttrFormatter(string.Formatter):
             raise ValueError(
                 f"No known mapping for string '{value}' with modifier '{format_spec}'"
             )
+        elif format_spec == "r":
+            return value
         return super().format_field(value, format_spec)
 
     def _match_value(self, value):

--- a/xclim/indicators/land/_streamflow.py
+++ b/xclim/indicators/land/_streamflow.py
@@ -75,7 +75,7 @@ base_flow_index = Streamflow(
 
 freq_analysis = FA(
     identifier="freq_analysis",
-    var_name="q{window}{mode}{indexer}",
+    var_name="q{window}{mode:r}{indexer}",
     long_name="N-year return period {mode} {indexer} {window}-day flow",
     description="Streamflow frequency analysis for the {mode} {indexer} {window}-day flow "
     "estimated using the {dist} distribution.",
@@ -94,7 +94,7 @@ rb_flashiness_index = Streamflow(
 
 stats = Stats(
     identifier="stats",
-    var_name="q{indexer}{op}",
+    var_name="q{indexer}{op:r}",
     long_name="{freq} {op} of {indexer} daily flow ",
     description="{freq} {op} of {indexer} daily flow",
     title="Statistic of the daily flow on a given period.",

--- a/xclim/indicators/seaIce/_seaice.py
+++ b/xclim/indicators/seaIce/_seaice.py
@@ -3,8 +3,6 @@
 Sea ice indicators
 ------------------
 """
-import abc
-
 from xclim import indices
 from xclim.core import cfchecks
 from xclim.core.indicator import Indicator2D

--- a/xclim/testing/tests/test_land.py
+++ b/xclim/testing/tests/test_land.py
@@ -22,12 +22,14 @@ class Test_FA:
             ndq_series, mode="max", t=[2, 5], dist="gamma", season="DJF"
         )
         assert out.long_name == "N-year return period maximal winter 1-day flow"
+        assert out.name == "q1maxwinter"
         assert out.shape == (2, 2, 3)  # nrt, nx, ny
         np.testing.assert_array_equal(out.isnull(), False)
 
     def test_no_indexer(self, ndq_series):
         out = land.freq_analysis(ndq_series, mode="max", t=[2, 5], dist="gamma")
         assert out.long_name == "N-year return period maximal annual 1-day flow"
+        assert out.name == "q1maxannual"
         assert out.shape == (2, 2, 3)  # nrt, nx, ny
         np.testing.assert_array_equal(out.isnull(), False)
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #728
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (major / minor / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->
Adds a default 'r' modifier to the string formatter. By default the string formatter, when encountering a string with known variations, will pass the first modified version. In the default formatter, that is the adjective and in the french one the adjective masculin singulier. The 'r' modifier overrides the formatting process and the raw value is passed. This useful for `var_name` fields that may not require complete language.

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
No, rather it repairs a unnoticed breaking change from #716.

* **Other information**:
