### PR TITLE
Docs pr contributions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,13 +6,13 @@
 - [ ] Tests for the changes have been added (for bug fixes / features)
 - [ ] Documentation has been added / updated (for bug fixes / features)
 - [ ] HISTORY.rst has been updated (with summary of main changes)
-- [ ] `bumpversion (major / minor / patch)` has been called on this branch
-- [ ] Tags have been pushed (`git push --tags`)
+  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.
+- [ ] `bumpversion patch` has been called on this branch
 - [ ] The relevant author information has been added to `.zenodo.json`
 
 ### What kind of change does this PR introduce?
 
-* ,,,
+* ...
 
 ### Does this PR introduce a breaking change?
 

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -26,3 +26,4 @@ Contributors
 * Jeremy Fyke `@jeremyfyke <https://github.com/jeremyfyke>`_
 * Clair Barnes <clair.barnes.16@ucl.ac.uk> `@clairbarnes <https://github.com/clairbarnes>`_
 * Raquel Alegre <raquel.alegre@gmail.com> `@raquel-ucl <https://github.com/raquel-ucl>`_
+* Abel Aoun <aoun.abel@gmail.com> `@bzah <https://github.com/bzah>`_

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,7 +8,7 @@ History
 
 Bug fixes
 ~~~~~~~~~
-* Fix a bug in bootstrapping where computation would fail when the dataset time coordinate is encoded using `cftime.datetime`.
+* Fix a bug in bootstrapping where computation would fail when the dataset time coordinate is encoded using `cftime.datetime`. (:pull:`859`). By `Abel Aoun <https://github.com/bzah>`_.
 
 0.30.1 (2021-10-01)
 -------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -91,6 +91,7 @@ extensions = [
     "sphinx.ext.todo",
     "sphinx.ext.autosectionlabel",
     "sphinx.ext.intersphinx",
+    "sphinx.ext.extlinks",
     "rstjinja",
     "nbsphinx",
     "IPython.sphinxext.ipython_console_highlighting",
@@ -105,6 +106,10 @@ napoleon_use_ivar = True
 intersphinx_mapping = {
     "clisops": ("https://clisops.readthedocs.io/en/latest/", None),
     "scipy": ("https://docs.scipy.org/doc/scipy/reference/", None),
+}
+extlinks = {
+    "issue": ("https://github.com/Ouranosinc/xclim/issues/%s", "GH/"),
+    "pull": ("https://github.com/Ouranosinc/xclim/pull/%s", "PR/"),
 }
 
 nbsphinx_execute = "auto"
@@ -184,7 +189,7 @@ html_context = {"indicators": indicators}
 # theme further.  For a list of options available for each theme, see the
 # documentation.
 #
-html_theme_options = {"logo_only": True}
+html_theme_options = {"logo_only": True, "style_external_links": True}
 
 html_sidebars = {
     "**": ["logo-text.html", "globaltoc.html", "localtoc.html", "searchbox.html"]

--- a/xclim/testing/tests/test_sdba/diagnostics.py
+++ b/xclim/testing/tests/test_sdba/diagnostics.py
@@ -29,14 +29,13 @@ def synth_rainfall(shape, scale=1, wet_freq=0.25, size=1):
 
     Notes
     -----
-    The probability density for the Gamma distribution is
+    The probability density for the Gamma distribution is:
 
-    .. math:: p(x) = x^{k-1}\frac{e^{-x/\theta}}{\theta^k\\Gamma(k)},
+    .. math::
 
-    where :math:`k` is the shape and :math:`\theta` the scale,
-    and :math:`\\Gamma` is the Gamma function.
+        p(x) = x^{k-1}\frac{e^{-x/\theta}}{\theta^k\\Gamma(k)},
 
-
+    where :math:`k` is the shape and :math:`\theta` the scale, and :math:`\\Gamma` is the Gamma function.
     """
     is_wet = np.random.binomial(1, p=wet_freq, size=size)
     wet_intensity = np.random.gamma(shape, scale, size)


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR addresses a problem raised in #854 
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [x] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

Taking a page from the xarray book of doing things elegantly, using `sphinx.ext.extinks`, we now ask that contributors mark the number and author of the Pull request in `HISTORY.rst`. Pull requests can be identified in a docs-related `rst` file or a Python docstring using:

- :pull:`number`

While GitHub issues can be referenced using:

- :issue:`number`

I have also enabled an HTML styling option to indicate when links point to an external source. 

### Does this PR introduce a breaking change?

No. 

### Other information:

#854
