### PR TITLE
Add interpolation args on bootstrap

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,10 +12,11 @@ New features and enhancements
 * New ``align_on='random`` option for ``xclim.core.calendar.convert_calendar``, for conversions involving '360_day' calendars. (:pull:`875`, :issue:`841`).
 * ``dry_spell_frequency`` now has a parameter `op: {"sum", "max"}` to choose if the threshold is compared against the accumulated or maximal precipitation, over the given window. (:pull:`879`).
 * ``maximum_consecutive_frost_free_days`` is now checking that the minimum temperature is above or equal to the threshold ( instead of only above). (:pull:`883`, :issue:`881`).
-* The ANUCLIM virtual module as been updated to accept weekly and monthly inputs and with improved metadata. (:pull:`885`, :issue:`538`)
+* The ANUCLIM virtual module has been updated to accept weekly and monthly inputs and with improved metadata. (:pull:`885`, :issue:`538`)
 * The ``sdba.loess`` algorithm has been optimized to run faster in all cases, with an even faster special case (``equal_spacing=True``) when the x coordinate is equally spaced. When activated, this special case might return results different from without, up to around 0.1%. (:pull:`865`)
-* Add support for group's window and additionnal dimensions in ``LoessDetrend``. Add new ``RollingMeanDetrend`` object. (:pull:`865`)
+* Add support for group's window and additional dimensions in ``LoessDetrend``. Add new ``RollingMeanDetrend`` object. (:pull:`865`)
 * Missing value algorithms now try to infer the source timestep of the input data when it is not given. (:pull:`885`)
+* On indices, `bootstrap` parameter documentation has been updated to explain when and why it should be used. (:pull:`893`, :issue:`846`)
 
 Breaking changes
 ~~~~~~~~~~~~~~~~
@@ -46,6 +47,7 @@ Bug fixes
 ~~~~~~~~~
 * Fix a bug in bootstrapping where computation would fail when the dataset time coordinate is encoded using `cftime.datetime`. (:pull:`859`).
 * Fix a bug in ``build_indicator_module_from_yaml`` where bases classes (Daily, Hourly, etc) were not usable with the `base` field. (:pull:`885`)
+* ``percentile_doy`` alpha and beta parameters are now properly transmitted to bootstrap calls of this function. (:pull:`893`, :issue:`846`)
 
 0.30.1 (2021-10-01)
 -------------------

--- a/xclim/core/bootstrapping.py
+++ b/xclim/core/bootstrapping.py
@@ -115,6 +115,8 @@ def bootstrap_func(compute_indice_func: Callable, **kwargs) -> xarray.DataArray:
     percentile = per.percentiles.data.tolist()  # Can be a list or scalar
     pdoy_args = dict(
         window=per.attrs["window"],
+        alpha=per.attrs["alpha"],
+        beta=per.attrs["beta"],
         per=percentile if np.isscalar(percentile) else percentile[0],
     )
 

--- a/xclim/core/calendar.py
+++ b/xclim/core/calendar.py
@@ -583,6 +583,8 @@ def percentile_doy(
         arr.time[0 :: n - 1].dt.strftime("%Y-%m-%d").values.tolist()
     )
     p.attrs["window"] = window
+    p.attrs["alpha"] = alpha
+    p.attrs["beta"] = beta
     return p.rename("per")
 
 

