### PR TITLE
Add cool night index

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -17,6 +17,7 @@ New indicators
 ~~~~~~~~~~~~~~
 * `biologically_effective_degree_days` (with ``method="gladstones"``) indice computes degree-days between two specific dates, with a capped daily max value as well as latitude and temperature range swing as modifying coefficients (based on Gladstones, J. (1992)). This has also been wrapped as an indicator.
 * An alternative implementation of `biologically_effective_degree_days` (with ``method="icclim"``, based on ICCLIM formula) ignores latitude and temperature range swing modifiers and uses an alternate ``end_date``. Wrapped and available as an ICCLIM indicator.
+* `cool_night_index` indice returns the mean minimum temperature in September (``lat >= 0`` deg N) or March (``lat < 0`` deg N), based on Tonietto & Carbonneau, 2004 (10.1016/j.agrformet.2003.06.001). Also available as an indicator (see indices `Notes` section on indicator usage recommendations).
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.27.2-beta
+current_version = 0.27.3-beta
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+).(?P<patch>\d+)(\-(?P<release>[a-z]+))?

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ URL = "https://github.com/Ouranosinc/xclim"
 AUTHOR = "Travis Logan"
 AUTHOR_EMAIL = "logan.travis@ouranos.ca"
 REQUIRES_PYTHON = ">=3.7.0"
-VERSION = "0.27.2-beta"
+VERSION = "0.27.3-beta"
 LICENSE = "Apache Software License 2.0"
 
 with open("README.rst") as readme_file:

--- a/xclim/__init__.py
+++ b/xclim/__init__.py
@@ -9,7 +9,7 @@ from xclim.indicators import atmos, land, seaIce  # noqa
 
 __author__ = """Travis Logan"""
 __email__ = "logan.travis@ouranos.ca"
-__version__ = "0.27.2-beta"
+__version__ = "0.27.3-beta"
 
 
 # Virtual modules creation:

--- a/xclim/data/fr.json
+++ b/xclim/data/fr.json
@@ -420,7 +420,6 @@
     "comment": "",
     "abstract": "Nombre de jours de vagues de froid. Une vague de froid se produit lorsque la température journalière minimale est sous le 10e percentile durant au moins un certain nombre de jours consécutifs."
   },
-
   "COLD_SPELL_FREQUENCY": {
     "long_name": "Nombre de vagues de froid",
     "description": "Nombre {freq:m} de vagues de froid. Une vague de froid se produit lorsque la température journalière minimale est sous {thresh} durant au moins {window} jours consécutifs.",
@@ -434,6 +433,13 @@
     "title": "Jours de vague de froid",
     "comment": "",
     "abstract": "Nombre de jours de vagues de froid. Une vague de froid se produit lorsque la température journalière minimale est sous un seuil durant au moins un certain nombre de jours consécutifs."
+  },
+  "COOL_NIGHT_INDEX": {
+    "long_name": "Indice  de  fraîcheur  des  nuits",
+    "description": "Moyenne {freq:f} de la température journalière minimale pendant septembre (hémisphère nord) ou mai (hémisphère sud)",
+    "title": "Indice  de  fraîcheur  des  nuits",
+    "comment": "Formule prise de Tonietto & Carbonneau, 2004 (10.1016/j.agrformet.2003.06.001).",
+    "abstract": "indicateur des conditions nycthermiques de maturation, qui correspond à la valeur moyenne de la température minimale de l'air sur les 30 jours précédents à la date de récolte potentielle."
   },
   "DLYFRZTHW": {
     "long_name": "Cycles de gel-dégel quotidien",

--- a/xclim/data/fr.json
+++ b/xclim/data/fr.json
@@ -436,10 +436,10 @@
   },
   "COOL_NIGHT_INDEX": {
     "long_name": "Indice  de  fraîcheur  des  nuits",
-    "description": "Moyenne {freq:f} de la température journalière minimale pendant septembre (hémisphère nord) ou mai (hémisphère sud)",
+    "description": "Moyenne {freq:f} de la température journalière minimale en septembre (hémisphère nord) ou en mars (hémisphère sud)",
     "title": "Indice  de  fraîcheur  des  nuits",
     "comment": "Formule prise de Tonietto & Carbonneau, 2004 (10.1016/j.agrformet.2003.06.001).",
-    "abstract": "indicateur des conditions nycthermiques de maturation, qui correspond à la valeur moyenne de la température minimale de l'air sur les 30 jours précédents à la date de récolte potentielle."
+    "abstract": "Indicateur des conditions nycthermiques de maturation, qui correspond à la valeur moyenne de la température minimale de l'air sur les 30 jours précédant la date de récolte potentielle."
   },
   "DLYFRZTHW": {
     "long_name": "Cycles de gel-dégel quotidien",

--- a/xclim/data/fr.json
+++ b/xclim/data/fr.json
@@ -435,9 +435,9 @@
     "abstract": "Nombre de jours de vagues de froid. Une vague de froid se produit lorsque la température journalière minimale est sous un seuil durant au moins un certain nombre de jours consécutifs."
   },
   "COOL_NIGHT_INDEX": {
-    "long_name": "Indice  de  fraîcheur  des  nuits",
+    "long_name": "Indice de fraîcheur des nuits",
     "description": "Moyenne {freq:f} de la température journalière minimale en septembre (hémisphère nord) ou en mars (hémisphère sud)",
-    "title": "Indice  de  fraîcheur  des  nuits",
+    "title": "Indice de fraîcheur des nuits",
     "comment": "Formule prise de Tonietto & Carbonneau, 2004 (10.1016/j.agrformet.2003.06.001).",
     "abstract": "Indicateur des conditions nycthermiques de maturation, qui correspond à la valeur moyenne de la température minimale de l'air sur les 30 jours précédant la date de récolte potentielle."
   },

--- a/xclim/indicators/atmos/_temperature.py
+++ b/xclim/indicators/atmos/_temperature.py
@@ -44,6 +44,7 @@ __all__ = [
     "cold_spell_duration_index",
     "cold_spell_days",
     "cold_spell_frequency",
+    "cool_night_index",
     "daily_freezethaw_cycles",
     "freezethaw_spell_frequency",
     "freezethaw_spell_max_length",
@@ -437,6 +438,16 @@ cold_spell_frequency = Tas(
     compute=indices.cold_spell_frequency,
 )
 
+cool_night_index = Tasmin(
+    identifier="cool_night_index",
+    units="degC",
+    long_name="cool night index",
+    description="Mean minimum temperature for September (northern hemisphere) or March (southern hemisphere).",
+    cell_methods="time: min within days time: mean over days",
+    comment="Original formula published in Tonietto & Carbonneau, 2004 (10.1016/j.agrformet.2003.06.001).",
+    allowed_periods=["A"],
+    compute=wrapped_partial(indices.cool_night_index, suggested=dict(lat=_empty)),
+)
 
 daily_freezethaw_cycles = TasminTasmax(
     identifier="dlyfrzthw",

--- a/xclim/indicators/atmos/_temperature.py
+++ b/xclim/indicators/atmos/_temperature.py
@@ -411,7 +411,7 @@ cold_spell_frequency = Temp(
     compute=indices.cold_spell_frequency,
 )
 
-cool_night_index = Tasmin(
+cool_night_index = Temp(
     identifier="cool_night_index",
     units="degC",
     long_name="cool night index",
@@ -420,7 +420,7 @@ cool_night_index = Tasmin(
     abstract="A night coolness variable which takes into account the mean minimum night temperatures during the "
     "month when ripening usually occurs beyond the ripening period.",
     allowed_periods=["A"],
-    compute=wrapped_partial(indices.cool_night_index, suggested=dict(lat=_empty)),
+    compute=indices.cool_night_index,
 )
 
 daily_freezethaw_cycles = Temp(

--- a/xclim/indicators/atmos/_temperature.py
+++ b/xclim/indicators/atmos/_temperature.py
@@ -444,7 +444,6 @@ cool_night_index = Tasmin(
     long_name="cool night index",
     description="Mean minimum temperature for September (northern hemisphere) or March (southern hemisphere).",
     cell_methods="time: min within days time: mean over days",
-    comment="Original formula published in Tonietto & Carbonneau, 2004 (10.1016/j.agrformet.2003.06.001).",
     abstract="A night coolness variable which takes into account the mean minimum night temperatures during the "
     "month when ripening usually occurs beyond the ripening period.",
     allowed_periods=["A"],

--- a/xclim/indicators/atmos/_temperature.py
+++ b/xclim/indicators/atmos/_temperature.py
@@ -445,6 +445,8 @@ cool_night_index = Tasmin(
     description="Mean minimum temperature for September (northern hemisphere) or March (southern hemisphere).",
     cell_methods="time: min within days time: mean over days",
     comment="Original formula published in Tonietto & Carbonneau, 2004 (10.1016/j.agrformet.2003.06.001).",
+    abstract="A night coolness variable which takes into account the mean minimum night temperatures during the "
+    "month when ripening usually occurs beyond the ripening period.",
     allowed_periods=["A"],
     compute=wrapped_partial(indices.cool_night_index, suggested=dict(lat=_empty)),
 )

--- a/xclim/indices/_agro.py
+++ b/xclim/indices/_agro.py
@@ -262,7 +262,7 @@ def cool_night_index(
 
     Notes
     -----
-    Given that this indice only examines September and May months, it possible to send in DataArrays containing only
+    Given that this indice only examines September and March months, it possible to send in DataArrays containing only
     these timesteps. Users should be aware that due to the missing values checks in wrapped Indicators, datasets that
     are missing several months will be flagged as invalid. This check can be ignored by setting the following context:
 

--- a/xclim/indices/_agro.py
+++ b/xclim/indices/_agro.py
@@ -262,7 +262,7 @@ def cool_night_index(
     are missing several months will be flagged as invalid. This check can be ignored by setting the following context:
 
     >>> with xclim.set_options(check_missing='skip', data_validation='log'):
-    >>>     cni = xclim.atmos.CNI(...)
+    >>>     cni = xclim.atmos.cool_night_index(...)  # xdoctest: +SKIP
 
     References
     ----------

--- a/xclim/indices/_agro.py
+++ b/xclim/indices/_agro.py
@@ -1,8 +1,7 @@
 # noqa: D100
 
-from typing import Optional, Union
+from typing import Optional
 
-import numpy as np
 import xarray
 
 import xclim.indices as xci
@@ -18,10 +17,11 @@ from xclim.indices.generic import aggregate_between_dates
 # -------------------------------------------------- #
 
 __all__ = [
-  "corn_heat_units",
-  "biologically_effective_degree_days",
-  "cool_night_index",
-  "water_budget"
+    "corn_heat_units",
+    "biologically_effective_degree_days",
+    "cool_night_index",
+    "water_budget",
+]
 
 
 @declare_units(

--- a/xclim/testing/tests/test_indices.py
+++ b/xclim/testing/tests/test_indices.py
@@ -283,6 +283,22 @@ class TestAgroclimaticIndices:
         if method == "icclim":
             np.testing.assert_array_equal(bedd, bedd_high_lat)
 
+    def test_cool_night_index(self):
+        ds = open_dataset("cmip5/tas_Amon_CanESM2_rcp85_r1i1p1_200701-200712.nc")
+        ds = ds.rename(dict(tas="tasmin"))
+
+        cni = xci.cool_night_index(tasmin=ds.tasmin, lat=ds.lat)
+        tasmin = convert_units_to(ds.tasmin, "degC")
+
+        cni_nh = cni.where(cni.lat >= 0, drop=True)
+        cni_sh = cni.where(cni.lat < 0, drop=True)
+
+        tn_nh = tasmin.where((tasmin.lat >= 0) & (tasmin.time.dt.month == 9), drop=True)
+        tn_sh = tasmin.where((tasmin.lat < 0) & (tasmin.time.dt.month == 3), drop=True)
+
+        np.testing.assert_array_equal(cni_nh, tn_nh)
+        np.testing.assert_array_equal(cni_sh, tn_sh)
+
 
 class TestDailyFreezeThawCycles:
     def test_simple(self, tasmin_series, tasmax_series):


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR partially addresses #355 
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [x] `bumpversion (major / minor / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

* **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, etc.)-->

This adds the Cool Night Index, based on the formula published in Tonietto & Carbonneau (2004) to xclim.

![cni](https://user-images.githubusercontent.com/10819524/121607779-a4f0b480-ca1e-11eb-9a76-58fef1228f0c.png)

* **Does this PR introduce a breaking change?** <!--(Has there been an API change?)-->

No. Just adds an indice and an indicator.

* **Other information**:

Due to the fact that this indicator creates a mosaic of two different months, depending on latitude, one could technically supply a dataset missing all other months and receive the data they demand from the indice. This is not the case for the _indicator_, as the missing data will trigger an invalid year if missing_values checks are enabled. This warning  has been mentioned in the indice docstring.
