### PR TITLE
Remove ExtremeValues from main API

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,7 +7,7 @@ History
 
 Announcements
 ~~~~~~~~~~~~~
-* It was found that the `ExtremeValues` adjustment algorithm was not as accurate and stable as first thought. It was hidden from `xclim.sdba` but it is still accessible through `xclim.sdba.adjustment`, with a warning. Work on improving the algorithm is on-going and a better version will be implemented in a future version.
+* It was found that the `ExtremeValues` adjustment algorithm was not as accurate and stable as first thought. It is now hidden from `xclim.sdba` but can still be accessed via `xclim.sdba.adjustment`, with a warning. Work on improving the algorithm is ongoing, and a better implementation will be in a future version.
 
 New indicators
 ~~~~~~~~~~~~~~

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,10 @@ History
 0.29.0 (unreleased)
 -------------------
 
+Announcements
+~~~~~~~~~~~~~
+* It was found that the `ExtremeValues` adjustment algorithm was not as accurate and stable as first thought. It was hidden from `xclim.sdba` but it is still accessible through `xclim.sdba.adjustment`, with a warning. Work on improving the algorithm is on-going and a better version will be implemented in a future version.
+
 New indicators
 ~~~~~~~~~~~~~~
 * ``effective_growing_degree_days`` indice returns growing degree days using dynamic start and end dates for the growing season (based on Bootsma et al. (2005)). This has also been wrapped as an indicator.

--- a/xclim/sdba/adjustment.py
+++ b/xclim/sdba/adjustment.py
@@ -540,7 +540,7 @@ class ExtremeValues(BaseAdjustment):
         .. [RRJF2021] Roy, P., Rondeau-Genesse, G., Jalbert, J., Fournier, É. 2021. Climate Scenarios of Extreme Precipitation Using a Combination of Parametric and Non-Parametric Bias Correction Methods. Submitted to Climate Services, April 2021.
         """
         warn(
-            "Work is on going on the ExtremeValues adjustment. The current version imitates the algorithm found in ClimateTools.jl, but results might not be accurate."
+            "The ExtremeValues adjustment is a work in progress and not production-ready. The current version imitates the algorithm found in ClimateTools.jl, but results might not be accurate."
         )
         super().__init__(q_thresh=q_thresh, cluster_thresh=cluster_thresh)
 

--- a/xclim/sdba/adjustment.py
+++ b/xclim/sdba/adjustment.py
@@ -41,7 +41,6 @@ __all__ = [
     "BaseAdjustment",
     "EmpiricalQuantileMapping",
     "DetrendedQuantileMapping",
-    "ExtremeValues",
     "LOCI",
     "PrincipalComponents",
     "QuantileDeltaMapping",
@@ -540,6 +539,9 @@ class ExtremeValues(BaseAdjustment):
         .. [ClimateTools] https://juliaclimate.github.io/ClimateTools.jl/stable/
         .. [RRJF2021] Roy, P., Rondeau-Genesse, G., Jalbert, J., Fournier, É. 2021. Climate Scenarios of Extreme Precipitation Using a Combination of Parametric and Non-Parametric Bias Correction Methods. Submitted to Climate Services, April 2021.
         """
+        warn(
+            "Work is on going on the ExtremeValues adjustment. The current version imitates the algorithm found in ClimateTools.jl, but results might not be accurate."
+        )
         super().__init__(q_thresh=q_thresh, cluster_thresh=cluster_thresh)
 
     def train(self, ref, hist, ref_params=None):
@@ -647,7 +649,8 @@ class ExtremeValues(BaseAdjustment):
             # Cumulative density function for extreme values in sim's distribution
             sim_cdf = dist.cdf(sim_maxs, *sim_fit)
             # Equivalent value of sim's CDF's but in ref's distribution.
-            new_sim = dist.ppf(sim_cdf, *ref_params) + thresh
+            # removed a +thresh that was a bug in the julia source.
+            new_sim = dist.ppf(sim_cdf, *ref_params)
 
             # Get the transition weights based on frac and power values
             transition = (

--- a/xclim/testing/tests/test_sdba/test_adjustment.py
+++ b/xclim/testing/tests/test_sdba/test_adjustment.py
@@ -533,7 +533,7 @@ class TestPrincipalComponents:
         assert (ref - scen).mean() < 5e-3
 
 
-@pytest.mark.slow
+@pytest.mark.xfail(reason="Inaccurate version.")
 class TestExtremeValues:
     @pytest.mark.parametrize(
         "c_thresh,q_thresh,frac,power,diags",


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (major / minor / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)
- [ ] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

* After discussion with @RondeauG and @Balinus, we realized that the ExtremeValues adjustment was not performing as well as intented. An obvious bug was removed (the `+ thresh`) but the whole algorithm still needs a rewrite. This PR removes it from the main API (from the `__all__`) and deactivates the tests, which were based on comparison with the julia code. A warning is also issued if the class is used nonetheless.

### Does this PR introduce a breaking change?

Yes. `ExtremeValues` was removed from `xclim.sdba`, but still accessible through `xclim.sdba.adjustment`.

### Other information:

Previous from the `+ thresh` removal, the xclim algo was giving results consistent with the julia code, which is also broken in regards to the bugs found by Gabriel.
