### PR TITLE
Override default machine dependent encoding for virtual modules

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -44,6 +44,7 @@ Bug fixes
 * Fix bug in ``missing_wmo``, where a period would be considered valid if all months met WMO criteria, but complete months in a year were missing. Now if any month does not meet criteria or is absent, the period will be considered missing.
 * Fix bootstrapping with dask arrays. Dask does not support using ``loc`` with multiple indexes to set new values so a workaround was necessary.
 * Fix bootstrapping when the bootstrapped year must be converted to a 366_day calendar.
+* Virtual modules and translations now use 'UTF-8' by default when reading yaml or json file, instead of a machine-dependent encoding.
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/xclim/core/indicator.py
+++ b/xclim/core/indicator.py
@@ -1292,6 +1292,7 @@ def build_indicator_module_from_yaml(
     keywords: Optional[str] = None,
     references: Optional[str] = None,
     notes: Optional[str] = None,
+    encoding: str = "UTF8",
 ) -> ModuleType:
     """Build or extend an indicator module from a YAML file.
 
@@ -1327,6 +1328,9 @@ def build_indicator_module_from_yaml(
       Other indicator attributes that would apply to all indicators in this module.
       Values given here are overridden by the ones given in individual definition, but
       they override the ones given at top-level in the YAMl file.
+    encoding: str
+      The encoding used to open the `.yaml` and `.json` files.
+      It defaults to UTF-8, overriding python's mechanism which is machine dependent.
 
     Returns
     -------
@@ -1359,7 +1363,7 @@ def build_indicator_module_from_yaml(
         ymlpath = filepath
 
     # Read YAML file
-    with ymlpath.open() as f:
+    with ymlpath.open(encoding=encoding) as f:
         yml = safe_load(f)
 
     # Load values from top-level in yml.
@@ -1380,7 +1384,9 @@ def build_indicator_module_from_yaml(
             translations = {}
             for locfile in filepath.parent.glob(filepath.stem + ".*.json"):
                 locale = locfile.suffixes[0][1:]
-                translations[locale] = read_locale_file(locfile, module=module_name)
+                translations[locale] = read_locale_file(
+                    locfile, module=module_name, encoding=encoding
+                )
 
     # Module-wide default values for some attributes
     defkwargs = {

--- a/xclim/core/locales.py
+++ b/xclim/core/locales.py
@@ -231,12 +231,21 @@ class UnavailableLocaleError(ValueError):
         )
 
 
-def read_locale_file(filename, module=None):
+def read_locale_file(filename, module=None, encoding="UTF8"):
     """Read a locale file (*.json) and return its dictionary.
 
-    If module is a string, this module name is added to all identifiers translated in this file.
+    Parameters
+    ----------
+    filename: PathLike
+      The file to read.
+    module: string, optional
+      If module is a string, this module name is added to all identifiers translated in this file.
+      Defaults to None, and no module name is added (as if the indicator was an official xclim indicator).
+    encoding : string
+      The encoding to use when reading the file.
+      Defaults to UTF-8, overriding python's default mechanism which is machine dependent.
     """
-    with open(filename, "r", encoding="utf-8") as f:
+    with open(filename, "r", encoding=encoding) as f:
         locdict = json.load(f)
 
     if module is not None:

--- a/xclim/testing/tests/test_modules.py
+++ b/xclim/testing/tests/test_modules.py
@@ -85,3 +85,24 @@ def test_custom_indices():
 
     # Check that missing was not modified even with injecting `freq`.
     assert ex1.RX5day.missing == indicators.atmos.max_n_day_precipitation_amount.missing
+
+
+# It's not really slow, but this is an unstable test (when it fails) and we might not want to execute it on all builds
+@pytest.mark.slow
+def test_encoding():
+    import sys
+
+    import _locale
+
+    # remove xclim
+    del sys.modules["xclim"]
+
+    # patch so that the default encoding is not UTF-8
+    old = _locale.nl_langinfo
+    _locale.nl_langinfo = lambda x: "GBK"
+
+    try:
+        import xclim  # noqa
+    finally:
+        # Put the correct function back
+        _locale.nl_langinfo = old


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #851
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (major / minor / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)
- [ ] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

* Add an `encoding` argument to `build_indicator_module_from_yaml` and `locale.read_locale_file` which defaults to UTF-8. This way, machines with non-UTF-8 default encoding will be able to import xclim.

### Does this PR introduce a breaking change?
No.

### Other information:
Sorry for the branch name, it was meant to be "fix-851".