### PR TITLE
Preserve missing when injecting freq

### DIFF
--- a/xclim/core/indicator.py
+++ b/xclim/core/indicator.py
@@ -359,7 +359,10 @@ class Indicator(IndicatorRegistrar):
         kwds["parameters"] = params
 
         # By default skip missing values handling if there is no resampling.
-        if "freq" not in params:
+        # Dont only check if freq is in current parameters but also if it was injected earlier.
+        if "freq" not in params and "freq" not in getattr(
+            kwds["compute"], "_injected", {}
+        ):
             kwds["missing"] = "skip"
 
         # Parse kwds to organize cf_attrs

--- a/xclim/testing/tests/test_modules.py
+++ b/xclim/testing/tests/test_modules.py
@@ -82,3 +82,6 @@ def test_custom_indices():
     out2 = ex2.R95p(pr=pr)  # noqa
 
     xr.testing.assert_equal(out1, out2)
+
+    # Check that missing was not modified even with injecting `freq`.
+    assert ex1.RX5day.missing == indicators.atmos.max_n_day_precipitation_amount.missing


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (major / minor / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)
- [ ] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

* When injected `freq` in the compute function of an indicator with `wrapped_partial`, the indicator's constructor (`__new__`) would assume it was a non-resampling indicator (since `'freq' not in params`), and override the missing method to `skip`. This adds a check within the `_injected`  field that `wrapped_partial` adds when injecting parameters.

### Does this PR introduce a breaking change?
Yes and no, some results might change but the behaviour will now be as announced.


### Other information:
This is most important  for workflows using yaml virtual submodules, where injecting  `freq` could be frequent.
