### PR TITLE
Stronger yaml structure

### DIFF
--- a/docs/notebooks/example.fr.json
+++ b/docs/notebooks/example.fr.json
@@ -5,8 +5,14 @@
     "description": "Nombre de jours où la température minimale passe sous 0°C."
   },
   "R95P": {
-    "title": "Précpitations accumulées lors des jours de fortes pluies (> 95e percentile)",
-    "long_name": "Accumulation {freq:f} des précipitations lors des jours de fortes pluies (> 95e percentile)",
-    "description": "Épaisseur équivalent des précipitations accumulées lors des jours où la pluie est plus forte que le 95e percentile de la série."
+    "title": "Précpitations accumulées lors des jours de fortes pluies (> {perc}e percentile)"
+  },
+  "R95P.R95p": {
+    "long_name": "Accumulation {freq:f} des précipitations lors des jours de fortes pluies (> {perc}e percentile)",
+    "description": "Épaisseur équivalent des précipitations accumulées lors des jours où la pluie est plus forte que le {perc}e percentile de la série."
+  },
+  "R95P.R95p_days": {
+    "long_name": "Nombre de jours de fortes pluies (> {perc}e percentile)",
+    "description": "Nombre de jours où la pluie est plus forte que le {perc}e percentile de la série."
   }
 }

--- a/docs/notebooks/example.py
+++ b/docs/notebooks/example.py
@@ -4,8 +4,10 @@ from xclim.core.units import declare_units, rate2amount
 
 
 @declare_units(pr="[precipitation]")
-def extreme_precip_accumulation(pr: xr.DataArray, perc: float = 95, freq: str = "YS"):
-    """Total precipitation accumulation during extreme events.
+def extreme_precip_accumulation_and_days(
+    pr: xr.DataArray, perc: float = 95, freq: str = "YS"
+):
+    """Total precipitation accumulation during extreme events and numbr of days of such precipitation.
 
     The `perc` percentile of the precipitation (including all values, not in a day-of-year manner)
     is computed. Then, for each period, the days where `pr` is above the threshold are accumulated,
@@ -24,11 +26,17 @@ def extreme_precip_accumulation(pr: xr.DataArray, perc: float = 95, freq: str = 
     -------
     xarray.DataArray
       Precipitation accumulated during events where pr was above the {perc}th percentile of the whole series.
+    xarray.DataArray
+      Number of days where pr was above the {perc}th percentile of the whole series.
     """
-    pr_thresh = pr.quantile(perc / 100, dim="time")
+    pr_thresh = pr.quantile(perc / 100, dim="time").drop_vars("quantile")
 
-    pr_extreme = rate2amount(pr).where(pr >= pr_thresh)
+    extreme_days = pr >= pr_thresh
+    pr_extreme = rate2amount(pr).where(extreme_days)
 
-    out = pr_extreme.resample(time=freq).sum().drop_vars("quantile")
-    out.attrs["units"] = pr_extreme.units
-    return out
+    out1 = pr_extreme.resample(time=freq).sum()
+    out1.attrs["units"] = pr_extreme.units
+
+    out2 = extreme_days.resample(time=freq).sum()
+    out2.attrs["units"] = "days"
+    return out1, out2

--- a/docs/notebooks/example.yml
+++ b/docs/notebooks/example.yml
@@ -1,85 +1,71 @@
-realm: atmos
 doc: |
   ==============
   Example module
   ==============
+
   This module is an example of YAML generated xclim submodule.
+realm: atmos
 references: xclim documentation https://xclim.readthedocs.io
 indices:
+  LPRatio:
+    base: liquid_precip_ratio
+    output:
+      description: "Precipitation is estimated to be solid when tas is under 0.5°C"
+      long_name: Liquid precip to total precip ratio.
+    parameters:
+      thresh: 0.5 degC
+  R75pdays:
+    base: days_over_precip_thresh
+    parameters:
+      per:
+        description: Daily 75th percentile of wet day precipitation flux.
+      thresh: 1 mm/day
+  R95p:
+    compute: extreme_precip_accumulation_and_days
+    output:
+      - cell_methods: 'time: sum within days time: sum over days'
+        long_name: Annual total PRCP when RR > {perc}th percentile
+        units: m
+        var_name: R95p
+      - long_name: Annual number of days when RR > {perc}th percentile
+        units: days
+        var_name: R95p_days
+    parameters:
+      perc: 95
+    references: climdex
+  R99p:
+    base: .R95p
+    compute: extreme_precip_accumulation_and_days
+    output:
+      - var_name: R99p
+      - var_name: R99p_days
+    parameters:
+      perc: 99
   RX1day:
+    allowed_periods: [Q, A]
     base: rx1day
-    period:
-      allowed:
-      - seasonal
-      - annual
-      default: annual
     output:
       long_name: Highest 1-day precipitation amount
   RX5day:
     base: max_n_day_precipitation_amount
     output:
       long_name: Highest 5-day precipitation amount
-    index_function:
-      parameters:
-        window: 5
-        freq: QS-DEC
-  R75pdays:
-    base: days_over_precip_thresh
-    index_function:
-      parameters:
-        thresh:
-          data: 1 mm/day
-        per:
-          data: {per}
-          description: Daily 75th percentile of wet day precipitation flux.
+    parameters:
+      freq: QS-DEC
+      window: 5
   fd:
-    reference: ETCCDI
-    period: weekly
-    output:
-      var_name: "fd"
-      standard_name: number_of_days_with_air_temperature_below_threshold
-      long_name: "Number of Frost Days (Tmin < 0C)"
-      units: "days"
-      cell_methods:
-        - time: minimum within days
-        - time: sum over days
+    compute: count_occurrences
     input:
       data: tasmin
-    index_function:
-      name: count_occurrences
-      parameters:
-        threshold: 0 degC
-        condition: "<"
-  R95p:
-    reference: climdex
-    period: annual
     output:
-      var_name: R95p
-      long_name: Annual total PRCP when RR > {perc}th percentile
-      units: m
-      cell_methods:
-        - time: sum within days
-        - time: sum over days
-    input:
-      pr: pr
-    index_function:
-      name: extreme_precip_accumulation
-      parameters:
-        perc: 95
-  R99p:
-    base: .R95p
-    index_function:
-      name: extreme_precip_accumulation
-      parameters:
-        perc: 99
-  LPRatio:
-    base: liquid_precip_ratio
-    input:
-      tas: tas
-      pr: pr
-    output:
-      long_name: Liquid precip to total precip ratio.
-      description: Precipitation is estimated to be solid when tas is under 0.5°C
-    index_function:
-      parameters:
-        thresh: 0.5 degC
+      cell_methods: 'time: minimum within days time: sum over days'
+      long_name: Number of Frost Days (Tmin < 0°C)
+      standard_name: number_of_days_with_air_temperature_below_threshold
+      units: days
+      var_name: fd
+    parameters:
+      condition: <
+      threshold: 0 degC
+      freq:
+        default: YS
+    references: ETCCDI

--- a/docs/notebooks/extendxclim.ipynb
+++ b/docs/notebooks/extendxclim.ipynb
@@ -378,24 +378,71 @@
     "\n",
     "- `RX1day` is simply the same as  `registry['RX1DAY']`, but with an updated `long_name`.\n",
     "- `RX5day` is based on `registry['MAX_N_DAY_PRECIPITATION_AMOUNT']`, changed the `long_name` and injects the `window` and `freq` arguments.\n",
-    "- `R75pdays` is based on `registry['DAYS_OVER_PRECIP_THRESH']`, injects the `thresh` argument and changes the description of the `per` argument. Passing \"data: {per}\" tells xclim the value is still to be determined by the user, but other parameter's metadata field might be changed.\n",
+    "- `R75pdays` is based on `registry['DAYS_OVER_PRECIP_THRESH']`, injects the `thresh` argument and changes the description of the `per` argument.\n",
     "- `fd` is a more complex example. As there were no `base:` entry, the `Daily` class serves as a base. As it is pretty much empty, a lot has to be given explicitly:\n",
-    "    * A list of allowed resampling frequency is passed\n",
     "    * Many output metadata fields are given\n",
-    "    * A index_function name if given (here it refers to a function in `xclim.indices.generic`).\n",
-    "    * Some parameters are injected.\n",
-    "    * The input variable `data` is mapped to a known variable. Functions in `xclim.indices.generic` are indeed generic. Here we tell xclim that the `data` argument is minimal daily temperature. This will set the proper units check, default value and CF-compliance checks.\n",
-    "- `R95p` is similar to `fd` but here the `index_function` is not defined in `xclim` but rather in  `example.py`.\n",
-    "- `R99p` is the same as `R95p` but changes the injected value. In order to avoid rewriting the output metadata, and allowed periods, we based it on `R95p` : as the latter was defined within the current yaml file, the identifier is prefixed by a dot (.). However, in order to _inject_ a parameter we still need to repeat the index_function name (and retrigger the indice function wrapping process under the hood).\n",
+    "    * A compute function name if given (here it refers to a function in `xclim.indices.generic`).\n",
+    "    * Some parameters are injected, a default for `freq` is set.\n",
+    "    * The input variable `data` is mapped to a known variable. Functions in `xclim.indices.generic` are indeed generic. Here we tell xclim that the `data` argument is minimum daily temperature. This will set the proper units check, default value and CF-compliance checks.\n",
+    "- `R95p` is similar to `fd` but here the `compute` is not defined in `xclim` but rather in  `example.py`. Also, the custom function returns two outputs, so the `output` section is a list of mappings rather than a mapping directly.\n",
+    "- `R99p` is the same as `R95p` but changes the injected value. In order to avoid rewriting the output metadata, and allowed periods, we based it on `R95p` : as the latter was defined within the current yaml file, the identifier is prefixed by a dot (.). However, in order to _inject_ a parameter we still need to repeat the `compute` name (and retrigger the indice function wrapping process under the hood).\n",
     "- `LPRatio` is a version of \"liquid precip ratio\" where we we force the use of `tas` (instead of having it an optional variable). We also inject a specific threshold.\n",
-    "\n",
-    "A few ways of prescribing _default_ or _allowed_ periods (resampling frequencies) are shown here. In `fd` and `R95p`, only the default value of `freq` is given. `R75pdays` will keep the default value in the signature of the underlying indice. `RX1day` goes in more details by prescribing a default value and a list of _allowed_ values. xclim will be relax and accept any `freq` values equivalent to those listed here. Finally, `RX5day` directly injects the `freq` argument, so that it doesn't even appear in the docstring.\n",
     "\n",
     "Additionnaly, the yaml specified a `realm` and `references` to be used on all indices and provided a submodule docstring. Creating the module is then simply:\n",
     "\n",
     "Finally, french translations for the main attributes and the new indicaters are given in `example.fr.json`. Even though new indicator objects are created for each yaml entry, non-specified translations are taken from the base classes if missing in the `json` file.\n",
     "\n",
-    "Note that all files are named the same way : `example.<ext>`, with the translations having an additionnal suffix giving the locale name. In the next cell, we build the module by passing only the path without extension. This absence of extension is what tells xclim to try to parse a module (`*.py`) and custom translations (`*.<locale>.json`). Those two could also be read beforehand and passed through the  `indices=` and `translations=` arguments."
+    "Note that all files are named the same way : `example.<ext>`, with the translations having an additionnal suffix giving the locale name. In the next cell, we build the module by passing only the path without extension. This absence of extension is what tells xclim to try to parse a module (`*.py`) and custom translations (`*.<locale>.json`). Those two could also be read beforehand and passed through the  `indices=` and `translations=` arguments.\n",
+    "\n",
+    "\n",
+    "#### Validation of the YAML file\n",
+    "Using [`yamale`](https://github.com/23andMe/Yamale), it is possible to check if the yaml file is valid. xclim ships with a schema (in `xclim/data/schema.yml`) file. The file can be located with:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from importlib.resources import path\n",
+    "\n",
+    "with path(\"xclim.data\", \"schema.yml\") as f:\n",
+    "    print(f)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And the validation can be executed either in a python session:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import yamale\n",
+    "\n",
+    "with path(\"xclim.data\", \"schema.yml\") as f:\n",
+    "    schema = yamale.make_schema(f)\n",
+    "    data = yamale.make_data(\"example.yml\")  # in the current folder\n",
+    "yamale.validate(schema, data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "No errors means it passed. The validation can also be run through the command line with:\n",
+    "\n",
+    "```bash\n",
+    "yamale -s path/to/schema.yml path/to/module.yml\n",
+    "```\n",
+    "\n",
+    "#### Loading the module and computating of the indices."
    ]
   },
   {
@@ -445,8 +492,11 @@
     "        print(f\"Indicator: {name}\")\n",
     "        print(f\"\\tIdentifier: {ind.identifier}\")\n",
     "        print(f\"\\tTitle: {ind.title}\")\n",
-    "        out = ind(ds=ds2)  # Use all default arguments and variables from the dataset,\n",
-    "        outs.append(out)"
+    "        out = ind(ds=ds2)  # Use all default arguments and variables from the dataset\n",
+    "        if isinstance(out, tuple):\n",
+    "            outs.extend(out)\n",
+    "        else:\n",
+    "            outs.append(out)"
    ]
   },
   {
@@ -556,7 +606,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.9.6"
   },
   "toc": {
    "base_numbering": 1,

--- a/environment.yml
+++ b/environment.yml
@@ -42,3 +42,4 @@ dependencies:
  - tokenize-rt
  - tox
  - xdoctest
+ - yamale

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -14,6 +14,7 @@ pytest-runner
 tokenize-rt
 tox
 xdoctest
+yamale
 # Documentation and examples
 distributed>=2.0
 ipykernel

--- a/xclim/core/indicator.py
+++ b/xclim/core/indicator.py
@@ -378,13 +378,15 @@ class Indicator(IndicatorRegistrar):
             output = deepcopy(parent_output)
         elif output is None:
             # Attributes were passed the "old" way, with lists or strings directly (only _cf_names)
-            # We need to get the number of outputs, defaulting to the length of parent's output or 1
+            # We need to get the number of outputs first, defaulting to the length of parent's output or 1
             n_outs = max(
                 [len(parent_output or [1])]
                 + [
-                    len(kwds.get(name))
+                    len(kwds.get(name, getattr(cls, name, None)))
                     for name in cls._cf_names
-                    if isinstance(kwds.get(name), (tuple, list))
+                    if isinstance(
+                        kwds.get(name, getattr(cls, name, None)), (tuple, list)
+                    )
                 ]
             )
 
@@ -392,7 +394,7 @@ class Indicator(IndicatorRegistrar):
             output = [{} for i in range(n_outs)]
 
             for name in cls._cf_names:
-                values = kwds.pop(name, None)
+                values = kwds.pop(name, getattr(cls, name, None))
                 if values is None:  # None passed, skip
                     continue
                 elif not isinstance(values, (tuple, list)):

--- a/xclim/core/indicator.py
+++ b/xclim/core/indicator.py
@@ -57,6 +57,9 @@ All fields are optional. Other fields found in the yaml file will trigger errors
 In the following, the section under `<identifier>` is refered to as `data`. When creating indicators from
 a dictionary, with :py:meth:`Indicator.from_dict`, the input dict must follow the same structure of `data`.
 
+The resulting yaml file can be validated using the provided schema (in xclim/data/schema.yml) and the [yamale](https://github.com/23andMe/Yamale) tool.
+See the "Extending xclim" notebook for more info.
+
 Inputs
 ~~~~~~
 As xclim has strict definitions of possible input variables (see :py:data:`xclim.core.utils.variables`),
@@ -222,7 +225,7 @@ class Indicator(IndicatorRegistrar):
       The `pint` unit context, for example use 'hydro' to allow conversion from kg m-2 s-1 to mm/day.
     allowed_periods : Sequence[str], optional
       A list of allowed periods, i.e. base parts of the `freq` parameter. For example, indicators meant to be
-      computed annually only will have `allowed_periods=["Y", "A"]`. `None` means, "any period" or that the
+      computed annually only will have `allowed_periods=["A"]`. `None` means "any period" or that the
       indicator doesn't take a `freq` argument.
 
     Notes
@@ -371,11 +374,13 @@ class Indicator(IndicatorRegistrar):
         if isinstance(output, dict):
             # Single output indicator, but we store as a list anyway.
             output = [output]
+        elif output is None and parent_output:
+            output = deepcopy(parent_output)
         elif output is None:
             # Attributes were passed the "old" way, with lists or strings directly (only _cf_names)
-            # We need to get the number of outputs, defaulting to 1
+            # We need to get the number of outputs, defaulting to the length of parent's output or 1
             n_outs = max(
-                [1]
+                [len(parent_output or [1])]
                 + [
                     len(kwds.get(name))
                     for name in cls._cf_names

--- a/xclim/core/units.py
+++ b/xclim/core/units.py
@@ -364,19 +364,6 @@ Mapping from offset base to CF-compliant unit. Only constant-length frequencies 
 """
 
 
-FREQ_NAMES = {
-    "annual": ("A", "YS"),  # A is the same as Y
-    "seasonal": ("Q", "QS-DEC"),
-    "monthly": ("M", "MS"),
-    "weekly": ("W", "W-SUN"),
-}
-"""
-Resampling frequency names for the "period" element of the YAML definition of indicators.
-
-Mapping from english name to a tuple of offset base and default freq value.
-"""
-
-
 def infer_sampling_units(
     da: xr.DataArray,
     deffreq: Optional[str] = "D",

--- a/xclim/core/utils.py
+++ b/xclim/core/utils.py
@@ -24,7 +24,7 @@ import xarray as xr
 from boltons.funcutils import update_wrapper
 from dask import array as dsk
 from xarray import DataArray, Dataset
-from yaml import safe_load
+from yaml import safe_dump, safe_load
 
 #: Type annotation for strings representing full dates (YYYY-MM-DD), may include time.
 DateStr = NewType("DateStr", str)
@@ -266,7 +266,7 @@ def raise_warn_or_log(
     elif mode == "warn":
         warnings.warn(msg, stacklevel=stacklevel + 1)
     else:  # mode == "raise"
-        raise err
+        raise ValueError(msg) from err
 
 
 class InputKind(IntEnum):
@@ -414,3 +414,116 @@ def infer_kind_from_parameter(param: Parameter, has_units: bool = False) -> Inpu
         return InputKind.KWARGS
 
     return InputKind.OTHER_PARAMETER
+
+
+def adapt_clix_meta_yaml(raw: os.PathLike, adapted: os.PathLike):
+    """Reads in a clix-meta yaml and refactors it to fit xclim's yaml specifications."""
+    from xclim.indices import generic
+
+    freq_names = {"annual": "A", "seasonal": "Q", "monthly": "M", "weekly": "W"}
+    freq_defs = {"annual": "YS", "seasonal": "QS-DEC", "monthly": "MS", "weekly": "W"}
+
+    with open(raw) as f:
+        yml = safe_load(f)
+
+    yml["realm"] = "atmos"
+    yml[
+        "doc"
+    ] = """  ===================
+  CF Standard indices
+  ===================
+
+  Indicator found here are defined by the team at `clix-meta`_.
+  Adapted documentation from that repository follows:
+
+  The repository aims to provide a platform for thinking about, and developing,
+  a unified view of metadata elements required to describe climate indices (aka climate indicators).
+
+  To facilitate data exchange and dissemination the metadata should, as far as possible,
+  follow the Climate and Forecasting (CF) Conventions. Considering the very rich and diverse flora of
+  climate indices this is however not always possible. By collecting a wide range of different indices
+  it is easier to discover any common patterns and features that are currently not well covered by the
+  CF Conventions. Currently identified issues frequently relate to standard_name or/and cell_methods
+  which both are controlled vocabularies of the CF Conventions.
+
+  .. _clix-meta: https://github.com/clix-meta/clix-meta
+"""
+    yml["references"] = "clix-meta https://github.com/clix-meta/clix-meta"
+
+    remove_ids = []
+    rename_ids = {}
+    for cmid, data in yml["indices"].items():
+        if "reference" in data:
+            data["references"] = data.pop("reference")
+
+        index_function = data.pop("index_function")
+
+        data["compute"] = index_function["name"]
+        if getattr(generic, data["compute"], None) is None:
+            remove_ids.append(cmid)
+            print(
+                f"Indicator {cmid} uses non-implemented function {data['compute']}, removing."
+            )
+            continue
+
+        rename_params = {}
+        if index_function["parameters"]:
+            data["parameters"] = index_function["parameters"]
+            for name, param in data["parameters"].copy().items():
+                if param["kind"] in ["operator", "reducer"]:
+                    data["parameters"][name] = param[param["kind"]]
+                else:  # kind = quantity
+                    if param.get("proposed_standard_name") == "temporal_window_size":
+                        # Window, nothing to do.
+                        del data["parameters"][name]
+                    elif isinstance(param["data"], dict):
+                        # No value
+                        data["parameters"][name] = {
+                            "description": param.get(
+                                "long_name",
+                                param.get(
+                                    "proposed_standard_name", param.get("standard_name")
+                                ).replace("_", " "),
+                            ),
+                            "units": param["units"],
+                        }
+                        rename_params[
+                            f"{{{name}}}"
+                        ] = f"{{{list(param['data'].keys())[0]}}}"
+                    else:
+                        # Value
+                        data["parameters"][name] = f"{param['data']} {param['units']}"
+
+        period = data.pop("period")
+        data["allowed_periods"] = [freq_names[per] for per in period["allowed"].keys()]
+        data.setdefault("parameters", {})["freq"] = {
+            "default": freq_defs[period["default"]]
+        }
+
+        if "proposed_standard_name" in data["output"]:
+            del data["output"]["proposed_standard_name"]
+        for attr in data["output"].keys():
+            if attr == "cell_methods" and data["output"][attr] is not None:
+                methods = []
+                for cell_method in data["output"][attr]:
+                    methods.append(
+                        "".join([f"{dim}: {meth}" for dim, meth in cell_method.items()])
+                    )
+                data["output"][attr] = " ".join(methods)
+            if attr in ["var_name", "long_name"]:
+                for new, old in rename_params.items():
+                    data["output"][attr] = data["output"][attr].replace(old, new)
+
+        del data["ET"]
+
+        if "{" in cmid:
+            rename_ids[cmid] = cmid.replace("{", "").replace("}", "")
+
+    for old, new in rename_ids.items():
+        yml["indices"][new] = yml["indices"].pop(old)
+
+    for cmid in remove_ids:
+        del yml["indices"][cmid]
+
+    with open(adapted, "w") as f:
+        safe_dump(yml, f)

--- a/xclim/core/utils.py
+++ b/xclim/core/utils.py
@@ -266,7 +266,7 @@ def raise_warn_or_log(
     elif mode == "warn":
         warnings.warn(msg, stacklevel=stacklevel + 1)
     else:  # mode == "raise"
-        raise ValueError(msg) from err
+        raise err
 
 
 class InputKind(IntEnum):

--- a/xclim/data/anuclim.yml
+++ b/xclim/data/anuclim.yml
@@ -1,44 +1,122 @@
-realm: atmos
-doc: |
-  ===============
+doc: '===============
   ANUCLIM indices
   ===============
 
-  The ANUCLIM (v6.1) software package' BIOCLIM sub-module produces a set of Bioclimatic
-  parameters derived values of temperature and precipitation. The methods in this module
-  are wrappers around a subset of corresponding methods of `xclim.indices`. Note that none
-  of the checks performed by the `xclim.utils.Indicator` class (like with `xclim.atmos`
+
+  The ANUCLIM (v6.1) software package'' BIOCLIM sub-module produces a set of Bioclimatic
+  parameters derived values of temperature and precipitation. The methods in this
+  module are wrappers around a subset of corresponding methods of `xclim.indices`. Note that
+  none of the checks performed by the `xclim.utils.Indicator` class (like with `xclim.atmos`
   indicators) are performed in this module.
 
-  Futhermore, according to the ANUCLIM user-guide https://fennerschool.anu.edu.au/files/anuclim61.pdf (ch. 6),
-  input values should be at a weekly (or monthly) frequency.  However, the xclim.indices
+  Futhermore, according to the ANUCLIM user-guide https://fennerschool.anu.edu.au/files/anuclim61.pdf
+  (ch. 6), input values should be at a weekly (or monthly) frequency.  However, the xclim.indices
   implementation here will calculate the result with input data of any frequency.
 
   .. _ANUCLIM: https://fennerschool.anu.edu.au/files/anuclim61.pdf (ch. 6)
-references: ANUCLIM https://fennerschool.anu.edu.au/files/anuclim61.pdf (ch. 6)
+
+  '
 indices:
+  P10_MeanTempWarmestQuarter:
+    allowed_periods:
+    - A
+    compute: tg_mean_warmcold_quarter
+    output:
+      units: K
+    parameters:
+      op: warmest
+  P11_MeanTempColdestQuarter:
+    allowed_periods:
+    - A
+    compute: tg_mean_warmcold_quarter
+    output:
+      units: K
+    parameters:
+      op: coldest
+  P12_AnnualPrecip:
+    allowed_periods:
+    - A
+    base: prcptot
+    output:
+      long_name: Annual precipitation
+  P13_PrecipWettestPeriod:
+    allowed_periods:
+    - A
+    compute: prcptot_wetdry_period
+    output:
+      units: mm
+    parameters:
+      op: wettest
+  P14_PrecipDriestPeriod:
+    allowed_periods:
+    - A
+    compute: prcptot_wetdry_period
+    output:
+      units: mm
+    parameters:
+      op: driest
+  P15_PrecipSeasonality:
+    allowed_periods:
+    - A
+    compute: precip_seasonality
+  P16_PrecipWettestQuarter:
+    allowed_periods:
+    - A
+    compute: prcptot_wetdry_quarter
+    output:
+      units: mm
+    parameters:
+      op: wettest
+  P17_PrecipDriestQuarter:
+    allowed_periods:
+    - A
+    compute: prcptot_wetdry_quarter
+    output:
+      units: mm
+    parameters:
+      op: driest
+  P18_PrecipWarmestQuarter:
+    allowed_periods:
+    - A
+    compute: prcptot_warmcold_quarter
+    output:
+      units: mm
+    parameters:
+      op: warmest
+  P19_PrecipColdestQuarter:
+    allowed_periods:
+    - A
+    compute: prcptot_warmcold_quarter
+    output:
+      units: mm
+    parameters:
+      op: coldest
   P1_AnnMeanTemp:
+    allowed_periods:
+    - A
     base: tg_mean
-    period: annual
   P2_MeanDiurnalRange:
+    allowed_periods:
+    - A
     base: dtr
-    period: annual
   P3_Isothermality:
-    period: annual
-    index_function:
-      name: isothermality
+    allowed_periods:
+    - A
+    compute: isothermality
   P4_TempSeasonality:
-    period: annual
-    index_function:
-      name: temperature_seasonality
+    allowed_periods:
+    - A
+    compute: temperature_seasonality
   P5_MaxTempWarmestPeriod:
+    allowed_periods:
+    - A
     base: tx_max
-    period: annual
     output:
       long_name: Max temperature of warmest period
   P6_MinTempColdestPeriod:
+    allowed_periods:
+    - A
     base: tn_min
-    period: annual
     output:
       long_name: Min temperature of coldest period
   P7_TempAnnualRange:
@@ -46,91 +124,20 @@ indices:
     output:
       long_name: Temperature annual range
   P8_MeanTempWettestQuarter:
-    period: annual
+    allowed_periods:
+    - A
+    compute: tg_mean_wetdry_quarter
     output:
       units: K
-    index_function:
-      name: tg_mean_wetdry_quarter
-      parameters:
-        op: wettest
+    parameters:
+      op: wettest
   P9_MeanTempDriestQuarter:
-    period: annual
+    allowed_periods:
+    - A
+    compute: tg_mean_wetdry_quarter
     output:
       units: K
-    index_function:
-      name: tg_mean_wetdry_quarter
-      parameters:
-        op: driest
-  P10_MeanTempWarmestQuarter:
-    period: annual
-    output:
-      units: K
-    index_function:
-      name: tg_mean_warmcold_quarter
-      parameters:
-        op: warmest
-  P11_MeanTempColdestQuarter:
-    period: annual
-    output:
-      units: K
-    index_function:
-      name: tg_mean_warmcold_quarter
-      parameters:
-        op: coldest
-  P12_AnnualPrecip:
-    period: annual
-    base: prcptot
-    output:
-      long_name: Annual precipitation
-  P13_PrecipWettestPeriod:
-    period: annual
-    output:
-      units: mm
-    index_function:
-      name: prcptot_wetdry_period
-      parameters:
-        op: wettest
-  P14_PrecipDriestPeriod:
-    period: annual
-    output:
-      units: mm
-    index_function:
-      name: prcptot_wetdry_period
-      parameters:
-        op: driest
-  P15_PrecipSeasonality:
-    period: annual
-    index_function:
-      name: precip_seasonality
-  P16_PrecipWettestQuarter:
-    period: annual
-    output:
-      units: mm
-    index_function:
-      name: prcptot_wetdry_quarter
-      parameters:
-        op: wettest
-  P17_PrecipDriestQuarter:
-    period: annual
-    output:
-      units: mm
-    index_function:
-      name: prcptot_wetdry_quarter
-      parameters:
-        op: driest
-  P18_PrecipWarmestQuarter:
-    period: annual
-    output:
-      units: mm
-    index_function:
-      name: prcptot_warmcold_quarter
-      parameters:
-        op: warmest
-  P19_PrecipColdestQuarter:
-    period: annual
-    output:
-      units: mm
-    index_function:
-      name: prcptot_warmcold_quarter
-      parameters:
-        op: coldest
+    parameters:
+      op: driest
+realm: atmos
+references: ANUCLIM https://fennerschool.anu.edu.au/files/anuclim61.pdf (ch. 6)

--- a/xclim/data/cf.yml
+++ b/xclim/data/cf.yml
@@ -1,3903 +1,1107 @@
-# These index definitions are auto-generated from the master table at
-# https://bitbucket.org/cf-index-meta/cf-index-meta
-
-# This is based on version 0.2.0+9.g972dadb.dirty.
-# Start of xclim modifications
-realm: atmos
-doc: |
-  ===================
-  CF Standard indices
-  ===================
-
-  Indicator found here are defined by the team at `clix-meta`_.
-  Adapted documentation from that repository follows:
-
-  The repository aims to provide a platform for thinking about, and developing,
-  a unified view of metadata elements required to describe climate indices (aka climate indicators).
-
-  To facilitate data exchange and dissemination the metadata should, as far as possible,
-  follow the Climate and Forecasting (CF) Conventions. Considering the very rich and diverse flora of
-  climate indices this is however not always possible. By collecting a wide range of different indices
-  it is easier to discover any common patterns and features that are currently not well covered by the
-  CF Conventions. Currently identified issues frequently relate to standard_name or/and cell_methods
-  which both are controlled vocabularies of the CF Conventions.
-
-  .. _clix-meta: https://github.com/clix-meta/clix-meta
-references: clix-meta https://github.com/clix-meta/clix-meta
-# End of xclim modification.
+doc: "  ===================\n  CF Standard indices\n  ===================\n\n  Indicator\
+  \ found here are defined by the team at `clix-meta`_.\n  Adapted documentation from\
+  \ that repository follows:\n\n  The repository aims to provide a platform for thinking\
+  \ about, and developing,\n  a unified view of metadata elements required to describe\
+  \ climate indices (aka climate indicators).\n\n  To facilitate data exchange and\
+  \ dissemination the metadata should, as far as possible,\n  follow the Climate and\
+  \ Forecasting (CF) Conventions. Considering the very rich and diverse flora of\n\
+  \  climate indices this is however not always possible. By collecting a wide range\
+  \ of different indices\n  it is easier to discover any common patterns and features\
+  \ that are currently not well covered by the\n  CF Conventions. Currently identified\
+  \ issues frequently relate to standard_name or/and cell_methods\n  which both are\
+  \ controlled vocabularies of the CF Conventions.\n\n  .. _clix-meta: https://github.com/clix-meta/clix-meta\n"
 indices:
-  # fd:
-  #   reference: ETCCDI
-  #   period:
-  #     allowed:
-  #       annual:
-  #       seasonal:
-  #       monthly:
-  #     default: annual
-  #   output:
-  #     var_name: "fd"
-  #     standard_name: number_of_days_with_air_temperature_below_threshold
-  #     proposed_standard_name: number_of_occurrences_with_air_temperature_below_threshold
-  #     long_name: "Number of Frost Days (Tmin < 0C)"
-  #     units: "1"
-  #     cell_methods:
-  #       - time: minimum within days
-  #       - time: sum over days
-  #   input:
-  #     data: tasmin
-  #   index_function:
-  #     name: count_occurrences
-  #     parameters:
-  #       threshold:
-  #         kind: quantity
-  #         standard_name: air_temperature
-  #         data: 0
-  #         units: "degree_Celsius"
-  #       condition:
-  #         kind: operator
-  #         operator: "<"
-  #   ET:
-  #     short_name: "fd"
-  #     long_name: "Frost days"
-  #     definition: "Count when TN < 0ºC"
-  #     comment: "count of days when daily minimum temperature is below 0 degC"
-
-  # tnlt2:
-  #   reference: ET-SCI
-  #   period:
-  #     allowed:
-  #       annual:
-  #       seasonal:
-  #       monthly:
-  #     default: annual
-  #   output:
-  #     var_name: "tnlt2"
-  #     standard_name: number_of_days_with_air_temperature_below_threshold
-  #     proposed_standard_name: number_of_occurrences_with_air_temperature_below_threshold
-  #     long_name: "Number of weak Frost Days (Tmin < +2C)"
-  #     units: "1"
-  #     cell_methods:
-  #       - time: minimum within days
-  #       - time: sum over days
-  #   input:
-  #     data: tasmin
-  #   index_function:
-  #     name: count_occurrences
-  #     parameters:
-  #       threshold:
-  #         kind: quantity
-  #         standard_name: air_temperature
-  #         data: 2
-  #         units: "degree_Celsius"
-  #       condition:
-  #         kind: operator
-  #         operator: "<"
-  #   ET:
-  #     short_name: "fd2"
-  #     long_name: "Frost days 2"
-  #     definition: "Count when TN < 2ºC"
-  #     comment: "count of days when daily minimum temperature is below plus 2 degC"
-
-  # tnltm2:
-  #   reference: ET-SCI
-  #   period:
-  #     allowed:
-  #       annual:
-  #       seasonal:
-  #       monthly:
-  #     default: annual
-  #   output:
-  #     var_name: "tnltm2"
-  #     standard_name: number_of_days_with_air_temperature_below_threshold
-  #     proposed_standard_name: number_of_occurrences_with_air_temperature_below_threshold
-  #     long_name: "Number of sharp Frost Days (Tmin < -2C)"
-  #     units: "1"
-  #     cell_methods:
-  #       - time: minimum within days
-  #       - time: sum over days
-  #   input:
-  #     data: tasmin
-  #   index_function:
-  #     name: count_occurrences
-  #     parameters:
-  #       threshold:
-  #         kind: quantity
-  #         standard_name: air_temperature
-  #         data: -2
-  #         units: "degree_Celsius"
-  #       condition:
-  #         kind: operator
-  #         operator: "<"
-  #   ET:
-  #     short_name: "fdm2"
-  #     long_name: "Hard freeze"
-  #     definition: "Count when TN < -2ºC"
-  #     comment: "count of days when daily minimum temperature is below minus 2 degC"
-
-  # tnltm20:
-  #   reference: ET-SCI
-  #   period:
-  #     allowed:
-  #       annual:
-  #       seasonal:
-  #       monthly:
-  #     default: annual
-  #   output:
-  #     var_name: "tnltm20"
-  #     standard_name: number_of_days_with_air_temperature_below_threshold
-  #     proposed_standard_name: number_of_occurrences_with_air_temperature_below_threshold
-  #     long_name:
-  #     units: "1"
-  #     cell_methods:
-  #       - time: minimum within days
-  #       - time: sum over days
-  #   input:
-  #     data: tasmin
-  #   index_function:
-  #     name: count_occurrences
-  #     parameters:
-  #       threshold:
-  #         kind: quantity
-  #         standard_name: air_temperature
-  #         data: -20
-  #         units: "degree_Celsius"
-  #       condition:
-  #         kind: operator
-  #         operator: "<"
-  #   ET:
-  #     short_name: "fdm20"
-  #     long_name: "Very hard freeze"
-  #     definition: "Count when TN < -20ºC"
-  #     comment: "count of days when daily minimum temperature is below minus 20 degC"
-
-  # id:
-  #   reference: ETCCDI
-  #   period:
-  #     allowed:
-  #       annual:
-  #       seasonal:
-  #       monthly:
-  #     default: annual
-  #   output:
-  #     var_name: "id"
-  #     standard_name: number_of_days_with_air_temperature_below_threshold
-  #     proposed_standard_name: number_of_occurrences_with_air_temperature_below_threshold
-  #     long_name: "Number of sharp Ice Days (Tmax < 0C)"
-  #     units: "1"
-  #     cell_methods:
-  #       - time: maximum within days
-  #       - time: sum over days
-  #   input:
-  #     data: tasmax
-  #   index_function:
-  #     name: count_occurrences
-  #     parameters:
-  #       threshold:
-  #         kind: quantity
-  #         standard_name: air_temperature
-  #         data: 0
-  #         units: "degree_Celsius"
-  #       condition:
-  #         kind: operator
-  #         operator: "<"
-  #   ET:
-  #     short_name: "id"
-  #     long_name: "Ice days"
-  #     definition: "Count when TX < 0ºC"
-  #     comment: "count of days when daily maximum temperature is below 0 degC"
-
-  # su:
-  #   reference: ETCCDI
-  #   period:
-  #     allowed:
-  #       annual:
-  #       seasonal:
-  #       monthly:
-  #     default: annual
-  #   output:
-  #     var_name: "su"
-  #     standard_name: number_of_days_with_air_temperature_above_threshold
-  #     proposed_standard_name: number_of_occurrences_with_air_temperature_above_threshold
-  #     long_name: "Number of Summer Days (Tmax > 25C)"
-  #     units: "1"
-  #     cell_methods:
-  #       - time: maximum within days
-  #       - time: sum over days
-  #   input:
-  #     data: tasmax
-  #   index_function:
-  #     name: count_occurrences
-  #     parameters:
-  #       threshold:
-  #         kind: quantity
-  #         standard_name: air_temperature
-  #         data: 25
-  #         units: "degree_Celsius"
-  #       condition:
-  #         kind: operator
-  #         operator: ">"
-  #   ET:
-  #     short_name: "su"
-  #     long_name: "Summer days"
-  #     definition: "Count when TX > 25ºC"
-  #     comment: "count of days when daily maximum temperature is above plus 25 degC"
-
-  # txge30:
-  #   reference: ET-SCI
-  #   period:
-  #     allowed:
-  #       annual:
-  #       seasonal:
-  #       monthly:
-  #     default: annual
-  #   output:
-  #     var_name: "txge30"
-  #     standard_name: number_of_days_with_air_temperature_above_threshold
-  #     proposed_standard_name: number_of_occurrences_with_air_temperature_at_or_above_threshold
-  #     long_name: "Number of Hot Days (Tmax >= 35C)"
-  #     units: "1"
-  #     cell_methods:
-  #       - time: maximum within days
-  #       - time: sum over days
-  #   input:
-  #     data: tasmax
-  #   index_function:
-  #     name: count_occurrences
-  #     parameters:
-  #       threshold:
-  #         kind: quantity
-  #         standard_name: air_temperature
-  #         data: 30
-  #         units: "degree_Celsius"
-  #       condition:
-  #         kind: operator
-  #         operator: ">"
-  #   ET:
-  #     short_name: "su30"
-  #     long_name: "Hot days"
-  #     definition: "Count when TX >= 30ºC"
-  #     comment: "count of days when daily maximum temperature is above or equal plus 30 degC"
-
-  # txge35:
-  #   reference: ET-SCI
-  #   period:
-  #     allowed:
-  #       annual:
-  #       seasonal:
-  #       monthly:
-  #     default: annual
-  #   output:
-  #     var_name: "txge35"
-  #     standard_name: number_of_days_with_air_temperature_above_threshold
-  #     proposed_standard_name: number_of_occurrences_with_air_temperature_at_or_above_threshold
-  #     long_name: "Number of Very Hot Days (Tmax >= 35C)"
-  #     units: "1"
-  #     cell_methods:
-  #       - time: maximum within days
-  #       - time: sum over days
-  #   input:
-  #     data: tasmax
-  #   index_function:
-  #     name: count_occurrences
-  #     parameters:
-  #       threshold:
-  #         kind: quantity
-  #         standard_name: air_temperature
-  #         data: 35
-  #         units: "degree_Celsius"
-  #       condition:
-  #         kind: operator
-  #         operator: ">"
-  #   ET:
-  #     short_name: "su35"
-  #     long_name: "Very hot days"
-  #     definition: "Count when TX >= 35ºC"
-  #     comment: "count of days when daily maximum temperature is above or equal plus 35 degC"
-
-  # tr:
-  #   reference: ETCCDI
-  #   period:
-  #     allowed:
-  #       annual:
-  #       seasonal:
-  #       monthly:
-  #     default: annual
-  #   output:
-  #     var_name: "tr"
-  #     standard_name: number_of_days_with_air_temperature_above_threshold
-  #     proposed_standard_name: number_of_occurrences_with_air_temperature_above_threshold
-  #     long_name: "Number of Tropical Nights (Tmin > 20C)"
-  #     units: "1"
-  #     cell_methods:
-  #       - time: minimum within days
-  #       - time: sum over days
-  #   input:
-  #     data: tasmin
-  #   index_function:
-  #     name: count_occurrences
-  #     parameters:
-  #       threshold:
-  #         kind: quantity
-  #         standard_name: air_temperature
-  #         data: 20
-  #         units: "degree_Celsius"
-  #       condition:
-  #         kind: operator
-  #         operator: ">"
-  #   ET:
-  #     short_name: "tr"
-  #     long_name: "Tropical nights"
-  #     definition: "Count when TN > 20ºC"
-  #     comment: "count of days when daily minimum temperature is above plus 20 degC"
-
-  # tmge5:
-  #   reference: ET-SCI
-  #   period:
-  #     allowed:
-  #       annual:
-  #       seasonal:
-  #       monthly:
-  #     default: annual
-  #   output:
-  #     var_name: "tmge5"
-  #     standard_name: number_of_days_with_air_temperature_above_threshold
-  #     proposed_standard_name: number_of_occurrences_with_air_temperature_at_or_above_threshold
-  #     long_name: "Number of days with Tmean >= 5C"
-  #     units: "1"
-  #     cell_methods:
-  #       - time: mean within days
-  #       - time: sum over days
-  #   input:
-  #     data: tas
-  #   index_function:
-  #     name: count_occurrences
-  #     parameters:
-  #       threshold:
-  #         kind: quantity
-  #         standard_name: air_temperature
-  #         data: 5
-  #         units: "degree_Celsius"
-  #       condition:
-  #         kind: operator
-  #         operator: ">"
-  #   ET:
-  #     short_name: "tm5a"
-  #     long_name: "TM above 5C"
-  #     definition: "Count when TM >= 5ºC"
-  #     comment: "count of days when daily mean temperature is above plus 5 degC"
-
-  # tmlt5:
-  #   reference: ET-SCI
-  #   period:
-  #     allowed:
-  #       annual:
-  #       seasonal:
-  #       monthly:
-  #     default: annual
-  #   output:
-  #     var_name: "tmlt5"
-  #     standard_name: number_of_days_with_air_temperature_below_threshold
-  #     proposed_standard_name: number_of_occurrences_with_air_temperature_below_threshold
-  #     long_name: "Number of days with Tmean < 5C"
-  #     units: "1"
-  #     cell_methods:
-  #       - time: mean within days
-  #       - time: sum over days
-  #   input:
-  #     data: tas
-  #   index_function:
-  #     name: count_occurrences
-  #     parameters:
-  #       threshold:
-  #         kind: quantity
-  #         standard_name: air_temperature
-  #         data: 5
-  #         units: "degree_Celsius"
-  #       condition:
-  #         kind: operator
-  #         operator: "<"
-  #   ET:
-  #     short_name: "tm5b"
-  #     long_name: "TM below 5C"
-  #     definition: "Count when TM < 5ºC"
-  #     comment: "count of days when daily mean temperature is below plus 5 degC"
-
-  # tmge10:
-  #   reference: ET-SCI
-  #   period:
-  #     allowed:
-  #       annual:
-  #       seasonal:
-  #       monthly:
-  #     default: annual
-  #   output:
-  #     var_name: "tmge10"
-  #     standard_name: number_of_days_with_air_temperature_above_threshold
-  #     proposed_standard_name: number_of_occurrences_with_air_temperature_at_or_above_threshold
-  #     long_name: "Number of days with Tmean >= 10C"
-  #     units: "1"
-  #     cell_methods:
-  #       - time: mean within days
-  #       - time: sum over days
-  #   input:
-  #     data: tas
-  #   index_function:
-  #     name: count_occurrences
-  #     parameters:
-  #       threshold:
-  #         kind: quantity
-  #         standard_name: air_temperature
-  #         data: 10
-  #         units: "degree_Celsius"
-  #       condition:
-  #         kind: operator
-  #         operator: ">"
-  #   ET:
-  #     short_name: "tm10a"
-  #     long_name: "TM above 10C"
-  #     definition: "Count when TM >= 10ºC"
-  #     comment: "count of days when daily mean temperature is above plus 10 degC"
-
-  # tmlt10:
-  #   reference: ET-SCI
-  #   period:
-  #     allowed:
-  #       annual:
-  #       seasonal:
-  #       monthly:
-  #     default: annual
-  #   output:
-  #     var_name: "tmlt10"
-  #     standard_name: number_of_days_with_air_temperature_below_threshold
-  #     proposed_standard_name: number_of_occurrences_with_air_temperature_below_threshold
-  #     long_name: "Number of days with Tmean < 10C"
-  #     units: "1"
-  #     cell_methods:
-  #       - time: mean within days
-  #       - time: sum over days
-  #   input:
-  #     data: tas
-  #   index_function:
-  #     name: count_occurrences
-  #     parameters:
-  #       threshold:
-  #         kind: quantity
-  #         standard_name: air_temperature
-  #         data: 10
-  #         units: "degree_Celsius"
-  #       condition:
-  #         kind: operator
-  #         operator: "<"
-  #   ET:
-  #     short_name: "tm10b"
-  #     long_name: "TM below 10C"
-  #     definition: "Count when TM < 10ºC"
-  #     comment: "count of days when daily mean temperature is below plus 10 degC"
-
-  # tngt{TT}:
-  #   reference: CLIPC
-  #   period:
-  #     allowed:
-  #       annual:
-  #       seasonal:
-  #       monthly:
-  #     default: annual
-  #   output:
-  #     var_name: "tngt{TT}"
-  #     standard_name: number_of_days_with_air_temperature_above_threshold
-  #     proposed_standard_name: number_of_occurrences_with_air_temperature_above_threshold
-  #     long_name: "Number of days with Tmin > {TT}C"
-  #     units: "1"
-  #     cell_methods:
-  #       - time: minimum within days
-  #       - time: sum over days
-  #   input:
-  #     data: tasmin
-  #   index_function:
-  #     name: count_occurrences
-  #     parameters:
-  #       threshold:
-  #         kind: quantity
-  #         standard_name: air_temperature
-  #         data: {TT}
-  #         units: "degree_Celsius"
-  #       condition:
-  #         kind: operator
-  #         operator: ">"
-  #   ET:
-  #     short_name:
-  #     long_name:
-  #     definition:
-  #     comment: "count of days when daily minimum temperature is above {TT} degC"
-
-  # tnlt{TT}:
-  #   reference: CLIPC
-  #   period:
-  #     allowed:
-  #       annual:
-  #       seasonal:
-  #       monthly:
-  #     default: annual
-  #   output:
-  #     var_name: "tnlt{TT}"
-  #     standard_name: number_of_days_with_air_temperature_below_threshold
-  #     proposed_standard_name: number_of_occurrences_with_air_temperature_below_threshold
-  #     long_name: "Number of days with Tmin < {TT}C"
-  #     units: "1"
-  #     cell_methods:
-  #       - time: minimum within days
-  #       - time: sum over days
-  #   input:
-  #     data: tasmin
-  #   index_function:
-  #     name: count_occurrences
-  #     parameters:
-  #       threshold:
-  #         kind: quantity
-  #         standard_name: air_temperature
-  #         data: {TT}
-  #         units: "degree_Celsius"
-  #       condition:
-  #         kind: operator
-  #         operator: "<"
-  #   ET:
-  #     short_name:
-  #     long_name:
-  #     definition:
-  #     comment: "count of days when daily minimum temperature is below {TT} degC"
-
-  # tnge{TT}:
-  #   reference: CLIPC
-  #   period:
-  #     allowed:
-  #       annual:
-  #       seasonal:
-  #       monthly:
-  #     default: annual
-  #   output:
-  #     var_name: "tnge{TT}"
-  #     standard_name: number_of_days_with_air_temperature_above_threshold
-  #     proposed_standard_name: number_of_occurrences_with_air_temperature_at_or_above_threshold
-  #     long_name: "Number of days with Tmin >= {TT}C"
-  #     units: "1"
-  #     cell_methods:
-  #       - time: minimum within days
-  #       - time: sum over days
-  #   input:
-  #     data: tasmin
-  #   index_function:
-  #     name: count_occurrences
-  #     parameters:
-  #       threshold:
-  #         kind: quantity
-  #         standard_name: air_temperature
-  #         data: {TT}
-  #         units: "degree_Celsius"
-  #       condition:
-  #         kind: operator
-  #         operator: ">"
-  #   ET:
-  #     short_name:
-  #     long_name:
-  #     definition:
-  #     comment: "count of days when daily minimum temperature is above or equal {TT} degC"
-
-  # tnle{TT}:
-  #   reference: CLIPC
-  #   period:
-  #     allowed:
-  #       annual:
-  #       seasonal:
-  #       monthly:
-  #     default: annual
-  #   output:
-  #     var_name: "tnle{TT}"
-  #     standard_name: number_of_days_with_air_temperature_below_threshold
-  #     proposed_standard_name: number_of_occurrences_with_air_temperature_at_or_below_threshold
-  #     long_name: "Number of days with Tmin <= {TT}C"
-  #     units: "1"
-  #     cell_methods:
-  #       - time: minimum within days
-  #       - time: sum over days
-  #   input:
-  #     data: tasmin
-  #   index_function:
-  #     name: count_occurrences
-  #     parameters:
-  #       threshold:
-  #         kind: quantity
-  #         standard_name: air_temperature
-  #         data: {TT}
-  #         units: "degree_Celsius"
-  #       condition:
-  #         kind: operator
-  #         operator: "<"
-  #   ET:
-  #     short_name:
-  #     long_name:
-  #     definition:
-  #     comment: "count of days when daily minimum temperature is below or equal{TT} degC"
-
-  # txgt{TT}:
-  #   reference: CLIPC
-  #   period:
-  #     allowed:
-  #       annual:
-  #       seasonal:
-  #       monthly:
-  #     default: annual
-  #   output:
-  #     var_name: "txgt{TT}"
-  #     standard_name: number_of_days_with_air_temperature_above_threshold
-  #     proposed_standard_name: number_of_occurrences_with_air_temperature_above_threshold
-  #     long_name: "Number of days with Tmax > {TT}C"
-  #     units: "1"
-  #     cell_methods:
-  #       - time: maximum within days
-  #       - time: sum over days
-  #   input:
-  #     data: tasmax
-  #   index_function:
-  #     name: count_occurrences
-  #     parameters:
-  #       threshold:
-  #         kind: quantity
-  #         standard_name: air_temperature
-  #         data: {TT}
-  #         units: "degree_Celsius"
-  #       condition:
-  #         kind: operator
-  #         operator: ">"
-  #   ET:
-  #     short_name:
-  #     long_name:
-  #     definition:
-  #     comment: "count of days when daily maximum temperature is above {TT} degC"
-
-  # txlt{TT}:
-  #   reference: CLIPC
-  #   period:
-  #     allowed:
-  #       annual:
-  #       seasonal:
-  #       monthly:
-  #     default: annual
-  #   output:
-  #     var_name: "txlt{TT}"
-  #     standard_name: number_of_days_with_air_temperature_below_threshold
-  #     proposed_standard_name: number_of_occurrences_with_air_temperature_below_threshold
-  #     long_name: "Number of days with Tmax < {TT}C"
-  #     units: "1"
-  #     cell_methods:
-  #       - time: maximum within days
-  #       - time: sum over days
-  #   input:
-  #     data: tasmax
-  #   index_function:
-  #     name: count_occurrences
-  #     parameters:
-  #       threshold:
-  #         kind: quantity
-  #         standard_name: air_temperature
-  #         data: {TT}
-  #         units: "degree_Celsius"
-  #       condition:
-  #         kind: operator
-  #         operator: "<"
-  #   ET:
-  #     short_name:
-  #     long_name:
-  #     definition:
-  #     comment: "count of days when daily maximum temperature is below {TT} degC"
-
-  # txge{TT}:
-  #   reference: CLIPC
-  #   period:
-  #     allowed:
-  #       annual:
-  #       seasonal:
-  #       monthly:
-  #     default: annual
-  #   output:
-  #     var_name: "txge{TT}"
-  #     standard_name: number_of_days_with_air_temperature_above_threshold
-  #     proposed_standard_name: number_of_occurrences_with_air_temperature_at_or_above_threshold
-  #     long_name: "Number of days with Tmax >= {TT}C"
-  #     units: "1"
-  #     cell_methods:
-  #       - time: maximum within days
-  #       - time: sum over days
-  #   input:
-  #     data: tasmax
-  #   index_function:
-  #     name: count_occurrences
-  #     parameters:
-  #       threshold:
-  #         kind: quantity
-  #         standard_name: air_temperature
-  #         data: {TT}
-  #         units: "degree_Celsius"
-  #       condition:
-  #         kind: operator
-  #         operator: ">"
-  #   ET:
-  #     short_name:
-  #     long_name:
-  #     definition:
-  #     comment: "count of days when daily maximum temperature is above or equal {TT} degC"
-
-  # txle{TT}:
-  #   reference: CLIPC
-  #   period:
-  #     allowed:
-  #       annual:
-  #       seasonal:
-  #       monthly:
-  #     default: annual
-  #   output:
-  #     var_name: "txle{TT}"
-  #     standard_name: number_of_days_with_air_temperature_below_threshold
-  #     proposed_standard_name: number_of_occurrences_with_air_temperature_at_or_below_threshold
-  #     long_name: "Number of days with Tmax <= {TT}C"
-  #     units: "1"
-  #     cell_methods:
-  #       - time: maximum within days
-  #       - time: sum over days
-  #   input:
-  #     data: tasmax
-  #   index_function:
-  #     name: count_occurrences
-  #     parameters:
-  #       threshold:
-  #         kind: quantity
-  #         standard_name: air_temperature
-  #         data: {TT}
-  #         units: "degree_Celsius"
-  #       condition:
-  #         kind: operator
-  #         operator: "<"
-  #   ET:
-  #     short_name:
-  #     long_name:
-  #     definition:
-  #     comment: "count of days when daily maximum temperature is below or equal {TT} degC"
-
-  # tmgt{TT}:
-  #   reference: CLIPC
-  #   period:
-  #     allowed:
-  #       annual:
-  #       seasonal:
-  #       monthly:
-  #     default: annual
-  #   output:
-  #     var_name: "tmgt{TT}"
-  #     standard_name: number_of_days_with_air_temperature_above_threshold
-  #     proposed_standard_name: number_of_occurrences_with_air_temperature_above_threshold
-  #     long_name: "Number of days with Tmean > {TT}C"
-  #     units: "1"
-  #     cell_methods:
-  #       - time: mean within days
-  #       - time: sum over days
-  #   input:
-  #     data: tas
-  #   index_function:
-  #     name: count_occurrences
-  #     parameters:
-  #       threshold:
-  #         kind: quantity
-  #         standard_name: air_temperature
-  #         data: {TT}
-  #         units: "degree_Celsius"
-  #       condition:
-  #         kind: operator
-  #         operator: ">"
-  #   ET:
-  #     short_name:
-  #     long_name:
-  #     definition:
-  #     comment: "count of days when daily mean temperature is above {TT} degC"
-
-  # tmlt{TT}:
-  #   reference: CLIPC
-  #   period:
-  #     allowed:
-  #       annual:
-  #       seasonal:
-  #       monthly:
-  #     default: annual
-  #   output:
-  #     var_name: "tmlt{TT}"
-  #     standard_name: number_of_days_with_air_temperature_below_threshold
-  #     proposed_standard_name: number_of_occurrences_with_air_temperature_below_threshold
-  #     long_name: "Number of days with Tmean < {TT}C"
-  #     units: "1"
-  #     cell_methods:
-  #       - time: mean within days
-  #       - time: sum over days
-  #   input:
-  #     data: tas
-  #   index_function:
-  #     name: count_occurrences
-  #     parameters:
-  #       threshold:
-  #         kind: quantity
-  #         standard_name: air_temperature
-  #         data: {TT}
-  #         units: "degree_Celsius"
-  #       condition:
-  #         kind: operator
-  #         operator: "<"
-  #   ET:
-  #     short_name:
-  #     long_name:
-  #     definition:
-  #     comment: "count of days when daily mean temperature is below {TT} degC"
-
-  # tmge{TT}:
-  #   reference: CLIPC
-  #   period:
-  #     allowed:
-  #       annual:
-  #       seasonal:
-  #       monthly:
-  #     default: annual
-  #   output:
-  #     var_name: "tmge{TT}"
-  #     standard_name: number_of_days_with_air_temperature_above_threshold
-  #     proposed_standard_name: number_of_occurrences_with_air_temperature_at_or_above_threshold
-  #     long_name: "Number of days with Tmean >= {TT}C"
-  #     units: "1"
-  #     cell_methods:
-  #       - time: mean within days
-  #       - time: sum over days
-  #   input:
-  #     data: tas
-  #   index_function:
-  #     name: count_occurrences
-  #     parameters:
-  #       threshold:
-  #         kind: quantity
-  #         standard_name: air_temperature
-  #         data: {TT}
-  #         units: "degree_Celsius"
-  #       condition:
-  #         kind: operator
-  #         operator: ">"
-  #   ET:
-  #     short_name:
-  #     long_name:
-  #     definition:
-  #     comment: "count of days when daily mean temperature is above or equal {TT} degC"
-
-  # tmle{TT}:
-  #   reference: CLIPC
-  #   period:
-  #     allowed:
-  #       annual:
-  #       seasonal:
-  #       monthly:
-  #     default: annual
-  #   output:
-  #     var_name: "tmle{TT}"
-  #     standard_name: number_of_days_with_air_temperature_below_threshold
-  #     proposed_standard_name: number_of_occurrences_with_air_temperature_at_or_below_threshold
-  #     long_name: "Number of days with Tmean <= {TT}C"
-  #     units: "1"
-  #     cell_methods:
-  #       - time: mean within days
-  #       - time: sum over days
-  #   input:
-  #     data: tas
-  #   index_function:
-  #     name: count_occurrences
-  #     parameters:
-  #       threshold:
-  #         kind: quantity
-  #         standard_name: air_temperature
-  #         data: {TT}
-  #         units: "degree_Celsius"
-  #       condition:
-  #         kind: operator
-  #         operator: "<"
-  #   ET:
-  #     short_name:
-  #     long_name:
-  #     definition:
-  #     comment: "count of days when daily mean temperature is below or equal{TT} degC"
-
-  ctngt{TT}:
-    reference: CLIPC
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
-    output:
-      var_name: "ctngt{TT}"
-      standard_name: spell_length_of_days_with_air_temperature_above_threshold
-      proposed_standard_name: spell_length_with_air_temperature_above_threshold
-      long_name: "Maximum number of consequtive days with Tmin > {TT}C"
-      units: "day"
-      cell_methods:
-        - time: minimum within days
-        - time: maximum over days
-    input:
-      data: tasmin
-    index_function:
-      name: spell_length
-      parameters:
-        threshold:
-          kind: quantity
-          standard_name: air_temperature
-          data: {TT}
-          units: "degree_Celsius"
-        condition:
-          kind: operator
-          operator: ">"
-        reducer:
-          kind: reducer
-          reducer: max
-    ET:
-      short_name:
-      long_name:
-      definition:
-      comment: "count of days when daily minimum temperature is above {TT} degC"
-
-  cfd:
-    reference: ECA&D
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
-    output:
-      var_name: "cfd"
-      standard_name: spell_length_of_days_with_air_temperature_below_threshold
-      proposed_standard_name: spell_length_with_air_temperature_below_threshold
-      long_name: "Maximum number of consecutive frost days (Tmin < 0 C)"
-      units: "day"
-      cell_methods:
-        - time: minimum within days
-        - time: maximum over days
-    input:
-      data: tasmin
-    index_function:
-      name: count_occurrences
-      parameters:
-        threshold:
-          kind: quantity
-          standard_name: air_temperature
-          data: 0
-          units: "degree_Celsius"
-        condition:
-          kind: operator
-          operator: "<"
-    ET:
-      short_name: "cfd"
-      long_name:
-      definition:
-      comment:
-
-  csu:
-    reference: ECA&D
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
-    output:
-      var_name: "csu"
-      standard_name: spell_length_of_days_with_air_temperature_above_threshold
-      proposed_standard_name: spell_length_with_air_temperature_above_threshold
-      long_name: "Maximum number of consecutive summer days (Tmax >25 C)"
-      units: "day"
-      cell_methods:
-        - time: maximum within days
-        - time: maximum over days
-    input:
-      data: tasmax
-    index_function:
-      name: count_occurrences
-      parameters:
-        threshold:
-          kind: quantity
-          standard_name: air_temperature
-          data: 25
-          units: "degree_Celsius"
-        condition:
-          kind: operator
-          operator: ">"
-    ET:
-      short_name: "cfd"
-      long_name:
-      definition:
-      comment:
-
-  ctnlt{TT}:
-    reference: CLIPC
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
-    output:
-      var_name: "ctnlt{TT}"
-      standard_name: spell_length_of_days_with_air_temperature_below_threshold
-      proposed_standard_name: spell_length_with_air_temperature_below_threshold
-      long_name: "Maximum number of consequtive days with Tmin < {TT}C"
-      units: "day"
-      cell_methods:
-        - time: minimum within days
-        - time: maximum over days
-    input:
-      data: tasmin
-    index_function:
-      name: spell_length
-      parameters:
-        threshold:
-          kind: quantity
-          standard_name: air_temperature
-          data: {TT}
-          units: "degree_Celsius"
-        condition:
-          kind: operator
-          operator: "<"
-        reducer:
-          kind: reducer
-          reducer: max
-    ET:
-      short_name:
-      long_name:
-      definition:
-      comment: "count of days when daily minimum temperature is below {TT} degC"
-
-  ctnge{TT}:
-    reference: CLIPC
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
-    output:
-      var_name: "ctnge{TT}"
-      standard_name: spell_length_of_days_with_air_temperature_above_threshold
-      proposed_standard_name: spell_length_with_air_temperature_at_or_above_threshold
-      long_name: "Maximum number of consequtive days with Tmin >= {TT}C"
-      units: "day"
-      cell_methods:
-        - time: minimum within days
-        - time: maximum over days
-    input:
-      data: tasmin
-    index_function:
-      name: spell_length
-      parameters:
-        threshold:
-          kind: quantity
-          standard_name: air_temperature
-          data: {TT}
-          units: "degree_Celsius"
-        condition:
-          kind: operator
-          operator: ">"
-        reducer:
-          kind: reducer
-          reducer: max
-    ET:
-      short_name:
-      long_name:
-      definition:
-      comment: "count of days when daily minimum temperature is above or equal {TT} degC"
-
-  ctnle{TT}:
-    reference: CLIPC
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
-    output:
-      var_name: "ctnle{TT}"
-      standard_name: spell_length_of_days_with_air_temperature_below_threshold
-      proposed_standard_name: spell_length_with_air_temperature_at_or_below_threshold
-      long_name: "Maximum number of consequtive days with Tmin <= {TT}C"
-      units: "day"
-      cell_methods:
-        - time: minimum within days
-        - time: maximum over days
-    input:
-      data: tasmin
-    index_function:
-      name: spell_length
-      parameters:
-        threshold:
-          kind: quantity
-          standard_name: air_temperature
-          data: {TT}
-          units: "degree_Celsius"
-        condition:
-          kind: operator
-          operator: "<"
-        reducer:
-          kind: reducer
-          reducer: max
-    ET:
-      short_name:
-      long_name:
-      definition:
-      comment: "count of days when daily minimum temperature is below or equal{TT} degC"
-
-  ctxgt{TT}:
-    reference: CLIPC
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
-    output:
-      var_name: "ctxgt{TT}"
-      standard_name: spell_length_of_days_with_air_temperature_above_threshold
-      proposed_standard_name: spell_length_with_air_temperature_above_threshold
-      long_name: "Maximum number of consequtive days with Tmax > {TT}C"
-      units: "day"
-      cell_methods:
-        - time: maximum within days
-        - time: maximum over days
-    input:
-      data: tasmax
-    index_function:
-      name: spell_length
-      parameters:
-        threshold:
-          kind: quantity
-          standard_name: air_temperature
-          data: {TT}
-          units: "degree_Celsius"
-        condition:
-          kind: operator
-          operator: ">"
-        reducer:
-          kind: reducer
-          reducer: max
-    ET:
-      short_name:
-      long_name:
-      definition:
-      comment: "count of days when daily maximum temperature is above {TT} degC"
-
-  ctxlt{TT}:
-    reference: CLIPC
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
-    output:
-      var_name: "ctxlt{TT}"
-      standard_name: spell_length_of_days_with_air_temperature_below_threshold
-      proposed_standard_name: spell_length_with_air_temperature_below_threshold
-      long_name: "Maximum number of consequtive days with Tmax < {TT}C"
-      units: "day"
-      cell_methods:
-        - time: maximum within days
-        - time: maximum over days
-    input:
-      data: tasmax
-    index_function:
-      name: spell_length
-      parameters:
-        threshold:
-          kind: quantity
-          standard_name: air_temperature
-          data: {TT}
-          units: "degree_Celsius"
-        condition:
-          kind: operator
-          operator: "<"
-        reducer:
-          kind: reducer
-          reducer: max
-    ET:
-      short_name:
-      long_name:
-      definition:
-      comment: "count of days when daily maximum temperature is below {TT} degC"
-
-  ctxge{TT}:
-    reference: CLIPC
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
-    output:
-      var_name: "ctxge{TT}"
-      standard_name: spell_length_of_days_with_air_temperature_above_threshold
-      proposed_standard_name: spell_length_with_air_temperature_at_or_above_threshold
-      long_name: "Maximum number of consequtive days with Tmax >= {TT}C"
-      units: "day"
-      cell_methods:
-        - time: maximum within days
-        - time: maximum over days
-    input:
-      data: tasmax
-    index_function:
-      name: spell_length
-      parameters:
-        threshold:
-          kind: quantity
-          standard_name: air_temperature
-          data: {TT}
-          units: "degree_Celsius"
-        condition:
-          kind: operator
-          operator: ">"
-        reducer:
-          kind: reducer
-          reducer: max
-    ET:
-      short_name:
-      long_name:
-      definition:
-      comment: "count of days when daily maximum temperature is above or equal {TT} degC"
-
-  ctxle{TT}:
-    reference: CLIPC
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
-    output:
-      var_name: "ctxle{TT}"
-      standard_name: spell_length_of_days_with_air_temperature_below_threshold
-      proposed_standard_name: spell_length_with_air_temperature_at_or_below_threshold
-      long_name: "Maximum number of consequtive days with Tmax <= {TT}C"
-      units: "day"
-      cell_methods:
-        - time: maximum within days
-        - time: maximum over days
-    input:
-      data: tasmax
-    index_function:
-      name: spell_length
-      parameters:
-        threshold:
-          kind: quantity
-          standard_name: air_temperature
-          data: {TT}
-          units: "degree_Celsius"
-        condition:
-          kind: operator
-          operator: "<"
-        reducer:
-          kind: reducer
-          reducer: max
-    ET:
-      short_name:
-      long_name:
-      definition:
-      comment: "count of days when daily maximum temperature is below or equal {TT} degC"
-
-  ctmgt{TT}:
-    reference: CLIPC
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
-    output:
-      var_name: "ctmgt{TT}"
-      standard_name: spell_length_of_days_with_air_temperature_above_threshold
-      proposed_standard_name: spell_length_with_air_temperature_above_threshold
-      long_name: "Maximum number of consequtive days with Tmean > {TT}C"
-      units: "day"
-      cell_methods:
-        - time: mean within days
-        - time: maximum over days
-    input:
-      data: tas
-    index_function:
-      name: spell_length
-      parameters:
-        threshold:
-          kind: quantity
-          standard_name: air_temperature
-          data: {TT}
-          units: "degree_Celsius"
-        condition:
-          kind: operator
-          operator: ">"
-        reducer:
-          kind: reducer
-          reducer: max
-    ET:
-      short_name:
-      long_name:
-      definition:
-      comment: "count of days when daily mean temperature is above {TT} degC"
-
-  ctmlt{TT}:
-    reference: CLIPC
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
-    output:
-      var_name: "ctmlt{TT}"
-      standard_name: spell_length_of_days_with_air_temperature_below_threshold
-      proposed_standard_name: spell_length_with_air_temperature_below_threshold
-      long_name: "Maximum number of consequtive days with Tmean < {TT}C"
-      units: "day"
-      cell_methods:
-        - time: mean within days
-        - time: maximum over days
-    input:
-      data: tas
-    index_function:
-      name: spell_length
-      parameters:
-        threshold:
-          kind: quantity
-          standard_name: air_temperature
-          data: {TT}
-          units: "degree_Celsius"
-        condition:
-          kind: operator
-          operator: "<"
-        reducer:
-          kind: reducer
-          reducer: max
-    ET:
-      short_name:
-      long_name:
-      definition:
-      comment: "count of days when daily mean temperature is below {TT} degC"
-
-  ctmge{TT}:
-    reference: CLIPC
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
-    output:
-      var_name: "ctmge{TT}"
-      standard_name: spell_length_of_days_with_air_temperature_above_threshold
-      proposed_standard_name: spell_length_with_air_temperature_at_or_above_threshold
-      long_name: "Maximum number of consequtive days with Tmean >= {TT}C"
-      units: "day"
-      cell_methods:
-        - time: mean within days
-        - time: maximum over days
-    input:
-      data: tas
-    index_function:
-      name: spell_length
-      parameters:
-        threshold:
-          kind: quantity
-          standard_name: air_temperature
-          data: {TT}
-          units: "degree_Celsius"
-        condition:
-          kind: operator
-          operator: ">"
-        reducer:
-          kind: reducer
-          reducer: max
-    ET:
-      short_name:
-      long_name:
-      definition:
-      comment: "count of days when daily mean temperature is above or equal {TT} degC"
-
-  ctmle{TT}:
-    reference: CLIPC
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
-    output:
-      var_name: "ctmle{TT}"
-      standard_name: spell_length_of_days_with_air_temperature_below_threshold
-      proposed_standard_name: spell_length_with_air_temperature_at_or_below_threshold
-      long_name: "Maximum number of consequtive days with Tmean <= {TT}C"
-      units: "day"
-      cell_methods:
-        - time: mean within days
-        - time: maximum over days
-    input:
-      data: tas
-    index_function:
-      name: spell_length
-      parameters:
-        threshold:
-          kind: quantity
-          standard_name: air_temperature
-          data: {TT}
-          units: "degree_Celsius"
-        condition:
-          kind: operator
-          operator: "<"
-        reducer:
-          kind: reducer
-          reducer: max
-    ET:
-      short_name:
-      long_name:
-      definition:
-      comment: "count of days when daily mean temperature is below or equal{TT} degC"
-
-  txx:
-    reference: ETCCDI
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
-    output:
-      var_name: "txx"
-      standard_name: air_temperature
-      long_name: "Maximum daily maximum temperature"
-      units: "degree_Celsius"
-      cell_methods:
-        - time: maximum within days
-        - time: maximum over days
-    input:
-      data: tasmax
-    index_function:
-      name: statistics
-      parameters:
-        reducer:
-          kind: reducer
-          reducer: max
-    ET:
-      short_name: "txx"
-      long_name: "Maximum daily maximum temperature"
-      definition: "Maximum value of daily TX"
-      comment: "maximum of daily maximum temperature"
-
-  tnx:
-    reference: ETCCDI
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
-    output:
-      var_name: "tnx"
-      standard_name: air_temperature
-      long_name: "Maximum daily minimum temperature"
-      units: "degree_Celsius"
-      cell_methods:
-        - time: minimum within days
-        - time: maximum over days
-    input:
-      data: tasmin
-    index_function:
-      name: statistics
-      parameters:
-        reducer:
-          kind: reducer
-          reducer: max
-    ET:
-      short_name: "tnx"
-      long_name: "Maximum daily minimum temperature"
-      definition: "Maximum value of daily TN"
-      comment: "maximum of daily minimum temperature"
-
-  txn:
-    reference: ETCCDI
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
-    output:
-      var_name: "txn"
-      standard_name: air_temperature
-      long_name: "Minimum daily maximum temperature"
-      units: "degree_Celsius"
-      cell_methods:
-        - time: maximum within days
-        - time: minimum over days
-    input:
-      data: tasmax
-    index_function:
-      name: statistics
-      parameters:
-        reducer:
-          kind: reducer
-          reducer: min
-    ET:
-      short_name: "txn"
-      long_name: "Minimum daily maximum temperature"
-      definition: "Minimum value of daily TX"
-      comment: "minimum of daily maximum temperature"
-
-  tnn:
-    reference: ETCCDI
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
-    output:
-      var_name: "tnn"
-      standard_name: air_temperature
-      long_name: "Minimum daily minimum temperature"
-      units: "degree_Celsius"
-      cell_methods:
-        - time: minimum within days
-        - time: minimum over days
-    input:
-      data: tasmin
-    index_function:
-      name: statistics
-      parameters:
-        reducer:
-          kind: reducer
-          reducer: min
-    ET:
-      short_name: "tnn"
-      long_name: "Minimum daily minimum temperature"
-      definition: "Minimum value of daily TN"
-      comment: "minimum of daily minimum temperature"
-
-  txm:
-    reference:
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
-    output:
-      var_name: "txm"
-      standard_name: air_temperature
-      long_name: "Mean daily maximum temperature"
-      units: "degree_Celsius"
-      cell_methods:
-        - time: maximum within days
-        - time: mean over days
-    input:
-      data: tasmax
-    index_function:
-      name: statistics
-      parameters:
-        reducer:
-          kind: reducer
-          reducer: mean
-    ET:
-      short_name: "txm"
-      long_name: "Mean daily maximum temperature"
-      definition: "Mean value of daily TX"
-      comment:
-
-  tnm:
-    reference:
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
-    output:
-      var_name: "tnm"
-      standard_name: air_temperature
-      long_name: "Mean daily minimum temperature"
-      units: "degree_Celsius"
-      cell_methods:
-        - time: minimum within days
-        - time: mean over days
-    input:
-      data: tasmin
-    index_function:
-      name: statistics
-      parameters:
-        reducer:
-          kind: reducer
-          reducer: mean
-    ET:
-      short_name: "tnx"
-      long_name: "Mean daily minimum temperature"
-      definition: "Mean value of daily TN"
-      comment:
-
-  tmx:
-    reference:
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
-    output:
-      var_name: "tmx"
-      standard_name: air_temperature
-      long_name: "Maximum daily mean temperature"
-      units: "degree_Celsius"
-      cell_methods:
-        - time: mean within days
-        - time: maximum over days
-    input:
-      data: tas
-    index_function:
-      name: statistics
-      parameters:
-        reducer:
-          kind: reducer
-          reducer: max
-    ET:
-      short_name: "tmx"
-      long_name: "Maximum daily mean temperature"
-      definition: "Maximum value of daily TM"
-      comment:
-
-  tmn:
-    reference:
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
-    output:
-      var_name: "tmn"
-      standard_name: air_temperature
-      long_name: "Minimum daily mean temperature"
-      units: "degree_Celsius"
-      cell_methods:
-        - time: mean within days
-        - time: minimum over days
-    input:
-      data: tas
-    index_function:
-      name: statistics
-      parameters:
-        reducer:
-          kind: reducer
-          reducer: min
-    ET:
-      short_name: "tmn"
-      long_name: "Minimum daily mean temperature"
-      definition: "Minimum value of daily TM"
-      comment:
-
-  tmm:
-    reference:
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
-    output:
-      var_name: "tmm"
-      standard_name: air_temperature
-      long_name: "Mean daily mean temperature"
-      units: "degree_Celsius"
-      cell_methods:
-        - time: mean within days
-        - time: mean over days
-    input:
-      data: tas
-    index_function:
-      name: statistics
-      parameters:
-        reducer:
-          kind: reducer
-          reducer: mean
-    ET:
-      short_name: "tmm"
-      long_name: "Mean daily mean temperature"
-      definition: "Mean value of daily TM"
-      comment:
-
-  txmax:
-    reference: CLIPC
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
-    output:
-      var_name: "txmax"
-      standard_name: air_temperature
-      long_name: "Maximum daily maximum temperature"
-      units: "degree_Celsius"
-      cell_methods:
-        - time: maximum within days
-        - time: maximum over days
-    input:
-      data: tasmax
-    index_function:
-      name: statistics
-      parameters:
-        reducer:
-          kind: reducer
-          reducer: max
-    ET:
-      short_name:
-      long_name:
-      definition:
-      comment: "mean of daily maximum temperature"
-
-  tnmax:
-    reference: CLIPC
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
-    output:
-      var_name: "tnmax"
-      standard_name: air_temperature
-      long_name: "Maximum daily minimum temperature"
-      units: "degree_Celsius"
-      cell_methods:
-        - time: minimum within days
-        - time: maximum over days
-    input:
-      data: tasmin
-    index_function:
-      name: statistics
-      parameters:
-        reducer:
-          kind: reducer
-          reducer: max
-    ET:
-      short_name:
-      long_name:
-      definition:
-      comment: "mean of daily minimum temperature"
-
-  txmin:
-    reference: CLIPC
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
-    output:
-      var_name: "txmin"
-      standard_name: air_temperature
-      long_name: "Minimum daily maximum temperature"
-      units: "degree_Celsius"
-      cell_methods:
-        - time: maximum within days
-        - time: minimum over days
-    input:
-      data: tasmax
-    index_function:
-      name: statistics
-      parameters:
-        reducer:
-          kind: reducer
-          reducer: min
-    ET:
-      short_name:
-      long_name:
-      definition:
-      comment: "maximum of daily mean temperature"
-
-  tnmin:
-    reference: CLIPC
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
-    output:
-      var_name: "tnmin"
-      standard_name: air_temperature
-      long_name: "Minimum daily minimum temperature"
-      units: "degree_Celsius"
-      cell_methods:
-        - time: minimum within days
-        - time: minimum over days
-    input:
-      data: tasmin
-    index_function:
-      name: statistics
-      parameters:
-        reducer:
-          kind: reducer
-          reducer: min
-    ET:
-      short_name:
-      long_name:
-      definition:
-      comment: "minimum of daily mean temperature"
-
-  txmean:
-    reference: CLIPC
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
-    output:
-      var_name: "txmean"
-      standard_name: air_temperature
-      long_name: "Mean daily maximum temperature"
-      units: "degree_Celsius"
-      cell_methods:
-        - time: maximum within days
-        - time: mean over days
-    input:
-      data: tasmax
-    index_function:
-      name: statistics
-      parameters:
-        reducer:
-          kind: reducer
-          reducer: mean
-    ET:
-      short_name:
-      long_name:
-      definition:
-      comment: "mean of daily maximum temperature"
-
-  tnmean:
-    reference: CLIPC
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
-    output:
-      var_name: "tnmean"
-      standard_name: air_temperature
-      long_name: "Mean daily minimum temperature"
-      units: "degree_Celsius"
-      cell_methods:
-        - time: minimum within days
-        - time: mean over days
-    input:
-      data: tasmin
-    index_function:
-      name: statistics
-      parameters:
-        reducer:
-          kind: reducer
-          reducer: mean
-    ET:
-      short_name:
-      long_name:
-      definition:
-      comment: "mean of daily minimum temperature"
-
-  tmmax:
-    reference: CLIPC
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
-    output:
-      var_name: "tmmax"
-      standard_name: air_temperature
-      long_name: "Maximum daily mean temperature"
-      units: "degree_Celsius"
-      cell_methods:
-        - time: mean within days
-        - time: maximum over days
-    input:
-      data: tas
-    index_function:
-      name: statistics
-      parameters:
-        reducer:
-          kind: reducer
-          reducer: max
-    ET:
-      short_name:
-      long_name:
-      definition:
-      comment: "maximum of daily mean temperature"
-
-  tmmin:
-    reference: CLIPC
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
-    output:
-      var_name: "tmmin"
-      standard_name: air_temperature
-      long_name: "Minimum daily mean temperature"
-      units: "degree_Celsius"
-      cell_methods:
-        - time: mean within days
-        - time: maximum over days
-    input:
-      data: tas
-    index_function:
-      name: statistics
-      parameters:
-        reducer:
-          kind: reducer
-          reducer: min
-    ET:
-      short_name:
-      long_name:
-      definition:
-      comment: "minimum of daily mean temperature"
-
-  tmmean:
-    reference: CLIPC
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
-    output:
-      var_name: "tmmean"
-      standard_name: air_temperature
-      long_name: "Mean daily mean temperature"
-      units: "degree_Celsius"
-      cell_methods:
-        - time: mean within days
-        - time: mean over days
-    input:
-      data: tas
-    index_function:
-      name: statistics
-      parameters:
-        reducer:
-          kind: reducer
-          reducer: mean
-    ET:
-      short_name:
-      long_name:
-      definition:
-      comment: "mean of daily mean temperature"
-
-  tn10p:
-    reference: ETCCDI
-    period:
-      allowed:
-        annual:
-      default: annual
-    output:
-      var_name: "tn10p"
-      standard_name:
-      long_name: "Percentage of days when Tmin < 10th percentile"
-      units: "%"
-      cell_methods:
-    input:
-      data: tasmin
-    index_function:
-      name: count_percentile_occurrences
-      parameters:
-        percentile:
-          kind: quantity
-          standard_name:
-          proposed_standard_name: quantile
-          data: 10
-          units: "%"
-        condition:
-          kind: operator
-          operator: "<"
-    ET:
-      short_name: "tn10p"
-      long_name: "WMO No.1500: Cold nights (count of days)"
-      definition: "Number of days when TN < 10th percentile"
-      comment:
-
-  tx10p:
-    reference: ETCCDI
-    period:
-      allowed:
-        annual:
-      default: annual
-    output:
-      var_name: "tx10p"
-      standard_name:
-      long_name: "Percentage of days when Tmax < 10th percentile"
-      units: "%"
-      cell_methods:
-    input:
-      data: tasmax
-    index_function:
-      name: count_percentile_occurrences
-      parameters:
-        percentile:
-          kind: quantity
-          standard_name:
-          proposed_standard_name: quantile
-          data: 10
-          units: "%"
-        condition:
-          kind: operator
-          operator: "<"
-    ET:
-      short_name: "tx10p"
-      long_name: "WMO No.1500: Cold day-times (count of days)"
-      definition: "Number of days when TX < 10th percentile"
-      comment:
-
-  tn90p:
-    reference: ETCCDI
-    period:
-      allowed:
-        annual:
-      default: annual
-    output:
-      var_name: "tn90p"
-      standard_name:
-      long_name: "Percentage of days when Tmin > 90th percentile"
-      units: "%"
-      cell_methods:
-    input:
-      data: tasmin
-    index_function:
-      name: count_percentile_occurrences
-      parameters:
-        percentile:
-          kind: quantity
-          standard_name:
-          proposed_standard_name: quantile
-          data: 90
-          units: "%"
-        condition:
-          kind: operator
-          operator: ">"
-    ET:
-      short_name: "tn90p"
-      long_name: "WMO No.1500: Warm nights (count of days)"
-      definition: "Number of days when TN > 90th percentile"
-      comment:
-
-  tx90p:
-    reference: ETCCDI
-    period:
-      allowed:
-        annual:
-      default: annual
-    output:
-      var_name: "tx90p"
-      standard_name:
-      long_name: "Percentage of days when Tmax > 90th percentile"
-      units: "%"
-      cell_methods:
-    input:
-      data: tasmax
-    index_function:
-      name: count_percentile_occurrences
-      parameters:
-        percentile:
-          kind: quantity
-          standard_name:
-          proposed_standard_name: quantile
-          data: 90
-          units: "%"
-        condition:
-          kind: operator
-          operator: ">"
-    ET:
-      short_name: "tx90p"
-      long_name: "WMO No.1500: Warm day-times (count of days)"
-      definition: "Number of days when TX > 90th percentile"
-      comment:
-
-  tg10p:
-    reference: ECA&D
-    period:
-      allowed:
-        annual:
-      default: annual
-    output:
-      var_name: "tg10p"
-      standard_name:
-      long_name: "Percentage of days when Tmean < 10th percentile"
-      units: "%"
-      cell_methods:
-    input:
-      data: tas
-    index_function:
-      name: count_percentile_occurrences
-      parameters:
-        percentile:
-          kind: quantity
-          standard_name:
-          proposed_standard_name: quantile
-          data: 10
-          units: "%"
-        condition:
-          kind: operator
-          operator: "<"
-    ET:
-      short_name: "tg10p"
-      long_name:
-      definition:
-      comment:
-
-  tg90p:
-    reference: ECA&D
-    period:
-      allowed:
-        annual:
-      default: annual
-    output:
-      var_name: "tg90p"
-      standard_name:
-      long_name: "Percentage of days when Tmean > 90th percentile"
-      units: "%"
-      cell_methods:
-    input:
-      data: tas
-    index_function:
-      name: count_percentile_occurrences
-      parameters:
-        percentile:
-          kind: quantity
-          standard_name:
-          proposed_standard_name: quantile
-          data: 90
-          units: "%"
-        condition:
-          kind: operator
-          operator: ">"
-    ET:
-      short_name: "tg90p"
-      long_name:
-      definition:
-      comment:
-
-  txgt50p:
-    reference: ET-SCI
-    period:
-      allowed:
-        annual:
-      default: annual
-    output:
-      var_name: "txgt50p"
-      standard_name:
-      long_name: "Percentage of days when Tmax > 50th percentile"
-      units: "%"
-      cell_methods:
-    input:
-      data: tasmax
-    index_function:
-      name: count_percentile_occurrences
-      parameters:
-        percentile:
-          kind: quantity
-          standard_name:
-          proposed_standard_name: quantile
-          data: 50
-          units: "%"
-        condition:
-          kind: operator
-          operator: ">"
-    ET:
-      short_name: "tx50p"
-      long_name: "Above average days"
-      definition: "Number of days where TX > 50th percentile"
-      comment:
-
-  txgt{PRC}p:
-    reference: CLIPC
-    period:
-      allowed:
-        annual:
-      default: annual
-    output:
-      var_name: "txgt{PRC}p"
-      standard_name:
-      long_name: "Percentage of days when Tmax > {PRC}th percentile"
-      units: "%"
-      cell_methods:
-    input:
-      data: tasmax
-    index_function:
-      name: count_percentile_occurrences
-      parameters:
-        percentile:
-          kind: quantity
-          standard_name:
-          proposed_standard_name: quantile
-          data: {PRC}
-          units: "%"
-        condition:
-          kind: operator
-          operator: ">"
-    ET:
-      short_name:
-      long_name:
-      definition:
-      comment:
-
-  tngt{PRC}p:
-    reference: CLIPC
-    period:
-      allowed:
-        annual:
-      default: annual
-    output:
-      var_name: "tngt{PRC}p"
-      standard_name:
-      long_name: "Percentage of days when Tmin > {PRC}th percentile"
-      units: "%"
-      cell_methods:
-    input:
-      data: tasmin
-    index_function:
-      name: count_percentile_occurrences
-      parameters:
-        percentile:
-          kind: quantity
-          standard_name:
-          proposed_standard_name: quantile
-          data: {PRC}
-          units: "%"
-        condition:
-          kind: operator
-          operator: ">"
-    ET:
-      short_name:
-      long_name:
-      definition:
-      comment:
-
-  tmgt{PRC}p:
-    reference: CLIPC
-    period:
-      allowed:
-        annual:
-      default: annual
-    output:
-      var_name: "tmgt{PRC}p"
-      standard_name:
-      long_name: "Percentage of days when Tmean > {PRC}th percentile"
-      units: "%"
-      cell_methods:
-    input:
-      data: tas
-    index_function:
-      name: count_percentile_occurrences
-      parameters:
-        percentile:
-          kind: quantity
-          standard_name:
-          proposed_standard_name: quantile
-          data: {PRC}
-          units: "%"
-        condition:
-          kind: operator
-          operator: ">"
-    ET:
-      short_name:
-      long_name:
-      definition:
-      comment:
-
-  txlt{PRC}p:
-    reference: CLIPC
-    period:
-      allowed:
-        annual:
-      default: annual
-    output:
-      var_name: "txlt{PRC}p"
-      standard_name:
-      long_name: "Percentage of days when Tmax < {PRC}th percentile"
-      units: "%"
-      cell_methods:
-    input:
-      data: tasmax
-    index_function:
-      name: count_percentile_occurrences
-      parameters:
-        percentile:
-          kind: quantity
-          standard_name:
-          proposed_standard_name: quantile
-          data: {PRC}
-          units: "%"
-        condition:
-          kind: operator
-          operator: "<"
-    ET:
-      short_name:
-      long_name:
-      definition:
-      comment:
-
-  tnlt{PRC}p:
-    reference: CLIPC
-    period:
-      allowed:
-        annual:
-      default: annual
-    output:
-      var_name: "tnlt{PRC}p"
-      standard_name:
-      long_name: "Percentage of days when Tmin < {PRC}th percentile"
-      units: "%"
-      cell_methods:
-    input:
-      data: tasmin
-    index_function:
-      name: count_percentile_occurrences
-      parameters:
-        percentile:
-          kind: quantity
-          standard_name:
-          proposed_standard_name: quantile
-          data: {PRC}
-          units: "%"
-        condition:
-          kind: operator
-          operator: "<"
-    ET:
-      short_name:
-      long_name:
-      definition:
-      comment:
-
-  tmlt{PRC}p:
-    reference: CLIPC
-    period:
-      allowed:
-        annual:
-      default: annual
-    output:
-      var_name: "tmlt{PRC}p"
-      standard_name:
-      long_name: "Percentage of days when Tmean < {PRC}th percentile"
-      units: "%"
-      cell_methods:
-    input:
-      data: tas
-    index_function:
-      name: count_percentile_occurrences
-      parameters:
-        percentile:
-          kind: quantity
-          standard_name:
-          proposed_standard_name: quantile
-          data: {PRC}
-          units: "%"
-        condition:
-          kind: operator
-          operator: "<"
-    ET:
-      short_name:
-      long_name:
-      definition:
-      comment:
-
-  dtr:
-    reference: ETCCDI
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: monthly
-    output:
-      var_name: "dtr"
-      standard_name:
-      proposed_standard_name: air_temperature_range
-      long_name: "Mean Diurnal Temperature Range"
-      units: "degree_Celsius"
-      cell_methods:
-        - time: range within days
-        - time: mean over days
-    input:
-      low_data: tasmin
-      high_data: tasmax
-    index_function:
-      name: diurnal_temperature_range
-      parameters:
-    ET:
-      short_name: "dtr"
-      long_name: "Daily temperature range"
-      definition: "Monthly mean difference between TX and TN"
-      comment: "mean of daily temperature range"
-
-  vdtr:
-    reference: ECA&D
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: monthly
-    output:
-      var_name: "vdtr"
-      standard_name:
-      proposed_standard_name: air_temperature_difference
-      long_name: "Mean day-to-day variation in Diurnal Temperature Range"
-      units: "degree_Celsius"
-      cell_methods:
-    input:
-      low_data: tasmin
-      high_data: tasmax
-    index_function:
-      name: interday_diurnal_temperature_range
-      parameters:
-    ET:
-      short_name:
-      long_name:
-      definition:
-      comment:
-
-  etr:
-    reference: ECA&D
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: monthly
-    output:
-      var_name: "etr"
-      standard_name:
-      proposed_standard_name: air_temperature_range
-      long_name: "Intra-period extreme temperature range"
-      units: "degree_Celsius"
-      cell_methods:
-        - time: range
-    input:
-      low_data: tasmin
-      high_data: tasmax
-    index_function:
-      name: extreme_temperature_range
-      parameters:
-    ET:
-      short_name:
-      long_name:
-      definition:
-      comment:
-
-  tx{PRC}pctl:
-    reference: CLIPC
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
-    output:
-      var_name: "tx{PRC}pctl"
-      standard_name: air_temperature
-      long_name: "{PRC}th percentile of Tmax"
-      units: "degree_Celsius"
-      cell_methods:
-    input:
-      data: tasmax
-    index_function:
-      name: percentile
-      parameters:
-        percentiles:
-          kind: quantity
-          standard_name:
-          proposed_standard_name: quantile
-          data: {PRC}
-          units: "%"
-    ET:
-      short_name:
-      long_name:
-      definition:
-      comment:
-
-  tn{PRC}pctl:
-    reference: CLIPC
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
-    output:
-      var_name: "tn{PRC}pctl"
-      standard_name: air_temperature
-      long_name: "{PRC}th percentile of Tmin"
-      units: "degree_Celsius"
-      cell_methods:
-    input:
-      data: tasmin
-    index_function:
-      name: percentile
-      parameters:
-        percentiles:
-          kind: quantity
-          standard_name:
-          proposed_standard_name: quantile
-          data: {PRC}
-          units: "%"
-    ET:
-      short_name:
-      long_name:
-      definition:
-      comment:
-
-  tm{PRC}pctl:
-    reference: CLIPC
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
-    output:
-      var_name: "tm{PRC}pctl"
-      standard_name: air_temperature
-      long_name: "{PRC}th percentile of Tmean"
-      units: "degree_Celsius"
-      cell_methods:
-    input:
-      data: tas
-    index_function:
-      name: percentile
-      parameters:
-        percentiles:
-          kind: quantity
-          standard_name:
-          proposed_standard_name: quantile
-          data: {PRC}
-          units: "%"
-    ET:
-      short_name:
-      long_name:
-      definition:
-      comment:
-
-  hd17:
-    reference: ECA&D
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
-    output:
-      var_name: "hd17"
-      standard_name: integral_of_air_temperature_excess_wrt_time
-      long_name: "Heating degree days (sum of Tmean > 17 C)"
-      units: "degree_Celsius day"
-      cell_methods:
-        - time: mean within days
-        - time: sum over days
-    input:
-      data: tas
-    index_function:
-      name: temperature_sum
-      parameters:
-        threshold:
-          kind: quantity
-          standard_name: air_temperature
-          data: 17
-          units: "degree_Celsius"
-        condition:
-          kind: operator
-          operator: ">"
-    ET:
-      short_name:
-      long_name:
-      definition:
-      comment:
-
-  hddheat{TT}:
-    reference: ET-SCI
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
-    output:
-      var_name: "hddheat{TT}"
-      standard_name: integral_of_air_temperature_deficit_wrt_time
-      long_name: "Heating Degree Days (Tmean < {TT}C)"
-      units: "degree_Celsius day"
-      cell_methods:
-        - time: mean within days
-        - time: sum over days
-    input:
-      data: tas
-    index_function:
-      name: temperature_sum
-      parameters:
-        threshold:
-          kind: quantity
-          standard_name: air_temperature
-          data: {TT}
-          units: "degree_Celsius"
-        condition:
-          kind: operator
-          operator: "<"
-    ET:
-      short_name: "hddheat"
-      long_name: "Heating degree days"
-      definition: "Sum of Tb- TM (where Tb is a user- defined location-specific base temperature and TM < Tb)"
-      comment:
-
-  ddgt{TT}:
-    reference: CLIPC
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
-    output:
-      var_name: "ddgt{TT}"
-      standard_name: integral_of_air_temperature_excess_wrt_time
-      long_name: "Degree Days (Tmean > {TT}C)"
-      units: "degree_Celsius day"
-      cell_methods:
-        - time: mean within days
-        - time: sum over days
-    input:
-      data: tas
-    index_function:
-      name: temperature_sum
-      parameters:
-        threshold:
-          kind: quantity
-          standard_name: air_temperature
-          data: {TT}
-          units: "degree_Celsius"
-        condition:
-          kind: operator
-          operator: ">"
-    ET:
-      short_name:
-      long_name:
-      definition:
-      comment:
-
-  cddcold{TT}:
-    reference: ET-SCI
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
-    output:
-      var_name: "cddcold{TT}"
-      standard_name: integral_of_air_temperature_excess_wrt_time
-      long_name: "Cooling Degree Days (Tmean > {TT}C)"
-      units: "degree_Celsius day"
-      cell_methods:
-        - time: mean within days
-        - time: sum over days
-    input:
-      data: tas
-    index_function:
-      name: temperature_sum
-      parameters:
-        threshold:
-          kind: quantity
-          standard_name: air_temperature
-          data: {TT}
-          units: "degree_Celsius"
-        condition:
-          kind: operator
-          operator: ">"
-    ET:
-      short_name: "cddcold"
-      long_name: "Cooling degree days"
-      definition: "Sum of TM - Tb (where Tb is a user- defined location-specific base temperature and TM > Tb)"
-      comment:
-
-  ddlt{TT}:
-    reference: CLIPC
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
-    output:
-      var_name: "ddlt{TT}"
-      standard_name: integral_of_air_temperature_deficit_wrt_time
-      long_name: "Degree Days (Tmean < {TT}C)"
-      units: "degree_Celsius day"
-      cell_methods:
-        - time: mean within days
-        - time: sum over days
-    input:
-      data: tas
-    index_function:
-      name: temperature_sum
-      parameters:
-        threshold:
-          kind: quantity
-          standard_name: air_temperature
-          data: {TT}
-          units: "degree_Celsius"
-        condition:
-          kind: operator
-          operator: "<"
-    ET:
-      short_name:
-      long_name:
-      definition:
-      comment:
-
-  gddgrow5:
-    reference: ET-SCI
-    period:
-      allowed:
-        annual:
-      default: annual
-    output:
-      var_name: "gddgrow5"
-      standard_name: integral_of_air_temperature_excess_wrt_time
-      long_name: "Annual Growing Degree Days (Tmean > 5C)"
-      units: "degree_Celsius day"
-      cell_methods:
-        - time: mean within days
-        - time: sum over days
-    input:
-      data: tas
-    index_function:
-      name: temperature_sum
-      parameters:
-        threshold:
-          kind: quantity
-          standard_name: air_temperature
-          data: 5
-          units: "degree_Celsius"
-        condition:
-          kind: operator
-          operator: ">"
-    ET:
-      short_name: "gddgrow"
-      long_name: "Growing degree days"
-      definition: "Annual sum of TM - Tb (where Tb is a user- defined location-specific base temperature and TM >Tb)"
-      comment:
-
-  gd4:
-    reference: ECA&D
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
-    output:
-      var_name: "gd4"
-      standard_name: integral_of_air_temperature_excess_wrt_time
-      long_name: "Growing degree days (sum of Tmean > 4 C)"
-      units: "degree_Celsius day"
-      cell_methods:
-        - time: mean within days
-        - time: sum over days
-    input:
-      data: tas
-    index_function:
-      name: temperature_sum
-      parameters:
-        threshold:
-          kind: quantity
-          standard_name: air_temperature
-          data: 4
-          units: "degree_Celsius"
-        condition:
-          kind: operator
-          operator: ">"
-    ET:
-      short_name:
-      long_name:
-      definition:
-      comment:
-
-  # r10mm:
-  #   reference: ETCCDI
-  #   period:
-  #     allowed:
-  #       annual:
-  #       seasonal:
-  #       monthly:
-  #     default: annual
-  #   output:
-  #     var_name: "r10mm"
-  #     standard_name: number_of_days_with_lwe_thickness_of_precipitation_amount_above_threshold
-  #     proposed_standard_name: number_of_occurrences_with_lwe_thickness_of_precipitation_amount_at_or_above_threshold
-  #     long_name: "Number of heavy precipitation days (Precip >=10mm)"
-  #     units: "1"
-  #     cell_methods:
-  #       - time: sum within days
-  #       - time: sum over days
-  #   input:
-  #     data: pr
-  #   index_function:
-  #     name: count_occurrences
-  #     parameters:
-  #       threshold:
-  #         kind: quantity
-  #         standard_name: lwe_precipitation_rate
-  #         data: 10
-  #         units: "mm day-1"
-  #       condition:
-  #         kind: operator
-  #         operator: ">"
-  #   ET:
-  #     short_name: "r10mm"
-  #     long_name: "Number of heavy precipitation days"
-  #     definition: "Count of days when P>=10mm"
-  #     comment: "count of days when daily total precipitation is above 10 mm"
-
-  # r20mm:
-  #   reference: ETCCDI
-  #   period:
-  #     allowed:
-  #       annual:
-  #       seasonal:
-  #       monthly:
-  #     default: annual
-  #   output:
-  #     var_name: "r20mm"
-  #     standard_name: number_of_days_with_lwe_thickness_of_precipitation_amount_above_threshold
-  #     proposed_standard_name: number_of_occurrences_with_lwe_thickness_of_precipitation_amount_at_or_above_threshold
-  #     long_name: "Number of very heavy precipitation days (Precip >= 20mm)"
-  #     units: "1"
-  #     cell_methods:
-  #       - time: sum within days
-  #       - time: sum over days
-  #   input:
-  #     data: pr
-  #   index_function:
-  #     name: count_occurrences
-  #     parameters:
-  #       threshold:
-  #         kind: quantity
-  #         standard_name: lwe_precipitation_rate
-  #         data: 20
-  #         units: "mm day-1"
-  #       condition:
-  #         kind: operator
-  #         operator: ">"
-  #   ET:
-  #     short_name: "r20mm"
-  #     long_name: "Number of very heavy precipitation days"
-  #     definition: "Count of days when P>=20mm"
-  #     comment: "count of days when daily total precipitation is above 20 mm"
-
-  # r{RT}mm:
-  #   reference: ETCCDI
-  #   period:
-  #     allowed:
-  #       annual:
-  #       seasonal:
-  #       monthly:
-  #     default: annual
-  #   output:
-  #     var_name: "r{RT}mm"
-  #     standard_name: number_of_days_with_lwe_thickness_of_precipitation_amount_above_threshold
-  #     proposed_standard_name: number_of_occurrences_with_lwe_thickness_of_precipitation_amount_at_or_above_threshold
-  #     long_name: "Number of days with daily Precip >= {RT}mm)"
-  #     units: "1"
-  #     cell_methods:
-  #       - time: sum within days
-  #       - time: sum over days
-  #   input:
-  #     data: pr
-  #   index_function:
-  #     name: count_occurrences
-  #     parameters:
-  #       threshold:
-  #         kind: quantity
-  #         standard_name: lwe_precipitation_rate
-  #         data: {RT}
-  #         units: "mm day-1"
-  #       condition:
-  #         kind: operator
-  #         operator: ">"
-  #   ET:
-  #     short_name: "rnnmm"
-  #     long_name: "Number of days above a user-defined threshold"
-  #     definition:
-  #     comment: "count of days when daily total precipitation is above X mm"
-
-  # wetdays:
-  #   reference: CLIPC
-  #   period:
-  #     allowed:
-  #       annual:
-  #       seasonal:
-  #       monthly:
-  #     default: annual
-  #   output:
-  #     var_name: "wetdays"
-  #     standard_name: number_of_days_with_lwe_thickness_of_precipitation_amount_above_threshold
-  #     proposed_standard_name: number_of_occurrences_with_lwe_thickness_of_precipitation_amount_at_or_above_threshold
-  #     long_name: "Number of Wet Days (precip >= 1 mm)"
-  #     units: "1"
-  #     cell_methods:
-  #       - time: sum within days
-  #       - time: sum over days
-  #   input:
-  #     data: pr
-  #   index_function:
-  #     name: count_occurrences
-  #     parameters:
-  #       threshold:
-  #         kind: quantity
-  #         standard_name: lwe_precipitation_rate
-  #         long_name: "Wet day threshold"
-  #         data: 1
-  #         units: "mm day-1"
-  #       condition:
-  #         kind: operator
-  #         operator: ">"
-  #   ET:
-  #     short_name:
-  #     long_name:
-  #     definition:
-  #     comment:
-
-  # rr1:
-  #   reference: ECA&D
-  #   period:
-  #     allowed:
-  #       annual:
-  #       seasonal:
-  #       monthly:
-  #     default: annual
-  #   output:
-  #     var_name: "rr1"
-  #     standard_name: number_of_days_with_lwe_thickness_of_precipitation_amount_above_threshold
-  #     proposed_standard_name: number_of_occurrences_with_lwe_thickness_of_precipitation_amount_at_or_above_threshold
-  #     long_name: "Number of Wet Days (precip >= 1 mm)"
-  #     units: "1"
-  #     cell_methods:
-  #       - time: sum within days
-  #       - time: sum over days
-  #   input:
-  #     data: pr
-  #   index_function:
-  #     name: count_occurrences
-  #     parameters:
-  #       threshold:
-  #         kind: quantity
-  #         standard_name: lwe_precipitation_rate
-  #         long_name: "Wet day threshold"
-  #         data: 1
-  #         units: "mm day-1"
-  #       condition:
-  #         kind: operator
-  #         operator: ">"
-  #   ET:
-  #     short_name:
-  #     long_name:
-  #     definition:
-  #     comment:
-
   cdd:
-    reference: ETCCDI
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: spell_length
+    input:
+      data: pr
     output:
-      var_name: "cdd"
+      cell_methods: 'time: sum within days time: sum over days'
+      long_name: Maximum consecutive dry days (Precip < 1mm)
       standard_name: spell_length_of_days_with_lwe_thickness_of_precipitation_amount_below_threshold
-      proposed_standard_name: spell_length_with_lwe_thickness_of_precipitation_amount_below_threshold
-      long_name: "Maximum consecutive dry days (Precip < 1mm)"
-      units: "day"
-      cell_methods:
-        - time: sum within days
-        - time: sum over days
-    input:
-      data: pr
-    index_function:
-      name: spell_length
-      parameters:
-        threshold:
-          kind: quantity
-          standard_name: lwe_precipitation_rate
-          long_name: "Wet day threshold"
-          data: 1
-          units: "mm day-1"
-        condition:
-          kind: operator
-          operator: "<"
-        reducer:
-          kind: reducer
-          reducer: max
-    ET:
-      short_name: "cdd"
-      long_name: "Consecutive dry days"
-      definition: "Maximum number of consecutive days with P<1mm"
-      comment: "maximum consecutive days when daily total precipitation is below 1 mm"
-
-  cwd:
-    reference: ETCCDI
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
-    output:
-      var_name: "cwd"
-      standard_name: spell_length_of_days_with_lwe_thickness_of_precipitation_amount_above_threshold
-      proposed_standard_name: spell_length_with_lwe_thickness_of_precipitation_amount_at_or_above_threshold
-      long_name: "Maximum consecutive wet days (Precip >= 1mm)"
-      units: "day"
-      cell_methods:
-        - time: sum within days
-        - time: sum over days
-    input:
-      data: pr
-    index_function:
-      name: spell_length
-      parameters:
-        threshold:
-          kind: quantity
-          standard_name: lwe_precipitation_rate
-          long_name: "Wet day threshold"
-          data: 1
-          units: "mm day-1"
-        condition:
-          kind: operator
-          operator: ">"
-        reducer:
-          kind: reducer
-          reducer: max
-    ET:
-      short_name: "cwd"
-      long_name: "Consecutive wet days"
-      definition: "Maximum number of consecutive days with P>=1mm"
-      comment: "maximum consecutive days when daily total precipitation is at least 1 mm"
-
-  # prcptot:
-  #   reference: ETCCDI
-  #   period:
-  #     allowed:
-  #       annual:
-  #       seasonal:
-  #       monthly:
-  #     default: annual
-  #   output:
-  #     var_name: "prcptot"
-  #     standard_name: lwe_thickness_of_precipitation_amount
-  #     long_name: "Total precipitation during Wet Days"
-  #     units: "mm"
-  #     cell_methods:
-  #       - time: sum within days
-  #       - time: mean over days
-  #   input:
-  #     data: pr
-  #   index_function:
-  #     name: thresholded_statistics
-  #     parameters:
-  #       threshold:
-  #         kind: quantity
-  #         standard_name: lwe_precipitation_rate
-  #         long_name: "Wet day threshold"
-  #         data: 1
-  #         units: "mm day-1"
-  #       condition:
-  #         kind: operator
-  #         operator: ">"
-  #       reducer:
-  #         kind: reducer
-  #         reducer: sum
-  #   ET:
-  #     short_name: "prcptot"
-  #     long_name: "Total wet- day precipitation"
-  #     definition: "PRCP from wet days (P>=1mm)"
-  #     comment: "sum of total daily precipitation during days having at least 1 mm"
-
-  sdii:
-    reference: ETCCDI
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
-    output:
-      var_name: "sdii"
-      standard_name: lwe_precipitation_rate
-      long_name: "Average precipitation during Wet Days (SDII)"
-      units: "mm day-1"
-      cell_methods:
-        - time: sum within days
-        - time: mean over days
-    input:
-      data: pr
-    index_function:
-      name: thresholded_statistics
-      parameters:
-        threshold:
-          kind: quantity
-          standard_name: lwe_precipitation_rate
-          long_name: "Wet day threshold"
-          data: 1
-          units: "mm day-1"
-        condition:
-          kind: operator
-          operator: ">"
-        reducer:
-          kind: reducer
-          reducer: mean
-    ET:
-      short_name: "sdii"
-      long_name: "Simple precipitation intensity index"
-      definition: "PRCPTOT / Nwetdays"
-      comment: "mean daily total precipitation during days having at least 1 mm"
-
-  r{PRC}pctl:
-    reference: CLIPC
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
-    output:
-      var_name: "r{PRC}pctl"
-      standard_name: lwe_thickness_of_precipitation_amount
-      long_name: "{PRC}th percentile of precipitation during wet days (Precip >= 1mm)"
-      units: "mm"
-      cell_methods:
-    input:
-      data: pr
-    index_function:
-      name: thresholded_percentile
-      parameters:
-        threshold:
-          kind: quantity
-          standard_name: lwe_precipitation_rate
-          long_name: "Wet day threshold"
-          data: 1
-          units: "mm day-1"
-        condition:
-          kind: operator
-          operator: ">"
-        percentiles:
-          kind: quantity
-          standard_name:
-          proposed_standard_name: quantile
-          data: {PRC}
-          units: "%"
-    ET:
-      short_name:
-      long_name:
-      definition:
-      comment:
-
-  # rx1day:
-  #   reference: ETCCDI
-  #   period:
-  #     allowed:
-  #       annual:
-  #       seasonal:
-  #       monthly:
-  #     default: annual
-  #   output:
-  #     var_name: "rx1day"
-  #     standard_name: lwe_thickness_of_precipitation_amount
-  #     long_name: "Maximum 1-day precipitation"
-  #     units: "mm"
-  #     cell_methods:
-  #       - time: sum within days
-  #       - time: maximum over days
-  #   input:
-  #     data: pr
-  #   index_function:
-  #     name: thresholded_statistics
-  #     parameters:
-  #       threshold:
-  #         kind: quantity
-  #         standard_name: lwe_precipitation_rate
-  #         long_name: "Wet day threshold"
-  #         data: 1
-  #         units: "mm day-1"
-  #       condition:
-  #         kind: operator
-  #         operator: ">"
-  #       reducer:
-  #         kind: reducer
-  #         reducer: max
-  #   ET:
-  #     short_name: "rx1day"
-  #     long_name: "Monthly maximum 1-day precipitation"
-  #     definition: "Maximum one-day precipitation"
-  #     comment:
-
-  rx5day:
-    reference: ETCCDI
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
-    output:
-      var_name: "rx5day"
-      standard_name: lwe_thickness_of_precipitation_amount
-      long_name: "Maximum 5-day precipitation"
-      units: "mm"
-      cell_methods:
-    input:
-      data: pr
-    index_function:
-      name: thresholded_running_statistics
-      parameters:
-        threshold:
-          kind: quantity
-          standard_name: lwe_precipitation_rate
-          long_name: "Wet day threshold"
-          data: 1
-          units: "mm day-1"
-        condition:
-          kind: operator
-          operator: ">"
-        rolling_aggregator:
-          kind: reducer
-          reducer: sum
-        window_size:
-          kind: quantity
-          standard_name:
-          proposed_standard_name: temporal_window_size
-          data: 5
-          units: "day"
-        reducer:
-          kind: reducer
-          reducer: max
-    ET:
-      short_name: "rx5day"
-      long_name: "Monthly maximum 5-day precipitation"
-      definition: "Maximum consecutive five-day precipitation"
-      comment:
-
-  rx{ND}day:
-    reference: ET-SCI
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: annual
-    output:
-      var_name: "rx{ND}day"
-      standard_name: lwe_thickness_of_precipitation_amount
-      long_name: "Maximum {ND}-day precipitation"
-      units: "mm"
-      cell_methods:
-    input:
-      data: pr
-    index_function:
-      name: thresholded_running_statistics
-      parameters:
-        threshold:
-          kind: quantity
-          standard_name: lwe_precipitation_rate
-          long_name: "Wet day threshold"
-          data: 1
-          units: "mm day-1"
-        condition:
-          kind: operator
-          operator: ">"
-        rolling_aggregator:
-          kind: reducer
-          reducer: sum
-        window_size:
-          kind: quantity
-          standard_name:
-          proposed_standard_name: temporal_window_size
-          data: {ND}
-          units: "day"
-        reducer:
-          kind: reducer
-          reducer: max
-    ET:
-      short_name: "rxnday"
-      long_name: "User-defined consecutive days precipitation amount"
-      definition: "Maximum consecutive n-day precipitation"
-      comment:
-
-  rh:
-    reference: ECA&D
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: monthly
-    output:
-      var_name: "rh"
-      standard_name: relative_humidity
-      long_name: "Mean of daily relative humidity"
-      units: "%"
-      cell_methods:
-        - time: mean
-    input:
-      data: hurs
-    index_function:
-      name: statistics
-      parameters:
-        reducer:
-          kind: reducer
-          reducer: mean
-    ET:
-      short_name:
-      long_name:
-      definition:
-      comment:
-
-  # rr:
-  #   reference: ECA&D
-  #   period:
-  #     allowed:
-  #       annual:
-  #       seasonal:
-  #       monthly:
-  #     default: monthly
-  #   output:
-  #     var_name: "rr"
-  #     standard_name: lwe_thickness_of_precipitation_amount
-  #     long_name: "Precipitation sum"
-  #     units: "mm"
-  #     cell_methods:
-  #       - time: mean within days
-  #       - time: mean over days
-  #   input:
-  #     data: pr
-  #   index_function:
-  #     name: thresholded_statistics
-  #     parameters:
-  #       threshold:
-  #         kind: quantity
-  #         standard_name: lwe_precipitation_rate
-  #         long_name: "Wet day threshold"
-  #         data: 1
-  #         units: "mm day-1"
-  #       condition:
-  #         kind: operator
-  #         operator: ">"
-  #       reducer:
-  #         kind: reducer
-  #         reducer: sum
-  #   ET:
-  #     short_name:
-  #     long_name:
-  #     definition:
-  #     comment:
-
-  pp:
-    reference: ECA&D
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: monthly
-    output:
-      var_name: "pp"
-      standard_name: air_pressure_at_sea_level
-      long_name: "Mean of daily sea level pressure"
-      units: "hPa"
-      cell_methods:
-        - time: mean
-    input:
-      data: psl
-    index_function:
-      name: statistics
-      parameters:
-        reducer:
-          kind: reducer
-          reducer: mean
-    ET:
-      short_name:
-      long_name:
-      definition:
-      comment:
-
-  tg:
-    reference: ECA&D
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: monthly
-    output:
-      var_name: "tg"
-      standard_name: air_temperature
-      long_name: "Mean of daily mean temperature"
-      units: "degree_Celsius"
-      cell_methods:
-        - time: mean
+      units: day
+      var_name: cdd
+    parameters:
+      condition: <
+      freq:
+        default: YS
+      reducer: max
+      threshold: 1 mm day-1
+    references: ETCCDI
+  cddcoldTT:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: temperature_sum
     input:
       data: tas
-    index_function:
-      name: statistics
-      parameters:
-        reducer:
-          kind: reducer
-          reducer: mean
-    ET:
-      short_name:
-      long_name:
-      definition:
-      comment:
-
-  tn:
-    reference: ECA&D
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: monthly
     output:
-      var_name: "tn"
-      standard_name: air_temperature
-      long_name: "Mean of daily minimum temperature"
-      units: "degree_Celsius"
-      cell_methods:
-        - time: mean
+      cell_methods: 'time: mean within days time: sum over days'
+      long_name: Cooling Degree Days (Tmean > {threshold}C)
+      standard_name: integral_wrt_time_of_air_temperature_excess
+      units: degree_Celsius day
+      var_name: cddcold{threshold}
+    parameters:
+      condition: '>'
+      freq:
+        default: YS
+      threshold:
+        description: air temperature
+        units: degree_Celsius
+    references: ET-SCI
+  cfd:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: count_occurrences
     input:
       data: tasmin
-    index_function:
-      name: statistics
-      parameters:
-        reducer:
-          kind: reducer
-          reducer: mean
-    ET:
-      short_name:
-      long_name:
-      definition:
-      comment:
-
-  tx:
-    reference: ECA&D
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: monthly
     output:
-      var_name: "tx"
-      standard_name: air_temperature
-      long_name: "Mean of daily maximum temperature"
-      units: "degree_Celsius"
-      cell_methods:
-        - time: mean
+      cell_methods: 'time: minimum within days time: maximum over days'
+      long_name: Maximum number of consecutive frost days (Tmin < 0 C)
+      standard_name: spell_length_of_days_with_air_temperature_below_threshold
+      units: day
+      var_name: cfd
+    parameters:
+      condition: <
+      freq:
+        default: YS
+      threshold: 0 degree_Celsius
+    references: ECA&D
+  csu:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: count_occurrences
     input:
       data: tasmax
-    index_function:
-      name: statistics
-      parameters:
-        reducer:
-          kind: reducer
-          reducer: mean
-    ET:
-      short_name:
-      long_name:
-      definition:
-      comment:
-
-  sd:
-    reference: ECA&D
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: monthly
     output:
-      var_name: "sd"
-      standard_name: surface_snow_thickness
-      long_name: "Mean of daily snow depth"
-      units: "cm"
-      cell_methods:
-        - time: mean
+      cell_methods: 'time: maximum within days time: maximum over days'
+      long_name: Maximum number of consecutive summer days (Tmax >25 C)
+      standard_name: spell_length_of_days_with_air_temperature_above_threshold
+      units: day
+      var_name: csu
+    parameters:
+      condition: '>'
+      freq:
+        default: YS
+      threshold: 25 degree_Celsius
+    references: ECA&D
+  ctmgeTT:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: spell_length
     input:
-      data: snd
-    index_function:
-      name: statistics
-      parameters:
-        reducer:
-          kind: reducer
-          reducer: mean
-    ET:
-      short_name:
-      long_name:
-      definition:
-      comment:
-
-  # sd1:
-  #   reference: ECA&D
-  #   period:
-  #     allowed:
-  #       annual:
-  #       seasonal:
-  #       monthly:
-  #     default: monthly
-  #   output:
-  #     var_name: "sd1"
-  #     standard_name: number_of_days_with_surface_snow_thickness_above_threshold
-  #     proposed_standard_name: number_of_occurrences_with_surface_snow_thickness_at_or_above_threshold
-  #     long_name: "Snow days (SD >= 1 cm)"
-  #     units: "day"
-  #     cell_methods:
-  #       - time: mean within days
-  #       - time: sum over days
-  #   input:
-  #     data: snd
-  #   index_function:
-  #     name: count_occurrences
-  #     parameters:
-  #       threshold:
-  #         kind: quantity
-  #         standard_name: surface_snow_thickness
-  #         data: 1
-  #         units: "cm"
-  #       condition:
-  #         kind: operator
-  #         operator: ">"
-  #   ET:
-  #     short_name:
-  #     long_name:
-  #     definition:
-  #     comment:
-
-  # sd5cm:
-  #   reference: ECA&D
-  #   period:
-  #     allowed:
-  #       annual:
-  #       seasonal:
-  #       monthly:
-  #     default: monthly
-  #   output:
-  #     var_name: "sd5cm"
-  #     standard_name: number_of_days_with_surface_snow_thickness_above_threshold
-  #     proposed_standard_name: number_of_occurrences_with_surface_snow_thickness_at_or_above_threshold
-  #     long_name: "Number of days with snow depth >= 5 cm"
-  #     units: "day"
-  #     cell_methods:
-  #       - time: mean within days
-  #       - time: sum over days
-  #   input:
-  #     data: snd
-  #   index_function:
-  #     name: count_occurrences
-  #     parameters:
-  #       threshold:
-  #         kind: quantity
-  #         standard_name: surface_snow_thickness
-  #         data: 5
-  #         units: "cm"
-  #       condition:
-  #         kind: operator
-  #         operator: ">"
-  #   ET:
-  #     short_name:
-  #     long_name:
-  #     definition:
-  #     comment:
-
-  # sd50cm:
-  #   reference: ECA&D
-  #   period:
-  #     allowed:
-  #       annual:
-  #       seasonal:
-  #       monthly:
-  #     default: monthly
-  #   output:
-  #     var_name: "sd50cm"
-  #     standard_name: number_of_days_with_surface_snow_thickness_above_threshold
-  #     proposed_standard_name: number_of_occurrences_with_surface_snow_thickness_at_or_above_threshold
-  #     long_name: "Number of days with snow depth >= 50 cm"
-  #     units: "day"
-  #     cell_methods:
-  #       - time: mean within days
-  #       - time: sum over days
-  #   input:
-  #     data: snd
-  #   index_function:
-  #     name: count_occurrences
-  #     parameters:
-  #       threshold:
-  #         kind: quantity
-  #         standard_name: surface_snow_thickness
-  #         data: 50
-  #         units: "cm"
-  #       condition:
-  #         kind: operator
-  #         operator: ">"
-  #   ET:
-  #     short_name:
-  #     long_name:
-  #     definition:
-  #     comment:
-
-  # sd{D}cm:
-  #   reference: ECA&D
-  #   period:
-  #     allowed:
-  #       annual:
-  #       seasonal:
-  #       monthly:
-  #     default: monthly
-  #   output:
-  #     var_name: "sd{D}cm"
-  #     standard_name: number_of_days_with_surface_snow_thickness_above_threshold
-  #     proposed_standard_name: number_of_occurrences_with_surface_snow_thickness_at_or_above_threshold
-  #     long_name: "Number of days with snow depth >= {D} cm"
-  #     units: "day"
-  #     cell_methods:
-  #       - time: mean within days
-  #       - time: sum over days
-  #   input:
-  #     data: snd
-  #   index_function:
-  #     name: count_occurrences
-  #     parameters:
-  #       threshold:
-  #         kind: quantity
-  #         standard_name: surface_snow_thickness
-  #         data: {D}
-  #         units: "cm"
-  #       condition:
-  #         kind: operator
-  #         operator: ">"
-  #   ET:
-  #     short_name:
-  #     long_name:
-  #     definition:
-  #     comment:
-
-  ss:
-    reference: ECA&D
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: monthly
+      data: tas
     output:
-      var_name: "ss"
-      standard_name: duration_of_sunshine
-      long_name: "Sunshine duration, sum"
-      units: "hour"
-      cell_methods:
+      cell_methods: 'time: mean within days time: maximum over days'
+      long_name: Maximum number of consequtive days with Tmean >= {threshold}C
+      standard_name: spell_length_of_days_with_air_temperature_above_threshold
+      units: day
+      var_name: ctmge{threshold}
+    parameters:
+      condition: '>'
+      freq:
+        default: YS
+      reducer: max
+      threshold:
+        description: air temperature
+        units: degree_Celsius
+    references: CLIPC
+  ctmgtTT:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: spell_length
     input:
-      data: sund
-    index_function:
-      name: statistics
-      parameters:
-        reducer:
-          kind: reducer
-          reducer: sum
-    ET:
-      short_name:
-      long_name:
-      definition:
-      comment:
-
-  fxx:
-    reference: ECA&D
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: monthly
+      data: tas
     output:
-      var_name: "fxx"
-      standard_name: wind_speed_of_gust
-      long_name: "Maximum value of daily maximum wind gust strength"
-      units: "meter second-1"
-      cell_methods:
-        - time: maximum
+      cell_methods: 'time: mean within days time: maximum over days'
+      long_name: Maximum number of consequtive days with Tmean > {threshold}C
+      standard_name: spell_length_of_days_with_air_temperature_above_threshold
+      units: day
+      var_name: ctmgt{threshold}
+    parameters:
+      condition: '>'
+      freq:
+        default: YS
+      reducer: max
+      threshold:
+        description: air temperature
+        units: degree_Celsius
+    references: CLIPC
+  ctmleTT:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: spell_length
     input:
-      data: wsgsmax
-    index_function:
-      name: statistics
-      parameters:
-        reducer:
-          kind: reducer
-          reducer: max
-    ET:
-      short_name:
-      long_name:
-      definition:
-      comment:
-
-  # fg6bft:
-  #   reference: ECA&D
-  #   period:
-  #     allowed:
-  #       annual:
-  #       seasonal:
-  #       monthly:
-  #     default: monthly
-  #   output:
-  #     var_name: "fg6bft"
-  #     standard_name: number_of_days_with_wind_speed_above_threshold
-  #     proposed_standard_name: number_of_occurrences_with_wind_speed_at_or_above_threshold
-  #     long_name: "Days with daily averaged wind strength >= 6 Bft (>=10.8 m/s)"
-  #     units: "1"
-  #     cell_methods:
-  #       - time: mean within days
-  #       - time: sum over days
-  #   input:
-  #     data: sfcWind
-  #   index_function:
-  #     name: count_occurrences
-  #     parameters:
-  #       threshold:
-  #         kind: quantity
-  #         standard_name: wind_speed
-  #         data: 10.8
-  #         units: "meter second-1"
-  #       condition:
-  #         kind: operator
-  #         operator: ">"
-  #   ET:
-  #     short_name:
-  #     long_name:
-  #     definition:
-  #     comment:
-
-  # fgcalm:
-  #   reference: ECA&D
-  #   period:
-  #     allowed:
-  #       annual:
-  #       seasonal:
-  #       monthly:
-  #     default: monthly
-  #   output:
-  #     var_name: "fgcalm"
-  #     standard_name: number_of_days_with_wind_speed_below_threshold
-  #     proposed_standard_name: number_of_occurrences_with_wind_speed_at_or_below_threshold
-  #     long_name: "Calm days (daily mean wind strength <= 2 m/s)"
-  #     units: "1"
-  #     cell_methods:
-  #       - time: mean within days
-  #       - time: sum over days
-  #   input:
-  #     data: sfcWind
-  #   index_function:
-  #     name: count_occurrences
-  #     parameters:
-  #       threshold:
-  #         kind: quantity
-  #         standard_name: wind_speed
-  #         data: 2
-  #         units: "meter second-1"
-  #       condition:
-  #         kind: operator
-  #         operator: "<"
-  #   ET:
-  #     short_name:
-  #     long_name:
-  #     definition:
-  #     comment:
-
+      data: tas
+    output:
+      cell_methods: 'time: mean within days time: maximum over days'
+      long_name: Maximum number of consequtive days with Tmean <= {threshold}C
+      standard_name: spell_length_of_days_with_air_temperature_below_threshold
+      units: day
+      var_name: ctmle{threshold}
+    parameters:
+      condition: <
+      freq:
+        default: YS
+      reducer: max
+      threshold:
+        description: air temperature
+        units: degree_Celsius
+    references: CLIPC
+  ctmltTT:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: spell_length
+    input:
+      data: tas
+    output:
+      cell_methods: 'time: mean within days time: maximum over days'
+      long_name: Maximum number of consequtive days with Tmean < {threshold}C
+      standard_name: spell_length_of_days_with_air_temperature_below_threshold
+      units: day
+      var_name: ctmlt{threshold}
+    parameters:
+      condition: <
+      freq:
+        default: YS
+      reducer: max
+      threshold:
+        description: air temperature
+        units: degree_Celsius
+    references: CLIPC
+  ctngeTT:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: spell_length
+    input:
+      data: tasmin
+    output:
+      cell_methods: 'time: minimum within days time: maximum over days'
+      long_name: Maximum number of consequtive days with Tmin >= {threshold}C
+      standard_name: spell_length_of_days_with_air_temperature_above_threshold
+      units: day
+      var_name: ctnge{threshold}
+    parameters:
+      condition: '>'
+      freq:
+        default: YS
+      reducer: max
+      threshold:
+        description: air temperature
+        units: degree_Celsius
+    references: CLIPC
+  ctngtTT:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: spell_length
+    input:
+      data: tasmin
+    output:
+      cell_methods: 'time: minimum within days time: maximum over days'
+      long_name: Maximum number of consequtive days with Tmin > {threshold}C
+      standard_name: spell_length_of_days_with_air_temperature_above_threshold
+      units: day
+      var_name: ctngt{threshold}
+    parameters:
+      condition: '>'
+      freq:
+        default: YS
+      reducer: max
+      threshold:
+        description: air temperature
+        units: degree_Celsius
+    references: CLIPC
+  ctnleTT:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: spell_length
+    input:
+      data: tasmin
+    output:
+      cell_methods: 'time: minimum within days time: maximum over days'
+      long_name: Maximum number of consequtive days with Tmin <= {threshold}C
+      standard_name: spell_length_of_days_with_air_temperature_below_threshold
+      units: day
+      var_name: ctnle{threshold}
+    parameters:
+      condition: <
+      freq:
+        default: YS
+      reducer: max
+      threshold:
+        description: air temperature
+        units: degree_Celsius
+    references: CLIPC
+  ctnltTT:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: spell_length
+    input:
+      data: tasmin
+    output:
+      cell_methods: 'time: minimum within days time: maximum over days'
+      long_name: Maximum number of consequtive days with Tmin < {threshold}C
+      standard_name: spell_length_of_days_with_air_temperature_below_threshold
+      units: day
+      var_name: ctnlt{threshold}
+    parameters:
+      condition: <
+      freq:
+        default: YS
+      reducer: max
+      threshold:
+        description: air temperature
+        units: degree_Celsius
+    references: CLIPC
+  ctxgeTT:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: spell_length
+    input:
+      data: tasmax
+    output:
+      cell_methods: 'time: maximum within days time: maximum over days'
+      long_name: Maximum number of consequtive days with Tmax >= {threshold}C
+      standard_name: spell_length_of_days_with_air_temperature_above_threshold
+      units: day
+      var_name: ctxge{threshold}
+    parameters:
+      condition: '>'
+      freq:
+        default: YS
+      reducer: max
+      threshold:
+        description: air temperature
+        units: degree_Celsius
+    references: CLIPC
+  ctxgtTT:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: spell_length
+    input:
+      data: tasmax
+    output:
+      cell_methods: 'time: maximum within days time: maximum over days'
+      long_name: Maximum number of consequtive days with Tmax > {threshold}C
+      standard_name: spell_length_of_days_with_air_temperature_above_threshold
+      units: day
+      var_name: ctxgt{threshold}
+    parameters:
+      condition: '>'
+      freq:
+        default: YS
+      reducer: max
+      threshold:
+        description: air temperature
+        units: degree_Celsius
+    references: CLIPC
+  ctxleTT:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: spell_length
+    input:
+      data: tasmax
+    output:
+      cell_methods: 'time: maximum within days time: maximum over days'
+      long_name: Maximum number of consequtive days with Tmax <= {threshold}C
+      standard_name: spell_length_of_days_with_air_temperature_below_threshold
+      units: day
+      var_name: ctxle{threshold}
+    parameters:
+      condition: <
+      freq:
+        default: YS
+      reducer: max
+      threshold:
+        description: air temperature
+        units: degree_Celsius
+    references: CLIPC
+  ctxltTT:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: spell_length
+    input:
+      data: tasmax
+    output:
+      cell_methods: 'time: maximum within days time: maximum over days'
+      long_name: Maximum number of consequtive days with Tmax < {threshold}C
+      standard_name: spell_length_of_days_with_air_temperature_below_threshold
+      units: day
+      var_name: ctxlt{threshold}
+    parameters:
+      condition: <
+      freq:
+        default: YS
+      reducer: max
+      threshold:
+        description: air temperature
+        units: degree_Celsius
+    references: CLIPC
+  cwd:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: spell_length
+    input:
+      data: pr
+    output:
+      cell_methods: 'time: sum within days time: sum over days'
+      long_name: Maximum consecutive wet days (Precip >= 1mm)
+      standard_name: spell_length_of_days_with_lwe_thickness_of_precipitation_amount_above_threshold
+      units: day
+      var_name: cwd
+    parameters:
+      condition: '>'
+      freq:
+        default: YS
+      reducer: max
+      threshold: 1 mm day-1
+    references: ETCCDI
+  ddgtTT:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: temperature_sum
+    input:
+      data: tas
+    output:
+      cell_methods: 'time: mean within days time: sum over days'
+      long_name: Degree Days (Tmean > {threshold}C)
+      standard_name: integral_wrt_time_of_air_temperature_excess
+      units: degree_Celsius day
+      var_name: ddgt{threshold}
+    parameters:
+      condition: '>'
+      freq:
+        default: YS
+      threshold:
+        description: air temperature
+        units: degree_Celsius
+    references: CLIPC
+  ddltTT:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: temperature_sum
+    input:
+      data: tas
+    output:
+      cell_methods: 'time: mean within days time: sum over days'
+      long_name: Degree Days (Tmean < {threshold}C)
+      standard_name: integral_wrt_time_of_air_temperature_deficit
+      units: degree_Celsius day
+      var_name: ddlt{threshold}
+    parameters:
+      condition: <
+      freq:
+        default: YS
+      threshold:
+        description: air temperature
+        units: degree_Celsius
+    references: CLIPC
+  dtr:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: diurnal_temperature_range
+    input:
+      high_data: tasmax
+      low_data: tasmin
+    output:
+      cell_methods: 'time: range within days time: mean over days'
+      long_name: Mean Diurnal Temperature Range
+      units: degree_Celsius
+      var_name: dtr
+    parameters:
+      freq:
+        default: MS
+    references: ETCCDI
+  etr:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: extreme_temperature_range
+    input:
+      high_data: tasmax
+      low_data: tasmin
+    output:
+      cell_methods: 'time: range'
+      long_name: Intra-period extreme temperature range
+      units: degree_Celsius
+      var_name: etr
+    parameters:
+      freq:
+        default: MS
+    references: ECA&D
   fg:
-    reference: ECA&D
-    period:
-      allowed:
-        annual:
-        seasonal:
-        monthly:
-      default: monthly
-    output:
-      var_name: "fg"
-      standard_name: wind_speed
-      long_name: "Mean of daily mean wind strength"
-      units: "meter second-1"
-      cell_methods:
-        - time: mean
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: statistics
     input:
       data: sfcWind
-    index_function:
-      name: statistics
-      parameters:
-        reducer:
-          kind: reducer
-          reducer: mean
-    ET:
-      short_name:
-      long_name:
-      definition:
-      comment:
-
-  # nzero:
-  #   reference: SMHI
-  #   period:
-  #     allowed:
-  #       annual:
-  #       seasonal:
-  #       monthly:
-  #     default: annual
-  #   output:
-  #     var_name: "nzero"
-  #     standard_name:
-  #     proposed_standard_name: number_of_occurrences_with_air_temperature_level_crossings
-  #     long_name: "Number of zero-crossing days (days when Tmin < 0 degC < Tmax)"
-  #     units: "days"
-  #     cell_methods:
-  #       - time: sum over days
-  #   input:
-  #     low_data: tasmin
-  #     high_data: tasmax
-  #   index_function:
-  #     name: count_level_crossings
-  #     parameters:
-  #       threshold:
-  #         kind: quantity
-  #         standard_name: air_temperature
-  #         long_name: "Level crossing value for daily air temperature"
-  #         data: 0
-  #         units: "degree_Celsius"
-  #   ET:
-  #     short_name:
-  #     long_name:
-  #     definition:
-  #     comment:
+    output:
+      cell_methods: 'time: mean'
+      long_name: Mean of daily mean wind strength
+      standard_name: wind_speed
+      units: meter second-1
+      var_name: fg
+    parameters:
+      freq:
+        default: MS
+      reducer: mean
+    references: ECA&D
+  fxx:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: statistics
+    input:
+      data: wsgsmax
+    output:
+      cell_methods: 'time: maximum'
+      long_name: Maximum value of daily maximum wind gust strength
+      standard_name: wind_speed_of_gust
+      units: meter second-1
+      var_name: fxx
+    parameters:
+      freq:
+        default: MS
+      reducer: max
+    references: ECA&D
+  gd4:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: temperature_sum
+    input:
+      data: tas
+    output:
+      cell_methods: 'time: mean within days time: sum over days'
+      long_name: Growing degree days (sum of Tmean > 4 C)
+      standard_name: integral_wrt_time_of_air_temperature_excess
+      units: degree_Celsius day
+      var_name: gd4
+    parameters:
+      condition: '>'
+      freq:
+        default: YS
+      threshold: 4 degree_Celsius
+    references: ECA&D
+  gddgrowTT:
+    allowed_periods:
+    - A
+    compute: temperature_sum
+    input:
+      data: tas
+    output:
+      cell_methods: 'time: mean within days time: sum over days'
+      long_name: Annual Growing Degree Days (Tmean > {threshold}C)
+      standard_name: integral_wrt_time_of_air_temperature_excess
+      units: degree_Celsius day
+      var_name: gddgrow{threshold}
+    parameters:
+      condition: '>'
+      freq:
+        default: YS
+      threshold:
+        description: air temperature
+        units: degree_Celsius
+    references: ET-SCI
+  hd17:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: temperature_sum
+    input:
+      data: tas
+    output:
+      cell_methods: 'time: mean within days time: sum over days'
+      long_name: Heating degree days (sum of Tmean < 17 C)
+      standard_name: integral_wrt_time_of_air_temperature_excess
+      units: degree_Celsius day
+      var_name: hd17
+    parameters:
+      condition: <
+      freq:
+        default: YS
+      threshold: 17 degree_Celsius
+    references: ECA&D
+  hddheatTT:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: temperature_sum
+    input:
+      data: tas
+    output:
+      cell_methods: 'time: mean within days time: sum over days'
+      long_name: Heating Degree Days (Tmean < {threshold}C)
+      standard_name: integral_wrt_time_of_air_temperature_deficit
+      units: degree_Celsius day
+      var_name: hddheat{threshold}
+    parameters:
+      condition: <
+      freq:
+        default: YS
+      threshold:
+        description: air temperature
+        units: degree_Celsius
+    references: ET-SCI
+  pp:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: statistics
+    input:
+      data: psl
+    output:
+      cell_methods: 'time: mean'
+      long_name: Mean of daily sea level pressure
+      standard_name: air_pressure_at_sea_level
+      units: hPa
+      var_name: pp
+    parameters:
+      freq:
+        default: MS
+      reducer: mean
+    references: ECA&D
+  rh:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: statistics
+    input:
+      data: hurs
+    output:
+      cell_methods: 'time: mean'
+      long_name: Mean of daily relative humidity
+      standard_name: relative_humidity
+      units: '%'
+      var_name: rh
+    parameters:
+      freq:
+        default: MS
+      reducer: mean
+    references: ECA&D
+  sd:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: statistics
+    input:
+      data: snd
+    output:
+      cell_methods: 'time: mean'
+      long_name: Mean of daily snow depth
+      standard_name: surface_snow_thickness
+      units: cm
+      var_name: sd
+    parameters:
+      freq:
+        default: MS
+      reducer: mean
+    references: ECA&D
+  sdii:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: thresholded_statistics
+    input:
+      data: pr
+    output:
+      cell_methods: 'time: sum within days time: mean over days'
+      long_name: Average precipitation during Wet Days (SDII)
+      standard_name: lwe_precipitation_rate
+      units: mm day-1
+      var_name: sdii
+    parameters:
+      condition: '>'
+      freq:
+        default: YS
+      reducer: mean
+      threshold: 1 mm day-1
+    references: ETCCDI
+  ss:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: statistics
+    input:
+      data: sund
+    output:
+      long_name: Sunshine duration, sum
+      standard_name: duration_of_sunshine
+      units: hour
+      var_name: ss
+    parameters:
+      freq:
+        default: MS
+      reducer: sum
+    references: ECA&D
+  tg:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: statistics
+    input:
+      data: tas
+    output:
+      cell_methods: 'time: mean'
+      long_name: Mean of daily mean temperature
+      standard_name: air_temperature
+      units: degree_Celsius
+      var_name: tg
+    parameters:
+      freq:
+        default: MS
+      reducer: mean
+    references: ECA&D
+  tmm:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: statistics
+    input:
+      data: tas
+    output:
+      cell_methods: 'time: mean within days time: mean over days'
+      long_name: Mean daily mean temperature
+      standard_name: air_temperature
+      units: degree_Celsius
+      var_name: tmm
+    parameters:
+      freq:
+        default: YS
+      reducer: mean
+    references: null
+  tmmax:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: statistics
+    input:
+      data: tas
+    output:
+      cell_methods: 'time: mean within days time: maximum over days'
+      long_name: Maximum daily mean temperature
+      standard_name: air_temperature
+      units: degree_Celsius
+      var_name: tmmax
+    parameters:
+      freq:
+        default: YS
+      reducer: max
+    references: CLIPC
+  tmmean:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: statistics
+    input:
+      data: tas
+    output:
+      cell_methods: 'time: mean within days time: mean over days'
+      long_name: Mean daily mean temperature
+      standard_name: air_temperature
+      units: degree_Celsius
+      var_name: tmmean
+    parameters:
+      freq:
+        default: YS
+      reducer: mean
+    references: CLIPC
+  tmmin:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: statistics
+    input:
+      data: tas
+    output:
+      cell_methods: 'time: mean within days time: maximum over days'
+      long_name: Minimum daily mean temperature
+      standard_name: air_temperature
+      units: degree_Celsius
+      var_name: tmmin
+    parameters:
+      freq:
+        default: YS
+      reducer: min
+    references: CLIPC
+  tmn:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: statistics
+    input:
+      data: tas
+    output:
+      cell_methods: 'time: mean within days time: minimum over days'
+      long_name: Minimum daily mean temperature
+      standard_name: air_temperature
+      units: degree_Celsius
+      var_name: tmn
+    parameters:
+      freq:
+        default: YS
+      reducer: min
+    references: null
+  tmx:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: statistics
+    input:
+      data: tas
+    output:
+      cell_methods: 'time: mean within days time: maximum over days'
+      long_name: Maximum daily mean temperature
+      standard_name: air_temperature
+      units: degree_Celsius
+      var_name: tmx
+    parameters:
+      freq:
+        default: YS
+      reducer: max
+    references: null
+  tn:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: statistics
+    input:
+      data: tasmin
+    output:
+      cell_methods: 'time: mean'
+      long_name: Mean of daily minimum temperature
+      standard_name: air_temperature
+      units: degree_Celsius
+      var_name: tn
+    parameters:
+      freq:
+        default: MS
+      reducer: mean
+    references: ECA&D
+  tnm:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: statistics
+    input:
+      data: tasmin
+    output:
+      cell_methods: 'time: minimum within days time: mean over days'
+      long_name: Mean daily minimum temperature
+      standard_name: air_temperature
+      units: degree_Celsius
+      var_name: tnm
+    parameters:
+      freq:
+        default: YS
+      reducer: mean
+    references: null
+  tnmax:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: statistics
+    input:
+      data: tasmin
+    output:
+      cell_methods: 'time: minimum within days time: maximum over days'
+      long_name: Maximum daily minimum temperature
+      standard_name: air_temperature
+      units: degree_Celsius
+      var_name: tnmax
+    parameters:
+      freq:
+        default: YS
+      reducer: max
+    references: CLIPC
+  tnmean:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: statistics
+    input:
+      data: tasmin
+    output:
+      cell_methods: 'time: minimum within days time: mean over days'
+      long_name: Mean daily minimum temperature
+      standard_name: air_temperature
+      units: degree_Celsius
+      var_name: tnmean
+    parameters:
+      freq:
+        default: YS
+      reducer: mean
+    references: CLIPC
+  tnmin:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: statistics
+    input:
+      data: tasmin
+    output:
+      cell_methods: 'time: minimum within days time: minimum over days'
+      long_name: Minimum daily minimum temperature
+      standard_name: air_temperature
+      units: degree_Celsius
+      var_name: tnmin
+    parameters:
+      freq:
+        default: YS
+      reducer: min
+    references: CLIPC
+  tnn:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: statistics
+    input:
+      data: tasmin
+    output:
+      cell_methods: 'time: minimum within days time: minimum over days'
+      long_name: Minimum daily minimum temperature
+      standard_name: air_temperature
+      units: degree_Celsius
+      var_name: tnn
+    parameters:
+      freq:
+        default: YS
+      reducer: min
+    references: ETCCDI
+  tnx:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: statistics
+    input:
+      data: tasmin
+    output:
+      cell_methods: 'time: minimum within days time: maximum over days'
+      long_name: Maximum daily minimum temperature
+      standard_name: air_temperature
+      units: degree_Celsius
+      var_name: tnx
+    parameters:
+      freq:
+        default: YS
+      reducer: max
+    references: ETCCDI
+  tx:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: statistics
+    input:
+      data: tasmax
+    output:
+      cell_methods: 'time: mean'
+      long_name: Mean of daily maximum temperature
+      standard_name: air_temperature
+      units: degree_Celsius
+      var_name: tx
+    parameters:
+      freq:
+        default: MS
+      reducer: mean
+    references: ECA&D
+  txm:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: statistics
+    input:
+      data: tasmax
+    output:
+      cell_methods: 'time: maximum within days time: mean over days'
+      long_name: Mean daily maximum temperature
+      standard_name: air_temperature
+      units: degree_Celsius
+      var_name: txm
+    parameters:
+      freq:
+        default: YS
+      reducer: mean
+    references: null
+  txmax:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: statistics
+    input:
+      data: tasmax
+    output:
+      cell_methods: 'time: maximum within days time: maximum over days'
+      long_name: Maximum daily maximum temperature
+      standard_name: air_temperature
+      units: degree_Celsius
+      var_name: txmax
+    parameters:
+      freq:
+        default: YS
+      reducer: max
+    references: CLIPC
+  txmean:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: statistics
+    input:
+      data: tasmax
+    output:
+      cell_methods: 'time: maximum within days time: mean over days'
+      long_name: Mean daily maximum temperature
+      standard_name: air_temperature
+      units: degree_Celsius
+      var_name: txmean
+    parameters:
+      freq:
+        default: YS
+      reducer: mean
+    references: CLIPC
+  txmin:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: statistics
+    input:
+      data: tasmax
+    output:
+      cell_methods: 'time: maximum within days time: minimum over days'
+      long_name: Minimum daily maximum temperature
+      standard_name: air_temperature
+      units: degree_Celsius
+      var_name: txmin
+    parameters:
+      freq:
+        default: YS
+      reducer: min
+    references: CLIPC
+  txn:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: statistics
+    input:
+      data: tasmax
+    output:
+      cell_methods: 'time: maximum within days time: minimum over days'
+      long_name: Minimum daily maximum temperature
+      standard_name: air_temperature
+      units: degree_Celsius
+      var_name: txn
+    parameters:
+      freq:
+        default: YS
+      reducer: min
+    references: ETCCDI
+  txx:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: statistics
+    input:
+      data: tasmax
+    output:
+      cell_methods: 'time: maximum within days time: maximum over days'
+      long_name: Maximum daily maximum temperature
+      standard_name: air_temperature
+      units: degree_Celsius
+      var_name: txx
+    parameters:
+      freq:
+        default: YS
+      reducer: max
+    references: ETCCDI
+  vdtr:
+    allowed_periods:
+    - A
+    - Q
+    - M
+    compute: interday_diurnal_temperature_range
+    input:
+      high_data: tasmax
+      low_data: tasmin
+    output:
+      long_name: Mean day-to-day variation in Diurnal Temperature Range
+      units: degree_Celsius
+      var_name: vdtr
+    parameters:
+      freq:
+        default: MS
+    references: ECA&D
+realm: atmos
+references: clix-meta https://github.com/clix-meta/clix-meta

--- a/xclim/data/icclim.yml
+++ b/xclim/data/icclim.yml
@@ -61,131 +61,115 @@ indices:
     output:
       long_name: Huglin heliothermal index (Summation of ((Tmin + Tmax)/2 - {thresh_tasmin}) * Latitude-based day-length coefficient (`k`), for days between 1 April and 31 October)
       comment: Metric originally published in Huglin, 1978. Also presented by ECAD/KNMI for ICCLIM, 2013.
-    index_function:
-      name: huglin_index
-      parameters:
-        method: icclim
-        thresh_tasmin: 10 degC
-        start_date: 04-01
-        end_date: 11-01
+    compute: huglin_index
+    parameters:
+      method: icclim
+      thresh_tasmin: 10 degC
+      start_date: 04-01
+      end_date: 11-01
   BEDD:
     base: biologically_effective_degree_days
     output:
       long_name: Biologically effective growing degree days (Summation of min((max((Tmin + Tmax)/2 - {thresh_tasmin}, 0)), 9°C), for days between 1 April and 30 September)
       comment: Revised formula published by ECAD/KNMI for ICCLIM, 2013.
-    index_function:
-      name: biologically_effective_degree_days
-      parameters:
-        method: icclim
-        thresh_tasmin: 10 degC
-        max_daily_degree_days: 9 degC
-        start_date: 04-01
-        end_date: 10-01
-        low_dtr: null
-        high_dtr: null
-        lat: null
+    compute: biologically_effective_degree_days
+    parameters:
+      method: icclim
+      thresh_tasmin: 10 degC
+      max_daily_degree_days: 9 degC
+      start_date: 04-01
+      end_date: 10-01
+      low_dtr: null
+      high_dtr: null
+      lat: null
   CSDI:
     base: cold_spell_duration_index
     output:
       long_name: Cold-spell duration index
-    index_function:
-      parameters:
-        window: 6
+    parameters:
+      window: 6
   WSDI:
     base: warm_spell_duration_index
     output:
       long_name: Warm-spell duration index
-    index_function:
-      parameters:
-        window: 6
+    parameters:
+      window: 6
   SU:
     base: tx_days_above
     output:
       long_name: Summer days (TX>25°C)
-    index_function:
-      parameters:
-        thresh: 25 degC
+    parameters:
+      thresh: 25 degC
   CSU:
     base: maximum_consecutive_warm_days
     output:
       long_name: Maximum number of consecutive summer day
-    index_function:
-      parameters:
-        thresh: 25 degC
+    parameters:
+      thresh: 25 degC
 
   TR:
     base: tropical_nights
     output:
       long_name: Tropical nights (TN>20°C)
-    index_function:
-      parameters:
-        thresh: 20 degC
+    parameters:
+      thresh: 20 degC
   GD4:
     base: growing_degree_days
     output:
       long_name: Growing degree days (sum of TG>4°C)
-    index_function:
-      parameters:
-        thresh: 4 degC
+    parameters:
+      thresh: 4 degC
   FD:
     base: frost_days
     output:
       long_name: Frost days (TN<0°C)
-    index_function:
-      parameters:
-        thresh: 0 degC
+    parameters:
+      thresh: 0 degC
   CFD:
     base: consecutive_frost_days
     output:
       long_name: Maximum number of consecutive frost days (TN<0°C)
-    index_function:
-      parameters:
-        thresh: 0 degC
+    parameters:
+      thresh: 0 degC
   GSL:
     base: growing_season_length
     output:
       long_name: Growing season length
-    index_function:
-      parameters:
-        thresh: 5 degC
-        window: 6
+    parameters:
+      thresh: 5 degC
+      window: 6
   ID:
     base: ice_days
     output:
       long_name: Ice days (TX<0°C)
-    index_function:
-      parameters:
-        thresh: 0 degC
+    parameters:
+      thresh: 0 degC
   HD17:
     base: heating_degree_days
     output:
       long_name: Heating degree days (sum of17°C - TG)
-    index_function:
-      parameters:
-        thresh: 17 degC
+    parameters:
+      thresh: 17 degC
   CDD:
     base: cdd
     output:
       long_name: Maximum number of consecutive dry days (RR<1 mm)
-    index_function:
-      parameters:
-        thresh: 1 mm/day
+    parameters:
+      thresh: 1 mm/day
   CWD:
     base: cwd
     output:
       long_name: Maximum number of consecutive wet days (RR≥1 mm)
-    index_function:
-      parameters:
-        thresh: 1 mm/day
+    parameters:
+      thresh: 1 mm/day
   RR:
     base: prcptot
     output:
       long_name: Precipitation sum
   SDII:
     base: sdii
-    index_function:
-      parameters:
-        thresh: 1 mm/day
+    parameters:
+      thresh: 1 mm/day
   ETR:
     base: etr
     output:
@@ -202,23 +186,20 @@ indices:
     base: wetdays
     output:
       long_name: Wet days (RR≥1 mm)
-    index_function:
-      parameters:
-        thresh: 1 mm/day
+    parameters:
+      thresh: 1 mm/day
   R10mm:
     base: wetdays
     ouput:
       long_name: Heavy precipitation days (precipitation≥10 mm)
-    index_function:
-      parameters:
-        thresh: 10 mm/day
+    parameters:
+      thresh: 10 mm/day
   R20mm:
     base: wetdays
     output:
       long_name: Very heavy precipitation days (precipitation≥20 mm)
-    index_function:
-      parameters:
-        thresh: 20 mm/day
+    parameters:
+      thresh: 20 mm/day
   RX1day:
     base: rx1day
     output:
@@ -227,65 +208,52 @@ indices:
     base: max_n_day_precipitation_amount
     output:
       long_name: Highest 5-day precipitation amount
-    index_function:
-      parameters:
-        window: 5
+    parameters:
+      window: 5
   R75p:
     base: days_over_precip_thresh
-    index_function:
-      parameters:
-        thresh: 1 mm/day
-        per:
-          data: {per}
-          description: Daily 75th percentile of wet day precipitation flux.
+    parameters:
+      thresh: 1 mm/day
+      per:
+        description: Daily 75th percentile of wet day precipitation flux.
 
   R95p:
     base: days_over_precip_thresh
-    index_function:
-      parameters:
-        thresh: 1 mm/day
-        per:
-          data: {per}
-          description: Daily 95th percentile of wet day precipitation flux.
+    parameters:
+      thresh: 1 mm/day
+      per:
+        description: Daily 95th percentile of wet day precipitation flux.
   R99p:
     base: days_over_precip_thresh
-    index_function:
-      parameters:
-        thresh: 1 mm/day
-        per:
-          data: {per}
-          description: Daily 99th percentile of wet day precipitation flux.
+    parameters:
+      thresh: 1 mm/day
+      per:
+        description: Daily 99th percentile of wet day precipitation flux.
   R75pTOT:
     base: fraction_over_precip_thresh
     output:
       long_name: Precipitation fraction due to moderate wet days (>75th percentile)
-    index_function:
-      parameters:
-        thresh: 1 mm/day
-        per:
-          data: {per}
-          description: Daily 75th percentile of wet day precipitation flux.
+    parameters:
+      thresh: 1 mm/day
+      per:
+        description: Daily 75th percentile of wet day precipitation flux.
 
   R95pTOT:
     base: fraction_over_precip_thresh
     output:
       long_name: Precipitation fraction due to very wet days (>95th percentile)
-    index_function:
-      parameters:
-        thresh: 1 mm/day
-        per:
-          data: {per}
-          description: Daily 95th percentile of wet day precipitation flux.
+    parameters:
+      thresh: 1 mm/day
+      per:
+        description: Daily 95th percentile of wet day precipitation flux.
   R99pTOT:
     base: fraction_over_precip_thresh
     output:
       long_name: Precipitation fraction due to extremely wet days (>99th percentile)
-    index_function:
-      parameters:
-        thresh: 1 mm/day
-        per:
-          data: {per}
-          description: Daily 99th percentile of wet day precipitation flux.
+    parameters:
+      thresh: 1 mm/day
+      per:
+        description: Daily 99th percentile of wet day precipitation flux.
   SD:
     realm: land
     base: snow_depth
@@ -296,70 +264,55 @@ indices:
     base: snow_cover_duration
     output:
       long_name: Snow days (SD≥1 cm)
-    index_function:
-      parameters:
-        thresh: 1 cm
+    parameters:
+      thresh: 1 cm
   SD5cm:
     realm: land
     base: snow_cover_duration
     output:
       long_name: Snow days (SD≥5 cm)
-    index_function:
-      parameters:
-        thresh: 5 cm
+    parameters:
+      thresh: 5 cm
   SD50cm:
     realm: land
     base: snow_cover_duration
     output:
       long_name: Snow days (SD≥50 cm)
-    index_function:
-      parameters:
-        thresh: 50 cm
+    parameters:
+      thresh: 50 cm
   CD:
     base: cold_and_dry_days
     output:
       long_name: Cold and dry days
-    index_function:
-      parameters:
-        tas_25:
-          data: {tas_25}
-          description: Daily 25th percentile of temperature.
-        pr_25:
-          data: {pr_25}
-          description: Daily 25th percentile of wet day precipitation flux.
+    parameters:
+      tas_25:
+        description: Daily 25th percentile of temperature.
+      pr_25:
+        description: Daily 25th percentile of wet day precipitation flux.
   WD:
     base: warm_and_dry_days
     output:
       long_name: Warm and dry days
-    index_function:
-      parameters:
-        tas_75:
-          data: {tas_75}
-          description: Daily 75th percentile of temperature.
-        pr_25:
-          data: {pr_25}
-          description: Daily 25th percentile of wet day precipitation flux.
+    parameters:
+      tas_75:
+        description: Daily 75th percentile of temperature.
+      pr_25:
+        description: Daily 25th percentile of wet day precipitation flux.
   WW:
     base: warm_and_wet_days
     output:
       long_name: Warm and wet days
-    index_function:
-      parameters:
-        tas_75:
-          data: {tas_75}
-          description: Daily 75th percentile of temperature.
-        pr_75:
-          data: {pr_75}
-          description: Daily 75th percentile of wet day precipitation flux.
+    parameters:
+      tas_75:
+        description: Daily 75th percentile of temperature.
+      pr_75:
+        description: Daily 75th percentile of wet day precipitation flux.
   CW:
     base: cold_and_wet_days
     output:
       long_name: cold and wet days
-    index_function:
-      parameters:
-        tas_25:
-          data: {tas_25}
-          description: Daily 25th percentile of temperature.
-        pr_75:
-          data: {pr_75}
-          description: Daily 75th percentile of wet day precipitation flux.
+    parameters:
+      tas_25:
+        description: Daily 25th percentile of temperature.
+      pr_75:
+        description: Daily 75th percentile of wet day precipitation flux.

--- a/xclim/data/icclim.yml
+++ b/xclim/data/icclim.yml
@@ -170,9 +170,8 @@ indices:
     base: wet_prcptot
     output:
       long_name: Precipitation sum over wet days
-    index_function:
-      parameters:
-        thresh: 1 mm/day
+    parameters:
+      thresh: 1 mm/day
   SDII:
     base: sdii
     parameters:

--- a/xclim/data/icclim.yml
+++ b/xclim/data/icclim.yml
@@ -34,7 +34,7 @@ indices:
     base: tg_min
   TX90p:
     base: tx90p
-    ouput:
+    output:
       long_name: Days with TX>90th percentile of daily maximum temperature (warm day-times)
   TX10p:
     base: tx10p
@@ -190,7 +190,7 @@ indices:
       thresh: 1 mm/day
   R10mm:
     base: wetdays
-    ouput:
+    output:
       long_name: Heavy precipitation days (precipitation≥10 mm)
     parameters:
       thresh: 10 mm/day

--- a/xclim/testing/tests/test_indicators.py
+++ b/xclim/testing/tests/test_indicators.py
@@ -489,3 +489,7 @@ def test_indicator_from_dict():
     # Default value for input variable injected and meta injected
     assert ind._sig.parameters["data"].default == "tas"
     assert ind.parameters["data"]["units"] == "K"
+
+    # Wrap a multi-output ind
+    d = dict(base="wind_speed_from_vector")
+    ind = Indicator.from_dict(d, identifier="wsfv", module="test")

--- a/xclim/testing/tests/test_indicators.py
+++ b/xclim/testing/tests/test_indicators.py
@@ -464,19 +464,17 @@ def test_indicator_from_dict():
     d = dict(
         realm="atmos",
         output=dict(
-            var_name="tmean{thresh}",
+            var_name="tmean{threshold}",
             units="K",
             long_name="{freq} mean surface temperature",
             standard_name="{freq} mean temperature",
             cell_methods=[{"time": "mean within days"}],
         ),
-        index_function=dict(
-            name="thresholded_statistics",
-            parameters=dict(
-                threshold={"data": {"thresh": None}, "description": "A threshold temp"},
-                condition={"data": "`<"},
-                reducer={"data": "mean"},
-            ),
+        compute="thresholded_statistics",
+        parameters=dict(
+            threshold={"description": "A threshold temp"},
+            condition="<",
+            reducer="mean",
         ),
         input={"data": "tas"},
     )
@@ -488,8 +486,6 @@ def test_indicator_from_dict():
     assert ind.parameters["threshold"]["description"] == "A threshold temp"
     # Injection of paramters
     assert "condition" in ind.compute._injected
-    # Placeholders were translated to name in signature
-    assert ind.cf_attrs[0]["var_name"] == "tmean{threshold}"
     # Default value for input variable injected and meta injected
     assert ind._sig.parameters["data"].default == "tas"
     assert ind.parameters["data"]["units"] == "K"

--- a/xclim/testing/tests/test_locales.py
+++ b/xclim/testing/tests/test_locales.py
@@ -155,7 +155,7 @@ def test_xclim_translations(locale, official_indicators):
 
 
 @pytest.mark.parametrize(
-    "initeng,expected", [(False, ""), (True, atmos.tg_mean.long_name)]
+    "initeng,expected", [(False, ""), (True, atmos.tg_mean.output[0]["long_name"])]
 )
 def test_local_dict_generation(initeng, expected):
     dic = generate_local_dict("tlh", init_english=initeng)

--- a/xclim/testing/tests/test_modules.py
+++ b/xclim/testing/tests/test_modules.py
@@ -79,7 +79,9 @@ def test_custom_indices():
     )
 
     # From mapping
-    exinds = {"extreme_precip_accumulation": example.extreme_precip_accumulation}
+    exinds = {
+        "extreme_precip_accumulation_and_days": example.extreme_precip_accumulation_and_days
+    }
     ex2 = build_indicator_module_from_yaml(
         nbpath / "example.yml", name="ex2", indices=exinds
     )
@@ -89,7 +91,7 @@ def test_custom_indices():
     out1 = ex1.R95p(pr=pr)  # noqa
     out2 = ex2.R95p(pr=pr)  # noqa
 
-    xr.testing.assert_equal(out1, out2)
+    xr.testing.assert_equal(out1[0], out2[0])
 
     # Check that missing was not modified even with injecting `freq`.
     assert ex1.RX5day.missing == indicators.atmos.max_n_day_precipitation_amount.missing


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #828 
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (major / minor / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)
- [ ] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

* Refactor of the yaml/dict parsing to simplify it for both users and developers. Instead of a mix between following clix-meta's syntax and opening up for xclim-specific/-simplified things, the YAML/dict specification is now stricter.
* `xclim.core.utils.adapt_clix_meta_yaml` translated the clix-meta yml files to xclim-compliant ones. A similar function is here : https://gist.github.com/aulemahal/80f5ab7f614e479a4e0c5a7eacfecd8f for yml files made with previous versions of xclim.

My goal was to make the yaml layout similar to that of the `Indicator` object itself. As the main aspect was to remove all the multiple ways to specify things and keep a single one, I can't show a perfect example, I invite reviewers to look at the changes to the yml files in `xclim/data` instead.

I tried to follow this plan to go from yaml to indicator module:

- `build_indicator_module_from_yaml` reads in the files (yml, py, json), cycles through the dicts in the `indices` section of the yaml. It sets the default according to module-wide attributes and parses the `base` and `compute` keys if they refer to something "local" (a base class from the same module, a compute function from the passed `py` file).
- `Indicator.from_dict` parses the compute function, the injected parameters, the modified parameters. Grosso modo, it performs the actions we would do within the call to the indicator's `__init__` in `xclim/indicators/*/*.py`.
- `Indicator.__new__` does the rest, as before.

This PR removes a lot of parsing from `from_dict` since the yaml now imitates `Indicator`.

Also, this add the possibility to check one's yaml with `yamale`. A schema is included in xclim (data/schema.yml) and `yamale` is added as a dev dep for testing.

### Does this PR introduce a breaking change?
Yes. All previously written yaml virtual module will break. I linked a function from my gist above to help convert them (the function is not complete, it might fail).

Also, I renamed `Indicator.cf_attrs` to `Indicator.output`. This is not the best name, I know, but it acknowledges that one can now pass non-cf attrs if they wish. I also removed the option to access attributes directly on the indicator. I.e.: `ind.standard_name` will now fail in most cases. It was a semi-working option before, with undocumented behaviour. One should use `ind.output[0]['standard_name']` instead. I expect discussion about this part.

### Other information:
