### PR TITLE
Fix lazy indexing and season

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -46,6 +46,7 @@ Bug fixes
 ~~~~~~~~~
 * Fix a bug in bootstrapping where computation would fail when the dataset time coordinate is encoded using `cftime.datetime`. (:pull:`859`).
 * Fix a bug in ``build_indicator_module_from_yaml`` where bases classes (Daily, Hourly, etc) were not usable with the `base` field. (:pull:`885`)
+* When called with a 1D da and ND index, ``xclim.indices.run_length.lazy_indexing`` now drops the auxiliary coordinate corresponding to da's index. This fixes a bug with ND data in ``xclim.indices.run_length.season``.
 
 0.30.1 (2021-10-01)
 -------------------

--- a/xclim/indices/run_length.py
+++ b/xclim/indices/run_length.py
@@ -471,8 +471,8 @@ def run_bounds(
         if isinstance(coord, str):
             crd = getattr(crd.dt, coord)
 
-        starts = lazy_indexing(crd, starts).drop(dim)
-        ends = lazy_indexing(crd, ends).drop(dim)
+        starts = lazy_indexing(crd, starts)
+        ends = lazy_indexing(crd, ends)
     return xr.concat((starts, ends), "bounds")
 
 
@@ -1107,7 +1107,7 @@ def lazy_indexing(
         if idx_ndim == 0:
             # 0-D case, drop useless coords and dummy dim
             out = out.drop_vars(da.dims[0]).squeeze()
-        return out
+        return out.drop_vars(dim or da.dims[0], errors="ignore")
 
     # Case where index.dims is a subset of da.dims.
     if dim is None:

--- a/xclim/testing/tests/test_run_length.py
+++ b/xclim/testing/tests/test_run_length.py
@@ -512,6 +512,20 @@ class TestRunsWithDates:
 
 
 @pytest.mark.parametrize("use_dask", [True, False])
+def test_lazy_indexing(use_dask):
+    idx = xr.DataArray([[0, 10], [33, 99]], dims=("x", "y"))
+    da = xr.DataArray(np.arange(100), dims=("time",))
+
+    if use_dask:
+        idx = idx.chunk({"x": 1})
+
+    out = rl.lazy_indexing(da, idx)
+    assert set(out.dims) == {"x", "y"}
+    np.testing.assert_array_equal(idx, out)
+    assert "time" not in out.coords
+
+
+@pytest.mark.parametrize("use_dask", [True, False])
 def test_lazy_indexing_special_cases(use_dask):
     a = xr.DataArray(np.random.rand(10, 10, 10), dims=("x", "y", "z"))
     b = xr.DataArray(np.random.rand(10, 10, 10), dims=("x", "y", "z"))

--- a/xclim/testing/tests/test_snow.py
+++ b/xclim/testing/tests/test_snow.py
@@ -26,13 +26,14 @@ class TestContinuousSnowCoverStartEnd:
         a = np.zeros(365)
         a[100:200] = 0.03
         snd = snd_series(a, start="2001-07-01")
+        snd = snd.expand_dims(lat=[0, 1, 2])
         out = land.continuous_snow_cover_start(snd)
         assert out.units == ""
-        np.testing.assert_array_equal(out, snd.time.dt.dayofyear[100])
+        np.testing.assert_array_equal(out.isel(lat=0), snd.time.dt.dayofyear[100])
 
         out = land.continuous_snow_cover_end(snd)
         assert out.units == ""
-        np.testing.assert_array_equal(out, snd.time.dt.dayofyear[200])
+        np.testing.assert_array_equal(out.isel(lat=0), snd.time.dt.dayofyear[200])
 
 
 class TestSndMaxDoy:


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes an issue communicated through slack.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.
- [ ] `bumpversion patch` has been called on this branch
- [ ] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

* `lazy_indexing` when called with a 1D data (`da`) and ND indexes (`idx`), like at the end of `run_length.season`, would add an auxiliary coordinate corresponding to the value of `da`'s coord at indexes `idx`. This made `run_length.season` fail. I dropped that auxiliary coord.

### Does this PR introduce a breaking change?
I don't think so. It's strange that went under our radar for so long! Maybe something changed in xarray recently? The tests were not covering this case anyway,


### Other information:
