### PR TITLE
Correct Huglin Index formula

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -39,7 +39,7 @@ Breaking changes
     - ``Indicator.parameters`` is now a property generated from ``Indicator._all_parameters``, as the latter includes the injected parameters. The keys of the former are instances of new ``xclim.core.indicator.Parameter``, and not dictionaries as before.
     - New ``Indicator.injected_parameters`` to see which compute function arguments will be injected at call time.
     - See the pull request (:pull:`873`) for all information.
-* The call signature for ``huglin_index`` has been modified to reflect the correct variables used in its formula (`tasmin` -> `tas`; `thresh_tasmin` -> `thresh`). (:issue:`902`).
+* The call signature for ``huglin_index`` has been modified to reflect the correct variables used in its formula (`tasmin` -> `tas`; `thresh_tasmin` -> `thresh`). (:pull:`903`, :issue:`902`).
 
 Internal changes
 ~~~~~~~~~~~~~~~~
@@ -61,7 +61,7 @@ Bug fixes
 * When called with a 1D da and ND index, ``xclim.indices.run_length.lazy_indexing`` now drops the auxiliary coordinate corresponding to da's index. This fixes a bug with ND data in ``xclim.indices.run_length.season``. (:pull:`900`)
 * Fix name of heating degree days in French (`"chauffe"` -> "`chauffage`"). (:pull:`895`).
 * Corrected several French indicator translation description strings (bad usages of `"."` in `description` and `long_name` fields). (:pull:`895`).
-* Fixed an error with the formula for ``huglin_index`` where `tasmin` was being used in the calculation instead of `tas`. (:issue:`902`).
+* Fixed an error with the formula for ``huglin_index`` where `tasmin` was being used in the calculation instead of `tas`. (:pull:`903`, :issue:`902`).
 
 0.30.1 (2021-10-01)
 -------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -34,12 +34,12 @@ Breaking changes
 * Removed ``xclim.generic.daily_downsampler``, as it served no purpose now that xarray's resampling works with cftime (:pull:`888`, :issue:`889`).
 * Refactor of ``xclim.core.calendar.parse_offset``, output types were changed to useful ones (:pull:`885`).
 * Major changes on how parameters are passed to indicators (:pull:`873`):
-
     - Their signature is now consistent : input variables (DataArrays, optional or not) are positional or keyword arguments and all other parameters are keyword only. (:issue:`855`, :issue:`857`)
     - Some indicators have modified signatures because we now rename variables when wrapping generic indices. This is the case for the whole cf module, for example.
     - ``Indicator.parameters`` is now a property generated from ``Indicator._all_parameters``, as the latter includes the injected parameters. The keys of the former are instances of new ``xclim.core.indicator.Parameter``, and not dictionaries as before.
     - New ``Indicator.injected_parameters`` to see which compute function arguments will be injected at call time.
     - See the pull request (:pull:`873`) for all information.
+* The call signature for ``huglin_index`` has been modified to reflect the correct variables used in its formula (`tasmin` -> `tas`; `thresh_tasmin` -> `thresh`). (:issue:`902`).
 
 Internal changes
 ~~~~~~~~~~~~~~~~
@@ -61,6 +61,7 @@ Bug fixes
 * When called with a 1D da and ND index, ``xclim.indices.run_length.lazy_indexing`` now drops the auxiliary coordinate corresponding to da's index. This fixes a bug with ND data in ``xclim.indices.run_length.season``. (:pull:`900`)
 * Fix name of heating degree days in French (`"chauffe"` -> "`chauffage`"). (:pull:`895`).
 * Corrected several French indicator translation description strings (bad usages of `"."` in `description` and `long_name` fields). (:pull:`895`).
+* Fixed an error with the formula for ``huglin_index`` where `tasmin` was being used in the calculation instead of `tas`. (:issue:`902`).
 
 0.30.1 (2021-10-01)
 -------------------

--- a/xclim/core/indicator.py
+++ b/xclim/core/indicator.py
@@ -527,7 +527,7 @@ class Indicator(IndicatorRegistrar):
         except KeyError as err:
             raise ValueError(
                 f"Parameter {err} was passed but it does not exist on the "
-                f" compute function (not one of {parameters.keys()})"
+                f"compute function (not one of {parameters.keys()})"
             ) from err
 
     @classmethod

