### PR TITLE
Allow requirement of optional variable

### DIFF
--- a/docs/notebooks/example.yml
+++ b/docs/notebooks/example.yml
@@ -72,3 +72,14 @@ indices:
       name: extreme_precip_accumulation
       parameters:
         perc: 99
+  LPRatio:
+    base: liquid_precip_ratio
+    input:
+      tas: tas
+      pr: pr
+    output:
+      long_name: Liquid precip to total precip ratio.
+      description: Precipitation is estimated to be solid when tas is under 0.5°C
+    index_function:
+      parameters:
+        thresh: 0.5 degC

--- a/docs/notebooks/extendxclim.ipynb
+++ b/docs/notebooks/extendxclim.ipynb
@@ -382,6 +382,7 @@
     "    * The input variable `data` is mapped to a known variable. Functions in `xclim.indices.generic` are indeed generic. Here we tell xclim that the `data` argument is minimal daily temperature. This will set the proper units check, default value and CF-compliance checks.\n",
     "- `R95p` is similar to `fd` but here the `index_function` is not defined in `xclim` but rather in  `example.py`.\n",
     "- `R99p` is the same as `R95p` but changes the injected value. In order to avoid rewriting the output metadata, and allowed periods, we based it on `R95p` : as the latter was defined within the current yaml file, the identifier is prefixed by a dot (.). However, in order to _inject_ a parameter we still need to repeat the index_function name (and retrigger the indice function wrapping process under the hood).\n",
+    "- `LPRatio` is a version of \"liquid precip ratio\" where we we force the use of `tas` (instead of having it an optional variable). We also inject a specific threshold.\n",
     "\n",
     "A few ways of prescribing _default_ or _allowed_ periods (resampling frequencies) are shown here. In `fd` and `R95p`, only the default value of `freq` is given. `R75pdays` will keep the default value in the signature of the underlying indice. `RX1day` goes in more details by prescribing a default value and a list of _allowed_ values. xclim will be relax and accept any `freq` values equivalent to those listed here. Finally, `RX5day` directly injects the `freq` argument, so that it doesn't even appear in the docstring.\n",
     "\n",

--- a/xclim/core/indicator.py
+++ b/xclim/core/indicator.py
@@ -694,8 +694,13 @@ class Indicator(IndicatorRegistrar):
         """Assign inputs passed as strings from ds."""
         ds = ba.arguments.pop("ds")
         for name, param in self._sig.parameters.items():
-            if param.annotation is Union[str, DataArray] and isinstance(
-                ba.arguments[name], str
+            if (
+                self.parameters[name]["kind"]
+                in (
+                    InputKind.VARIABLE,
+                    InputKind.OPTIONAL_VARIABLE,
+                )
+                and isinstance(ba.arguments[name], str)
             ):
                 if ds is not None:
                     try:

--- a/xclim/core/utils.py
+++ b/xclim/core/utils.py
@@ -372,11 +372,10 @@ def infer_kind_from_parameter(param: Parameter, has_units: bool = False) -> Inpu
     ):
         return InputKind.VARIABLE
 
-    if (
-        Optional[param.annotation]
-        in [Optional[DataArray], Optional[Union[DataArray, str]]]
-        and param.default is None
-    ):
+    if Optional[param.annotation] in [
+        Optional[DataArray],
+        Optional[Union[DataArray, str]],
+    ]:
         return InputKind.OPTIONAL_VARIABLE
 
     if _typehint_is_in(param.annotation, (str, None)) and has_units:

--- a/xclim/core/utils.py
+++ b/xclim/core/utils.py
@@ -77,7 +77,7 @@ def wrapped_partial(
     )
 
     # Store all injected params,
-    injected = getattr(func, "_injected", {})
+    injected = getattr(func, "_injected", {}).copy()
     injected.update(fixed)
     fully_wrapped._injected = injected
     return fully_wrapped


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (major / minor / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

### What kind of change does this PR introduce?

* Fixes a bug in `core.utils.infer_kind_from_parameter` and  in `Indicator._assign_named_args` that was forbidding the requirement of optional variables (i.e. : change an indicator through yaml so that an optional variable is not optional anymore.)

### Does this PR introduce a breaking change?
No

### Other information:
The way to make a variable non-optional in a yaml def, is the following:
```yaml
WATER_BUDGET:
  base: water_budget
  input:
    tasmin: tasmin
    tasmax: tasmax
  index_function:
    parameters:
      method: BR64
```
In this example, the variables `tasmin` and `tasmax`, which are optional in `atmos.water_budget` are now semi-optional. There is still a "bug" that makes the annotation unchanged (i.e.: `WATER_BUDGET.parameters['tasmin']['kind'] == OPTIONAL_VARIABLE`), but the default value has passed from `None` to `"tasmin"`. Thus a call with `WATER_BUDGET(ds=ds)` will be successful (it would fail earlier). And a call like `WATER_BUDGET(pr=ds.pr)` will fail because tasmin wasn't None, it was "tasmin". However, the error raised will be unclear. I'll fix this in a further PR.