### PR TITLE
[sdba] Refactor adjustment objects

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,16 @@ Announcements
 ~~~~~~~~~~~~~
 * It was found that the `ExtremeValues` adjustment algorithm was not as accurate and stable as first thought. It is now hidden from `xclim.sdba` but can still be accessed via `xclim.sdba.adjustment`, with a warning. Work on improving the algorithm is ongoing, and a better implementation will be in a future version.
 
+Breaking changes
+~~~~~~~~~~~~~~~~
+* The Adjustment classes of ``xclim.sdba`` have been refactored into 2 categories:
+
+    - ``TwoStepAdjustment`` objects (most of the algorithms), which are created **and** trained in the same call:
+      ``obj = Adj.train(ref, hist, **kwargs)``. The ``.adjust`` step stays the same.
+
+    - ``SingleStepAdjustment`` objects (only ``NpdfTransform``), which are never initialized. Their ``adjust``
+      class method performs all the work in one call.
+
 New indicators
 ~~~~~~~~~~~~~~
 * ``effective_growing_degree_days`` indice returns growing degree days using dynamic start and end dates for the growing season (based on Bootsma et al. (2005)). This has also been wrapped as an indicator.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -13,10 +13,10 @@ Breaking changes
 ~~~~~~~~~~~~~~~~
 * The Adjustment classes of ``xclim.sdba`` have been refactored into 2 categories:
 
-    - ``TwoStepAdjustment`` objects (most of the algorithms), which are created **and** trained in the same call:
+    - ``TrainAdjust`` objects (most of the algorithms), which are created **and** trained in the same call:
       ``obj = Adj.train(ref, hist, **kwargs)``. The ``.adjust`` step stays the same.
 
-    - ``SingleStepAdjustment`` objects (only ``NpdfTransform``), which are never initialized. Their ``adjust``
+    - ``Adjust`` objects (only ``NpdfTransform``), which are never initialized. Their ``adjust``
       class method performs all the work in one call.
 
 New indicators

--- a/docs/notebooks/sdba-advanced.ipynb
+++ b/docs/notebooks/sdba-advanced.ipynb
@@ -217,8 +217,7 @@
    "source": [
     "from xclim.sdba.adjustment import QuantileDeltaMapping\n",
     "\n",
-    "QDM = QuantileDeltaMapping(nquantiles=15, kind='+', group='time.dayofyear')\n",
-    "QDM.train(ref, hist)\n",
+    "QDM = QuantileDeltaMapping.train(ref, hist, nquantiles=15, kind='+', group='time.dayofyear')\n",
     "QDM"
    ]
   },
@@ -303,8 +302,7 @@
     "from xclim import set_options\n",
     "\n",
     "with set_options(sdba_extra_output=True):\n",
-    "    QDM = QuantileDeltaMapping(nquantiles=15, kind='+', group='time.dayofyear')\n",
-    "    QDM.train(ref, hist)\n",
+    "    QDM = QuantileDeltaMapping.train(ref, hist, nquantiles=15, kind='+', group='time.dayofyear')\n",
     "    out = QDM.adjust(sim)\n",
     "\n",
     "out.sim_q"
@@ -338,8 +336,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "QDM = QuantileDeltaMapping(nquantiles=15, kind='+', group='time.dayofyear')\n",
-    "QDM.train(ref, hist)\n",
+    "QDM = QuantileDeltaMapping.train(ref, hist, nquantiles=15, kind='+', group='time.dayofyear')\n",
     "\n",
     "scen_nowin = QDM.adjust(sim)"
    ]

--- a/docs/notebooks/sdba.ipynb
+++ b/docs/notebooks/sdba.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Statistical Downscaling and Bias-Adjustment\n",
     "\n",
-    "`xclim` provides tools and utilities to ease the bias-adjustement process through its `xclim.sdba` module. Almost all adjustment algorithms conform to the `train` - `adjust` scheme, formalized within `TwoStepAdjustment` classes. Given a reference time series (ref), historical simulations (hist) and simulations to be adjusted (sim), any bias-adjustment method would be applied by first estimating the adjustment factors between the historical simulation and the observations series, and then applying these factors to `sim`, which could be a future simulation.\n",
+    "`xclim` provides tools and utilities to ease the bias-adjustement process through its `xclim.sdba` module. Almost all adjustment algorithms conform to the `train` - `adjust` scheme, formalized within `TrainAdjust` classes. Given a reference time series (ref), historical simulations (hist) and simulations to be adjusted (sim), any bias-adjustment method would be applied by first estimating the adjustment factors between the historical simulation and the observations series, and then applying these factors to `sim`, which could be a future simulation.\n",
     "\n",
     "A very simple \"Quantile Mapping\" approach is available through the \"Empirical Quantile Mapping\" object. The object is created through the `.train` method of the class, and the simulation is adjusted with `.adjust`."
    ]

--- a/docs/notebooks/sdba.ipynb
+++ b/docs/notebooks/sdba.ipynb
@@ -6,9 +6,9 @@
    "source": [
     "# Statistical Downscaling and Bias-Adjustment\n",
     "\n",
-    "`xclim` provides tools and utilities to ease the bias-adjustement process through its `xclim.sdba` module. Adjustment algorithms all conform to the `train` - `adjust` scheme, formalized within `Adjustment` classes. Given a reference time series (ref), historical simulations (hist) and simulations to be adjusted (sim), any bias-adjustment method would be applied by first estimating the adjustment factors between the historical simulation and the observations series, and then applying these factors to `sim`, which could be a future simulation.\n",
+    "`xclim` provides tools and utilities to ease the bias-adjustement process through its `xclim.sdba` module. Almost all adjustment algorithms conform to the `train` - `adjust` scheme, formalized within `TwoStepAdjustment` classes. Given a reference time series (ref), historical simulations (hist) and simulations to be adjusted (sim), any bias-adjustment method would be applied by first estimating the adjustment factors between the historical simulation and the observations series, and then applying these factors to `sim`, which could be a future simulation.\n",
     "\n",
-    "A very simple \"Quantile Mapping\" approach is available through the \"Empirical Quantile Mapping\" object."
+    "A very simple \"Quantile Mapping\" approach is available through the \"Empirical Quantile Mapping\" object. The object is created through the `.train` method of the class, and the simulation is adjusted with `.adjust`."
    ]
   },
   {
@@ -50,8 +50,7 @@
    "source": [
     "from xclim import sdba\n",
     "\n",
-    "QM = sdba.EmpiricalQuantileMapping(nquantiles=15, group='time', kind='+')\n",
-    "QM.train(ref, hist)\n",
+    "QM = sdba.EmpiricalQuantileMapping.train(ref, hist, nquantiles=15, group='time', kind='+')\n",
     "scen = QM.adjust(sim, extrapolation='constant', interp='nearest')\n",
     "\n",
     "ref.groupby('time.dayofyear').mean().plot(label='Reference')\n",
@@ -74,8 +73,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "QM_mo = sdba.EmpiricalQuantileMapping(nquantiles=15, group='time.month', kind='+')\n",
-    "QM_mo.train(ref, hist)\n",
+    "QM_mo = sdba.EmpiricalQuantileMapping.train(ref, hist, nquantiles=15, group='time.month', kind='+')\n",
     "scen = QM_mo.adjust(sim, extrapolation='constant', interp='linear')\n",
     "\n",
     "ref.groupby('time.dayofyear').mean().plot(label='Reference')\n",
@@ -128,8 +126,7 @@
    "outputs": [],
    "source": [
     "group = sdba.Grouper('time.dayofyear', window=31)\n",
-    "QM_doy = sdba.Scaling(group=group, kind='+')\n",
-    "QM_doy.train(ref, hist)\n",
+    "QM_doy = sdba.Scaling.train(ref, hist, group=group, kind='+')\n",
     "scen = QM_doy.adjust(sim)\n",
     "\n",
     "ref.groupby('time.dayofyear').mean().plot(label='Reference')\n",
@@ -167,8 +164,7 @@
     "A generic bias adjustment process is laid out as follows:\n",
     "\n",
     "- preprocessing on `ref`, `hist` and `sim` (using methods in `xclim.sdba.processing` or `xclim.sdba.detrending`)\n",
-    "- creating the adjustment object `Adj = Adjustment(**kwargs)` (from `xclim.sdba.adjustment`)\n",
-    "- training `Adj.train(obs, sim)`\n",
+    "- creating and training the adjustment object `Adj = Adjustment.train(obs, hist, **kwargs)` (from `xclim.sdba.adjustment`)\n",
     "- adjustment `scen = Adj.adjust(sim, **kwargs)`\n",
     "- post-processing on `scen` (for example: re-trending)\n",
     "\n",
@@ -210,8 +206,7 @@
    "outputs": [],
    "source": [
     "# 1st try without adapt_freq\n",
-    "QM = sdba.EmpiricalQuantileMapping(nquantiles=15, kind='*', group='time')\n",
-    "QM.train(pr_ref, pr_hist)\n",
+    "QM = sdba.EmpiricalQuantileMapping.train(ref, pr_hist, nquantiles=15, kind='*', group='time')\n",
     "scen = QM.adjust(pr_sim)\n",
     "\n",
     "pr_ref.sel(time='2010').plot(alpha=0.9, label='Reference')\n",
@@ -239,8 +234,7 @@
    "source": [
     "# 2nd try with adapt_freq\n",
     "ds_ad = sdba.processing.adapt_freq(xr.Dataset(dict(sim=pr_hist, ref=pr_ref, thresh=0.05)), group='time')\n",
-    "QM_ad = sdba.EmpiricalQuantileMapping(nquantiles=15, kind='*', group='time')\n",
-    "QM_ad.train(pr_ref, ds_ad.sim_ad)\n",
+    "QM_ad = sdba.EmpiricalQuantileMapping.train(pr_ref, ds_ad.sim_ad, nquantiles=15, kind='*', group='time')\n",
     "scen_ad = QM_ad.adjust(pr_sim)\n",
     "\n",
     "pr_ref.sel(time='2010').plot(alpha=0.9, label='Reference')\n",
@@ -267,8 +261,7 @@
    "outputs": [],
    "source": [
     "doy_win31 = sdba.Grouper('time.dayofyear', window=15)\n",
-    "Sca = sdba.Scaling(group=doy_win31, kind='+')\n",
-    "Sca.train(ref, hist)\n",
+    "Sca = sdba.Scaling.train(ref, hist, group=doy_win31, kind='+')\n",
     "sim_scl = Sca.adjust(sim)\n",
     "\n",
     "detrender = sdba.detrending.PolyDetrend(degree=1, group='time.dayofyear', kind='+')\n",
@@ -278,8 +271,7 @@
     "ref_n = sdba.processing.normalize(ref.rename('data').to_dataset(), group=doy_win31, kind='+').data\n",
     "hist_n = sdba.processing.normalize(hist.rename('data').to_dataset(), group=doy_win31, kind='+').data\n",
     "\n",
-    "QM = sdba.EmpiricalQuantileMapping(nquantiles=15, group='time.month', kind='+')\n",
-    "QM.train(ref_n, hist_n)\n",
+    "QM = sdba.EmpiricalQuantileMapping.train(ref_n, hist_n, nquantiles=15, group='time.month', kind='+')\n",
     "scen_detrended = QM.adjust(sim_detrended, extrapolation='constant', interp='nearest')\n",
     "scen = sim_fit.retrend(scen_detrended)\n",
     "\n",
@@ -317,13 +309,11 @@
     "simt = ds.air.isel(lat=18, lon=[17, 35]).drop_vars([\"lon\", \"lat\"])\n",
     "\n",
     "# Principal Components Adj, no grouping and use \"lon\" as the space dimensions\n",
-    "PCA = sdba.PrincipalComponents(group=\"time\", crd_dims=['lon'])\n",
-    "PCA.train(reft, simt)\n",
+    "PCA = sdba.PrincipalComponents.train(reft, simt, group=\"time\", crd_dims=['lon'])\n",
     "scen1 = PCA.adjust(simt)\n",
     "\n",
     "# QM, no grouping, 20 quantiles and additive adjustment\n",
-    "EQM = sdba.EmpiricalQuantileMapping(group='time', nquantiles=50, kind='+')\n",
-    "EQM.train(reft, scen1)\n",
+    "EQM = sdba.EmpiricalQuantileMapping.train(reft, scen1, group='time', nquantiles=50, kind='+')\n",
     "scen2 = EQM.adjust(scen1)"
    ]
   },
@@ -419,8 +409,7 @@
    "outputs": [],
    "source": [
     "# additive for tasmax\n",
-    "QDMtx = sdba.QuantileDeltaMapping(nquantiles=20, kind='+', group='time')\n",
-    "QDMtx.train(dref.tasmax, dhist.tasmax)\n",
+    "QDMtx = sdba.QuantileDeltaMapping.train(dref.tasmax, dhist.tasmax, nquantiles=20, kind='+', group='time')\n",
     "# Adjust both hist and sim, we'll feed both to the Npdf transform.\n",
     "scenh_tx = QDMtx.adjust(dhist.tasmax)\n",
     "scens_tx = QDMtx.adjust(dsim.tasmax)\n",
@@ -431,8 +420,7 @@
     "dsim['pr'] = sdba.processing.jitter_under_thresh(dsim.pr, 1e-5)\n",
     "\n",
     "# multiplicative for pr\n",
-    "QDMpr = sdba.QuantileDeltaMapping(nquantiles=20, kind='*', group='time')\n",
-    "QDMpr.train(dref.pr, dhist.pr)\n",
+    "QDMpr = sdba.QuantileDeltaMapping.train(dref.pr, dhist.pr, nquantiles=20, kind='*', group='time')\n",
     "# Adjust both hist and sim, we'll feed both to the Npdf transform.\n",
     "scenh_pr = QDMpr.adjust(dhist.pr)\n",
     "scens_pr = QDMpr.adjust(dsim.pr)\n",
@@ -487,16 +475,19 @@
    "source": [
     "from xclim import set_options\n",
     "\n",
-    "NpdfT = sdba.adjustment.NpdfTransform(\n",
-    "    base=sdba.QuantileDeltaMapping,  # Use QDM as the univariate adjustment.\n",
-    "    base_kws={'nquantiles': 20, 'group': 'time'},\n",
-    "    n_iter=20,  # perform 20 iteration\n",
-    "    n_escore=1000,  # only send 1000 points to the escore metric (it is realy slow)\n",
-    ")\n",
-    "\n",
     "# See the advanced notebook for details on how this option work\n",
     "with set_options(sdba_extra_output=True):\n",
-    "    hist, sim, extra = NpdfT.train_adjust(ref, hist, sim)"
+    "    out = sdba.adjustment.NpdfTransform.adjust(\n",
+    "        ref, hist, sim,\n",
+    "        base=sdba.QuantileDeltaMapping,  # Use QDM as the univariate adjustment.\n",
+    "        base_kws={'nquantiles': 20, 'group': 'time'},\n",
+    "        n_iter=20,  # perform 20 iteration\n",
+    "        n_escore=1000,  # only send 1000 points to the escore metric (it is realy slow)\n",
+    "    )\n",
+    "\n",
+    "scenh = out.scenh.rename(time_hist='time')  # Bias-adjusted historical period\n",
+    "scens = out.scen  # Bias-adjusted future period\n",
+    "extra = out.drop_vars(['scenh', 'scen'])"
    ]
   },
   {

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.28.1
+current_version = 0.28.2-beta
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+).(?P<patch>\d+)(\-(?P<release>[a-z]+))?

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ URL = "https://github.com/Ouranosinc/xclim"
 AUTHOR = "Travis Logan"
 AUTHOR_EMAIL = "logan.travis@ouranos.ca"
 REQUIRES_PYTHON = ">=3.7.0"
-VERSION = "0.28.1"
+VERSION = "0.28.2-beta"
 LICENSE = "Apache Software License 2.0"
 
 with open("README.rst") as readme_file:

--- a/xclim/__init__.py
+++ b/xclim/__init__.py
@@ -10,7 +10,7 @@ from xclim.indicators import atmos, land, seaIce  # noqa
 
 __author__ = """Travis Logan"""
 __email__ = "logan.travis@ouranos.ca"
-__version__ = "0.28.1"
+__version__ = "0.28.2-beta"
 
 
 # Load official locales

--- a/xclim/sdba/__init__.py
+++ b/xclim/sdba/__init__.py
@@ -6,7 +6,7 @@ Statistical Downscaling and Bias Adjustment
 ===========================================
 
 The `xclim.sdba` submodule provides bias-adjustment methods and will eventually provide statistical downscaling algorithms.
-Almost all adjustment algorithms conform to the `train` - `adjust` scheme, formalized within `TwoStepAdjustment` classes.
+Almost all adjustment algorithms conform to the `train` - `adjust` scheme, formalized within `TrainAdjust` classes.
 Given a reference time series (ref), historical simulations (hist) and simulations to be adjusted (sim),
 any bias-adjustment method would be applied by first estimating the adjustment factors between the historical simulation and the observations series, and then applying these factors to `sim`, which could be a future simulation::
 

--- a/xclim/sdba/__init__.py
+++ b/xclim/sdba/__init__.py
@@ -6,12 +6,13 @@ Statistical Downscaling and Bias Adjustment
 ===========================================
 
 The `xclim.sdba` submodule provides bias-adjustment methods and will eventually provide statistical downscaling algorithms.
-Adjustment algorithms all conform to the `train` - `adjust` scheme, formalized within `Adjustment` classes.
+Almost all adjustment algorithms conform to the `train` - `adjust` scheme, formalized within `TwoStepAdjustment` classes.
 Given a reference time series (ref), historical simulations (hist) and simulations to be adjusted (sim),
 any bias-adjustment method would be applied by first estimating the adjustment factors between the historical simulation and the observations series, and then applying these factors to `sim`, which could be a future simulation::
 
-  Adj = Adjustment(group="time.month")
-  Adj.train(ref, hist)
+  # Create the adjustment object by training it with reference and model data, plus certains arguments
+  Adj = Adjustment.train(ref, hist, group="time.month")
+  # Get a scenario by applying the adjustment to a simulated timeseries.
   scen = Adj.adjust(sim, interp="linear")
   Adj.ds.af  # adjustment factors.
 
@@ -36,8 +37,7 @@ This module adopts a modular approach instead of implementing published and name
 A generic bias adjustment process is laid out as follows:
 
 - preprocessing on `ref`, `hist` and `sim` (using methods in `xclim.sdba.processing` or `xclim.sdba.detrending`)
-- creating the adjustment object `Adj = Adjustment(**kwargs)` (from `xclim.sdba.adjustment`)
-- training `Adj.train(obs, sim)`
+- creating and training the adjustment object `Adj = Adjustment.train(obs, sim, **kwargs)` (from `xclim.sdba.adjustment`)
 - adjustment `scen = Adj.adjust(sim, **kwargs)`
 - post-processing on `scen` (for example: re-trending)
 

--- a/xclim/sdba/_adjustment.py
+++ b/xclim/sdba/_adjustment.py
@@ -205,8 +205,8 @@ def npdf_transform(ds: xr.Dataset, **kwargs) -> xr.Dataset:
       respectively after adjustment according to `ref`. If `n_escore` is negative, `escores` will be filled with NaNs.
     """
     ref = ds.ref
-    hist = ds.hist
-    sim = ds.sim.rename(time_sim="time")
+    hist = ds.hist.rename(time_hist="time")
+    sim = ds.sim
     dim = kwargs["pts_dim"]
 
     escores = []
@@ -218,8 +218,7 @@ def npdf_transform(ds: xr.Dataset, **kwargs) -> xr.Dataset:
         simp = sim @ R
 
         # Perform univariate adjustment in rotated space (x')
-        ADJ = kwargs["base"](**kwargs["base_kws"])
-        ADJ.train(refp, histp)
+        ADJ = kwargs["base"].train(refp, histp, **kwargs["base_kws"])
         scenhp = ADJ.adjust(histp, **kwargs["adj_kws"])
         scensp = ADJ.adjust(simp, **kwargs["adj_kws"])
 
@@ -252,8 +251,8 @@ def npdf_transform(ds: xr.Dataset, **kwargs) -> xr.Dataset:
 
     return xr.Dataset(
         data_vars={
-            "scenh": hist.transpose(*ds.hist.dims),
-            "scens": sim.rename(time="time_sim").transpose(*ds.sim.dims),
+            "scenh": hist.rename(time="time_hist").transpose(*ds.hist.dims),
+            "scen": sim.transpose(*ds.sim.dims),
             "escores": escores,
         }
     )

--- a/xclim/sdba/_adjustment.py
+++ b/xclim/sdba/_adjustment.py
@@ -204,7 +204,7 @@ def npdf_transform(ds: xr.Dataset, **kwargs) -> xr.Dataset:
       Dataset with `scenh`, `scens` and `escores` DataArrays, where `scenh` and `scens` are `hist` and `sim`
       respectively after adjustment according to `ref`. If `n_escore` is negative, `escores` will be filled with NaNs.
     """
-    ref = ds.ref
+    ref = ds.ref.rename(time_hist="time")
     hist = ds.hist.rename(time_hist="time")
     sim = ds.sim
     dim = kwargs["pts_dim"]

--- a/xclim/sdba/adjustment.py
+++ b/xclim/sdba/adjustment.py
@@ -94,7 +94,7 @@ class BaseAdjustment(ParametrizableWithDataset):
         ):
             warn(
                 "Strange results could be returned when using dayofyear grouping "
-                "on data defined in the proleptic_greogrian calendar "
+                "on data defined in the proleptic_gregorian calendar "
             )
 
     @classmethod
@@ -193,7 +193,7 @@ class TwoStepAdjustment(BaseAdjustment):
 
 
 class SingleStepAdjustment(BaseAdjustment):
-    """Adjustment with a single step, not fittable into the train-adjust scheme.
+    """Adjustment with no intermediate trained object. 
 
     Children classes should implement a `_adjust` classmethod taking as input the three DataArrays
     and returning the scen dataset/array.
@@ -494,7 +494,7 @@ class QuantileDeltaMapping(EmpiricalQuantileMapping):
 
 
 class ExtremeValues(TwoStepAdjustment):
-    r"""Adjustement correction for extreme values.
+    r"""Adjustment correction for extreme values.
 
     The tail of the distribution of adjusted data is corrected according to the
     parametric Generalized Pareto distribution of the reference data, [RRJF2021]_.

--- a/xclim/sdba/adjustment.py
+++ b/xclim/sdba/adjustment.py
@@ -55,7 +55,7 @@ class BaseAdjustment(ParametrizableWithDataset):
     Children classes should implement the `train` and / or the `adjust` method.
 
     This base class defined the basic input and output checks. It should only be used for a real adjustment
-    if neither `TwoStepAdjustment` or `SingleStepAdjustment` fit the algorithm.
+    if neither `TrainAdjust` or `Adjust` fit the algorithm.
     """
 
     _allow_diff_calendars = True
@@ -105,7 +105,7 @@ class BaseAdjustment(ParametrizableWithDataset):
         raise NotImplementedError()
 
 
-class TwoStepAdjustment(BaseAdjustment):
+class TrainAdjust(BaseAdjustment):
     """Base class for adjustment objects obeying the train-adjust scheme.
 
     Children classes should implement these methods:
@@ -192,7 +192,7 @@ class TwoStepAdjustment(BaseAdjustment):
         raise NotImplementedError
 
 
-class SingleStepAdjustment(BaseAdjustment):
+class Adjust(BaseAdjustment):
     """Adjustment with no intermediate trained object.
 
     Children classes should implement a `_adjust` classmethod taking as input the three DataArrays
@@ -231,7 +231,7 @@ class SingleStepAdjustment(BaseAdjustment):
         return scen
 
 
-class EmpiricalQuantileMapping(TwoStepAdjustment):
+class EmpiricalQuantileMapping(TrainAdjust):
     """Empirical Quantile Mapping bias-adjustment.
 
     Adjustment factors are computed between the quantiles of `ref` and `sim`.
@@ -312,7 +312,7 @@ class EmpiricalQuantileMapping(TwoStepAdjustment):
         ).scen
 
 
-class DetrendedQuantileMapping(TwoStepAdjustment):
+class DetrendedQuantileMapping(TrainAdjust):
     r"""Detrended Quantile Mapping bias-adjustment.
 
     The algorithm follows these steps, 1-3 being the 'train' and 4-6, the 'adjust' steps.
@@ -493,7 +493,7 @@ class QuantileDeltaMapping(EmpiricalQuantileMapping):
         return out.scen
 
 
-class ExtremeValues(TwoStepAdjustment):
+class ExtremeValues(TrainAdjust):
     r"""Adjustment correction for extreme values.
 
     The tail of the distribution of adjusted data is corrected according to the
@@ -690,7 +690,7 @@ class ExtremeValues(TwoStepAdjustment):
         return new_scen
 
 
-class LOCI(TwoStepAdjustment):
+class LOCI(TrainAdjust):
     r"""Local Intensity Scaling (LOCI) bias-adjustment.
 
     This bias adjustment method is designed to correct daily precipitation time series by considering wet and dry days
@@ -762,7 +762,7 @@ class LOCI(TwoStepAdjustment):
         ).scen
 
 
-class Scaling(TwoStepAdjustment):
+class Scaling(TrainAdjust):
     """Scaling bias-adjustment.
 
     Simple bias-adjustment method scaling variables by an additive or multiplicative factor so that the mean of `hist`
@@ -809,7 +809,7 @@ class Scaling(TwoStepAdjustment):
         ).scen
 
 
-class PrincipalComponents(TwoStepAdjustment):
+class PrincipalComponents(TrainAdjust):
     r"""Principal component adjustment.
 
     This bias-correction method maps model simulation values to the observation
@@ -1005,7 +1005,7 @@ class PrincipalComponents(TwoStepAdjustment):
         return scen.unstack(lbl_R)
 
 
-class NpdfTransform(SingleStepAdjustment):
+class NpdfTransform(Adjust):
     r"""N-dimensional probability density function transform.
 
     This adjustment object combines both training and adjustent steps in the `adjust` class method.
@@ -1099,7 +1099,7 @@ class NpdfTransform(SingleStepAdjustment):
         hist: xr.DataArray,
         sim: xr.DataArray,
         *,
-        base: TwoStepAdjustment = QuantileDeltaMapping,
+        base: TrainAdjust = QuantileDeltaMapping,
         base_kws: Optional[Mapping[str, Any]] = None,
         n_escore: int = 0,
         n_iter: int = 20,

--- a/xclim/sdba/adjustment.py
+++ b/xclim/sdba/adjustment.py
@@ -193,7 +193,7 @@ class TwoStepAdjustment(BaseAdjustment):
 
 
 class SingleStepAdjustment(BaseAdjustment):
-    """Adjustment with no intermediate trained object. 
+    """Adjustment with no intermediate trained object.
 
     Children classes should implement a `_adjust` classmethod taking as input the three DataArrays
     and returning the scen dataset/array.

--- a/xclim/sdba/base.py
+++ b/xclim/sdba/base.py
@@ -50,7 +50,7 @@ class Parametrizable(dict):
         return dict(**self)
 
     def __repr__(self):
-        """Return a string representation that allows eval to recreate it."""
+        """Return a string representation."""
         params = ", ".join(
             [
                 f"{k}={repr(v)}"

--- a/xclim/sdba/base.py
+++ b/xclim/sdba/base.py
@@ -417,12 +417,10 @@ def parse_group(func: Callable) -> Callable:
 
     @wraps(func)
     def _parse_group(*args, **kwargs):
-        if default_group:
+        if default_group or "group" in kwargs:
             kwargs.setdefault("group", default_group)
-        elif "group" not in kwargs:
-            raise ValueError("'group' argument not given.")
-        if not isinstance(kwargs["group"], Grouper):
-            kwargs = Grouper.from_kwargs(**kwargs)
+            if not isinstance(kwargs["group"], Grouper):
+                kwargs = Grouper.from_kwargs(**kwargs)
         return func(*args, **kwargs)
 
     return _parse_group

--- a/xclim/testing/tests/test_sdba/test_adjustment.py
+++ b/xclim/testing/tests/test_sdba/test_adjustment.py
@@ -50,8 +50,7 @@ class TestLoci:
         ref_fit = series(y, "pr").where(y > thresh, 0.1)
         ref = series(y, "pr")
 
-        loci = LOCI(group=group, thresh=thresh)
-        loci.train(ref_fit, hist)
+        loci = LOCI.train(ref_fit, hist, group=group, thresh=thresh)
         np.testing.assert_array_almost_equal(loci.ds.hist_thresh, 1, dec)
         np.testing.assert_array_almost_equal(loci.ds.af, 2, dec)
 
@@ -86,8 +85,7 @@ class TestScaling:
         hist = sim = series(x, name)
         ref = series(apply_correction(x, 2, kind), name)
 
-        scaling = Scaling(group="time", kind=kind)
-        scaling.train(ref, hist)
+        scaling = Scaling.train(ref, hist, group="time", kind=kind)
         np.testing.assert_array_almost_equal(scaling.ds.af, 2)
 
         p = scaling.adjust(sim)
@@ -105,8 +103,7 @@ class TestScaling:
         ref = mon_series(apply_correction(x, 2, kind), name)
 
         # Test train
-        scaling = Scaling(group="time.month", kind=kind)
-        scaling.train(ref, hist)
+        scaling = Scaling.train(ref, hist, group="time.month", kind=kind)
         expected = apply_correction(mon_triangular, 2, kind)
         np.testing.assert_array_almost_equal(scaling.ds.af, expected)
 
@@ -140,12 +137,13 @@ class TestDQM:
         hist = sim = series(x, name)
         ref = series(y, name)
 
-        DQM = DetrendedQuantileMapping(
+        DQM = DetrendedQuantileMapping.train(
+            ref,
+            hist,
             kind=kind,
             group="time",
             nquantiles=50,
         )
-        DQM.train(ref, hist)
         p = DQM.adjust(sim, interp="linear")
 
         q = DQM.ds.quantiles
@@ -217,8 +215,9 @@ class TestDQM:
             sim = sim.expand_dims(lat=[0, 1, 2]).chunk({"lat": 1})
             ref_t = ref_t.expand_dims(lat=[0, 1, 2])
 
-        DQM = DetrendedQuantileMapping(kind=kind, group="time.month", nquantiles=5)
-        DQM.train(ref, hist)
+        DQM = DetrendedQuantileMapping.train(
+            ref, hist, kind=kind, group="time.month", nquantiles=5
+        )
         mqm = DQM.ds.af.mean(dim="quantiles")
         p = DQM.adjust(sim)
 
@@ -230,8 +229,7 @@ class TestDQM:
     def test_cannon_and_from_ds(self, cannon_2015_rvs, tmp_path):
         ref, hist, sim = cannon_2015_rvs(15000)
 
-        DQM = DetrendedQuantileMapping(kind="*", group="time")
-        DQM.train(ref, hist)
+        DQM = DetrendedQuantileMapping.train(ref, hist, kind="*", group="time")
         p = DQM.adjust(sim)
 
         np.testing.assert_almost_equal(p.mean(), 41.6, 0)
@@ -272,12 +270,13 @@ class TestQDM:
         hist = sim = series(x, name)
         ref = series(y, name)
 
-        QDM = QuantileDeltaMapping(
+        QDM = QuantileDeltaMapping.train(
+            ref,
+            hist,
             kind=kind,
             group="time",
             nquantiles=10,
         )
-        QDM.train(ref, hist)
         p = QDM.adjust(sim, interp="linear")
 
         q = QDM.ds.coords["quantiles"]
@@ -328,8 +327,9 @@ class TestQDM:
         else:
             sel = {}
 
-        QDM = QuantileDeltaMapping(kind=kind, group="time.month", nquantiles=40)
-        QDM.train(ref, hist)
+        QDM = QuantileDeltaMapping.train(
+            ref, hist, kind=kind, group="time.month", nquantiles=40
+        )
         p = QDM.adjust(sim, interp="linear" if kind == "+" else "nearest")
 
         q = QDM.ds.coords["quantiles"]
@@ -350,8 +350,9 @@ class TestQDM:
 
         # Quantile mapping
         with set_options(sdba_extra_output=True):
-            QDM = QuantileDeltaMapping(kind="*", group="time", nquantiles=50)
-            QDM.train(ref, hist)
+            QDM = QuantileDeltaMapping.train(
+                ref, hist, kind="*", group="time", nquantiles=50
+            )
             scends = QDM.adjust(sim)
 
         assert isinstance(scends, xr.Dataset)
@@ -398,12 +399,13 @@ class TestQM:
         # Test train
         hist = sim = series(x, name)
         ref = series(y, name)
-        QM = EmpiricalQuantileMapping(
+        QM = EmpiricalQuantileMapping.train(
+            ref,
+            hist,
             kind=kind,
             group="time",
             nquantiles=50,
         )
-        QM.train(ref, hist)
         p = QM.adjust(sim, interp="linear")
 
         q = QM.ds.coords["quantiles"]
@@ -440,8 +442,9 @@ class TestQM:
         hist = sim = series(x, name)
         ref = mon_series(y, name)
 
-        QM = EmpiricalQuantileMapping(kind=kind, group="time.month", nquantiles=5)
-        QM.train(ref, hist)
+        QM = EmpiricalQuantileMapping.train(
+            ref, hist, kind=kind, group="time.month", nquantiles=5
+        )
         p = QM.adjust(sim)
         mqm = QM.ds.af.mean(dim="quantiles")
         expected = apply_correction(mon_triangular, 2, kind)
@@ -475,8 +478,9 @@ class TestPrincipalComponents:
         sim = xr.DataArray([sim_x, sim_y], dims=("lat", "lon", "time"))
         sim["time"] = ref["time"]
 
-        PCA = PrincipalComponents(group=group, crd_dims=crd_dims, pts_dims=pts_dims)
-        PCA.train(ref, sim)
+        PCA = PrincipalComponents.train(
+            ref, sim, group=group, crd_dims=crd_dims, pts_dims=pts_dims
+        )
         scen = PCA.adjust(sim)
 
         group = group if isinstance(group, Grouper) else Grouper("time")
@@ -518,8 +522,7 @@ class TestPrincipalComponents:
         ref = ds.air.isel(lat=21, lon=[40, 52]).drop_vars(["lon", "lat"])
         sim = ds.air.isel(lat=18, lon=[17, 35]).drop_vars(["lon", "lat"])
 
-        PCA = PrincipalComponents(group=group)
-        PCA.train(ref, sim)
+        PCA = PrincipalComponents.train(ref, sim, group=group)
         scen = PCA.adjust(sim)
 
         def dist(ref, sim):
@@ -565,15 +568,14 @@ class TestExtremeValues:
         hist = jitter_under_thresh(gen_testdata(-0.1, 2), 1e-3)
         sim = gen_testdata(-0.15, 2.5)
 
-        EQM = EmpiricalQuantileMapping(group="time.dayofyear", nquantiles=15, kind="*")
-        EQM.train(ref, hist)
+        EQM = EmpiricalQuantileMapping.train(
+            ref, hist, group="time.dayofyear", nquantiles=15, kind="*"
+        )
 
         scen = EQM.adjust(sim)
 
-        EX = ExtremeValues(c_thresh, q_thresh=q_thresh)
-
         with set_options(sdba_extra_output=diags):
-            EX.train(ref, hist)
+            EX = ExtremeValues.train(ref, hist, c_thresh, q_thresh=q_thresh)
 
         if diags:
             assert "nclusters" in EX.ds
@@ -604,19 +606,17 @@ class TestExtremeValues:
 
         quantiles = np.linspace(0.01, 0.99, num=50)
 
-        EQM = EmpiricalQuantileMapping(
-            group=Grouper("time.dayofyear", window=31), nquantiles=quantiles
-        )
-
         with xr.set_options(keep_attrs=True):
             ref = ref + uniform_noise_like(ref, low=1e-6, high=1e-3)
             hist = hist + uniform_noise_like(hist, low=1e-6, high=1e-3)
 
-        EQM.train(ref, hist)
+        EQM = EmpiricalQuantileMapping.train(
+            ref, hist, group=Grouper("time.dayofyear", window=31), nquantiles=quantiles
+        )
+
         scen = EQM.adjust(hist, interp="linear", extrapolation="constant")
 
-        EX = ExtremeValues(cluster_thresh="1 mm/day", q_thresh=0.97)
-        EX.train(ref, hist)
+        EX = ExtremeValues.train(ref, hist, cluster_thresh="1 mm/day", q_thresh=0.97)
         new_scen = EX.adjust(scen, hist, frac=0.000000001)
 
         new_scen.load()
@@ -632,6 +632,5 @@ class TestExtremeValues:
 
 def test_raise_on_multiple_chunks(tas_series):
     ref = tas_series(np.arange(730)).chunk({"time": 365})
-    Adj = BaseAdjustment(group=Grouper("time.month"))
     with pytest.raises(ValueError):
-        Adj.train(ref, ref)
+        EmpiricalQuantileMapping.train(ref, ref, group=Grouper("time.month"))


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #754 
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [x] `bumpversion (major / minor / patch)` has been called on this branch
- [x] Tags have been pushed (`git push --tags`)
- [x] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

* Instead of a single `BaseAdjustment` class, Adjustment algorithm inherit from either `SingleStepAdjustment` or `TwoStepAdjustment`.  In the former, only one (class) method is exposed: `cls.adjust(ref, hist, sim, **kwargs) -> scen`. In the latter, two methods: `train` and `adjust`.


### Does this PR introduce a breaking change?
Yes. Most adjustment object are now created directly through `train`, there is no need to call the `__init__` before.
So:
```python3
# Before:
DQM = DetrendedQuantileMapping(nquantiles=15, group='time.dayofyear')
DQM.train(ref, hist)
scen = DQM.adjust(sim)

# Now:
DQM = DetrendedQuantileMapping.train(ref, hist, nquantiles=15, group='time.dayofyear')
scen = DQM.adjust(sim)
```

### Other information:
I also made minor changes to the docstrings, moved them to the class instead of the `__init__`. The only algo that doesn't fit the two-step scheme is `NpdfTransfer`, so I also made the `SingleStepAdjustment`, where the object is never actually created, it's only a `adjust` class method.