### PR TITLE
restrict pandas version < 1.3

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
  - xarray>=0.17
  - scipy>=1.2
  - numba
- - pandas>=0.23
+ - pandas>=0.23,<1.3
  - cftime>=1.4.1
  - poppler>=0.67
  - dask>=2.6.0

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ requirements = [
     "xarray>=0.17",
     "scipy>=1.2",
     "numba",
-    "pandas>=0.23",
+    "pandas>=0.23,<1.3",
     "cftime>=1.4.1",
     "dask[array]>=2.6",
     "pint>=0.9",


### PR DESCRIPTION
I think the sdba.ipynb is broken due to a recent pandas release. 
Here I'm restricting the version to < 1.3 to confirm this fixes the bug and will open a new issue to tackle this. 

