### PR TITLE
sdba - Fixes for dimensions without indexes - optionalize unit handing in detrending.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,7 @@ Breaking changes
 
 Bug fixes
 ~~~~~~~~~
+* Fixes in ``sdba`` for (1) inputs with dimensions without coordinates, for (2) ``sdba.detrending.MeanDetrend`` and for (3) ``DetrendedQuantileMapping`` when used with dask's distributed scheduler.
 * Replaced instances of `'◦'` ("White bullet") with `'°'` ("Degree Sign") in ``icclim.yaml`` as it was causing issues for non-UTF8 environments.
 * Addressed an edge case where ``test_sdba::test_standardize`` randomness could generate values that surpass the test error tolerance.
 * Added a missing `.txt` file to the MANIFEST of the source distributable in order to be able to run all tests.
@@ -28,7 +29,7 @@ Internal Changes
 
 New features and enhancements
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-* ``xc.core.utils.nan_calc_percentiles`` now uses a custom algorithm instead of ``numpy.nanpercentiles`` to have more flexibility on the interpolation method. The performance is also improved. 
+* ``xc.core.utils.nan_calc_percentiles`` now uses a custom algorithm instead of ``numpy.nanpercentiles`` to have more flexibility on the interpolation method. The performance is also improved.
 * ``xc.core.calendar.percentile_doy`` now uses the 8th method of Hyndman & Fan for linear interpolation (alpha = beta = 1/3). Previously, the function used Numpy's percentile, which corresponds to the 7th method. This change is motivated by the fact that the 8th is recommended by Hyndman & Fay and it ensures consistency with other climate indices packages (climdex, icclim). Using `alpha = beta = 1` restores the previous behaviour.
 * ``xc.core.utils._cal_perc`` is now only a proxy for ``xc.core.utils.nan_calc_percentiles`` with some axis moves.
 

--- a/xclim/sdba/__init__.py
+++ b/xclim/sdba/__init__.py
@@ -65,6 +65,8 @@ to manage xarray attributes (including units) correctly and their signatures are
 this reason, the module is often divided in two parts : the (decorated) compute functions in a "private" file (ex: ``_adjustment.py``)
 and the user-facing functions or objects in corresponding public file (ex: ``adjustment.py``). See the `sdba-advanced`
 notebook for more info on the reasons for this move.
+
+Other restrictions : `map_blocks` will remove any "auxiliary" coordinates before calling the wrapped function and will add them back on exit.
 """
 from . import detrending, processing, utils
 from .adjustment import *

--- a/xclim/sdba/_adjustment.py
+++ b/xclim/sdba/_adjustment.py
@@ -113,8 +113,6 @@ def dqm_adjust(ds, *, group, interp, kind, extrapolation, detrend):
         extrapolation=extrapolation,
         kind=kind,
     ).scen
-    # Circumvent random dask bug, same as discussed in  #810
-    scen.attrs["units"] = ds.sim.units
     scen = detrend.retrend(scen)
 
     out = xr.Dataset({"scen": scen, "trend": detrend.ds.trend})

--- a/xclim/sdba/adjustment.py
+++ b/xclim/sdba/adjustment.py
@@ -147,7 +147,6 @@ class TrainAdjust(BaseAdjustment):
         hist : DataArray
           Training data, usually a model output whose biases are to be adjusted.
         """
-
         (ref, hist), train_units = cls._harmonize_units(ref, hist)
 
         if "group" in kwargs:

--- a/xclim/sdba/base.py
+++ b/xclim/sdba/base.py
@@ -635,7 +635,9 @@ def map_blocks(reduces=None, **outvars):
             _call_and_transpose_on_exit.__name__ = f"block_{func.__name__}"
 
             # Remove all auxiliary coords on both tmpl and ds
-            extra_coords = {nam: crd for nam, crd in ds.coords.items() if nam not in crd.dims}
+            extra_coords = {
+                nam: crd for nam, crd in ds.coords.items() if nam not in crd.dims
+            }
             ds = ds.drop_vars(extra_coords.keys())
             tmpl = tmpl.drop_vars(extra_coords.keys())
 
@@ -645,10 +647,16 @@ def map_blocks(reduces=None, **outvars):
             )
 
             # Add back the extra coords, but only those which have compatible dimensions (like xarray would have done)
-            out = out.assign_coords({nam: crd for nam, crd in extra_coords.items() if set(crd.dims).issubset(out.dims)})
+            out = out.assign_coords(
+                {
+                    nam: crd
+                    for nam, crd in extra_coords.items()
+                    if set(crd.dims).issubset(out.dims)
+                }
+            )
 
             # Finally remove coords we added... 'ignore' in case they were already removed.
-            out = out.drop_vars(added_coords, errors='ignore')
+            out = out.drop_vars(added_coords, errors="ignore")
             return out
 
         _map_blocks.__dict__["func"] = func

--- a/xclim/sdba/base.py
+++ b/xclim/sdba/base.py
@@ -562,6 +562,7 @@ def map_blocks(reduces=None, **outvars):
             # All dimensions of the output data, new_dims are added at the end on purpose.
             all_dims = base_dims + new_dims
             # The coordinates of the output data.
+            added_coords = []
             coords = {}
             sizes = {}
             for dim in all_dims:
@@ -569,13 +570,15 @@ def map_blocks(reduces=None, **outvars):
                     coords[group.prop] = group.get_coordinate(ds=ds)
                 elif dim == group.dim:
                     coords[group.dim] = ds[group.dim]
-                elif dim in ds.coords:
-                    coords[dim] = ds[dim]
                 elif dim in kwargs:
                     coords[dim] = xr.DataArray(kwargs[dim], dims=(dim,), name=dim)
                 elif dim in ds.dims:
-                    # Dimension with no coordinate, but it is in the inputs so we can get the size.
-                    sizes[dim] = ds[dim].size
+                    # If a dim has no coords : some sdba function will add them, so to be safe we add them right now
+                    # and note them to remove them afterwards.
+                    if dim not in ds.coords:
+                        added_coords.append(dim)
+                    ds[dim] = ds[dim]
+                    coords[dim] = ds[dim]
                 else:
                     raise ValueError(
                         f"This function adds the {dim} dimension, its coordinate must be provided as a keyword argument."
@@ -617,18 +620,26 @@ def map_blocks(reduces=None, **outvars):
                     raise ValueError(
                         f"{func.__name__} failed on block with coords : {dsblock.coords}."
                     ) from err
-                for name, crd in dsblock.coords.items():
-                    if name not in out.coords and set(crd.dims).issubset(out.dims):
-                        out = out.assign_coords({name: dsblock[name]})
                 return out
 
             # Fancy patching for explicit dask task names
             _call_and_transpose_on_exit.__name__ = f"block_{func.__name__}"
 
+            # Remove all auxiliary coords on both tmpl and ds
+            extra_coords = {nam: crd for nam, crd in ds.coords.items() if nam not in crd.dims}
+            ds = ds.drop_vars(extra_coords.keys())
+            tmpl = tmpl.drop_vars(extra_coords.keys())
+
+            # Call
             out = ds.map_blocks(
                 _call_and_transpose_on_exit, template=tmpl, kwargs=kwargs
             )
 
+            # Add back the extra coords, but only those which have compatible dimensions (like xarray would have done)
+            out = out.assign_coords({nam: crd for nam, crd in extra_coords.items() if set(crd.dims).issubset(out.dims)})
+
+            # Finally remove coords we added... 'ignore' in case they were already removed.
+            out = out.drop_vars(added_coords, errors='ignore')
             return out
 
         _map_blocks.__dict__["func"] = func

--- a/xclim/sdba/detrending.py
+++ b/xclim/sdba/detrending.py
@@ -56,7 +56,7 @@ class BaseDetrend(ParametrizableWithDataset):
         """
         new = self.__class__(**self.parameters)
         new.set_dataset(new._get_trend(da).rename("trend").to_dataset())
-        new.ds.trend.attrs["units"] = da.units
+        new.ds.trend.attrs["units"] = da.attrs.get('units', "")
         return new
 
     def _get_trend(self, da: xr.DataArray):
@@ -79,14 +79,18 @@ class BaseDetrend(ParametrizableWithDataset):
         """Remove the previously fitted trend from a DataArray."""
         if not self.fitted:
             raise ValueError("You must call fit() before detrending.")
-        trend = convert_units_to(self.ds.trend, da)
+        trend = self.ds.trend
+        if 'units' in da.attrs:
+            trend = convert_units_to(self.ds.trend, da)
         return self._detrend(da, trend)
 
     def retrend(self, da: xr.DataArray):
         """Put the previously fitted trend back on a DataArray."""
         if not self.fitted:
             raise ValueError("You must call fit() before retrending")
-        trend = convert_units_to(self.ds.trend, da)
+        trend = self.ds.trend
+        if 'units' in da.attrs:
+            trend = convert_units_to(self.ds.trend, da)
         return self._retrend(da, trend)
 
     def _detrend(self, da, trend):
@@ -124,12 +128,12 @@ class MeanDetrend(BaseDetrend):
     """Simple detrending removing only the mean from the data, quite similar to normalizing."""
 
     def _get_trend(self, da):
-        return _meandetrend_get_trend(da, **self)
+        return _meandetrend_get_trend(da, **self).trend
 
 
-@map_groups(main_only=True, trend=["<DIM>"])
+@map_groups(main_only=True, trend=[Grouper.DIM])
 def _meandetrend_get_trend(da, *, dim, kind):
-    trend = xr.full_like(da, da.mean(dim))
+    trend = da.mean(dim).broadcast_like(da)
     return trend.rename("trend").to_dataset()
 
 

--- a/xclim/sdba/detrending.py
+++ b/xclim/sdba/detrending.py
@@ -56,7 +56,7 @@ class BaseDetrend(ParametrizableWithDataset):
         """
         new = self.__class__(**self.parameters)
         new.set_dataset(new._get_trend(da).rename("trend").to_dataset())
-        new.ds.trend.attrs["units"] = da.attrs.get('units', "")
+        new.ds.trend.attrs["units"] = da.attrs.get("units", "")
         return new
 
     def _get_trend(self, da: xr.DataArray):
@@ -80,7 +80,7 @@ class BaseDetrend(ParametrizableWithDataset):
         if not self.fitted:
             raise ValueError("You must call fit() before detrending.")
         trend = self.ds.trend
-        if 'units' in da.attrs:
+        if "units" in da.attrs:
             trend = convert_units_to(self.ds.trend, da)
         return self._detrend(da, trend)
 
@@ -89,7 +89,7 @@ class BaseDetrend(ParametrizableWithDataset):
         if not self.fitted:
             raise ValueError("You must call fit() before retrending")
         trend = self.ds.trend
-        if 'units' in da.attrs:
+        if "units" in da.attrs:
             trend = convert_units_to(self.ds.trend, da)
         return self._retrend(da, trend)
 

--- a/xclim/testing/tests/test_sdba/test_adjustment.py
+++ b/xclim/testing/tests/test_sdba/test_adjustment.py
@@ -348,11 +348,13 @@ class TestQDM:
         ref = mon_series(y, name)
         hist = sim = series(x, name)
         if use_dask:
+            ref = ref.chunk({"time": -1})
+            hist = hist.chunk({"time": -1})
             sim = sim.chunk({"time": -1})
         if add_dims:
-            ref = ref.expand_dims(site=[0, 1, 2, 3, 4])
-            hist = hist.expand_dims(site=[0, 1, 2, 3, 4])
-            sim = sim.expand_dims(site=[0, 1, 2, 3, 4])
+            ref = ref.expand_dims(site=[0, 1, 2, 3, 4]).drop_vars("site")
+            hist = hist.expand_dims(site=[0, 1, 2, 3, 4]).drop_vars("site")
+            sim = sim.expand_dims(site=[0, 1, 2, 3, 4]).drop_vars("site")
             sel = {"site": 0}
         else:
             sel = {}

--- a/xclim/testing/tests/test_sdba/test_detrending.py
+++ b/xclim/testing/tests/test_sdba/test_detrending.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from xclim.sdba.detrending import LoessDetrend, PolyDetrend
+from xclim.sdba.detrending import LoessDetrend, MeanDetrend, PolyDetrend
 
 
 def test_poly_detrend_and_from_ds(series, tmp_path):
@@ -41,3 +41,15 @@ def test_loess_detrend(series):
     # Strong boundary effects in LOESS, remove ~ f * Nx on each side.
     np.testing.assert_array_almost_equal(dx.isel(time=slice(880, 3500)), 0)
     np.testing.assert_array_almost_equal(xt, x)
+
+
+def test_mean_detrend(series):
+    x = series(np.arange(20 * 365.25), "tas")
+
+    md = MeanDetrend().fit(x)
+    assert (md.ds.trend == x.mean()).all()
+
+    anomaly = md.detrend(x)
+    x2 = md.retrend(anomaly)
+
+    np.testing.assert_array_almost_equal(x, x2)


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes partially #831.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (major / minor / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)
- [ ] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

* Adds a workaround in `map_blocks` for cases where a dimension doesn't have a coordinate. Sometimes, xarray/xclim functions will automatically add integer coordinates on such dimensions, but that makes map_blocks fail, because new coordinates appear. The workaround adds the missing coords and removes it afterwards.
* Fix `MeanDetrending`, which was broken and untested (woupsi)
* Optionalize unit handling on `Detrend` objects to workaround #831 in `DetrendedQuantileMapping`. This is not a real fix and `NpdfTransform` should still be affected, but it at least makes DQM stable with distributed schedulers.

### Does this PR introduce a breaking change?
No.

EDIT:
There was a line in `DQM.adjust` which was supposed to workaround the 831 bug, but it wasn't enough, thus this PR.