### PR TITLE
Refactor how indicators know what are variables and what are parameters

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,15 @@
 History
 =======
 
+0.28.0 (unreleased)
+-------------------
+
+Internal Changes
+~~~~~~~~~~~~~~~~
+* The indicator call sequence now considers "variable" the inputs annoted so. Dropped the ``nvar`` attribute.
+* Default cfcheck is now to check metadata according to the variable name, using CMIP6 names in xclim/data/variable.yml.
+* ``Indicator.missing`` defaults to "skip" is ``freq`` is absent from the list of parameters.
+
 0.27.0 (2021-05-28)
 -------------------
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,7 +9,7 @@ Internal Changes
 ~~~~~~~~~~~~~~~~
 * The indicator call sequence now considers "variable" the inputs annoted so. Dropped the ``nvar`` attribute.
 * Default cfcheck is now to check metadata according to the variable name, using CMIP6 names in xclim/data/variable.yml.
-* ``Indicator.missing`` defaults to "skip" is ``freq`` is absent from the list of parameters.
+* ``Indicator.missing`` defaults to "skip" if ``freq`` is absent from the list of parameters.
 
 0.27.0 (2021-05-28)
 -------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.27.1-beta
+current_version = 0.27.2-beta
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+).(?P<patch>\d+)(\-(?P<release>[a-z]+))?

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ URL = "https://github.com/Ouranosinc/xclim"
 AUTHOR = "Travis Logan"
 AUTHOR_EMAIL = "logan.travis@ouranos.ca"
 REQUIRES_PYTHON = ">=3.7.0"
-VERSION = "0.27.1-beta"
+VERSION = "0.27.2-beta"
 LICENSE = "Apache Software License 2.0"
 
 with open("README.rst") as readme_file:

--- a/xclim/__init__.py
+++ b/xclim/__init__.py
@@ -9,7 +9,7 @@ from xclim.indicators import atmos, land, seaIce  # noqa
 
 __author__ = """Travis Logan"""
 __email__ = "logan.travis@ouranos.ca"
-__version__ = "0.27.1-beta"
+__version__ = "0.27.2-beta"
 
 
 # Virtual modules creation:

--- a/xclim/core/cfchecks.py
+++ b/xclim/core/cfchecks.py
@@ -32,16 +32,21 @@ def check_valid(var, key: str, expected: Union[str, Sequence[str]]):
         )
 
 
+def cfcheck_from_name(varname, vardata):
+    """Perform cfchecks on a DataArray using specifications from xclim's default variables."""
+    data = VARIABLES[varname]
+    if "cell_methods" in data:
+        check_valid(
+            vardata, "cell_methods", parse_cell_methods(data["cell_methods"]) + "*"
+        )
+    if "standard_name" in data:
+        check_valid(vardata, "standard_name", data["standard_name"])
+
+
 def generate_cfcheck(*varnames):
     def _generated_check(*args):
         for varname, var in zip(varnames, args):
-            data = VARIABLES[varname]
-            if "cell_methods" in data:
-                check_valid(
-                    var, "cell_methods", parse_cell_methods(data["cell_methods"]) + "*"
-                )
-            if "standard_name" in data:
-                check_valid(var, "standard_name", data["standard_name"])
+            cfcheck_from_name(varname, var)
 
     return _generated_check
 

--- a/xclim/data/variables.yml
+++ b/xclim/data/variables.yml
@@ -55,6 +55,7 @@ variables:
     cmip6: False
     canonical_units: degree
     cell_methods:
+    - time: mean
     description: Surface wind direction of provenance.
     standard_name: wind_from_direction
   siconc:

--- a/xclim/indicators/atmos/_conversion.py
+++ b/xclim/indicators/atmos/_conversion.py
@@ -28,7 +28,6 @@ class Converter(Indicator):
 
 humidex = Converter(
     identifier="humidex",
-    nvar=2,
     units="C",
     standard_name="air_temperature",
     long_name="humidex index",
@@ -40,7 +39,6 @@ humidex = Converter(
 
 tg = Converter(
     identifier="tg",
-    nvar=2,
     units="K",
     standard_name="air_temperature",
     long_name="Daily mean temperature",
@@ -52,7 +50,6 @@ tg = Converter(
 
 wind_speed_from_vector = Converter(
     identifier="wind_speed_from_vector",
-    nvar=2,
     var_name=["sfcWind", "sfcWindfromdir"],
     units=["m s-1", "degree"],
     standard_name=["wind_speed", "wind_from_direction"],
@@ -69,7 +66,6 @@ wind_speed_from_vector = Converter(
 
 wind_vector_from_speed = Converter(
     identifier="wind_vector_from_speed",
-    nvar=2,
     var_name=["uas", "vas"],
     units=["m s-1", "m s-1"],
     standard_name=["eastward_wind", "northward_wind"],
@@ -85,7 +81,6 @@ wind_vector_from_speed = Converter(
 
 saturation_vapor_pressure = Converter(
     identifier="e_sat",
-    nvar=1,
     units="Pa",
     long_name="Saturation vapor pressure",
     description=lambda **kws: (
@@ -103,7 +98,6 @@ saturation_vapor_pressure = Converter(
 
 relative_humidity_from_dewpoint = Converter(
     identifier="hurs_fromdewpoint",
-    nvar=2,
     units="%",
     var_name="hurs",
     long_name="Relative Humidity",
@@ -131,7 +125,6 @@ relative_humidity_from_dewpoint = Converter(
 
 relative_humidity = Converter(
     identifier="hurs",
-    nvar=3,
     units="%",
     long_name="Relative Humidity",
     standard_name="relative_humidity",
@@ -154,7 +147,6 @@ relative_humidity = Converter(
 
 specific_humidity = Converter(
     identifier="huss",
-    nvar=3,
     units="",
     long_name="Specific Humidity",
     standard_name="specific_humidity",
@@ -174,7 +166,6 @@ specific_humidity = Converter(
 
 snowfall_approximation = Converter(
     identifier="prsn",
-    nvar=2,
     units="kg m-2 s-1",
     standard_name="solid_precipitation_flux",
     long_name="Solid precipitation",
@@ -187,7 +178,6 @@ snowfall_approximation = Converter(
 
 rain_approximation = Converter(
     identifier="prlp",
-    nvar=2,
     units="kg m-2 s-1",
     standard_name="precipitation_flux",
     long_name="Liquid precipitation",
@@ -201,7 +191,6 @@ rain_approximation = Converter(
 
 wind_chill_index = Converter(
     identifier="wind_chill",
-    nvar=2,
     units="degC",
     long_name="Wind chill index",
     description=lambda **kws: (

--- a/xclim/indicators/atmos/_precip.py
+++ b/xclim/indicators/atmos/_precip.py
@@ -4,7 +4,7 @@ from inspect import _empty
 
 from xclim import indices
 from xclim.core import cfchecks
-from xclim.core.indicator import Daily, Daily2D, Hourly
+from xclim.core.indicator import Daily, Hourly
 from xclim.core.utils import wrapped_partial
 
 __all__ = [
@@ -32,43 +32,27 @@ __all__ = [
 ]
 
 
-class Pr(Daily):
+class Precip(Daily):
     """Indicator involving daily pr series."""
 
     context = "hydro"
-    cfcheck = staticmethod(cfchecks.generate_cfcheck("pr"))
 
 
-class HrPr(Hourly):
-    """Indicator involving hourly pr series,"""
-
-    context = "hydro"
-    cfcheck = staticmethod(cfchecks.generate_cfcheck("pr"))
-
-
-class PrTasx(Daily2D):
+class PrTasx(Daily):
     """Indicator involving pr and one of tas, tasmin or tasmax."""
 
     context = "hydro"
 
     @staticmethod
     def cfcheck(pr, tas):
-        cfchecks.generate_cfcheck("pr")(pr)
+        cfchecks.cfcheck_from_name("pr", pr)
         cfchecks.check_valid(tas, "standard_name", "air_temperature")
 
 
-class PrTas(Daily2D):
-    """Indicator involving pr and one of tas, tasmin or tasmax."""
+class HrPrecip(Hourly):
+    """Indicator involving hourly pr series,"""
 
     context = "hydro"
-    cfcheck = staticmethod(cfchecks.generate_cfcheck("pr", "tas"))
-
-
-class Prsn(Daily):
-    """Indicator involving daily prsn series."""
-
-    context = "hydro"
-    cfcheck = staticmethod(cfchecks.generate_cfcheck("prsn"))
 
 
 rain_on_frozen_ground_days = PrTasx(
@@ -86,7 +70,7 @@ rain_on_frozen_ground_days = PrTasx(
     compute=indices.rain_on_frozen_ground_days,
 )
 
-max_1day_precipitation_amount = Pr(
+max_1day_precipitation_amount = Precip(
     identifier="rx1day",
     units="mm/day",
     standard_name="lwe_thickness_of_precipitation_amount",
@@ -96,7 +80,7 @@ max_1day_precipitation_amount = Pr(
     compute=indices.max_1day_precipitation_amount,
 )
 
-max_n_day_precipitation_amount = Pr(
+max_n_day_precipitation_amount = Precip(
     identifier="max_n_day_precipitation_amount",
     var_name="rx{window}day",
     units="mm",
@@ -107,7 +91,7 @@ max_n_day_precipitation_amount = Pr(
     compute=indices.max_n_day_precipitation_amount,
 )
 
-wetdays = Pr(
+wetdays = Precip(
     identifier="wetdays",
     units="days",
     standard_name="number_of_days_with_lwe_thickness_of_precipitation_amount_at_or_above_threshold",
@@ -117,7 +101,7 @@ wetdays = Pr(
     compute=indices.wetdays,
 )
 
-dry_days = Pr(
+dry_days = Precip(
     identifier="dry_days",
     units="days",
     standard_name="number_of_days_with_lwe_thickness_of_precipitation_amount_below_threshold",
@@ -127,7 +111,7 @@ dry_days = Pr(
     compute=indices.dry_days,
 )
 
-maximum_consecutive_wet_days = Pr(
+maximum_consecutive_wet_days = Precip(
     identifier="cwd",
     units="days",
     standard_name="number_of_days_with_lwe_thickness_of_"
@@ -139,7 +123,7 @@ maximum_consecutive_wet_days = Pr(
     compute=indices.maximum_consecutive_wet_days,
 )
 
-maximum_consecutive_dry_days = Pr(
+maximum_consecutive_dry_days = Precip(
     identifier="cdd",
     units="days",
     standard_name="number_of_days_with_lwe_thickness_of_"
@@ -151,7 +135,7 @@ maximum_consecutive_dry_days = Pr(
     compute=indices.maximum_consecutive_dry_days,
 )
 
-daily_pr_intensity = Pr(
+daily_pr_intensity = Precip(
     identifier="sdii",
     units="mm/day",
     standard_name="lwe_thickness_of_precipitation_amount",
@@ -163,7 +147,7 @@ daily_pr_intensity = Pr(
     compute=indices.daily_pr_intensity,
 )
 
-max_pr_intensity = HrPr(
+max_pr_intensity = HrPrecip(
     identifier="max_pr_intensity",
     units="mm/h",
     standard_name="precipitation",
@@ -175,7 +159,7 @@ max_pr_intensity = HrPr(
     keywords="IDF curves",
 )
 
-precip_accumulation = Pr(
+precip_accumulation = Precip(
     title="Accumulated total precipitation (solid and liquid)",
     identifier="prcptot",
     units="mm",
@@ -212,7 +196,7 @@ solid_precip_accumulation = PrTasx(
     ),
 )
 
-drought_code = PrTas(
+drought_code = Precip(
     identifier="dc",
     units="",
     standard_name="drought_code",
@@ -222,9 +206,7 @@ drought_code = PrTas(
     missing="skip",
 )
 
-fire_weather_indexes = Daily(
-    module="atmos",  # Hack because we aren't using a class defined within xclim.indicators.atmos.
-    nvar=4,
+fire_weather_indexes = Precip(
     identifier="fwi",
     realm="atmos",
     var_name=["dc", "dmc", "ffmc", "isi", "bui", "fwi"],
@@ -258,7 +240,7 @@ fire_weather_indexes = Daily(
 )
 
 
-last_snowfall = Prsn(
+last_snowfall = Precip(
     identifier="last_snowfall",
     standard_name="day_of_year",
     long_name="Date of last snowfall",
@@ -267,7 +249,7 @@ last_snowfall = Prsn(
     compute=indices.last_snowfall,
 )
 
-first_snowfall = Prsn(
+first_snowfall = Precip(
     identifier="first_snowfall",
     standard_name="day_of_year",
     long_name="Date of first snowfall",
@@ -276,7 +258,7 @@ first_snowfall = Prsn(
     compute=indices.first_snowfall,
 )
 
-days_with_snow = Prsn(
+days_with_snow = Precip(
     identifier="days_with_snow",
     title="Days with snowfall",
     long_name="Number of days with solid precipitation flux between low and high thresholds.",
@@ -285,7 +267,7 @@ days_with_snow = Prsn(
     compute=indices.days_with_snow,
 )
 
-days_over_precip_thresh = Pr(
+days_over_precip_thresh = Precip(
     identifier="days_over_precip_thresh",
     standard_name="number_of_days_with_lwe_thickness_of_precipitation_amount_above_threshold",
     description="{freq} number of days with precipitation above a daily percentile."
@@ -305,7 +287,7 @@ high_precip_low_temp = PrTasx(
 )
 
 
-fraction_over_precip_thresh = Pr(
+fraction_over_precip_thresh = Precip(
     identifier="fraction_over_precip_thresh",
     description="{freq} fraction of total precipitation due to days with precipitation above a daily percentile."
     " Only days with at least {thresh} are included in the total.",

--- a/xclim/indicators/atmos/_temperature.py
+++ b/xclim/indicators/atmos/_temperature.py
@@ -3,7 +3,7 @@
 
 from xclim import indices
 from xclim.core import cfchecks
-from xclim.core.indicator import Daily, Daily2D
+from xclim.core.indicator import Daily
 from xclim.core.utils import wrapped_partial
 
 __all__ = [
@@ -69,39 +69,14 @@ __all__ = [
 ]
 
 
-class Tas(Daily):
-    """Class for univariate indices using mean daily temperature as the input."""
+# We need to declare the class here so that the `atmos` realm is automatically detected.
+class Temp(Daily):
+    """Indicators involving temperature."""
 
-    cfcheck = staticmethod(cfchecks.generate_cfcheck("tas"))
-
-
-class Tasmin(Daily):
-    """Class for univariate indices using min daily temperature as the input."""
-
-    cfcheck = staticmethod(cfchecks.generate_cfcheck("tasmin"))
+    pass
 
 
-class Tasmax(Daily):
-    """Class for univariate indices using max daily temperature as the input."""
-
-    cfcheck = staticmethod(cfchecks.generate_cfcheck("tasmax"))
-
-
-class Tasx(Daily):
-    """Class for univariate indices using mean, max or min daily temperature as the input."""
-
-    @staticmethod
-    def cfcheck(tas):
-        cfchecks.check_valid(tas, "standard_name", "air_temperature")
-
-
-class TasminTasmax(Daily2D):
-    """Class for bivariate indices using max and min daily temperature as inputs."""
-
-    cfcheck = staticmethod(cfchecks.generate_cfcheck("tasmin", "tasmax"))
-
-
-tn_days_above = Tasmin(
+tn_days_above = Temp(
     identifier="tn_days_above",
     units="days",
     standard_name="number_of_days_with_air_temperature_above_threshold",
@@ -111,7 +86,7 @@ tn_days_above = Tasmin(
     compute=indices.tn_days_above,
 )
 
-tn_days_below = Tasmin(
+tn_days_below = Temp(
     identifier="tn_days_below",
     units="days",
     standard_name="number_of_days_with_air_temperature_below_threshold",
@@ -121,7 +96,7 @@ tn_days_below = Tasmin(
     compute=indices.tn_days_below,
 )
 
-tg_days_above = Tas(
+tg_days_above = Temp(
     identifier="tg_days_above",
     units="days",
     standard_name="number_of_days_with_air_temperature_above_threshold",
@@ -131,7 +106,7 @@ tg_days_above = Tas(
     compute=indices.tg_days_above,
 )
 
-tg_days_below = Tas(
+tg_days_below = Temp(
     identifier="tg_days_below",
     units="days",
     standard_name="number_of_days_with_air_temperature_below_threshold",
@@ -141,7 +116,7 @@ tg_days_below = Tas(
     compute=indices.tg_days_below,
 )
 
-tx_days_above = Tasmax(
+tx_days_above = Temp(
     identifier="tx_days_above",
     units="days",
     standard_name="number_of_days_with_air_temperature_above_threshold",
@@ -151,7 +126,7 @@ tx_days_above = Tasmax(
     compute=indices.tx_days_above,
 )
 
-tx_days_below = Tasmin(
+tx_days_below = Temp(
     identifier="tx_days_below",
     units="days",
     standard_name="number_of_days_with_air_temperature_below_threshold",
@@ -161,7 +136,7 @@ tx_days_below = Tasmin(
     compute=indices.tx_days_below,
 )
 
-tx_tn_days_above = TasminTasmax(
+tx_tn_days_above = Temp(
     identifier="tx_tn_days_above",
     units="days",
     standard_name="number_of_days_with_air_temperature_above_threshold",
@@ -173,7 +148,7 @@ tx_tn_days_above = TasminTasmax(
 )
 
 
-heat_wave_frequency = TasminTasmax(
+heat_wave_frequency = Temp(
     identifier="heat_wave_frequency",
     units="",
     standard_name="heat_wave_events",
@@ -189,7 +164,7 @@ heat_wave_frequency = TasminTasmax(
     compute=indices.heat_wave_frequency,
 )
 
-heat_wave_max_length = TasminTasmax(
+heat_wave_max_length = Temp(
     identifier="heat_wave_max_length",
     units="days",
     standard_name="spell_length_of_days_with_air_temperature_above_threshold",
@@ -205,7 +180,7 @@ heat_wave_max_length = TasminTasmax(
     compute=indices.heat_wave_max_length,
 )
 
-heat_wave_total_length = TasminTasmax(
+heat_wave_total_length = Temp(
     identifier="heat_wave_total_length",
     units="days",
     standard_name="spell_length_of_days_with_air_temperature_above_threshold",
@@ -222,7 +197,7 @@ heat_wave_total_length = TasminTasmax(
 )
 
 
-heat_wave_index = Tasmax(
+heat_wave_index = Temp(
     identifier="heat_wave_index",
     units="days",
     standard_name="heat_wave_index",
@@ -234,7 +209,7 @@ heat_wave_index = Tasmax(
 )
 
 
-hot_spell_frequency = Tasmax(
+hot_spell_frequency = Temp(
     identifier="hot_spell_frequency",
     units="",
     standard_name="hot_spell_events",
@@ -247,7 +222,7 @@ hot_spell_frequency = Tasmax(
     compute=indices.hot_spell_frequency,
 )
 
-hot_spell_max_length = Tasmax(
+hot_spell_max_length = Temp(
     identifier="hot_spell_max_length",
     units="days",
     standard_name="spell_length_of_days_with_air_temperature_above_threshold",
@@ -260,7 +235,7 @@ hot_spell_max_length = Tasmax(
     compute=indices.hot_spell_max_length,
 )
 
-tg_mean = Tas(
+tg_mean = Temp(
     identifier="tg_mean",
     units="K",
     standard_name="air_temperature",
@@ -270,7 +245,7 @@ tg_mean = Tas(
     compute=indices.tg_mean,
 )
 
-tg_max = Tas(
+tg_max = Temp(
     identifier="tg_max",
     units="K",
     standard_name="air_temperature",
@@ -280,7 +255,7 @@ tg_max = Tas(
     compute=indices.tg_max,
 )
 
-tg_min = Tas(
+tg_min = Temp(
     identifier="tg_min",
     units="K",
     standard_name="air_temperature",
@@ -290,7 +265,7 @@ tg_min = Tas(
     compute=indices.tg_min,
 )
 
-tx_mean = Tasmax(
+tx_mean = Temp(
     identifier="tx_mean",
     units="K",
     standard_name="air_temperature",
@@ -300,7 +275,7 @@ tx_mean = Tasmax(
     compute=indices.tx_mean,
 )
 
-tx_max = Tasmax(
+tx_max = Temp(
     identifier="tx_max",
     units="K",
     standard_name="air_temperature",
@@ -310,7 +285,7 @@ tx_max = Tasmax(
     compute=indices.tx_max,
 )
 
-tx_min = Tasmax(
+tx_min = Temp(
     identifier="tx_min",
     units="K",
     standard_name="air_temperature",
@@ -320,7 +295,7 @@ tx_min = Tasmax(
     compute=indices.tx_min,
 )
 
-tn_mean = Tasmin(
+tn_mean = Temp(
     identifier="tn_mean",
     units="K",
     standard_name="air_temperature",
@@ -330,7 +305,7 @@ tn_mean = Tasmin(
     compute=indices.tn_mean,
 )
 
-tn_max = Tasmin(
+tn_max = Temp(
     identifier="tn_max",
     units="K",
     standard_name="air_temperature",
@@ -340,7 +315,7 @@ tn_max = Tasmin(
     compute=indices.tn_max,
 )
 
-tn_min = Tasmin(
+tn_min = Temp(
     identifier="tn_min",
     units="K",
     standard_name="air_temperature",
@@ -350,7 +325,7 @@ tn_min = Tasmin(
     compute=indices.tn_min,
 )
 
-daily_temperature_range = TasminTasmax(
+daily_temperature_range = Temp(
     title="Mean of daily temperature range.",
     identifier="dtr",
     units="K",
@@ -361,7 +336,7 @@ daily_temperature_range = TasminTasmax(
     compute=wrapped_partial(indices.daily_temperature_range, op="mean"),
 )
 
-max_daily_temperature_range = TasminTasmax(
+max_daily_temperature_range = Temp(
     title="Maximum of daily temperature range.",
     identifier="dtrmax",
     units="K",
@@ -372,7 +347,7 @@ max_daily_temperature_range = TasminTasmax(
     compute=wrapped_partial(indices.daily_temperature_range, op="max"),
 )
 
-daily_temperature_range_variability = TasminTasmax(
+daily_temperature_range_variability = Temp(
     identifier="dtrvar",
     units="K",
     standard_name="air_temperature",
@@ -386,7 +361,7 @@ daily_temperature_range_variability = TasminTasmax(
     compute=indices.daily_temperature_range_variability,
 )
 
-extreme_temperature_range = TasminTasmax(
+extreme_temperature_range = Temp(
     identifier="etr",
     units="K",
     standard_name="air_temperature",
@@ -396,7 +371,7 @@ extreme_temperature_range = TasminTasmax(
     compute=indices.extreme_temperature_range,
 )
 
-cold_spell_duration_index = Tasmin(
+cold_spell_duration_index = Temp(
     identifier="cold_spell_duration_index",
     var_name="csdi_{window}",
     units="days",
@@ -410,7 +385,7 @@ cold_spell_duration_index = Tasmin(
     compute=indices.cold_spell_duration_index,
 )
 
-cold_spell_days = Tas(
+cold_spell_days = Temp(
     identifier="cold_spell_days",
     units="days",
     standard_name="cold_spell_days",
@@ -422,7 +397,7 @@ cold_spell_days = Tas(
     compute=indices.cold_spell_days,
 )
 
-cold_spell_frequency = Tas(
+cold_spell_frequency = Temp(
     identifier="cold_spell_frequency",
     units="",
     standard_name="cold_spell_frequency",
@@ -435,7 +410,7 @@ cold_spell_frequency = Tas(
 )
 
 
-daily_freezethaw_cycles = TasminTasmax(
+daily_freezethaw_cycles = Temp(
     identifier="dlyfrzthw",
     units="days",
     long_name="daily freezethaw cycles",
@@ -451,7 +426,7 @@ daily_freezethaw_cycles = TasminTasmax(
 )
 
 
-freezethaw_spell_frequency = TasminTasmax(
+freezethaw_spell_frequency = Temp(
     identifier="freezethaw_spell_frequency",
     title="Frequency of freeze-thaw spells",
     units="days",
@@ -468,7 +443,7 @@ freezethaw_spell_frequency = TasminTasmax(
 )
 
 
-freezethaw_spell_mean_length = TasminTasmax(
+freezethaw_spell_mean_length = Temp(
     identifier="freezethaw_spell_mean_length",
     title="Averge length of freeze-thaw spells.",
     units="days",
@@ -485,7 +460,7 @@ freezethaw_spell_mean_length = TasminTasmax(
 )
 
 
-freezethaw_spell_max_length = TasminTasmax(
+freezethaw_spell_max_length = Temp(
     identifier="freezethaw_spell_max_length",
     title="Maximal length of freeze-thaw spells.",
     units="days",
@@ -502,7 +477,7 @@ freezethaw_spell_max_length = TasminTasmax(
 )
 
 
-cooling_degree_days = Tas(
+cooling_degree_days = Temp(
     identifier="cooling_degree_days",
     units="K days",
     standard_name="integral_of_air_temperature_excess_wrt_time",
@@ -512,7 +487,7 @@ cooling_degree_days = Tas(
     compute=indices.cooling_degree_days,
 )
 
-heating_degree_days = Tas(
+heating_degree_days = Temp(
     identifier="heating_degree_days",
     units="K days",
     standard_name="integral_of_air_temperature_deficit_wrt_time",
@@ -522,7 +497,7 @@ heating_degree_days = Tas(
     compute=indices.heating_degree_days,
 )
 
-growing_degree_days = Tas(
+growing_degree_days = Temp(
     identifier="growing_degree_days",
     units="K days",
     standard_name="integral_of_air_temperature_excess_wrt_time",
@@ -532,7 +507,7 @@ growing_degree_days = Tas(
     compute=indices.growing_degree_days,
 )
 
-freshet_start = Tas(
+freshet_start = Temp(
     identifier="freshet_start",
     units="",
     standard_name="day_of_year",
@@ -542,7 +517,7 @@ freshet_start = Tas(
     compute=indices.freshet_start,
 )
 
-frost_days = Tasmin(
+frost_days = Temp(
     identifier="frost_days",
     units="days",
     standard_name="days_with_air_temperature_below_threshold",
@@ -552,7 +527,7 @@ frost_days = Tasmin(
     compute=indices.frost_days,
 )
 
-frost_season_length = Tasmin(
+frost_season_length = Temp(
     identifier="frost_season_length",
     units="days",
     standard_name="days_with_air_temperature_below_threshold",
@@ -565,7 +540,7 @@ frost_season_length = Tasmin(
     compute=wrapped_partial(indices.frost_season_length, thresh="0 degC"),
 )
 
-last_spring_frost = Tasmin(
+last_spring_frost = Temp(
     identifier="last_spring_frost",
     units="",
     standard_name="day_of_year",
@@ -575,7 +550,7 @@ last_spring_frost = Tasmin(
     compute=indices.last_spring_frost,
 )
 
-first_day_below = Tasmin(
+first_day_below = Temp(
     identifier="first_day_below",
     units="",
     standard_name="day_of_year",
@@ -584,7 +559,7 @@ first_day_below = Tasmin(
     compute=indices.first_day_below,
 )
 
-first_day_above = Tasmin(
+first_day_above = Temp(
     identifier="first_day_above",
     units="",
     standard_name="day_of_year",
@@ -594,7 +569,7 @@ first_day_above = Tasmin(
 )
 
 
-ice_days = Tasmax(
+ice_days = Temp(
     identifier="ice_days",
     standard_name="days_with_air_temperature_below_threshold",
     units="days",
@@ -604,7 +579,7 @@ ice_days = Tasmax(
     compute=indices.ice_days,
 )
 
-consecutive_frost_days = Tasmin(
+consecutive_frost_days = Temp(
     identifier="consecutive_frost_days",
     units="days",
     standard_name="spell_length_of_days_with_air_temperature_below_threshold",
@@ -615,7 +590,7 @@ consecutive_frost_days = Tasmin(
     compute=indices.maximum_consecutive_frost_days,
 )
 
-maximum_consecutive_frost_free_days = Tasmin(
+maximum_consecutive_frost_free_days = Temp(
     identifier="consecutive_frost_free_days",
     units="days",
     standard_name="spell_length_of_days_with_air_temperature_above_threshold",
@@ -626,7 +601,7 @@ maximum_consecutive_frost_free_days = Tasmin(
     compute=indices.maximum_consecutive_frost_free_days,
 )
 
-growing_season_length = Tas(
+growing_season_length = Temp(
     identifier="growing_season_length",
     units="days",
     standard_name="growing_season_length",
@@ -639,7 +614,7 @@ growing_season_length = Tas(
     compute=indices.growing_season_length,
 )
 
-growing_season_end = Tas(
+growing_season_end = Temp(
     identifier="growing_season_end",
     units="",
     standard_name="day_of_year",
@@ -651,7 +626,7 @@ growing_season_end = Tas(
     compute=indices.growing_season_end,
 )
 
-tropical_nights = Tasmin(
+tropical_nights = Temp(
     identifier="tropical_nights",
     units="days",
     standard_name="number_of_days_with_air_temperature_above_threshold",
@@ -662,7 +637,7 @@ tropical_nights = Tasmin(
     compute=wrapped_partial(indices.tn_days_above, suggested=dict(thresh="20 degC")),
 )
 
-tg90p = Tas(
+tg90p = Temp(
     identifier="tg90p",
     units="days",
     standard_name="days_with_air_temperature_above_threshold",
@@ -674,7 +649,7 @@ tg90p = Tas(
     compute=indices.tg90p,
 )
 
-tg10p = Tas(
+tg10p = Temp(
     identifier="tg10p",
     units="days",
     standard_name="days_with_air_temperature_below_threshold",
@@ -686,7 +661,7 @@ tg10p = Tas(
     compute=indices.tg10p,
 )
 
-tx90p = Tasmax(
+tx90p = Temp(
     identifier="tx90p",
     units="days",
     standard_name="days_with_air_temperature_above_threshold",
@@ -698,7 +673,7 @@ tx90p = Tasmax(
     compute=indices.tx90p,
 )
 
-tx10p = Tasmax(
+tx10p = Temp(
     identifier="tx10p",
     units="days",
     standard_name="days_with_air_temperature_below_threshold",
@@ -710,7 +685,7 @@ tx10p = Tasmax(
     compute=indices.tx10p,
 )
 
-tn90p = Tasmin(
+tn90p = Temp(
     identifier="tn90p",
     units="days",
     standard_name="days_with_air_temperature_above_threshold",
@@ -722,7 +697,7 @@ tn90p = Tasmin(
     compute=indices.tn90p,
 )
 
-tn10p = Tasmin(
+tn10p = Temp(
     identifier="tn10p",
     units="days",
     standard_name="days_with_air_temperature_below_threshold",
@@ -735,7 +710,7 @@ tn10p = Tasmin(
 )
 
 
-degree_days_exceedance_date = Tas(
+degree_days_exceedance_date = Temp(
     identifier="degree_days_exceedance_date",
     units="",
     standard_name="day_of_year",
@@ -747,7 +722,7 @@ degree_days_exceedance_date = Tas(
 )
 
 
-warm_spell_duration_index = Tasmax(
+warm_spell_duration_index = Temp(
     identifier="warm_spell_duration_index",
     description="{freq} total number of days within spells of at least {window} days"
     " with tmax above the 90th daily percentile.",
@@ -758,7 +733,7 @@ warm_spell_duration_index = Tasmax(
 )
 
 
-maximum_consecutive_warm_days = Tasmax(
+maximum_consecutive_warm_days = Temp(
     identifier="maximum_consecutive_warm_days",
     description="{freq} longest spell of consecutive days with Tmax above {thresh}.",
     units="days",
@@ -768,14 +743,24 @@ maximum_consecutive_warm_days = Tasmax(
 )
 
 
-fire_season = Tasx(
+class FireSeasonBase(Daily):
+    """Special Indicator class for FireSeason that accepts any tas[min/max] and optional snd."""
+
+    @staticmethod
+    def cfcheck(tas, snd=None):
+        cfchecks.check_valid(tas, "standard_name", "air_temperature")
+        cfchecks.cfcheck_from_name("snd", snd)
+
+
+fire_season = FireSeasonBase(
     identifier="fire_season",
     description="Fire season mask, computed with method {method}.",
     units="",
     compute=indices.fire_season,
 )
 
-corn_heat_units = TasminTasmax(
+
+corn_heat_units = Temp(
     identifier="corn_heat_units",
     units="",
     long_name="Corn heat units (Tmin > {thresh_tasmin} and Tmax > {thresh_tasmax}).",

--- a/xclim/indicators/atmos/_temperature.py
+++ b/xclim/indicators/atmos/_temperature.py
@@ -76,8 +76,6 @@ __all__ = [
 class Temp(Daily):
     """Indicators involving temperature."""
 
-    pass
-
 
 tn_days_above = Temp(
     identifier="tn_days_above",
@@ -775,7 +773,7 @@ corn_heat_units = Temp(
     compute=indices.corn_heat_units,
 )
 
-biologically_effective_degree_days = TasminTasmax(
+biologically_effective_degree_days = Temp(
     identifier="biologically_effective_degree_days",
     units="K days",
     long_name="Biologically effective degree days computed with {method} formula (Summation of min((max((Tmin + Tmax)/2"

--- a/xclim/indicators/land/_snow.py
+++ b/xclim/indicators/land/_snow.py
@@ -16,8 +16,6 @@ __all__ = [
 class Snow(Daily):
     """Indicators dealing with snow variables."""
 
-    pass
-
 
 snow_cover_duration = Snow(
     identifier="snow_cover_duration",

--- a/xclim/indicators/land/_snow.py
+++ b/xclim/indicators/land/_snow.py
@@ -1,6 +1,5 @@
 from xclim import indices as xci
-from xclim.core.cfchecks import generate_cfcheck
-from xclim.core.indicator import Daily, Daily2D
+from xclim.core.indicator import Daily
 
 __all__ = [
     "blowing_snow",
@@ -13,27 +12,14 @@ __all__ = [
 ]
 
 
-class SnowDepth(Daily):
-    cfcheck = staticmethod(generate_cfcheck("snd"))
+# We need to declare the base class here so the `land` module is detected automatically.
+class Snow(Daily):
+    """Indicators dealing with snow variables."""
+
+    pass
 
 
-class SnowCover(Daily):
-    cfcheck = staticmethod(generate_cfcheck("snc"))
-
-
-class SnowAmount(Daily):
-    cfcheck = staticmethod(generate_cfcheck("snw"))
-
-
-class SnwPr(Daily2D):
-    cfcheck = staticmethod(generate_cfcheck("snw", "pr"))
-
-
-class SndWs(Daily2D):
-    cfcheck = staticmethod(generate_cfcheck("snd", "sfcWind"))
-
-
-snow_cover_duration = SnowDepth(
+snow_cover_duration = Snow(
     identifier="snow_cover_duration",
     units="days",
     long_name="Number of days with snow depth above threshold",
@@ -41,7 +27,7 @@ snow_cover_duration = SnowDepth(
     compute=xci.snow_cover_duration,
 )
 
-continuous_snow_cover_start = SnowDepth(
+continuous_snow_cover_start = Snow(
     identifier="continuous_snow_cover_start",
     standard_name="day_of_year",
     long_name="Start date of continuous snow cover",
@@ -50,7 +36,7 @@ continuous_snow_cover_start = SnowDepth(
     compute=xci.continuous_snow_cover_start,
 )
 
-continuous_snow_cover_end = SnowDepth(
+continuous_snow_cover_end = Snow(
     identifier="continuous_snow_cover_end",
     standard_name="day_of_year",
     long_name="Start date of continuous snow cover",
@@ -59,7 +45,7 @@ continuous_snow_cover_end = SnowDepth(
     compute=xci.continuous_snow_cover_end,
 )
 
-snd_max_doy = SnowDepth(
+snd_max_doy = Snow(
     identifier="snd_max_doy",
     var_name="{freq}_snd_max_doy",
     long_name="Date when snow depth reaches its maximum value.",
@@ -69,7 +55,7 @@ snd_max_doy = SnowDepth(
     compute=xci.snd_max_doy,
 )
 
-snow_melt_we_max = SnowAmount(
+snow_melt_we_max = Snow(
     identifier="snow_melt_we_max",
     standard_name="change_over_time_in_surface_snow_amount",
     var_name="{freq}_snow_melt_we_max",
@@ -79,7 +65,7 @@ snow_melt_we_max = SnowAmount(
 )
 
 
-melt_and_precip_max = SnwPr(
+melt_and_precip_max = Snow(
     identifier="melt_and_precip_max",
     var_name="{freq}_melt_and_precip_max",
     description="{freq} maximum precipitation flux and negative change in snow amount over {window} days.",
@@ -88,7 +74,7 @@ melt_and_precip_max = SnwPr(
 )
 
 
-winter_storm = SnowDepth(
+winter_storm = Snow(
     identifier="winter_storm",
     var_name="{freq}_winter_storm",
     description="{freq} number of days with snowfall accumulation above {thresh}.",
@@ -97,7 +83,7 @@ winter_storm = SnowDepth(
 )
 
 
-blowing_snow = SndWs(
+blowing_snow = Snow(
     identifier="blowing_snow",
     var_name="{freq}_blowing_snow",
     description="{freq} number of days with snowfall over last {window} days above {snd_thresh} and wind speed above "

--- a/xclim/indicators/seaIce/_seaice.py
+++ b/xclim/indicators/seaIce/_seaice.py
@@ -4,18 +4,15 @@ Sea ice indicators
 ------------------
 """
 from xclim import indices
-from xclim.core.cfchecks import generate_cfcheck
-from xclim.core.indicator import Indicator2D
+from xclim.core.indicator import Indicator
 
 __all__ = ["sea_ice_area", "sea_ice_extent"]
 
 
-class SiconcAreacello(Indicator2D):
+class SiconcAreacello(Indicator):
     """Class for indicators having sea ice concentration and grid cell area inputs."""
 
     missing = "skip"
-
-    cfcheck = staticmethod(generate_cfcheck("siconc", "areacello"))
 
 
 sea_ice_extent = SiconcAreacello(

--- a/xclim/indices/fwi.py
+++ b/xclim/indices/fwi.py
@@ -1118,7 +1118,6 @@ def fire_weather_ufunc(
         input_core_dims=input_core_dims,
         output_core_dims=output_core_dims,
         dask="parallelized",
-        output_dtypes=output_dtypes,
         dask_gufunc_kwargs={
             "meta": tuple(np.array((), dtype=dtype) for dtype in output_dtypes)
         },

--- a/xclim/testing/tests/test_indicators.py
+++ b/xclim/testing/tests/test_indicators.py
@@ -3,7 +3,7 @@
 # Tests for the Indicator objects
 import gc
 import json
-from typing import Union
+from typing import Optional, Union
 
 import dask
 import numpy as np
@@ -37,7 +37,7 @@ class UniIndTemp(Daily):
     cell_methods = "time: mean within {freq:noun}"
 
     @staticmethod
-    def compute(da: xr.DataArray, thresh=0.0, freq="YS"):
+    def compute(da: xr.DataArray, thresh: int = 0.0, freq: str = "YS"):
         """Docstring"""
         out = da
         out -= thresh
@@ -62,7 +62,7 @@ class UniClim(Daily):
     units = "K"
 
     @staticmethod
-    def compute(da: xr.DataArray, **indexer):
+    def compute(da: xr.DataArray, freq="YS", **indexer):
         select = select_time(da, **indexer)
         return select.mean(dim="time", keep_attrs=True)
 
@@ -83,6 +83,23 @@ class MultiTemp(Daily):
         )
 
 
+class MultiOptVar(Daily):
+    realm = "atmos"
+    identifier = "multiopt"
+    units = "K"
+
+    @staticmethod
+    def compute(
+        tas: Optional[xr.DataArray] = None,
+        tasmax: Optional[xr.DataArray] = None,
+        tasmin: Optional[xr.DataArray] = None,
+    ):
+        if tas is None:
+            with xr.set_options(keep_attrs=True):
+                return (tasmin + tasmax) / 2
+        return tas
+
+
 def test_attrs(tas_series):
     import datetime as dt
 
@@ -94,6 +111,15 @@ def test_attrs(tas_series):
     assert "TMIN(da=<array>, thresh=5, freq='YS')" in txm.attrs["xclim_history"]
     assert f"xclim version: {__version__}." in txm.attrs["xclim_history"]
     assert txm.name == "tmin5"
+
+
+def test_opt_vars(tasmin_series, tasmax_series):
+    tn = tasmin_series(np.zeros(365))
+    tx = tasmax_series(np.zeros(365))
+
+    ind = MultiOptVar()
+
+    ind(tasmin=tn, tasmax=tx)
 
 
 def test_registering():
@@ -110,7 +136,7 @@ def test_registering():
 
     # Confirm registries live in subclasses.
     class IndicatorNew(Indicator):
-        nvar = 2
+        pass
 
     # Identifier must be given
     with pytest.raises(AttributeError, match="has not been set."):
@@ -467,5 +493,3 @@ def test_indicator_from_dict():
     # Default value for input variable injected and meta injected
     assert ind._sig.parameters["data"].default == "tas"
     assert ind.parameters["data"]["units"] == "K"
-    # Cf checks were generated
-    assert ind.cfcheck is not Daily.cfcheck

--- a/xclim/testing/tests/test_utils.py
+++ b/xclim/testing/tests/test_utils.py
@@ -43,7 +43,12 @@ def test_wrapped_partial():
 
 
 def test_wrapped_indicator(tas_series):
-    def indice(tas, tas2=None, thresh=0, freq="YS"):
+    def indice(
+        tas: xr.DataArray,
+        tas2: xr.DataArray = None,
+        thresh: int = float,
+        freq: str = "YS",
+    ):
         if tas2 is None:
             out = tas < thresh
         else:
@@ -55,7 +60,6 @@ def test_wrapped_indicator(tas_series):
     ind1 = Daily(
         realm="atmos",
         identifier="test_ind1",
-        nvar=1,
         units="days",
         compute=wrapped_partial(indice, tas2=None),
     )
@@ -63,7 +67,6 @@ def test_wrapped_indicator(tas_series):
     ind2 = Daily(
         realm="atmos",
         identifier="test_ind2",
-        nvar=2,
         units="days",
         compute=wrapped_partial(indice, thresh=None),
     )


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (major / minor / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

## What kind of change does this PR introduce?
Internal changes in how `Indicators` decide which inputs are "variables" and which are "parameters". 

Changes:

- "Variables" are those with a "VARIABLE" or "OPTIONAL_VARIABLE" _kind_ so those with a `xr.DataArray` annotation (or optional). "Parameters" are the others. Before we had `Indicator.nvar` that would say the number of parameters (in signature order) which were "variables". This is dropped, `nvar` doesn't exist anymore.
- ONLY "Variables" are send to cf, data and missing checks. Optional variables that were not given (= None) are not sent.
- To simplify the internals, the default `cfcheck` will perform a check based on the CF metadata available in xclim/data/variables.yml, looking up the name of the variable (which should all be conform to CMIP6 now). No need to manually write `cfchecks` for indicators declared within xclim (except a few special cases).
- The missing method defaults to `skip` if the indice has no `freq` parameters. This inverts the previous behaviour where we had to explicitly pass `missing='skip'` when no resampling was performed.
- The last two have reduced the need for custom indicator base class in `indicators/*.py`.
 
* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->
Hopefully not.

* **Other information**:
This small afternoon fix took the full afternoon. I am sorry for the reviewer.