--- a/xclim/indices/_multivariate.py
+++ b/xclim/indices/_multivariate.py
@@ -88,7 +88,12 @@ def cold_spell_duration_index(
     freq : str
       Resampling frequency.
     bootstrap : bool
-      Flag to run bootstrapping. Used by percentile_bootstrap decorator.
+      Flag to run bootstrapping of percentiles. Used by percentile_bootstrap decorator.
+      Bootstrapping is only useful when the percentiles are computed on a part of the studied sample.
+      This perdiod, common to percentiles and the sample must be bootstrapped to avoid inhomogeneities with
+      the rest of the timeserie.
+      Keep bootstrap to False when there is no common period, it would give wrong results
+      plus, bootstrapping is always expensive.
 
     Returns
     -------
@@ -1097,7 +1102,12 @@ def days_over_precip_thresh(
     freq : str
       Resampling frequency.
     bootstrap : bool
-      Flag to run bootstrapping. Used by percentile_bootstrap decorator.
+      Flag to run bootstrapping of percentiles. Used by percentile_bootstrap decorator.
+      Bootstrapping is only useful when the percentiles are computed on a part of the studied sample.
+      This perdiod commun to percentiles and the sample must be bootstrapped to avoid inhomogeneities with
+      the rest of the timeserie.
+      Keep bootstrap to False when there is no common period, it would give wrong results
+      plus, bootstrapping is always expensive.
 
     Returns
     -------
@@ -1149,7 +1159,12 @@ def fraction_over_precip_thresh(
     freq : str
       Resampling frequency.
     bootstrap : bool
-      Flag to run bootstrapping. Used by percentile_bootstrap decorator.
+      Flag to run bootstrapping of percentiles. Used by percentile_bootstrap decorator.
+      Bootstrapping is only useful when the percentiles are computed on a part of the studied sample.
+      This perdiod commun to percentiles and the sample must be bootstrapped to avoid inhomogeneities with
+      the rest of the timeserie.
+      Keep bootstrap to False when there is no common period, it would give wrong results
+      plus, bootstrapping is always expensive.
 
     Returns
     -------
@@ -1197,7 +1212,12 @@ def tg90p(
     freq : str
       Resampling frequency.
     bootstrap : bool
-      Flag to run bootstrapping. Used by percentile_bootstrap decorator.
+      Flag to run bootstrapping of percentiles. Used by percentile_bootstrap decorator.
+      Bootstrapping is only useful when the percentiles are computed on a part of the studied sample.
+      This perdiod commun to percentiles and the sample must be bootstrapped to avoid inhomogeneities with
+      the rest of the timeserie.
+      Keep bootstrap to False when there is no common period, it would give wrong results
+      plus, bootstrapping is always expensive.
 
     Returns
     -------
@@ -1247,7 +1267,12 @@ def tg10p(
     freq : str
       Resampling frequency.
     bootstrap : bool
-      Flag to run bootstrapping. Used by percentile_bootstrap decorator.
+      Flag to run bootstrapping of percentiles. Used by percentile_bootstrap decorator.
+      Bootstrapping is only useful when the percentiles are computed on a part of the studied sample.
+      This perdiod commun to percentiles and the sample must be bootstrapped to avoid inhomogeneities with
+      the rest of the timeserie.
+      Keep bootstrap to False when there is no common period, it would give wrong results
+      plus, bootstrapping is always expensive.
 
     Returns
     -------
@@ -1297,7 +1322,12 @@ def tn90p(
     freq : str
       Resampling frequency.
     bootstrap : bool
-      Flag to run bootstrapping. Used by percentile_bootstrap decorator.
+      Flag to run bootstrapping of percentiles. Used by percentile_bootstrap decorator.
+      Bootstrapping is only useful when the percentiles are computed on a part of the studied sample.
+      This perdiod commun to percentiles and the sample must be bootstrapped to avoid inhomogeneities with
+      the rest of the timeserie.
+      Keep bootstrap to False when there is no common period, it would give wrong results
+      plus, bootstrapping is always expensive.
 
     Returns
     -------
@@ -1347,7 +1377,12 @@ def tn10p(
     freq : str
       Resampling frequency.
     bootstrap : bool
-      Flag to run bootstrapping. Used by percentile_bootstrap decorator.
+      Flag to run bootstrapping of percentiles. Used by percentile_bootstrap decorator.
+      Bootstrapping is only useful when the percentiles are computed on a part of the studied sample.
+      This perdiod commun to percentiles and the sample must be bootstrapped to avoid inhomogeneities with
+      the rest of the timeserie.
+      Keep bootstrap to False when there is no common period, it would give wrong results
+      plus, bootstrapping is always expensive.
 
     Returns
     -------
@@ -1397,7 +1432,12 @@ def tx90p(
     freq : str
       Resampling frequency.
     bootstrap : bool
-      Flag to run bootstrapping. Used by percentile_bootstrap decorator.
+      Flag to run bootstrapping of percentiles. Used by percentile_bootstrap decorator.
+      Bootstrapping is only useful when the percentiles are computed on a part of the studied sample.
+      This perdiod commun to percentiles and the sample must be bootstrapped to avoid inhomogeneities with
+      the rest of the timeserie.
+      Keep bootstrap to False when there is no common period, it would give wrong results
+      plus, bootstrapping is always expensive.
 
     Returns
     -------
@@ -1447,7 +1487,12 @@ def tx10p(
     freq : str
       Resampling frequency.
     bootstrap : bool
-      Flag to run bootstrapping. Used by percentile_bootstrap decorator.
+      Flag to run bootstrapping of percentiles. Used by percentile_bootstrap decorator.
+      Bootstrapping is only useful when the percentiles are computed on a part of the studied sample.
+      This perdiod commun to percentiles and the sample must be bootstrapped to avoid inhomogeneities with
+      the rest of the timeserie.
+      Keep bootstrap to False when there is no common period, it would give wrong results
+      plus, bootstrapping is always expensive.
 
     Returns
     -------
@@ -1562,7 +1607,12 @@ def warm_spell_duration_index(
     freq : str
       Resampling frequency.
     bootstrap : bool
-      Flag to run bootstrapping. Used by percentile_bootstrap decorator.
+      Flag to run bootstrapping of percentiles. Used by percentile_bootstrap decorator.
+      Bootstrapping is only useful when the percentiles are computed on a part of the studied sample.
+      This perdiod commun to percentiles and the sample must be bootstrapped to avoid inhomogeneities with
+      the rest of the timeserie.
+      Keep bootstrap to False when there is no common period, it would give wrong results
+      plus, bootstrapping is always expensive.
 
     Returns
     -------

--- a/xclim/indices/_multivariate.py
+++ b/xclim/indices/_multivariate.py
@@ -90,10 +90,10 @@ def cold_spell_duration_index(
     bootstrap : bool
       Flag to run bootstrapping of percentiles. Used by percentile_bootstrap decorator.
       Bootstrapping is only useful when the percentiles are computed on a part of the studied sample.
-      This perdiod, common to percentiles and the sample must be bootstrapped to avoid inhomogeneities with
-      the rest of the timeserie.
+      This period, common to percentiles and the sample must be bootstrapped to avoid inhomogeneities with
+      the rest of the time series.
       Keep bootstrap to False when there is no common period, it would give wrong results
-      plus, bootstrapping is always expensive.
+      plus, bootstrapping is computationally expensive.
 
     Returns
     -------

--- a/xclim/indices/_multivariate.py
+++ b/xclim/indices/_multivariate.py
@@ -1104,10 +1104,10 @@ def days_over_precip_thresh(
     bootstrap : bool
       Flag to run bootstrapping of percentiles. Used by percentile_bootstrap decorator.
       Bootstrapping is only useful when the percentiles are computed on a part of the studied sample.
-      This perdiod commun to percentiles and the sample must be bootstrapped to avoid inhomogeneities with
-      the rest of the timeserie.
+      This period, common to percentiles and the sample must be bootstrapped to avoid inhomogeneities with
+      the rest of the time series.
       Keep bootstrap to False when there is no common period, it would give wrong results
-      plus, bootstrapping is always expensive.
+      plus, bootstrapping is computationally expensive.
 
     Returns
     -------
@@ -1161,10 +1161,10 @@ def fraction_over_precip_thresh(
     bootstrap : bool
       Flag to run bootstrapping of percentiles. Used by percentile_bootstrap decorator.
       Bootstrapping is only useful when the percentiles are computed on a part of the studied sample.
-      This perdiod commun to percentiles and the sample must be bootstrapped to avoid inhomogeneities with
-      the rest of the timeserie.
+      This period, common to percentiles and the sample must be bootstrapped to avoid inhomogeneities with
+      the rest of the time series.
       Keep bootstrap to False when there is no common period, it would give wrong results
-      plus, bootstrapping is always expensive.
+      plus, bootstrapping is computationally expensive.
 
     Returns
     -------
@@ -1214,10 +1214,10 @@ def tg90p(
     bootstrap : bool
       Flag to run bootstrapping of percentiles. Used by percentile_bootstrap decorator.
       Bootstrapping is only useful when the percentiles are computed on a part of the studied sample.
-      This perdiod commun to percentiles and the sample must be bootstrapped to avoid inhomogeneities with
-      the rest of the timeserie.
+      This period, common to percentiles and the sample must be bootstrapped to avoid inhomogeneities with
+      the rest of the time series.
       Keep bootstrap to False when there is no common period, it would give wrong results
-      plus, bootstrapping is always expensive.
+      plus, bootstrapping is computationally expensive.
 
     Returns
     -------
@@ -1269,10 +1269,10 @@ def tg10p(
     bootstrap : bool
       Flag to run bootstrapping of percentiles. Used by percentile_bootstrap decorator.
       Bootstrapping is only useful when the percentiles are computed on a part of the studied sample.
-      This perdiod commun to percentiles and the sample must be bootstrapped to avoid inhomogeneities with
-      the rest of the timeserie.
+      This period, common to percentiles and the sample must be bootstrapped to avoid inhomogeneities with
+      the rest of the time series.
       Keep bootstrap to False when there is no common period, it would give wrong results
-      plus, bootstrapping is always expensive.
+      plus, bootstrapping is computationally expensive.
 
     Returns
     -------
@@ -1324,10 +1324,10 @@ def tn90p(
     bootstrap : bool
       Flag to run bootstrapping of percentiles. Used by percentile_bootstrap decorator.
       Bootstrapping is only useful when the percentiles are computed on a part of the studied sample.
-      This perdiod commun to percentiles and the sample must be bootstrapped to avoid inhomogeneities with
-      the rest of the timeserie.
+      This period, common to percentiles and the sample must be bootstrapped to avoid inhomogeneities with
+      the rest of the time series.
       Keep bootstrap to False when there is no common period, it would give wrong results
-      plus, bootstrapping is always expensive.
+      plus, bootstrapping is computationally expensive.
 
     Returns
     -------
@@ -1379,10 +1379,10 @@ def tn10p(
     bootstrap : bool
       Flag to run bootstrapping of percentiles. Used by percentile_bootstrap decorator.
       Bootstrapping is only useful when the percentiles are computed on a part of the studied sample.
-      This perdiod commun to percentiles and the sample must be bootstrapped to avoid inhomogeneities with
-      the rest of the timeserie.
+      This period, common to percentiles and the sample must be bootstrapped to avoid inhomogeneities with
+      the rest of the time series.
       Keep bootstrap to False when there is no common period, it would give wrong results
-      plus, bootstrapping is always expensive.
+      plus, bootstrapping is computationally expensive.
 
     Returns
     -------
@@ -1434,10 +1434,10 @@ def tx90p(
     bootstrap : bool
       Flag to run bootstrapping of percentiles. Used by percentile_bootstrap decorator.
       Bootstrapping is only useful when the percentiles are computed on a part of the studied sample.
-      This perdiod commun to percentiles and the sample must be bootstrapped to avoid inhomogeneities with
-      the rest of the timeserie.
+      This period, common to percentiles and the sample must be bootstrapped to avoid inhomogeneities with
+      the rest of the time series.
       Keep bootstrap to False when there is no common period, it would give wrong results
-      plus, bootstrapping is always expensive.
+      plus, bootstrapping is computationally expensive.
 
     Returns
     -------
@@ -1489,10 +1489,10 @@ def tx10p(
     bootstrap : bool
       Flag to run bootstrapping of percentiles. Used by percentile_bootstrap decorator.
       Bootstrapping is only useful when the percentiles are computed on a part of the studied sample.
-      This perdiod commun to percentiles and the sample must be bootstrapped to avoid inhomogeneities with
-      the rest of the timeserie.
+      This period, common to percentiles and the sample must be bootstrapped to avoid inhomogeneities with
+      the rest of the time series.
       Keep bootstrap to False when there is no common period, it would give wrong results
-      plus, bootstrapping is always expensive.
+      plus, bootstrapping is computationally expensive.
 
     Returns
     -------
@@ -1609,10 +1609,10 @@ def warm_spell_duration_index(
     bootstrap : bool
       Flag to run bootstrapping of percentiles. Used by percentile_bootstrap decorator.
       Bootstrapping is only useful when the percentiles are computed on a part of the studied sample.
-      This perdiod commun to percentiles and the sample must be bootstrapped to avoid inhomogeneities with
-      the rest of the timeserie.
+      This period, common to percentiles and the sample must be bootstrapped to avoid inhomogeneities with
+      the rest of the time series.
       Keep bootstrap to False when there is no common period, it would give wrong results
-      plus, bootstrapping is always expensive.
+      plus, bootstrapping is computationally expensive.
 
     Returns
     -------


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #846
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.
- [ ] `bumpversion patch` has been called on this branch
- [x] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?
- Update doc of `bootstrap` parameter mainly to warn the user that there are cases where bootstrap should be left to False
- Added _alpha_ and _beta_ parameters on `climatology_bounds.attrs` to treat them the same way _window_ is handled in bootstrapping.

### Does this PR introduce a breaking change?
Non.

### Other information:
I'm not sure how to unit test this.