--- a/xclim/data/icclim.yml
+++ b/xclim/data/icclim.yml
@@ -59,12 +59,12 @@ indicators:
   HI:
     base: huglin_index
     cf_attrs:
-      long_name: Huglin heliothermal index (Summation of ((Tmin + Tmax)/2 - {thresh_tasmin}) * Latitude-based day-length coefficient (`k`), for days between 1 April and 31 October)
+      long_name: Huglin heliothermal index (Summation of ((Tmean + Tmax)/2 - {thresh}) * Latitude-based day-length coefficient (`k`), for days between 1 April and 31 October)
       comment: Metric originally published in Huglin, 1978. Also presented by ECAD/KNMI for ICCLIM, 2013.
     compute: huglin_index
     parameters:
       method: icclim
-      thresh_tasmin: 10 degC
+      thresh: 10 degC
       start_date: 04-01
       end_date: 11-01
   BEDD:

--- a/xclim/indicators/atmos/_temperature.py
+++ b/xclim/indicators/atmos/_temperature.py
@@ -882,10 +882,10 @@ corn_heat_units = Temp(
 huglin_index = Temp(
     identifier="huglin_index",
     units="",
-    long_name="Huglin heliothermal index (Summation of ((Tmin + Tmax)/2 - {thresh_tasmin}) * Latitude-based day-length"
+    long_name="Huglin heliothermal index (Summation of ((Tmin + Tmax)/2 - {thresh}) * Latitude-based day-length"
     "coefficient (`k`), for days between {start_date} and {end_date}).",
     description="Heat-summation index for agroclimatic suitability estimation, developed specifically for viticulture. "
-    "Considers daily Tmin and Tmax with a base of {thresh_tasmin}, typically between 1 April and 30 September. "
+    "Considers daily Tmin and Tmax with a base of {thresh}, typically between 1 April and 30 September. "
     "Integrates a day-length coefficient calculation for higher latitudes.",
     cell_methods="",
     comment="Metric originally published in Huglin (1978). Day-length coefficient based on Hall & Jones (2010)",

--- a/xclim/indices/_agro.py
+++ b/xclim/indices/_agro.py
@@ -148,7 +148,7 @@ def huglin_index(
     lat: xarray.DataArray
       Latitude coordinate.
     thresh: str
-      The minimum temperature threshold.
+      The temperature threshold.
     method: {"smoothed", "icclim", "jones"}
       The formula to use for the latitude coefficient calculation.
     start_date: DayOfYearStr

--- a/xclim/indices/_agro.py
+++ b/xclim/indices/_agro.py
@@ -118,16 +118,16 @@ def corn_heat_units(
 
 
 @declare_units(
-    tasmin="[temperature]",
+    tas="[temperature]",
     tasmax="[temperature]",
     lat="[]",
-    thresh_tasmin="[temperature]",
+    thresh="[temperature]",
 )
 def huglin_index(
-    tasmin: xarray.DataArray,
+    tas: xarray.DataArray,
     tasmax: xarray.DataArray,
     lat: xarray.DataArray,
-    thresh_tasmin: str = "10 degC",
+    thresh: str = "10 degC",
     method: str = "smoothed",
     start_date: DayOfYearStr = "04-01",
     end_date: DayOfYearStr = "10-01",
@@ -141,13 +141,13 @@ def huglin_index(
 
     Parameters
     ----------
-    tasmin: xarray.DataArray
-      Minimum daily temperature.
+    tas: xarray.DataArray
+      Mean daily temperature.
     tasmax: xarray.DataArray
       Maximum daily temperature.
     lat: xarray.DataArray
       Latitude coordinate.
-    thresh_tasmin: str
+    thresh: str
       The minimum temperature threshold.
     method: {"smoothed", "icclim", "jones"}
       The formula to use for the latitude coefficient calculation.
@@ -165,13 +165,13 @@ def huglin_index(
 
     Notes
     -----
-    Let :math:`TX_{i}` and :math:`TN_{i}` be the daily maximum and minimum temperature at day :math:`i` and
-    :math:`TN_{thresh}` the base threshold needed for heat summation (typically, 10 degC). A day-length multiplication,
+    Let :math:`TX_{i}` and :math:`TG_{i}` be the daily maximum and mean temperature at day :math:`i` and
+    :math:`T_{thresh}` the base threshold needed for heat summation (typically, 10 degC). A day-length multiplication,
     :math:`k`, based on latitude, :math:`lat`, is also considered. Then the Huglin heliothermal index for dates between
     1 April and 30 September is:
 
     .. math::
-        HI = \sum_{i=\text{April 1}}^{\text{September 30}} \left( \frac{TX_i  + TN_i)}{2} - 10 \right) * k
+        HI = \sum_{i=\text{April 1}}^{\text{September 30}} \left( \frac{TX_i  + TG_i)}{2} - T_{thresh} \right) * k
 
     For the `smoothed` method, the day-length multiplication factor, :math:`k`, is calculated as follows:
 
@@ -196,9 +196,8 @@ def huglin_index(
                         NaN, & \text{if } |lat| > 50 \\
                     \end{cases}
 
-    For a more robust day-length calculation based on latitude, calendar, day-of-year, and obliquity is available is
-    available with `method="jones"`.
-    see: :py:func:`xclim.indices.generic.day_lengths` or Hall and Jones (2010) for more information.
+    A more robust day-length calculation based on latitude, calendar, day-of-year, and obliquity is available with
+    `method="jones"`. See: :py:func:`xclim.indices.generic.day_lengths` or Hall and Jones (2010) for more information.
 
     References
     ----------
@@ -210,9 +209,9 @@ def huglin_index(
     climate in winegrape-growing regions in Australia. Australian Journal of Grape and Wine Research, 16(3), 389‑404.
     https://doi.org/10.1111/j.1755-0238.2010.00100.x
     """
-    tasmin = convert_units_to(tasmin, "degC")
+    tas = convert_units_to(tas, "degC")
     tasmax = convert_units_to(tasmax, "degC")
-    thresh_tasmin = convert_units_to(thresh_tasmin, "degC")
+    thresh = convert_units_to(thresh, "degC")
 
     if method.lower() == "smoothed":
         lat_mask = abs(lat) <= 50
@@ -248,7 +247,7 @@ def huglin_index(
         k_aggregated = 1
     elif method.lower() == "jones":
         day_length = day_lengths(
-            dates=tasmin.time,
+            dates=tas.time,
             lat=lat,
             start_date=start_date,
             end_date=end_date,
@@ -259,7 +258,7 @@ def huglin_index(
     else:
         raise NotImplementedError(f"'{method}' method is not implemented.")
 
-    hi = (((tasmin + tasmax) / 2) - thresh_tasmin).clip(min=0) * k
+    hi = (((tas + tasmax) / 2) - thresh).clip(min=0) * k
     hi = (
         aggregate_between_dates(hi, start=start_date, end=end_date, freq=freq)
         * k_aggregated

--- a/xclim/testing/tests/test_indices.py
+++ b/xclim/testing/tests/test_indices.py
@@ -354,17 +354,17 @@ class TestAgroclimaticIndices:
         ds = open_dataset("cmip5/tas_Amon_CanESM2_rcp85_r1i1p1_200701-200712.nc")
         ds = ds.drop_isel(time=0)  # drop time=2006/12 for one year of data
 
-        tasmax, tasmin = ds.tas + 15, ds.tas - 5
+        tasmax, tas = ds.tas + 15, ds.tas - 5
         # It would be much better if the index would interpolate to daily from monthly data intelligently.
-        tasmax, tasmin = (
+        tasmax, tas = (
             tasmax.resample(time="1D").interpolate("cubic"),
-            tasmin.resample(time="1D").interpolate("cubic"),
+            tas.resample(time="1D").interpolate("cubic"),
         )
-        tasmax.attrs["units"], tasmin.attrs["units"] = "K", "K"
+        tasmax.attrs["units"], tas.attrs["units"] = "K", "K"
 
         hi = xci.huglin_index(
             tasmax=tasmax,
-            tasmin=tasmin,
+            tas=tas,
             lat=ds.lat,
             method=method,
             end_date=end_date,  # noqa


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #902 
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.
- [ ] `bumpversion patch` has been called on this branch
- [ ] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

* Corrects the formula used in `huglin_index` that was previously using `tasmin` instead of `tas`.
* Updates the call signature of `huglin_index` to reflect this change. 

### Does this PR introduce a breaking change?
Yes. The call signature for `huglin_index` should not have been using `tasmin`, nor should `thresh_tasmin` have been used, considering the `thresh` applies to both temperature variable inputs. This call signatures change has been effected in the Indicators (`atmos` and `icclim`).

### Other information:
