### PR TITLE
Add polynomial calculation methods for snowfall approximation based on CLASS

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,10 @@ Announcements
 ~~~~~~~~~~~~~
 * It was found that the `ExtremeValues` adjustment algorithm was not as accurate and stable as first thought. It is now hidden from `xclim.sdba` but can still be accessed via `xclim.sdba.adjustment`, with a warning. Work on improving the algorithm is ongoing, and a better implementation will be in a future version.
 
+New features and enhancements
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* ``snowfall_approximation`` has gained support for new estimation methods used in CLASS: 'brown' and 'auer'.
+
 New indicators
 ~~~~~~~~~~~~~~
 * ``effective_growing_degree_days`` indice returns growing degree days using dynamic start and end dates for the growing season (based on Bootsma et al. (2005)). This has also been wrapped as an indicator.
@@ -19,10 +23,15 @@ New indicators
 * ``cold_and_wet_days`` indicator returns the number of days where the mean daily temperature is below the 25th percentile and the mean daily precipitation is above the 75th percentile over period. Added as ``CW`` to ICCLIM module.
 
 Bug fixes
-~~~~~~~~~~~~~~
+~~~~~~~~~
 * Various bug fixes in bootstrapping:
    - in ``percentile_bootstrap`` decorator, fix the popping of bootstrap argument to propagate in to the function call.
    - in ``bootstrap_func``, fix some issues with the resampling frequency which was not working when anchored.
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+* ``snowfall_approximation`` used a < condition instead of <= to determine the snow fraction based on the freezing point temperature. The new version sticks to the convention used in the Canadian Land Surface Scheme (CLASS).
+
 
 0.28.1 (2021-07-29)
 -------------------

--- a/xclim/indices/_conversion.py
+++ b/xclim/indices/_conversion.py
@@ -575,7 +575,7 @@ def snowfall_approximation(
       Mean, maximum, or minimum daily temperature.
     thresh : str,
       Threshold temperature, used by method "binary".
-    method : {"binary"}
+    method : {"binary", "brown", "auer"}
       Which method to use when approximating snowfall from total precipitation. See notes.
 
     Returns
@@ -585,18 +585,74 @@ def snowfall_approximation(
 
     Notes
     -----
-    The following methods are available to approximate snowfall:
+    The following methods are available to approximate snowfall and are drawn from the
+    Canadian Land Surface Scheme (CLASS, [Verseghy09]_).
 
-    - "binary" : When the given temperature is under a given threshold, precipitation
+    - "binary" : When the temperature is under the freezing threshold, precipitation
         is assumed to be solid. The method is agnostic to the type of temperature used
         (mean, maximum or minimum).
+    - "brown" : The phase between the freezing threshold goes from solid to liquid linearly
+        over a range of 2°C over the freezing point.
+    - "auer" : The phase between the freezing threshold goes from solid to liquid as a degree six
+        polynomial over a range of 6°C over the freezing point.
 
+    .. [Verseghy09]: Diana Verseghy (2009), CLASS – The Canadian Land Surface Scheme (Version 3.4), Technical
+    Documentation (Version 1.1), Environment Canada, Climate Research Division, Science and Technology Branch.
     """
-    thresh = convert_units_to(thresh, tas)
+    # https://gitlab.com/cccma/classic/-/blob/master/src/atmosphericVarsCalc.f90
+
     if method == "binary":
-        prsn = pr.where(tas < thresh, 0)
+        thresh = convert_units_to(thresh, tas)
+        prsn = pr.where(tas <= thresh, 0)
+
+    elif method == "brown":
+        # Freezing point + 2C in the native units
+        upper = convert_units_to(convert_units_to(thresh, "degC") + 2, tas)
+        thresh = convert_units_to(thresh, tas)
+
+        # Interpolate fraction over temperature (in units of tas)
+        t = xr.DataArray(
+            [-np.inf, thresh, upper, np.inf], dims=("tas",), attrs={"units": "degC"}
+        )
+        fraction = xr.DataArray([1.0, 1.0, 0.0, 0.0], dims=("tas",), coords={"tas": t})
+
+        # Multiply precip by snowfall fraction
+        prsn = pr * fraction.interp(tas=tas, method="linear")
+
+    elif method == "auer":
+        dtas = convert_units_to(tas, "degK") - convert_units_to(thresh, "degK")
+
+        # Create nodes for the snowfall fraction: -inf, thresh, ..., thresh+6, inf [degC]
+        t = np.concatenate(
+            [
+                [
+                    -273.15,
+                ],
+                np.linspace(0, 6, 100, endpoint=False),
+                [6, 1e10],
+            ]
+        )
+        t = xr.DataArray(t, dims="tas")
+
+        # I can't get polyval to work directly with a DataArray, hence the empty values serving no purpose.
+        tmp = xr.DataArray(np.empty_like(t), dims="tas", coords={"tas": t})
+
+        # The polynomial coefficients, valid between thresh and thresh + 6 (defined in CLASS)
+        coeffs = xr.DataArray(
+            [100, 4.6664, -15.038, -1.5089, 2.0399, -0.366, 0.0202],
+            dims=("degree",),
+            coords={"degree": range(7)},
+        )
+
+        fraction = xr.polyval(tmp.tas, coeffs) / 100
+        fraction[0] = 1
+        fraction[-2:] = 0
+
+        # Convert snowfall fraction coordinates to native tas units
+        prsn = pr * fraction.interp(tas=dtas, method="linear")
+
     else:
-        raise ValueError(f"Method {method} not in ['binary'].")
+        raise ValueError(f"Method {method} not one of 'binary', 'brown' or 'auer'.")
 
     prsn.attrs["units"] = pr.attrs["units"]
     return prsn

--- a/xclim/indices/_conversion.py
+++ b/xclim/indices/_conversion.py
@@ -624,18 +624,9 @@ def snowfall_approximation(
 
         # Create nodes for the snowfall fraction: -inf, thresh, ..., thresh+6, inf [degC]
         t = np.concatenate(
-            [
-                [
-                    -273.15,
-                ],
-                np.linspace(0, 6, 100, endpoint=False),
-                [6, 1e10],
-            ]
+            [[-273.15], np.linspace(0, 6, 100, endpoint=False), [6, 1e10]]
         )
-        t = xr.DataArray(t, dims="tas")
-
-        # I can't get polyval to work directly with a DataArray, hence the empty values serving no purpose.
-        tmp = xr.DataArray(np.empty_like(t), dims="tas", coords={"tas": t})
+        t = xr.DataArray(t, dims="tas", name="tas", coords={"tas": t})
 
         # The polynomial coefficients, valid between thresh and thresh + 6 (defined in CLASS)
         coeffs = xr.DataArray(
@@ -644,7 +635,7 @@ def snowfall_approximation(
             coords={"degree": range(7)},
         )
 
-        fraction = xr.polyval(tmp.tas, coeffs) / 100
+        fraction = xr.polyval(t.tas, coeffs) / 100
         fraction[0] = 1
         fraction[-2:] = 0
 
@@ -678,7 +669,7 @@ def rain_approximation(
       Mean, maximum, or minimum daily temperature.
     thresh : str,
       Threshold temperature, used by method "binary".
-    method : {"binary"}
+    method : {"binary", "brown", "auer"}
       Which method to use when approximating snowfall from total precipitation. See notes.
 
     Returns

--- a/xclim/indices/_conversion.py
+++ b/xclim/indices/_conversion.py
@@ -635,7 +635,7 @@ def snowfall_approximation(
             coords={"degree": range(7)},
         )
 
-        fraction = xr.polyval(t.tas, coeffs) / 100
+        fraction = xr.polyval(t.tas, coeffs).clip(0, 100) / 100
         fraction[0] = 1
         fraction[-2:] = 0
 

--- a/xclim/testing/tests/test_cli.py
+++ b/xclim/testing/tests/test_cli.py
@@ -102,7 +102,7 @@ def test_normal_computation(
 
 
 def test_multi_input(tas_series, pr_series, tmp_path):
-    tas = tas_series(np.ones(366) + 272.15, start="1/1/2000")
+    tas = tas_series(np.ones(366) + 273.15, start="1/1/2000")
     pr = pr_series(np.ones(366), start="1/1/2000")
     tas_file = tmp_path / "multi_tas_in.nc"
     pr_file = tmp_path / "multi_pr_in.nc"

--- a/xclim/testing/tests/test_indices.py
+++ b/xclim/testing/tests/test_indices.py
@@ -1930,7 +1930,7 @@ def test_snowfall_approximation(pr_series, tasmax_series, method, exp):
     np.testing.assert_allclose(prsn, exp, atol=1e-5, rtol=1e-3)
 
 
-@pytest.mark.parametrize("method,exp", [("binary", [0, 0, 0, 0, 0, 1, 1, 1, 1, 1])])
+@pytest.mark.parametrize("method,exp", [("binary", [0, 0, 0, 0, 0, 0, 1, 1, 1, 1])])
 def test_rain_approximation(pr_series, tas_series, method, exp):
     pr = pr_series(np.ones(10))
     tas = tas_series(np.arange(10) + K2C)

--- a/xclim/testing/tests/test_indices.py
+++ b/xclim/testing/tests/test_indices.py
@@ -1913,12 +1913,19 @@ def test_degree_days_exceedance_date(tas_series):
     assert out.attrs["is_dayofyear"] == 1
 
 
-@pytest.mark.parametrize("method,exp", [("binary", [1, 1, 1, 1, 1, 0, 0, 0, 0, 0])])
+@pytest.mark.parametrize(
+    "method,exp",
+    [
+        ("binary", [1, 1, 1, 0, 0, 0, 0, 0, 0, 0]),
+        ("brown", [1, 1, 1, 0.5, 0, 0, 0, 0, 0, 0]),
+        ("auer", [1, 1, 1, 0.89805, 0.593292, 0.289366, 0.116624, 0.055821, 0, 0]),
+    ],
+)
 def test_snowfall_approximation(pr_series, tasmax_series, method, exp):
     pr = pr_series(np.ones(10))
     tasmax = tasmax_series(np.arange(10) + K2C)
 
-    prsn = xci.snowfall_approximation(pr, tas=tasmax, thresh="5 degC", method=method)
+    prsn = xci.snowfall_approximation(pr, tas=tasmax, thresh="2 degC", method=method)
 
     np.testing.assert_allclose(prsn, exp, atol=1e-5, rtol=1e-3)
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #667
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (major / minor / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)
- [ ] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

* Add snowfall estimation methods found in CLASS

### Does this PR introduce a breaking change?

Yes. I changed the condition for the binary method to match CLASS behaviour. Precip is now snow when tas <= 0, instead of tas < 0. 

### Other information:
