### PR TITLE
[sdba] Work around map_blocks bug with 1D input and auxiliary coordinates

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,13 @@
 History
 =======
 
+0.30.1 (unreleased)
+-------------------
+
+Bug fixes
+~~~~~~~~~
+* Fix a bug in sdba's ``map_groups`` where 1D input including an auxialiary coordinate would fail with an obscure error on a reducing operation.
+
 0.30.0 (2021-09-28)
 -------------------
 

--- a/xclim/sdba/base.py
+++ b/xclim/sdba/base.py
@@ -639,7 +639,8 @@ def map_blocks(reduces=None, **outvars):
                 nam: crd for nam, crd in ds.coords.items() if nam not in crd.dims
             }
             ds = ds.drop_vars(extra_coords.keys())
-            tmpl = tmpl.drop_vars(extra_coords.keys())
+            # Coords not sharing dims with `all_dims` (like scalar aux coord on reduced 1D input) are absent from tmpl
+            tmpl = tmpl.drop_vars(extra_coords.keys(), errors="ignore")
 
             # Call
             out = ds.map_blocks(

--- a/xclim/testing/tests/test_sdba/test_base.py
+++ b/xclim/testing/tests/test_sdba/test_base.py
@@ -174,7 +174,7 @@ def test_map_blocks(tas_series):
 
     data = func(
         xr.Dataset(dict(tas=tas)), group="time.dayofyear", window=5, lon=[1, 2, 3, 4]
-    )
+    ).load()
     assert set(data.data.dims) == {"time", "lon"}
 
     @map_groups(data=[Grouper.PROP])
@@ -185,7 +185,7 @@ def test_map_blocks(tas_series):
 
     data = func(
         xr.Dataset(dict(tas=tas)), group="time.dayofyear", window=5, add_dims=["lat"]
-    )
+    ).load()
     assert set(data.data.dims) == {"dayofyear"}
 
     @map_groups(data=[Grouper.PROP], main_only=True)
@@ -194,5 +194,10 @@ def test_map_blocks(tas_series):
         data = ds.tas.mean(dim)
         return data.rename("data").to_dataset()
 
-    data = func(xr.Dataset(dict(tas=tas)), group="time.dayofyear")
-    assert set(data.data.dims) == {"dayofyear", "lat"}
+    # with a scalar aux coord
+    data = func(
+        xr.Dataset(dict(tas=tas.isel(lat=0, drop=True)), coords=dict(leftover=1)),
+        group="time.dayofyear",
+    ).load()
+    assert set(data.data.dims) == {"dayofyear"}
+    assert "leftover" in data


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #854
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [ ] `bumpversion (major / minor / patch)` has been called on this branch
- [ ] Tags have been pushed (`git push --tags`)
- [ ] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

* Work around the  case where `map_blocks` receives a 1D input that gets reduced by the grouping operation AND where that input has an auxiliary coordinate (1D or scalar).

### Does this PR introduce a breaking change?
No.

### Other information:
Should we publish a bug fix release? I understand that `climpred` relies on us.

I do not like what the mess `map_blocks` has become... But it still has a far better performance than without!