### PR TITLE
Allow passing multi-index dimension to spatial_analogs

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,7 +9,7 @@ New features and enhancements
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Automatic load of translations on import and possibility to pass translations for virtual modules.
 * New ``xclim.testing.list_datasets`` function listing all available test datasets in repo `xclim-testdata`.
-* `spatial_analogs` accepts multi-indexes as the `dist_dim` parameter.
+* `spatial_analogs` accepts multi-indexes as the `dist_dim` parameter and will work with candidates and target arrays of different lengths.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,10 +9,11 @@ New features and enhancements
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Automatic load of translations on import and possibility to pass translations for virtual modules.
 * New ``xclim.testing.list_datasets`` function listing all available test datasets in repo `xclim-testdata`.
+* `spatial_analogs` accepts multi-indexes as the `dist_dim` parameter.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~
-* Nothing yet.
+* `spatial_analogs` does not support sequence of `dist_dim` anymore. Users are responsible for stacking dimensions prior to calling `spatial_analogs`.
 
 New indicators
 ~~~~~~~~~~~~~~

--- a/xclim/analog.py
+++ b/xclim/analog.py
@@ -118,20 +118,19 @@ def spatial_analogs(
     # Create the target DataArray:
     target = xr.concat(
         target.data_vars.values(),
-        xr.DataArray(
-            list(target.data_vars.keys()), dims=("target_indices",), name="indices"
-        ),
+        xr.DataArray(list(target.data_vars.keys()), dims=("indices",), name="indices"),
     )
 
-    # Create the target DataArray:
+    # Create the target DataArray with different dist_dim
+    c_dist_dim = "candidate_dist_dim"
     candidates = xr.concat(
         candidates.data_vars.values(),
         xr.DataArray(
             list(candidates.data_vars.keys()),
-            dims=("candidate_indices",),
+            dims=("indices",),
             name="indices",
         ),
-    )
+    ).rename({dist_dim: c_dist_dim})
 
     try:
         metric = metrics[method]
@@ -145,7 +144,7 @@ def spatial_analogs(
         metric,
         target,
         candidates,
-        input_core_dims=[(dist_dim, "target_indices"), (dist_dim, "candidate_indices")],
+        input_core_dims=[(dist_dim, "indices"), (c_dist_dim, "indices")],
         output_core_dims=[()],
         vectorize=True,
         dask="parallelized",

--- a/xclim/testing/tests/test_analog.py
+++ b/xclim/testing/tests/test_analog.py
@@ -70,7 +70,14 @@ def test_spatial_analogs(method):
     candidates = data.sel(time=slice("1970", "1990"))
 
     out = xca.spatial_analogs(target, candidates, method=method)
+    np.testing.assert_allclose(diss[method], out, rtol=1e-3, atol=1e-3)
 
+    # Test multi-indexes
+    target_stacked = target.stack(sample=["time"])
+    candidates_stacked = candidates.stack(sample=["time"])
+    out = xca.spatial_analogs(
+        target_stacked, candidates_stacked, dist_dim="sample", method=method
+    )
     np.testing.assert_allclose(diss[method], out, rtol=1e-3, atol=1e-3)
 
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #743
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (major / minor / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)

### What kind of change does this PR introduce?

* Add support for multi-index in spatial_analogs

### Does this PR introduce a breaking change?

Yes, `dist_dim` will not accept lists of dimensions anymore. Users are expected to create multi-indexes themselves.

### Other information: