### PR TITLE
Fix/bootstrapping with dask

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -18,6 +18,9 @@ Bug fixes
 * In the ``potential_evapotranspiration`` indice, add abbreviated ``method`` names to docstring.
 * Fixed an issue that prevented using the default ``group`` arg in adjustment objects.
 * Fix bug in ``missing_wmo``, where a period would be considered valid if all months met WMO criteria, but complete months in a year were missing. Now if any month does not meet criteria or is absent, the period will be considered missing.
+* Fix bootstrapping with dask arrays. Dask does not support using ``loc`` with multiple indexes to set new values so a workaround was necessary.
+* Fix bootstrapping when the bootstrapped year must be converted to a 366_day calendar.
+
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/xclim/core/bootstrapping.py
+++ b/xclim/core/bootstrapping.py
@@ -186,17 +186,17 @@ def bootstrap_year(
     # Replace `bloc` by every other group
     for i, (key, group_slice) in enumerate(gr.items()):
         source = da.isel({dim: group_slice})
-
+        out_view = out.loc[{bdim: i}]
         if len(source[dim]) == len(bloc):
-            out.loc[{bdim: i, dim: bloc}] = source.data
+            out_view.loc[{dim: bloc}] = source.data
         if len(source[dim]) < len(bloc):
             pass
         elif len(bloc) == 365:
-            out.loc[{bdim: i, dim: bloc}] = convert_calendar(source, "365_day").data
+            out_view.loc[{dim: bloc}] = convert_calendar(source, "365_day").data
         elif len(bloc) == 366:
-            out.loc[{bdim: i, dim: bloc}] = convert_calendar(source, "366_day").data
+            out_view.loc[{dim: bloc}] = convert_calendar(source, "366_day").data
         elif len(bloc) < 365:
-            out.loc[{bdim: i, dim: bloc}] = source.data[: len(bloc)]
+            out_view.loc[{dim: bloc}] = source.data[: len(bloc)]
         else:
             raise NotImplementedError
 

--- a/xclim/testing/tests/test_bootstrapping.py
+++ b/xclim/testing/tests/test_bootstrapping.py
@@ -129,7 +129,7 @@ class Test_bootstrap:
 
     def bootstrap_testor(
         self,
-        serie: Callable[[...], DataArray],
+        series,
         per: int,
         compute_indice: Callable[[DataArray, DataArray], DataArray],
         positive_values=False,
@@ -139,7 +139,7 @@ class Test_bootstrap:
         n = int(4 * 365.25)
         alpha = 0.8
         arr = self.ar1(alpha, n, positive_values)
-        climat_variable = serie(arr, start="2000-01-01")
+        climat_variable = series(arr, start="2000-01-01")
         if use_dask:
             climat_variable = climat_variable.chunk(dict(time=2))
         in_base_slice = slice("2000-01-01", "2001-12-31")

--- a/xclim/testing/tests/test_bootstrapping.py
+++ b/xclim/testing/tests/test_bootstrapping.py
@@ -21,6 +21,7 @@ from xclim.testing import open_dataset
 
 
 class Test_bootstrap:
+    @pytest.mark.slow
     @pytest.mark.parametrize("use_dask", [True, False])
     def test_bootstrap_tg90p(self, tas_series, use_dask):
         self.bootstrap_testor(

--- a/xclim/testing/tests/test_bootstrapping.py
+++ b/xclim/testing/tests/test_bootstrapping.py
@@ -21,78 +21,109 @@ from xclim.testing import open_dataset
 
 
 class Test_bootstrap:
-    @pytest.mark.slow
-    def test_bootstrap_tg90p(self, tas_series):
+    @pytest.mark.parametrize("use_dask", [True, False])
+    def test_bootstrap_tg90p(self, tas_series, use_dask):
         self.bootstrap_testor(
-            tas_series, 98, lambda x, y, z: tg90p(x, y, freq="MS", bootstrap=z)
+            tas_series,
+            98,
+            lambda x, y, z: tg90p(x, y, freq="MS", bootstrap=z),
+            use_dask=use_dask,
         )
 
     @pytest.mark.slow
-    def test_bootstrap_tn90p(self, tasmin_series):
+    @pytest.mark.parametrize("use_dask", [True, False])
+    def test_bootstrap_tn90p(self, tasmin_series, use_dask):
         self.bootstrap_testor(
-            tasmin_series, 98, lambda x, y, z: tn90p(x, y, freq="A-JUL", bootstrap=z)
+            tasmin_series,
+            98,
+            lambda x, y, z: tn90p(x, y, freq="A-JUL", bootstrap=z),
+            use_dask=use_dask,
         )
 
     @pytest.mark.slow
-    def test_bootstrap_tx90p(self, tasmax_series):
+    @pytest.mark.parametrize("use_dask", [True, False])
+    def test_bootstrap_tx90p(self, tasmax_series, use_dask):
         self.bootstrap_testor(
-            tasmax_series, 98, lambda x, y, z: tx90p(x, y, freq="Q-APR", bootstrap=z)
+            tasmax_series,
+            98,
+            lambda x, y, z: tx90p(x, y, freq="Q-APR", bootstrap=z),
+            use_dask=use_dask,
         )
 
     @pytest.mark.slow
-    def test_bootstrap_tn10p(self, tasmin_series):
+    @pytest.mark.parametrize("use_dask", [True, False])
+    def test_bootstrap_tn10p(self, tasmin_series, use_dask):
         self.bootstrap_testor(
-            tasmin_series, 2, lambda x, y, z: tn10p(x, y, freq="MS", bootstrap=z)
+            tasmin_series,
+            2,
+            lambda x, y, z: tn10p(x, y, freq="MS", bootstrap=z),
+            use_dask=use_dask,
         )
 
     @pytest.mark.slow
-    def test_bootstrap_tx10p(self, tasmax_series):
+    @pytest.mark.parametrize("use_dask", [True, False])
+    def test_bootstrap_tx10p(self, tasmax_series, use_dask):
         self.bootstrap_testor(
-            tasmax_series, 2, lambda x, y, z: tx10p(x, y, freq="YS", bootstrap=z)
+            tasmax_series,
+            2,
+            lambda x, y, z: tx10p(x, y, freq="YS", bootstrap=z),
+            use_dask=use_dask,
         )
 
     @pytest.mark.slow
-    def test_bootstrap_tg10p(self, tas_series):
+    @pytest.mark.parametrize("use_dask", [True, False])
+    def test_bootstrap_tg10p(self, tas_series, use_dask):
         self.bootstrap_testor(
-            tas_series, 2, lambda x, y, z: tg10p(x, y, freq="MS", bootstrap=z)
+            tas_series,
+            2,
+            lambda x, y, z: tg10p(x, y, freq="MS", bootstrap=z),
+            use_dask=use_dask,
         )
 
     @pytest.mark.slow
-    def test_bootstrap_warm_spell_duration_index(self, tasmax_series):
+    @pytest.mark.parametrize("use_dask", [True, False])
+    def test_bootstrap_warm_spell_duration_index(self, tasmax_series, use_dask):
         self.bootstrap_testor(
             tasmax_series,
             98,
             lambda x, y, z: warm_spell_duration_index(
                 x, y, window=6, freq="MS", bootstrap=z
             ),
+            use_dask=use_dask,
         )
 
     @pytest.mark.slow
-    def test_bootstrap_cold_spell_duration_index(self, tasmin_series):
+    @pytest.mark.parametrize("use_dask", [True, False])
+    def test_bootstrap_cold_spell_duration_index(self, tasmin_series, use_dask):
         self.bootstrap_testor(
             tasmin_series,
             2,
             lambda x, y, z: cold_spell_duration_index(
                 x, y, window=6, freq="MS", bootstrap=z
             ),
+            use_dask=use_dask,
         )
 
     @pytest.mark.slow
-    def test_bootstrap_days_over_precip_thresh(self, pr_series):
+    @pytest.mark.parametrize("use_dask", [True, False])
+    def test_bootstrap_days_over_precip_thresh(self, pr_series, use_dask):
         self.bootstrap_testor(
             pr_series,
             99,
             lambda x, y, z: days_over_precip_thresh(x, y, freq="MS", bootstrap=z),
             positive_values=True,
+            use_dask=use_dask,
         )
 
     @pytest.mark.slow
-    def test_bootstrap_fraction_over_precip_thresh(self, pr_series):
+    @pytest.mark.parametrize("use_dask", [True, False])
+    def test_bootstrap_fraction_over_precip_thresh(self, pr_series, use_dask):
         self.bootstrap_testor(
             pr_series,
             98,
             lambda x, y, z: fraction_over_precip_thresh(x, y, freq="MS", bootstrap=z),
             positive_values=True,
+            use_dask=use_dask,
         )
 
     def bootstrap_testor(
@@ -101,11 +132,15 @@ class Test_bootstrap:
         per: int,
         compute_indice: Callable[[DataArray, DataArray], DataArray],
         positive_values=False,
+        use_dask=False,
     ):
         # GIVEN
         n = int(4 * 365.25)
         alpha = 0.8
-        climat_variable = serie(self.ar1(alpha, n, positive_values), start="2000-01-01")
+        arr = self.ar1(alpha, n, positive_values)
+        climat_variable = serie(arr, start="2000-01-01")
+        if use_dask:
+            climat_variable = climat_variable.chunk(dict(time=2))
         in_base_slice = slice("2000-01-01", "2001-12-31")
         out_base_slice = slice("2002-01-01", "2003-12-31")
         per = percentile_doy(climat_variable.sel(time=in_base_slice), per=per)

--- a/xclim/testing/tests/test_bootstrapping.py
+++ b/xclim/testing/tests/test_bootstrapping.py
@@ -20,102 +20,130 @@ from xclim.indices import (
 from xclim.testing import open_dataset
 
 
-def ar1(alpha, n, positive_values=False):
-    """Return random AR1 DataArray."""
+class Test_bootstrap:
+    @pytest.mark.slow
+    def test_bootstrap_tg90p(self, tas_series):
+        self.bootstrap_testor(
+            tas_series, 98, lambda x, y, z: tg90p(x, y, freq="MS", bootstrap=z)
+        )
 
-    # White noise
-    wn = np.random.randn(n - 1) * np.sqrt(1 - alpha ** 2)
+    @pytest.mark.slow
+    def test_bootstrap_tn90p(self, tasmin_series):
+        self.bootstrap_testor(
+            tasmin_series, 98, lambda x, y, z: tn90p(x, y, freq="A-JUL", bootstrap=z)
+        )
 
-    # Autoregressive series of order 1
-    out = np.empty(n)
-    out[0] = np.random.randn()
-    for i, w in enumerate(wn):
-        if positive_values:
-            out[i + 1] = np.abs(alpha * out[i] + w)
-        else:
-            out[i + 1] = alpha * out[i] + w
+    @pytest.mark.slow
+    def test_bootstrap_tx90p(self, tasmax_series):
+        self.bootstrap_testor(
+            tasmax_series, 98, lambda x, y, z: tx90p(x, y, freq="Q-APR", bootstrap=z)
+        )
 
-    return out
+    @pytest.mark.slow
+    def test_bootstrap_tn10p(self, tasmin_series):
+        self.bootstrap_testor(
+            tasmin_series, 2, lambda x, y, z: tn10p(x, y, freq="MS", bootstrap=z)
+        )
 
+    @pytest.mark.slow
+    def test_bootstrap_tx10p(self, tasmax_series):
+        self.bootstrap_testor(
+            tasmax_series, 2, lambda x, y, z: tx10p(x, y, freq="YS", bootstrap=z)
+        )
 
-def bootstrap_testor(
-    serie: DataArray,
-    per: int,
-    compute_indice: Callable[[DataArray, DataArray], DataArray],
-    positive_values=False,
-):
-    # GIVEN
-    n = int(60 * 365.25)
-    alpha = 0.8
-    climat_variable = serie(ar1(alpha, n, positive_values), start="2000-01-01")
-    in_base_slice = slice("2000-01-01", "2029-12-31")
-    out_base_slice = slice("2030-01-01", "2059-12-31")
-    per = percentile_doy(climat_variable.sel(time=in_base_slice), per=per)
-    # WHEN
-    no_bootstrap = compute_indice(climat_variable, per, False)
-    no_bs_in_base = no_bootstrap.sel(time=(in_base_slice))
-    no_bs_out_base = no_bootstrap.sel(time=(out_base_slice))
-    bootstrap = compute_indice(climat_variable, per, True)
-    bootstrapped_in_base = bootstrap.sel(time=(in_base_slice))
-    bs_out_base = bootstrap.sel(time=(out_base_slice))
-    # THEN
-    # bootstrapping should increase the indices values within the in_base
-    # will not work on unrealistic values such as a constant temperature
-    assert np.count_nonzero(bootstrapped_in_base > no_bs_in_base) > np.count_nonzero(
-        bootstrapped_in_base < no_bs_in_base
-    )
-    # bootstrapping should let the out of base unchanged
-    assert np.count_nonzero(no_bs_out_base != bs_out_base) == 0
+    @pytest.mark.slow
+    def test_bootstrap_tg10p(self, tas_series):
+        self.bootstrap_testor(
+            tas_series, 2, lambda x, y, z: tg10p(x, y, freq="MS", bootstrap=z)
+        )
 
+    @pytest.mark.slow
+    def test_bootstrap_warm_spell_duration_index(self, tasmax_series):
+        self.bootstrap_testor(
+            tasmax_series,
+            98,
+            lambda x, y, z: warm_spell_duration_index(
+                x, y, window=6, freq="MS", bootstrap=z
+            ),
+        )
 
-@pytest.mark.slow
-def test_bootstrap(tas_series, tasmax_series, tasmin_series, pr_series):
-    # The closer the targetted percentile is to the median the less bootstrapping makes sense to use.
-    # The tests may even fail if the chosen percentile is close to 50
-    # temperatures
-    bootstrap_testor(
-        tas_series, 98, lambda x, y, z: tg90p(x, y, freq="MS", bootstrap=z)
-    )
-    bootstrap_testor(
-        tasmin_series, 98, lambda x, y, z: tn90p(x, y, freq="A-JUL", bootstrap=z)
-    )
-    bootstrap_testor(
-        tasmax_series, 98, lambda x, y, z: tx90p(x, y, freq="Q-APR", bootstrap=z)
-    )
-    bootstrap_testor(
-        tasmin_series, 2, lambda x, y, z: tn10p(x, y, freq="MS", bootstrap=z)
-    )
-    bootstrap_testor(
-        tasmax_series, 2, lambda x, y, z: tx10p(x, y, freq="YS", bootstrap=z)
-    )
-    bootstrap_testor(tas_series, 2, lambda x, y, z: tg10p(x, y, freq="MS", bootstrap=z))
-    bootstrap_testor(
-        tasmax_series,
-        98,
-        lambda x, y, z: warm_spell_duration_index(
-            x, y, window=6, freq="MS", bootstrap=z
-        ),
-    )
-    bootstrap_testor(
-        tasmin_series,
-        2,
-        lambda x, y, z: cold_spell_duration_index(
-            x, y, window=6, freq="MS", bootstrap=z
-        ),
-    )
-    # precipitations
-    bootstrap_testor(
-        pr_series,
-        99,
-        lambda x, y, z: days_over_precip_thresh(x, y, freq="MS", bootstrap=z),
-        positive_values=True,
-    )
-    bootstrap_testor(
-        pr_series,
-        98,
-        lambda x, y, z: fraction_over_precip_thresh(x, y, freq="MS", bootstrap=z),
-        positive_values=True,
-    )
+    @pytest.mark.slow
+    def test_bootstrap_cold_spell_duration_index(self, tasmin_series):
+        self.bootstrap_testor(
+            tasmin_series,
+            2,
+            lambda x, y, z: cold_spell_duration_index(
+                x, y, window=6, freq="MS", bootstrap=z
+            ),
+        )
+
+    @pytest.mark.slow
+    def test_bootstrap_days_over_precip_thresh(self, pr_series):
+        self.bootstrap_testor(
+            pr_series,
+            99,
+            lambda x, y, z: days_over_precip_thresh(x, y, freq="MS", bootstrap=z),
+            positive_values=True,
+        )
+
+    @pytest.mark.slow
+    def test_bootstrap_fraction_over_precip_thresh(self, pr_series):
+        self.bootstrap_testor(
+            pr_series,
+            98,
+            lambda x, y, z: fraction_over_precip_thresh(x, y, freq="MS", bootstrap=z),
+            positive_values=True,
+        )
+
+    def bootstrap_testor(
+        self,
+        serie: Callable[[...], DataArray],
+        per: int,
+        compute_indice: Callable[[DataArray, DataArray], DataArray],
+        positive_values=False,
+    ):
+        # GIVEN
+        n = int(4 * 365.25)
+        alpha = 0.8
+        climat_variable = serie(self.ar1(alpha, n, positive_values), start="2000-01-01")
+        in_base_slice = slice("2000-01-01", "2001-12-31")
+        out_base_slice = slice("2002-01-01", "2003-12-31")
+        per = percentile_doy(climat_variable.sel(time=in_base_slice), per=per)
+        # WHEN
+        no_bootstrap = compute_indice(climat_variable, per, False)
+        no_bs_in_base = no_bootstrap.sel(time=(in_base_slice))
+        no_bs_out_base = no_bootstrap.sel(time=(out_base_slice))
+        bootstrap = compute_indice(climat_variable, per, True)
+        bootstrapped_in_base = bootstrap.sel(time=(in_base_slice))
+        bs_out_base = bootstrap.sel(time=(out_base_slice))
+        # THEN
+        # bootstrapping should increase the indices values within the in_base
+        # will not work on unrealistic values such as a constant temperature
+        # However, the closer the targeted percentile is to the median
+        # the less bootstrapping makes sense to use.
+        # The tests may even fail if the chosen percentile is close to 50
+        assert np.count_nonzero(
+            bootstrapped_in_base > no_bs_in_base
+        ) > np.count_nonzero(bootstrapped_in_base < no_bs_in_base)
+        # bootstrapping should let the out of base unchanged
+        assert np.count_nonzero(no_bs_out_base != bs_out_base) == 0
+
+    def ar1(self, alpha, n, positive_values=False):
+        """Return random AR1 DataArray."""
+
+        # White noise
+        wn = np.random.randn(n - 1) * np.sqrt(1 - alpha ** 2)
+
+        # Autoregressive series of order 1
+        out = np.empty(n)
+        out[0] = np.random.randn()
+        for i, w in enumerate(wn):
+            if positive_values:
+                out[i + 1] = np.abs(alpha * out[i] + w)
+            else:
+                out[i + 1] = alpha * out[i] + w
+
+        return out
 
 
 def test_doctest_ndims():


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #840 
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (major / minor / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)
- [ ] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?
Bootstrapping with Dask arrays was broken, it is now fixed.
This PR also fixes bootstrapping years where `len(bloc) == 366` and where `len(source[dim]) < 360 and len(source[dim]) < len(bloc)`


### Does this PR introduce a breaking change?
No.

### Other information:
