### PR TITLE
conda-forge: mark test_custom_indices() as requiring the docs folder

### DIFF
--- a/xclim/testing/tests/test_modules.py
+++ b/xclim/testing/tests/test_modules.py
@@ -55,6 +55,7 @@ def test_virtual_modules(virtual_indicator, atmosds):
         ind(ds=atmosds)
 
 
+@pytest.mark.requires_docs
 def test_custom_indices():
     # Use the example in the Extending Xclim notebook for testing.
     pr = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc").pr


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (major / minor / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)
- [ ] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

* Added a `@pytest.mark.requires_docs` to `test_custom_indcies`.

This is needed for tests to pass on the conda-forge build, as the docs are not bundled in the PyPI source files for xclim, so will always fail. The test needs to be skipped on that infrastructure.

### Does this PR introduce a breaking change?

Negative.

### Other information:

https://github.com/conda-forge/xclim-feedstock/pull/44