### PR TITLE
Weighted Mean Average (Qian et al. 2010) and EGDD (Bootsma et al. 2005)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,7 +8,7 @@ History
 New indicators
 ~~~~~~~~~~~~~~
 * ``effective_growing_degree_days`` indice returns growing degree days using dynamic start and end dates for the growing season (based on Bootsma et al. (2005)). This has also been wrapped as an indicator.
-* ``qian_weighted_mean_average`` (based on Qian et al. (2010)) is offered as an alternate method for determining the start date using a weighted 5-day average (``method="qian"``)
+* ``qian_weighted_mean_average`` (based on Qian et al. (2010)) is offered as an alternate method for determining the start date using a weighted 5-day average (``method="qian"``). Can also be used directly as an indice.
 
 0.28.1 (2021-07-29)
 -------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,13 @@
 History
 =======
 
+0.29.0 (unreleased)
+-------------------
+
+New indicators
+~~~~~~~~~~~~~~
+* ``effective_growing_degree_days`` indice returns growing degree days using dynamic start and end dates for the growing season (based on Bootsma et al. (2005)). This has also been wrapped as an indicator.
+* ``qian_weighted_mean_average`` (based on Qian et al. (2010)) is offered as an alternate method for determining the start date using a weighted 5-day average (``method="qian"``)
 
 0.28.1 (2021-07-29)
 -------------------

--- a/xclim/data/fr.json
+++ b/xclim/data/fr.json
@@ -497,10 +497,17 @@
   },
   "BIOLOGICALLY_EFFECTIVE_DEGREE_DAYS": {
     "long_name": "Degrés-jours biologiquement actifs",
-    "description": "Accumulation des degrés-jours borné par Tmin > {thresh_tasmin} et Tmax-Tmin < {max_daily_degree_days}. Les degrés jours quotidiens sont corrigés selon Tmax-Tmin et selon un coefficient de longueur du jour dépendent de la laittude.",
+    "description": "Accumulation des degrés-jours borné par Tmin > {thresh_tasmin} et Tmax-Tmin < {max_daily_degree_days}. Les degrés jours quotidiens sont corrigés selon Tmax-Tmin et selon un coefficient de longueur du jour dépendent de la latitude.",
     "title": "Degrés-jours biologiquement actifs",
     "comment": "Formule originale prise de Gladstones 1992.",
     "abstract": "Indice basé sur une relation non linéaire entre la température et les processus physiologiques. Il intègre une borne supérieure du cumul, un coefficient lié à la longueur du jour et une correction liée à l'écart journalier des températures."
+  },
+  "EFFECTIVE_GROWING_DEGREE_DAYS": {
+  "long_name": "Degrés-jours effectives",
+  "description": "Accumulation des degrés-jours borné par (Tmax + Tmin)/2 > {thresh} et des dates de début et fin de la saison de croissance generés dynamiquement.",
+  "title": "Degrés-jours effectives",
+  "comment": "Formule originale prise de Bootsma et al. 2005.",
+  "abstract": "Indice de degrés-jours de croissance basés sur un début et une fin dynamiques de la saison de croissance."
   },
   "LATITUDE_TEMPERATURE_INDEX": {
     "long_name": "Indice latitude-température",

--- a/xclim/indicators/atmos/_temperature.py
+++ b/xclim/indicators/atmos/_temperature.py
@@ -833,6 +833,29 @@ biologically_effective_degree_days = Temp(
     ),
 )
 
+effective_growing_degree_days = Temp(
+    identifier="effective_growing_degree_days",
+    units="K days",
+    long_name="Effective growing degree days computed with {method} formula (Summation of max((Tmin + Tmax)/2 "
+    "- {thresh}, 0), for days between between dynamically-determined start and end dates).",
+    description="Heat-summation index for agroclimatic suitability estimation."
+    "Considers daily Tmin and Tmax with a base of {thresh} between dynamically-determined growing season start"
+    "and end dates. The 'bootsma' method uses a 10-day average temperature above {thresh} to identify a start date, "
+    "while the 'qian' method uses a weighted mean average above {thresh} over 5 days to determine start date. "
+    "The end date of the growing season is the date of first fall frost (Tmin < 0 degC).",
+    cell_methods="",
+    comment="Original formula published in Bootsma et al. 2005.",
+    var_name="egdd",
+    compute=wrapped_partial(
+        indices.effective_growing_degree_days,
+        suggested=dict(
+            thresh="5 degC",
+            method="bootsma",
+            after_date="07-01",
+        ),
+    ),
+)
+
 
 latitude_temperature_index = Temp(
     identifier="latitude_temperature_index",

--- a/xclim/indices/_agro.py
+++ b/xclim/indices/_agro.py
@@ -760,7 +760,7 @@ def effective_growing_degree_days(
     For "bootsma", the start date is defined as 10 days after the average temperature exceeds a threshold (5 degC).
     For "qian", the start date is based on a weighted 5-day rolling average, based on `qian_weighted_mean_average()`.
 
-    The end date is determined as the first day with minimum temperature below 0 degC.
+    The end date is determined as the day preceding the first day with minimum temperature below 0 degC.
 
     References
     ----------
@@ -784,12 +784,16 @@ def effective_growing_degree_days(
     else:
         raise NotImplementedError(f"Method: {method}.")
 
-    end = first_day_below(
-        tasmin=tasmin,
-        thresh="0 degC",
-        after_date=after_date,
-        window=1,
-        freq=freq,
+    # The day before the first day below 0 degC
+    end = (
+        first_day_below(
+            tasmin=tasmin,
+            thresh="0 degC",
+            after_date=after_date,
+            window=1,
+            freq=freq,
+        )
+        - 1
     )
 
     deg_days = (tas - thresh).clip(min=0)

--- a/xclim/indices/_agro.py
+++ b/xclim/indices/_agro.py
@@ -711,7 +711,7 @@ def qian_weighted_mean_average(
 
 
 @declare_units(
-    tas="[temperature]",
+    tasmax="[temperature]",
     tasmin="[temperature]",
     thresh="[temperature]",
 )
@@ -721,6 +721,7 @@ def effective_growing_degree_days(
     tasmin: xarray.DataArray,
     thresh: str = "5 degC",
     method: str = "bootsma",
+    after_date: DayOfYearStr = "07-01",
     dim: str = "time",
     freq: str = "YS",
 ) -> xarray.DataArray:
@@ -740,6 +741,8 @@ def effective_growing_degree_days(
       The window method used to determine the temperature-based start date.
       For "bootsma", the start date is defined as 10 days after the average temperature exceeds a threshold (5 degC).
       For "qian", the start date is based on a weighted 5-day rolling average, based on `qian_weighted_mean_average()`.
+    after_date : str
+      Date of the year after which to look for the first frost event. Should have the format '%m-%d'.
     dim: str
       Time dimension.
     freq : str
@@ -787,7 +790,7 @@ def effective_growing_degree_days(
     end = first_day_below(
         tasmin=tasmin,
         thresh="0 degC",
-        after_date="07-01",  # noqa
+        after_date=after_date,
         window=1,
         freq=freq,
     )

--- a/xclim/indices/generic.py
+++ b/xclim/indices/generic.py
@@ -888,21 +888,3 @@ def day_lengths(
         )
     else:
         return day_length_hours
-
-
-def bootsma_weighted_mean_average(tas: xr.DataArray, dim="time") -> xr.DataArray:
-    """Bootsma at al. weighted mean average.
-
-    Parameters
-    ----------
-    tas: xr.DataArray
-    dim: str
-
-    Returns
-    -------
-    xr.DataArray
-    """
-    weights = xr.DataArray([0.0625, 0.25, 0.375, 0.25, 0.0625], dims=["window"])
-    weighted_mean = tas.rolling({dim: 5}, center=True).construct("window").dot(weights)
-
-    return weighted_mean

--- a/xclim/indices/generic.py
+++ b/xclim/indices/generic.py
@@ -26,18 +26,33 @@ from xclim.core.units import (
     to_agg_units,
 )
 
-# __all__ = [
-#     "select_time",
-#     "select_resample_op",
-#     "doymax",
-#     "doymin",
-#     "default_freq",
-#     "threshold_count",
-#     "get_daily_events",
-#     "daily_downsampler",
-# ]
 from ..core.utils import DayOfYearStr
 from . import run_length as rl
+
+__all__ = [
+    "aggregate_between_dates",
+    "compare",
+    "count_level_crossings",
+    "count_occurrences",
+    "daily_downsampler",
+    "day_lengths",
+    "default_freq",
+    "degree_days",
+    "diurnal_temperature_range",
+    "domain_count",
+    "doymax",
+    "doymin",
+    "get_daily_events",
+    "get_op",
+    "interday_diurnal_temperature_range",
+    "last_occurrence",
+    "select_resample_op",
+    "select_time",
+    "statistics",
+    "temperature_sum",
+    "threshold_count",
+    "thresholded_statistics",
+]
 
 binary_ops = {">": "gt", "<": "lt", ">=": "ge", "<=": "le", "==": "eq", "!=": "ne"}
 
@@ -873,3 +888,21 @@ def day_lengths(
         )
     else:
         return day_length_hours
+
+
+def bootsma_weighted_mean_average(tas: xr.DataArray, dim="time") -> xr.DataArray:
+    """Bootsma at al. weighted mean average.
+
+    Parameters
+    ----------
+    tas: xr.DataArray
+    dim: str
+
+    Returns
+    -------
+    xr.DataArray
+    """
+    weights = xr.DataArray([0.0625, 0.25, 0.375, 0.25, 0.0625], dims=["window"])
+    weighted_mean = tas.rolling({dim: 5}, center=True).construct("window").dot(weights)
+
+    return weighted_mean

--- a/xclim/testing/tests/test_indices.py
+++ b/xclim/testing/tests/test_indices.py
@@ -253,10 +253,10 @@ class TestAgroclimaticIndices:
         bedd = xci.biologically_effective_degree_days(
             tasmin=tn,
             tasmax=tx,
-            lat=lat,
+            lat=lat,  # noqa
             method=method,
-            end_date=end_date,
-            freq="YS",  # noqa
+            end_date=end_date,  # noqa
+            freq="YS",
         )
         bedd_hot = xci.biologically_effective_degree_days(
             tasmin=tn,

--- a/xclim/testing/tests/test_indices.py
+++ b/xclim/testing/tests/test_indices.py
@@ -380,7 +380,7 @@ class TestAgroclimaticIndices:
         mg = tas_series(mg + K2C)
         out = xci.qian_weighted_mean_average(mg, dim="time")
         np.testing.assert_array_equal(
-            out[7:12], [273.15, 273.2125, 273.525, 274.3375, 275.5875]
+            out[7:12], [273.15, 273.2125, 273.525, 274.3375, 275.775]
         )
         assert out[50].values < (10 + K2C)
         assert out[51].values > K2C

--- a/xclim/testing/tests/test_indices.py
+++ b/xclim/testing/tests/test_indices.py
@@ -362,7 +362,7 @@ class TestAgroclimaticIndices:
             tasmin=tasmin,
             lat=ds.lat,
             method=method,
-            end_date=end_date,
+            end_date=end_date,  # noqa
         )
 
         np.testing.assert_almost_equal(np.mean(hi), values, 2)
@@ -386,7 +386,7 @@ class TestAgroclimaticIndices:
         assert out[51].values > K2C
         assert out.attrs["units"] == "K"
 
-    @pytest.mark.parametrize("method,expected", [("bootsma", 2272), ("qian", 2257.0)])
+    @pytest.mark.parametrize("method,expected", [("bootsma", 2267), ("qian", 2252.0)])
     def test_effective_growing_degree_days(
         self, tasmax_series, tasmin_series, method, expected
     ):


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR addresses objectives of #355 
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (major / minor / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)
- [ ] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

* Adds Qian et al.'s 5-day weighted mean average, used to calculate the start and end dates of growing season for annual crops.
* Add Effective Growing Degree Days (based on Bootsma et al. 2005) with option of `bootsma` and `qian` start date identification methods + wrapped indicator.
* Re-adds the `__all__` magic in `indices.generic.py`

### Does this PR introduce a breaking change?

No.

### Other information:
