### PR TITLE
Fix logging override in dataflags

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,13 @@
 History
 =======
 
+0.32.0 (unreleased)
+-------------------
+
+Internal changes
+~~~~~~~~~~~~~~~~
+* Remove some logging configuration in ``dataflags`` that were polluting python's main logging configuration.
+
 0.31.0 (2021-11-05)
 -------------------
 Contributors to this version: Abel Aoun (:user:`bzah`), Pascal Bourgault (:user:`aulemahal`), David Huard (:user:`huard`), Juliette Lavoie (:user:`juliettelavoie`), Travis Logan (:user:`tlogan2000`), Trevor James Smith (:user:`Zeitsperre`).

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,7 +7,8 @@ History
 
 Internal changes
 ~~~~~~~~~~~~~~~~
-* Remove some logging configuration in ``dataflags`` that were polluting python's main logging configuration.
+* Removed some logging configurations in ``dataflags`` that were polluting python's main logging configuration. (:pull:`909`).
+* Synchronized logging formatters in `xclim.ensembles` and `xclim.core.utils`. (:pull:`909`).
 
 0.31.0 (2021-11-05)
 -------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.31.0
+current_version = 0.31.1-beta
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+).(?P<patch>\d+)(\-(?P<release>[a-z]+))?

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ URL = "https://github.com/Ouranosinc/xclim"
 AUTHOR = "Travis Logan"
 AUTHOR_EMAIL = "logan.travis@ouranos.ca"
 REQUIRES_PYTHON = ">=3.7.0"
-VERSION = "0.31.0"
+VERSION = "0.31.1-beta"
 LICENSE = "Apache Software License 2.0"
 
 with open("README.rst") as readme_file:

--- a/xclim/__init__.py
+++ b/xclim/__init__.py
@@ -10,7 +10,7 @@ from xclim.indicators import atmos, land, seaIce  # noqa
 
 __author__ = """Travis Logan"""
 __email__ = "logan.travis@ouranos.ca"
-__version__ = "0.31.0"
+__version__ = "0.31.1-beta"
 
 
 # Load official locales

--- a/xclim/core/dataflags.py
+++ b/xclim/core/dataflags.py
@@ -512,7 +512,7 @@ def data_flags(
     flags: Optional[dict] = None,
     dims: Union[None, str, Sequence[str]] = "all",
     freq: Optional[str] = None,
-    on_error: str = 'warn',
+    raise_flags: bool = False,
 ) -> xarray.Dataset:
     """Evaluate the supplied DataArray for a set of data flag checks.
 
@@ -535,8 +535,8 @@ def data_flags(
     freq : str, optional
       Resampling frequency to have data_flags aggregated over periods.
       Defaults to None, which means the "time" axis is treated as any other dimension (see `dims`).
-    on_error : {'raise', 'warn', 'log', 'ignore'}
-      Raise, warn, log or ignore exception if any of the quality assessment flags are raised. Default: 'warn'.
+    raise_flags : bool
+      Raise exception if any of the quality assessment flags are raised. Default: False.
 
     Returns
     -------
@@ -619,7 +619,7 @@ def data_flags(
         except (KeyError, TypeError) as err:
             raise_warn_or_log(
                 err,
-                mode=on_error,
+                mode='raise' if raise_flags else 'log',
                 msg=f"Data quality checks do not exist for '{var}' variable.",
                 err_type=NotImplementedError
             )
@@ -656,7 +656,7 @@ def data_flags(
 
     dsflags = xarray.Dataset(data_vars=flags)
 
-    if on_error == 'raise':
+    if raise_flags:
         if np.any(dsflags.data_vars.values()):
             raise DataQualityException(dsflags)
 

--- a/xclim/core/dataflags.py
+++ b/xclim/core/dataflags.py
@@ -18,7 +18,13 @@ from ..indices.run_length import suspicious_run
 from .calendar import climatological_mean_doy, within_bnds_doy
 from .formatting import update_xclim_history
 from .units import convert_units_to, declare_units, str2pint
-from .utils import VARIABLES, InputKind, MissingVariableError, infer_kind_from_parameter, raise_warn_or_log
+from .utils import (
+    VARIABLES,
+    InputKind,
+    MissingVariableError,
+    infer_kind_from_parameter,
+    raise_warn_or_log,
+)
 
 _REGISTRY = dict()
 
@@ -619,9 +625,9 @@ def data_flags(
         except (KeyError, TypeError) as err:
             raise_warn_or_log(
                 err,
-                mode='raise' if raise_flags else 'log',
+                mode="raise" if raise_flags else "log",
                 msg=f"Data quality checks do not exist for '{var}' variable.",
-                err_type=NotImplementedError
+                err_type=NotImplementedError,
             )
             return xarray.Dataset()
     else:

--- a/xclim/core/utils.py
+++ b/xclim/core/utils.py
@@ -25,6 +25,8 @@ from boltons.funcutils import update_wrapper
 from dask import array as dsk
 from xarray import DataArray, Dataset
 from yaml import safe_dump, safe_load
+logger = logging.getLogger('xclim')
+
 
 #: Type annotation for strings representing full dates (YYYY-MM-DD), may include time.
 DateStr = NewType("DateStr", str)
@@ -359,7 +361,7 @@ def _nan_quantile(
 
 
 def raise_warn_or_log(
-    err: Exception, mode: str, msg: Optional[str] = None, stacklevel: int = 1
+    err: Exception, mode: str, msg: Optional[str] = None, err_type=ValueError, stacklevel: int = 1
 ):
     """Raise, warn or log an error according.
 
@@ -379,11 +381,11 @@ def raise_warn_or_log(
     if mode == "ignore":
         pass
     elif mode == "log":
-        logging.info(msg)
+        logger.info(msg)
     elif mode == "warn":
         warnings.warn(msg, stacklevel=stacklevel + 1)
     else:  # mode == "raise"
-        raise err from ValueError(msg)
+        raise err from err_type(msg)
 
 
 class InputKind(IntEnum):

--- a/xclim/core/utils.py
+++ b/xclim/core/utils.py
@@ -25,7 +25,8 @@ from boltons.funcutils import update_wrapper
 from dask import array as dsk
 from xarray import DataArray, Dataset
 from yaml import safe_dump, safe_load
-logger = logging.getLogger('xclim')
+
+logger = logging.getLogger("xclim")
 
 
 #: Type annotation for strings representing full dates (YYYY-MM-DD), may include time.
@@ -361,7 +362,11 @@ def _nan_quantile(
 
 
 def raise_warn_or_log(
-    err: Exception, mode: str, msg: Optional[str] = None, err_type=ValueError, stacklevel: int = 1
+    err: Exception,
+    mode: str,
+    msg: Optional[str] = None,
+    err_type=ValueError,
+    stacklevel: int = 1,
 ):
     """Raise, warn or log an error according.
 

--- a/xclim/ensembles/_base.py
+++ b/xclim/ensembles/_base.py
@@ -1,5 +1,4 @@
 """Ensembles creation and statistics."""
-import logging
 from pathlib import Path
 from typing import List, Optional, Sequence, Union
 
@@ -8,7 +7,7 @@ import xarray as xr
 
 from xclim.core.calendar import convert_calendar, get_calendar
 from xclim.core.formatting import update_history
-from xclim.core.utils import calc_perc
+from xclim.core.utils import calc_perc, logger
 
 
 def create_ensemble(
@@ -301,7 +300,7 @@ def _ens_align_datasets(
 
     ds_all = []
     for i, n in enumerate(datasets):
-        logging.info(f"Accessing {n} of {len(datasets)}")
+        logger.info(f"Accessing {n} of {len(datasets)}")
         if mf_flag:
             ds = xr.open_mfdataset(n, combine="by_coords", **xr_kwargs)
         else:

--- a/xclim/ensembles/_reduce.py
+++ b/xclim/ensembles/_reduce.py
@@ -15,16 +15,17 @@ import scipy.stats
 import xarray
 from scipy.spatial.distance import cdist
 from sklearn.cluster import KMeans
+logger = logging.getLogger('xclim')
 
 # Avoid having to include matplotlib in xclim requirements
 try:
     from matplotlib import pyplot as plt
 
-    logging.info("Matplotlib installed. Setting make_graph to True.")
+    logger.info("Matplotlib installed. Setting make_graph to True.")
     MPL_INSTALLED = True
 
 except ImportError:
-    logging.info("Matplotlib not found. No graph data will be produced.")
+    logger.info("Matplotlib not found. No graph data will be produced.")
     plt = None
     MPL_INSTALLED = False
 

--- a/xclim/ensembles/_reduce.py
+++ b/xclim/ensembles/_reduce.py
@@ -15,7 +15,8 @@ import scipy.stats
 import xarray
 from scipy.spatial.distance import cdist
 from sklearn.cluster import KMeans
-logger = logging.getLogger('xclim')
+
+logger = logging.getLogger("xclim")
 
 # Avoid having to include matplotlib in xclim requirements
 try:

--- a/xclim/testing/tests/test_flags.py
+++ b/xclim/testing/tests/test_flags.py
@@ -132,7 +132,7 @@ class TestDataFlags:
             df.DataQualityException,
             match="Maximum temperature values found below minimum temperatures.",
         ):
-            df.data_flags(bad_ds.tasmax, bad_ds, raise_flags=True)
+            df.data_flags(bad_ds.tasmax, bad_ds, on_error='raise')
 
     def test_era5_ecad_qc_flag(self):
         bad_ds = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc")  # noqa
@@ -144,7 +144,7 @@ class TestDataFlags:
             df.DataQualityException,
             match="Runs of repetitive values for 5 or more days found for tas.",
         ):
-            df.ecad_compliant(bad_ds, raise_flags=True)
+            df.ecad_compliant(bad_ds, on_error='raise')
 
         df_flagged = df.ecad_compliant(bad_ds)
         np.testing.assert_array_equal(df_flagged.ecad_qc_flag, False)

--- a/xclim/testing/tests/test_flags.py
+++ b/xclim/testing/tests/test_flags.py
@@ -132,7 +132,7 @@ class TestDataFlags:
             df.DataQualityException,
             match="Maximum temperature values found below minimum temperatures.",
         ):
-            df.data_flags(bad_ds.tasmax, bad_ds, on_error='raise')
+            df.data_flags(bad_ds.tasmax, bad_ds, raise_flags=True)
 
     def test_era5_ecad_qc_flag(self):
         bad_ds = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc")  # noqa
@@ -144,7 +144,7 @@ class TestDataFlags:
             df.DataQualityException,
             match="Runs of repetitive values for 5 or more days found for tas.",
         ):
-            df.ecad_compliant(bad_ds, on_error='raise')
+            df.ecad_compliant(bad_ds, raise_flags=True)
 
         df_flagged = df.ecad_compliant(bad_ds)
         np.testing.assert_array_equal(df_flagged.ecad_qc_flag, False)


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.
- [x] `bumpversion patch` has been called on this branch
- [x] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

* Removes a `logging.basicConfig` call in xclim that was polluting script logging. Changes it to a call of `raise_warn_or_log` and use `logger = logging.getLogger('xclim')` there.

With this change I am able to use `basicConfig` in a normal script that imports xclim.

### Does this PR introduce a breaking change?
No.

### Other information:
Tant qu'à y être, I changed all logging calls of xclim to use the "xclim" logger".