### PR TITLE
exclude setup.cfg in trailing whitespace autoformatter and update black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,13 +15,14 @@ repos:
     rev: v4.0.1
     hooks:
     -   id: trailing-whitespace
+        exclude: setup.cfg
     -   id: end-of-file-fixer
         exclude: ".ipynb"
     -   id: check-yaml
         args: ['--allow-multiple-documents']
     -   id: debug-statements
 -   repo: https://github.com/ambv/black
-    rev: 21.9b0
+    rev: 21.10b0
     hooks:
     -   id: black
         args: ["--target-version", "py37"]
@@ -38,7 +39,7 @@ repos:
 #    -   id: autopep8
 #        args: ['--global-config=setup.cfg','--in-place']
 -   repo: https://github.com/timothycrosley/isort
-    rev: 5.9.3
+    rev: 5.10.0
     hooks:
     -   id: isort
         args: ['--profile', 'black']

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -42,6 +42,7 @@ Internal changes
 * Added automated TestPyPI and PyPI-publishing workflows for GitHub CI. (:pull:`872`).
 * Changes on how indicators are constructed (:pull:`873`).
 * Added missing algorithms tests for conversion from hourly to daily (:pull:`888`).
+* Updated pre-commit hooks to use black v21.10.b0. (:pull:`896`).
 
 Bug fixes
 ~~~~~~~~~


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.
- [ ] `bumpversion patch` has been called on this branch
- [ ] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

* update black
* add a workaround so that running `$ bumpversion` doesn't require running pre-commit twice to deal with whitespace issues.

### Does this PR introduce a breaking change?

No.

### Other information:
