### PR TITLE
Simplify parts of the yaml, allow injecting freq

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -28,6 +28,8 @@ Internal Changes
 * Default cfcheck is now to check metadata according to the variable name, using CMIP6 names in xclim/data/variable.yml.
 * ``Indicator.missing`` defaults to "skip" if ``freq`` is absent from the list of parameters.
 * Minor modifications to the GitHub Pull Requests template.
+* Simplification of some yaml elements for virtual modules.
+* Allow injecting `freq` without the missing checks failing.
 
 
 0.27.0 (2021-05-28)

--- a/docs/notebooks/example.py
+++ b/docs/notebooks/example.py
@@ -29,6 +29,6 @@ def extreme_precip_accumulation(pr: xr.DataArray, perc: float = 95, freq: str = 
 
     pr_extreme = rate2amount(pr).where(pr >= pr_thresh)
 
-    out = pr_extreme.resample(time=freq).sum()
+    out = pr_extreme.resample(time=freq).sum().drop_vars("quantile")
     out.attrs["units"] = pr_extreme.units
     return out

--- a/docs/notebooks/example.yml
+++ b/docs/notebooks/example.yml
@@ -9,19 +9,20 @@ indices:
   RX1day:
     base: rx1day
     period:
-      seasonal: [DJFMA, MJJ, ASON]
+      allowed:
+      - seasonal
+      - annual
+      default: annual
     output:
       long_name: Highest 1-day precipitation amount
   RX5day:
     base: max_n_day_precipitation_amount
-    period:
-        monthly
     output:
       long_name: Highest 5-day precipitation amount
     index_function:
       parameters:
-        window:
-          data: 5
+        window: 5
+        freq: QS-DEC
   R75pdays:
     base: days_over_precip_thresh
     index_function:
@@ -47,20 +48,14 @@ indices:
     index_function:
       name: count_occurrences
       parameters:
-        threshold:
-          data: 0 degC
-        condition:
-          data: "<"
+        threshold: 0 degC
+        condition: "<"
   R95p:
     reference: climdex
-    period:
-      allowed:
-        - annual
-        - seasonal
-      default: annual
+    period: annual
     output:
       var_name: R95p
-      long_name: Annual total PRCP when RR > 95th percentile
+      long_name: Annual total PRCP when RR > {perc}th percentile
       units: m
       cell_methods:
         - time: sum within days
@@ -70,5 +65,10 @@ indices:
     index_function:
       name: extreme_precip_accumulation
       parameters:
-        perc:
-          data: 95
+        perc: 95
+  R99p:
+    base: .R95p
+    index_function:
+      name: extreme_precip_accumulation
+      parameters:
+        perc: 99

--- a/docs/notebooks/extendxclim.ipynb
+++ b/docs/notebooks/extendxclim.ipynb
@@ -372,17 +372,18 @@
     "`example.yml` created a module of 4 indicators.\n",
     "\n",
     "- `RX1day` is simply the same as  `registry['RX1DAY']`, but with an updated `long_name`.\n",
-    "- `RX5day` is based on `registry['MAX_N_DAY_PRECIPITATION_AMOUNT']`, changed the `long_name` and injects the `window` argument.\n",
+    "- `RX5day` is based on `registry['MAX_N_DAY_PRECIPITATION_AMOUNT']`, changed the `long_name` and injects the `window` and `freq` arguments.\n",
     "- `R75pdays` is based on `registry['DAYS_OVER_PRECIP_THRESH']`, injects the `thresh` argument and changes the description of the `per` argument. Passing \"data: {per}\" tells xclim the value is still to be determined by the user, but other parameter's metadata field might be changed.\n",
     "- `fd` is a more complex example. As there were no `base:` entry, the `Daily` class serves as a base. As it is pretty much empty, a lot has to be given explicitly:\n",
     "    * A list of allowed resampling frequency is passed\n",
     "    * Many output metadata fields are given\n",
     "    * A index_function name if given (here it refers to a function in `xclim.indices.generic`).\n",
     "    * Some parameters are injected.\n",
-    "    * The input variable `data` is mapped to a known variable. Function in `xclim.indices.generic` are indeed generic. Here we tell xclim that the `data` argument is minimal daily temperature. This will set the proper units check, default value and CF-compliance checks.\n",
-    "- `R95p` is similar to `fd` but here the `index_function` is not defined in `xclim` but rather in  `example.py`. Thus, we must first import this module and pass it to the module builder.\n",
+    "    * The input variable `data` is mapped to a known variable. Functions in `xclim.indices.generic` are indeed generic. Here we tell xclim that the `data` argument is minimal daily temperature. This will set the proper units check, default value and CF-compliance checks.\n",
+    "- `R95p` is similar to `fd` but here the `index_function` is not defined in `xclim` but rather in  `example.py`.\n",
+    "- `R99p` is the same as `R95p` but changes the injected value. In order to avoid rewriting the output metadata, and allowed periods, we based it on `R95p` : as the latter was defined within the current yaml file, the identifier is prefixed by a dot (.). However, in order to _inject_ a parameter we still need to repeat the index_function name (and retrigger the indice function wrapping process under the hood).\n",
     "\n",
-    "A few ways of prescribing _default_ or _allowed_ periods (resampling frequencies) are shown here. In `RX1day`, `RX5day` and `fd`, only the default value of `freq` is given. Note the the extra season specification in `RX1day` is not parsed by xclim, it exists for compatibility with [clix-meta](https://github.com/clix-meta/clix-meta). `R75pdays` will keep the default value in the signature of the underlying indice. Finally, `R95p` goes in more details by prescribing a default value and a list of _allowed_ values. xclim will be relax and accept any `freq` values equivalent to those listed here.\n",
+    "A few ways of prescribing _default_ or _allowed_ periods (resampling frequencies) are shown here. In `fd` and `R95p`, only the default value of `freq` is given. `R75pdays` will keep the default value in the signature of the underlying indice. `RX1day` goes in more details by prescribing a default value and a list of _allowed_ values. xclim will be relax and accept any `freq` values equivalent to those listed here. Finally, `RX5day` directly injects the `freq` argument, so that it doesn't even appear in the docstring.\n",
     "\n",
     "Additionnaly, the yaml specified a `realm` and `references` to be used on all indices and provided a submodule docstring. Creating the module is then simply:\n",
     "\n",
@@ -410,7 +411,7 @@
    "source": [
     "print(example.__doc__)\n",
     "print('--')\n",
-    "print(xc.indicators.example.R95p.__doc__)"
+    "print(xc.indicators.example.R99p.__doc__)"
    ]
   },
   {
@@ -426,7 +427,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ds2 = ds.assign(per=xc.core.calendar.percentile_doy(ds.pr, window=5, per=75).isel(percentiles=0))\n",
+    "ds2 = ds.assign(per=xc.core.calendar.percentile_doy(ds.pr, window=5, per=75).isel(percentiles=0, drop=True))\n",
     "\n",
     "outs = []\n",
     "with xc.set_options(metadata_locales='fr'):\n",
@@ -434,14 +435,16 @@
     "        print(f'Indicator: {name}')\n",
     "        print(f'\\tIdentifier: {ind.identifier}')\n",
     "        print(f'\\tTitle: {ind.title}')\n",
-    "        outs.append(ind(ds=ds2))"
+    "        out = ind(ds=ds2)  # Use all default arguments and variables from the dataset,\n",
+    "        outs.append(out)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`out` contains all the computed indices, with translated metadata."
+    "`out` contains all the computed indices, with translated metadata.\n",
+    "Note that this merge doesn't make much sense with the current list of indicators since they have different frequencies (`freq`)."
    ]
   },
   {
@@ -451,6 +454,7 @@
    "outputs": [],
    "source": [
     "out = xr.merge(outs)\n",
+    "out.attrs = {'title': 'Indicators computed from the example module.'} # Merge puts the attributes of the first variable, we don't want that.\n",
     "out"
    ]
   },

--- a/xclim/core/indicator.py
+++ b/xclim/core/indicator.py
@@ -31,6 +31,7 @@ Indicator-defining yaml files are structured in the following way:
     indices:
       <identifier>:
         base: <base indicator class>  # Defaults to module-wide base class or "Daily".
+                                      # If the name startswith a '.', the base class is taken from the current module (thus an indicator declared _above_)
         realm: <realm>  # Defaults to the module-wide realm or "atmos"
         reference: <references>
         references: <references>  # Plural or singular accepted (for harmonizing clix-meta and xclim)
@@ -54,7 +55,8 @@ Indicator-defining yaml files are structured in the following way:
           name: <function name>  # Refering to a function in the passed indices module, xclim.indices.generic or xclim.indices
           # When using Indicator.from_dict, the "name" field can also be a function (instead of a string)
           parameters:  # See below for details on that section.
-            <param name>  # Refering to a parameter of the function above.
+            <param name>: <param data>  # Simplest case when only injecting is needed.
+            <param name>:  # Most complex case where we want to change parameters metadata. Also retrocompatible with clix-meta.
               kind: <param kind>  # Optional, one of quantity, operator or reducer
               data: <param data>
               units: <param units>
@@ -491,8 +493,11 @@ class Indicator(IndicatorRegistrar):
             injected_params = {}
             # In clix-meta, when there are no parameters, the key is still there with a None value.
             for name, param in (data["index_function"].get("parameters") or {}).items():
+                if not isinstance(param, dict):
+                    # Simplest case for injecting, passing a value directly.
+                    value = param
                 # Handle clix-meta cases
-                if param.get("kind") == "quantity" and isinstance(
+                elif param.get("kind") == "quantity" and isinstance(
                     param["data"], (str, int, float)
                 ):
                     # A string with units, but not a placeholder (where data is a dict)
@@ -621,8 +626,9 @@ class Indicator(IndicatorRegistrar):
         # Put the variables in `das`, parse them according to the annotations
         # das : OrderedDict of variables (required + non-None optionals)
         # params : OrderedDict of parameters INCLUDING unpacked kwargs
-        # bound_kwargs: OrderedDict of parameters with PACKED kwargs. <- this is needed by _update_attrs and _mask because of `indexer`.
-        das, params, bound_kwargs = self._parse_variables_from_call(args, kwds)
+        # all_params: OrderedDict of parameters with PACKED kwargs <- this is needed by _update_attrs and _mask because of `indexer`.
+        #                  AND includes injected arguments <- this is needed by update_attrs and missing (when "freq" is injected)
+        das, params, all_params = self._parse_variables_from_call(args, kwds)
 
         # Metadata attributes from templates
         var_id = None
@@ -632,7 +638,7 @@ class Indicator(IndicatorRegistrar):
                 var_id = attrs["var_name"]
             var_attrs.append(
                 self._update_attrs(
-                    bound_kwargs.copy(), das, attrs, names=self._cf_names, var_id=var_id
+                    all_params.copy(), das, attrs, names=self._cf_names, var_id=var_id
                 )
             )
 
@@ -643,11 +649,11 @@ class Indicator(IndicatorRegistrar):
         # Check if the period is allowed:
         if (
             self.allowed_periods is not None
-            and "freq" in kwds
-            and parse_offset(kwds["freq"])[1] not in self.allowed_periods
+            and "freq" in all_params
+            and parse_offset(all_params["freq"])[1] not in self.allowed_periods
         ):
             raise ValueError(
-                f"Resampling frequency {kwds['freq']} is not allowed for indicator {self.identifier} (needs something equivalent to one of {self.allowed_periods})."
+                f"Resampling frequency {all_params['freq']} is not allowed for indicator {self.identifier} (needs something equivalent to one of {self.allowed_periods})."
             )
 
         # Compute the indicator values, ignoring NaNs and missing values.
@@ -675,8 +681,8 @@ class Indicator(IndicatorRegistrar):
 
         if self.missing != "skip":
             # Mask results that do not meet criteria defined by the `missing` method.
-            # This means all variables must have the same dimensions...
-            mask = self._mask(*das.values(), **bound_kwargs)
+            # This means all outputs must have the same dimensions as the broadcasted inputs (excluding time)
+            mask = self._mask(*das.values(), **all_params)
             outs = [out.where(~mask) for out in outs]
 
         # Return a single DataArray in case of single output, otherwise a tuple
@@ -729,7 +735,10 @@ class Indicator(IndicatorRegistrar):
                 kwargs = params.pop(param.name)
                 params.update(**kwargs)
 
-        return das, params, ba.arguments
+        # Add injected kwargs to the all_params
+        all_params = ba.arguments
+        all_params.update(getattr(self._indcompute, "_injected", {}))
+        return das, params, all_params
 
     def _bind_call(self, func, **das):
         """Call function using `__call__` `DataArray` arguments.
@@ -779,9 +788,8 @@ class Indicator(IndicatorRegistrar):
         cl = cls
         while hasattr(cl, "_registry_id"):
             family_tree.append(cl._registry_id + var_id)
-            cl = cl.__bases__[
-                0
-            ]  # The indicator mechanism always has single inheritance.
+            # The indicator mechanism always has single inheritance.
+            cl = cl.__bases__[0]
 
         return get_local_attrs(
             family_tree,
@@ -977,8 +985,7 @@ class Indicator(IndicatorRegistrar):
         # Use defaults
         if args is None:
             args = {k: v["default"] for k, v in cls.parameters.items()}
-
-        args.update(getattr(cls._indcompute, "_injected", {}))
+            args.update(getattr(cls._indcompute, "_injected", {}))
 
         out = {}
         for key, val in attrs.items():
@@ -1376,7 +1383,11 @@ def build_indicator_module_from_yaml(
             )
 
             if "base" in data:
-                base = registry[data["base"].upper()]
+                if data["base"].startswith("."):
+                    # A point means the base has been declared above.
+                    base = registry[module_name + data["base"].upper()]
+                else:
+                    base = registry[data["base"].upper()]
             else:
                 base = default_base
 

--- a/xclim/data/anuclim.yml
+++ b/xclim/data/anuclim.yml
@@ -19,44 +19,26 @@ references: ANUCLIM https://fennerschool.anu.edu.au/files/anuclim61.pdf (ch. 6)
 indices:
   P1_AnnMeanTemp:
     base: tg_mean
-    period:
-      allowed:
-        annual:
-      default: annual
+    period: annual
   P2_MeanDiurnalRange:
     base: dtr
-    period:
-      allowed:
-        annual:
-      default: annual
+    period: annual
   P3_Isothermality:
-    period:
-      allowed:
-        annual:
-      default: annual
+    period: annual
     index_function:
       name: isothermality
   P4_TempSeasonality:
-    period:
-      allowed:
-        annual:
-      default: annual
+    period: annual
     index_function:
       name: temperature_seasonality
   P5_MaxTempWarmestPeriod:
     base: tx_max
-    period:
-      allowed:
-        annual:
-      default: annual
+    period: annual
     output:
       long_name: Max temperature of warmest period
   P6_MinTempColdestPeriod:
     base: tn_min
-    period:
-      allowed:
-        annual:
-      default: annual
+    period: annual
     output:
       long_name: Min temperature of coldest period
   P7_TempAnnualRange:
@@ -64,137 +46,91 @@ indices:
     output:
       long_name: Temperature annual range
   P8_MeanTempWettestQuarter:
-    period:
-      allowed:
-        annual:
-      default: annual
+    period: annual
     output:
       units: K
     index_function:
       name: tg_mean_wetdry_quarter
       parameters:
-        op:
-          data: wettest
+        op: wettest
   P9_MeanTempDriestQuarter:
-    period:
-      allowed:
-        annual:
-      default: annual
+    period: annual
     output:
       units: K
     index_function:
       name: tg_mean_wetdry_quarter
       parameters:
-        op:
-          data: driest
+        op: driest
   P10_MeanTempWarmestQuarter:
-    period:
-      allowed:
-        annual:
-      default: annual
+    period: annual
     output:
       units: K
     index_function:
       name: tg_mean_warmcold_quarter
       parameters:
-        op:
-          data: warmest
+        op: warmest
   P11_MeanTempColdestQuarter:
-    period:
-      allowed:
-        annual:
-      default: annual
+    period: annual
     output:
       units: K
     index_function:
       name: tg_mean_warmcold_quarter
       parameters:
-        op:
-          data: coldest
+        op: coldest
   P12_AnnualPrecip:
-    period:
-      allowed:
-        annual:
-      default: annual
+    period: annual
     base: prcptot
     output:
       long_name: Annual precipitation
   P13_PrecipWettestPeriod:
-    period:
-      allowed:
-        annual:
-      default: annual
+    period: annual
     output:
       units: mm
     index_function:
       name: prcptot_wetdry_period
       parameters:
-        op:
-          data: wettest
+        op: wettest
   P14_PrecipDriestPeriod:
-    period:
-      allowed:
-        annual:
-      default: annual
+    period: annual
     output:
       units: mm
     index_function:
       name: prcptot_wetdry_period
       parameters:
-        op:
-          data: driest
+        op: driest
   P15_PrecipSeasonality:
-    period:
-      allowed:
-        annual:
-      default: annual
+    period: annual
     index_function:
       name: precip_seasonality
   P16_PrecipWettestQuarter:
-    period:
-      allowed:
-        annual:
-      default: annual
+    period: annual
     output:
       units: mm
     index_function:
       name: prcptot_wetdry_quarter
       parameters:
-        op:
-          data: wettest
+        op: wettest
   P17_PrecipDriestQuarter:
-    period:
-      allowed:
-        annual:
-      default: annual
+    period: annual
     output:
       units: mm
     index_function:
       name: prcptot_wetdry_quarter
       parameters:
-        op:
-          data: driest
+        op: driest
   P18_PrecipWarmestQuarter:
-    period:
-      allowed:
-        annual:
-      default: annual
+    period: annual
     output:
       units: mm
     index_function:
       name: prcptot_warmcold_quarter
       parameters:
-        op:
-          data: warmest
+        op: warmest
   P19_PrecipColdestQuarter:
-    period:
-      allowed:
-        annual:
-      default: annual
+    period: annual
     output:
       units: mm
     index_function:
       name: prcptot_warmcold_quarter
       parameters:
-        op:
-          data: coldest
+        op: coldest

--- a/xclim/data/icclim.yml
+++ b/xclim/data/icclim.yml
@@ -64,54 +64,42 @@ indices:
     index_function:
       name: biologically_effective_degree_days
       parameters:
-        method:
-          data: icclim
-        thresh_tasmin:
-          data: 10 degC
-        max_daily_degree_days:
-          data: 9 degC
-        start_date:
-          data: 04-01
-        end_date:
-          data: 10-01
-        low_dtr:
-          data: null
-        high_dtr:
-          data: null
-        lat:
-          data: null
+        method: icclim
+        thresh_tasmin: 10 degC
+        max_daily_degree_days: 9 degC
+        start_date: 04-01
+        end_date: 10-01
+        low_dtr: null
+        high_dtr: null
+        lat: null
   CSDI:
     base: cold_spell_duration_index
     output:
       long_name: Cold-spell duration index
     index_function:
       parameters:
-        window:
-          data: 6
+        window: 6
   WSDI:
     base: warm_spell_duration_index
     output:
       long_name: Warm-spell duration index
     index_function:
       parameters:
-        window:
-          data: 6
+        window: 6
   SU:
     base: tx_days_above
     output:
       long_name: Summer days (TX>25◦C)
     index_function:
       parameters:
-        thresh:
-          data: 25 degC
+        thresh: 25 degC
   CSU:
     base: maximum_consecutive_warm_days
     output:
       long_name: Maximum number of consecutive summer day
     index_function:
       parameters:
-        thresh:
-          data: 25 degC
+        thresh: 25 degC
 
   TR:
     base: tropical_nights
@@ -119,74 +107,64 @@ indices:
       long_name: Tropical nights (TN>20◦C)
     index_function:
       parameters:
-        thresh:
-          data: 20 degC
+        thresh: 20 degC
   GD4:
     base: growing_degree_days
     output:
       long_name: Growing degree days (sum of TG>4◦C)
     index_function:
       parameters:
-        thresh:
-          data: 4 degC
+        thresh: 4 degC
   FD:
     base: frost_days
     output:
       long_name: Frost days (TN<0◦C)
     index_function:
       parameters:
-        thresh:
-          data: 0 degC
+        thresh: 0 degC
   CFD:
     base: consecutive_frost_days
     output:
       long_name: Maximum number of consecutive frost days (TN<0◦C)
     index_function:
       parameters:
-        thresh:
-          data: 0 degC
+        thresh: 0 degC
   GSL:
     base: growing_season_length
     output:
       long_name: Growing season length
     index_function:
       parameters:
-        thresh:
-          data: 5 degC
-        window:
-          data: 6
+        thresh: 5 degC
+        window: 6
   ID:
     base: ice_days
     output:
       long_name: Ice days (TX<0◦C)
     index_function:
       parameters:
-        thresh:
-          data: 0 degC
+        thresh: 0 degC
   HD17:
     base: heating_degree_days
     output:
       long_name: Heating degree days (sum of17◦C - TG)
     index_function:
       parameters:
-        thresh:
-          data: 17 degC
+        thresh: 17 degC
   CDD:
     base: cdd
     output:
       long_name: Maximum number of consecutive dry days (RR<1 mm)
     index_function:
       parameters:
-        thresh:
-          data: 1 mm/day
+        thresh: 1 mm/day
   CWD:
     base: cwd
     output:
       long_name: Maximum number of consecutive wet days (RR≥1 mm)
     index_function:
       parameters:
-        thresh:
-          data: 1 mm/day
+        thresh: 1 mm/day
   RR:
     base: prcptot
     output:
@@ -195,8 +173,7 @@ indices:
     base: sdii
     index_function:
       parameters:
-        thresh:
-          data: 1 mm/day
+        thresh: 1 mm/day
   ETR:
     base: etr
     output:
@@ -215,24 +192,21 @@ indices:
       long_name: Wet days (RR≥1 mm)
     index_function:
       parameters:
-        thresh:
-          data: 1 mm/day
+        thresh: 1 mm/day
   R10mm:
     base: wetdays
     ouput:
       long_name: Heavy precipitation days (precipitation≥10 mm)
     index_function:
       parameters:
-        thresh:
-          data: 10 mm/day
+        thresh: 10 mm/day
   R20mm:
     base: wetdays
     output:
       long_name: Very heavy precipitation days (precipitation≥20 mm)
     index_function:
       parameters:
-        thresh:
-          data: 20 mm/day
+        thresh: 20 mm/day
   RX1day:
     base: rx1day
     output:
@@ -243,14 +217,12 @@ indices:
       long_name: Highest 5-day precipitation amount
     index_function:
       parameters:
-        window:
-          data: 5
+        window: 5
   R75p:
     base: days_over_precip_thresh
     index_function:
       parameters:
-        thresh:
-          data: 1 mm/day
+        thresh: 1 mm/day
         per:
           data: {per}
           description: Daily 75th percentile of wet day precipitation flux.
@@ -259,8 +231,7 @@ indices:
     base: days_over_precip_thresh
     index_function:
       parameters:
-        thresh:
-          data: 1 mm/day
+        thresh: 1 mm/day
         per:
           data: {per}
           description: Daily 95th percentile of wet day precipitation flux.
@@ -268,8 +239,7 @@ indices:
     base: days_over_precip_thresh
     index_function:
       parameters:
-        thresh:
-          data: 1 mm/day
+        thresh: 1 mm/day
         per:
           data: {per}
           description: Daily 99th percentile of wet day precipitation flux.
@@ -279,8 +249,7 @@ indices:
       long_name: Precipitation fraction due to moderate wet days (>75th percentile)
     index_function:
       parameters:
-        thresh:
-          data: 1 mm/day
+        thresh: 1 mm/day
         per:
           data: {per}
           description: Daily 75th percentile of wet day precipitation flux.
@@ -291,8 +260,7 @@ indices:
       long_name: Precipitation fraction due to very wet days (>95th percentile)
     index_function:
       parameters:
-        thresh:
-          data: 1 mm/day
+        thresh: 1 mm/day
         per:
           data: {per}
           description: Daily 95th percentile of wet day precipitation flux.
@@ -302,8 +270,7 @@ indices:
       long_name: Precipitation fraction due to extremely wet days (>99th percentile)
     index_function:
       parameters:
-        thresh:
-          data: 1 mm/day
+        thresh: 1 mm/day
         per:
           data: {per}
           description: Daily 99th percentile of wet day precipitation flux.
@@ -314,8 +281,7 @@ indices:
       long_name: Snow days (SD≥1 cm)
     index_function:
       parameters:
-        thresh:
-          data: 1 cm
+        thresh: 1 cm
   SD5cm:
     realm: land
     base: snow_cover_duration
@@ -323,8 +289,7 @@ indices:
       long_name: Snow days (SD≥5 cm)
     index_function:
       parameters:
-        thresh:
-          data: 5 cm
+        thresh: 5 cm
   SD50cm:
     realm: land
     base: snow_cover_duration
@@ -332,5 +297,4 @@ indices:
       long_name: Snow days (SD≥50 cm)
     index_function:
       parameters:
-        thresh:
-          data: 50 cm
+        thresh: 50 cm


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (major / minor / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

### What kind of change does this PR introduce?

* Simplifies the yaml syntax for injecting parameters, now allowing:
```yaml
index_function:
  parameters:
    thresh: 20 degC
```
* Allow basing an indicator in a yaml file on another indicator defined in the same yaml (but above). To do this, the name in the `base:` field must be preceded by a dot (`.`).
* Allow injecting the `freq` keyword. Before, this would cause trouble with the missing checks. Here, injected parameters are added to the kwargs dict that is passed to `missing`.

### Does this PR introduce a breaking change?
 No.

### Other information:
 @marielabonte , so you know.

Also, yamls of anuclim and icclim were simplified with this change (and an earlier one concerning the allowed periods).