### PR TITLE
[sdba] Fix 832 - Parse default group

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -15,6 +15,7 @@ Bug fixes
 * Addressed an edge case where ``test_sdba::test_standardize`` randomness could generate values that surpass the test error tolerance.
 * Added a missing `.txt` file to the MANIFEST of the source distributable in order to be able to run all tests.
 * ``xc.core.units.rate2amount`` is now exact when the sampling frequency is monthly, seasonal or yearly. Earlier, monthly and yearly data were computed using constant month and year length. End-of-period frequencies are also correctly understood (ex: "M" vs "MS").
+* Fixed an issue that prevented using the default ``group`` arg in adjustment objects.
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/xclim/sdba/adjustment.py
+++ b/xclim/sdba/adjustment.py
@@ -136,7 +136,6 @@ class TrainAdjust(BaseAdjustment):
     _repr_hide_params = ["hist_calendar", "train_units"]
 
     @classmethod
-    @parse_group
     def train(cls, ref: DataArray, hist: DataArray, **kwargs):
         """Train the adjustment object. Refer to the class documentation for the algorithm details.
 
@@ -147,6 +146,7 @@ class TrainAdjust(BaseAdjustment):
         hist : DataArray
           Training data, usually a model output whose biases are to be adjusted.
         """
+        kwargs = parse_group(cls._train, kwargs)
 
         (ref, hist), train_units = cls._harmonize_units(ref, hist)
 
@@ -224,7 +224,6 @@ class Adjust(BaseAdjustment):
     """
 
     @classmethod
-    @parse_group
     def adjust(
         cls,
         ref: xr.DataArray,
@@ -232,7 +231,20 @@ class Adjust(BaseAdjustment):
         sim: xr.DataArray,
         **kwargs,
     ):
+        """Return bias-adjusted data. Refer to the class documentation for the algorithm details.
 
+        Parameters
+        ----------
+        ref : DataArray
+          Training target, usually a reference time series drawn from observations.
+        hist : DataArray
+          Training data, usually a model output whose biases are to be adjusted.
+        sim : DataArray
+          Time series to be bias-adjusted, usually a model output.
+        kwargs :
+          Algorithm-specific keyword arguments, see class doc.
+        """
+        kwargs = parse_group(cls._adjust, kwargs)
         if "group" in kwargs:
             cls._check_inputs(ref, hist, sim, group=kwargs["group"])
 

--- a/xclim/testing/tests/test_sdba/test_adjustment.py
+++ b/xclim/testing/tests/test_sdba/test_adjustment.py
@@ -429,6 +429,7 @@ class TestQM:
         # Test train
         hist = sim = series(x, name)
         ref = series(y, name)
+
         QM = EmpiricalQuantileMapping.train(
             ref,
             hist,
@@ -698,6 +699,14 @@ class TestExtremeValues:
 
 
 def test_raise_on_multiple_chunks(tas_series):
-    ref = tas_series(np.arange(730)).chunk({"time": 365})
+    ref = tas_series(np.arange(730).astype(float)).chunk({"time": 365})
     with pytest.raises(ValueError):
         EmpiricalQuantileMapping.train(ref, ref, group=Grouper("time.month"))
+
+
+def test_default_grouper_understood(tas_series):
+    ref = tas_series(np.arange(730).astype(float))
+
+    EQM = EmpiricalQuantileMapping.train(ref, ref)
+    EQM.adjust(ref)
+    assert EQM.group.dim == "time"


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #832
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (major / minor / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)
- [ ] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

* Expanded `parse_group` so it can be used as a decorator OR as a direct function. In `TrainAdjust.train` and `Adjust.adjust`, the parsing is done within the function, so it can use the children `_train` (or `_adjust`) method's signature to guess the default `group`. This makes not passing `group` possible again. I avoided having to make it non-optional this way. 

### Does this PR introduce a breaking change?
No

### Other information:
Added a very basic test.