### PR TITLE
Run-length optimizations for window=1

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,10 @@ History
 -------------------
 Contributors to this version: Pascal Bourgault (:user:`aulemahal`), Travis Logan (:user:`tlogan2000`)
 
+New features and enhancements
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Added an optimized pathway for ``xclim.indices.run_length`` functions when ``window=1``.
+
 Internal changes
 ~~~~~~~~~~~~~~~~
 * Removed some logging configurations in ``dataflags`` that were polluting python's main logging configuration. (:pull:`909`).

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,7 +8,7 @@ Contributors to this version: Pascal Bourgault (:user:`aulemahal`), Travis Logan
 
 New features and enhancements
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-* Added an optimized pathway for ``xclim.indices.run_length`` functions when ``window=1``.
+* Added an optimized pathway for ``xclim.indices.run_length`` functions when ``window=1``, (:pull:`911`, :issue:`910`).
 
 Internal changes
 ~~~~~~~~~~~~~~~~

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,7 +8,7 @@ Contributors to this version: Pascal Bourgault (:user:`aulemahal`), Travis Logan
 
 New features and enhancements
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-* Added an optimized pathway for ``xclim.indices.run_length`` functions when ``window=1``, (:pull:`911`, :issue:`910`).
+* Added an optimized pathway for ``xclim.indices.run_length`` functions when ``window=1``. (:pull:`911`, :issue:`910`).
 
 Internal changes
 ~~~~~~~~~~~~~~~~

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.31.1-beta
+current_version = 0.31.2-beta
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+).(?P<patch>\d+)(\-(?P<release>[a-z]+))?

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ URL = "https://github.com/Ouranosinc/xclim"
 AUTHOR = "Travis Logan"
 AUTHOR_EMAIL = "logan.travis@ouranos.ca"
 REQUIRES_PYTHON = ">=3.7.0"
-VERSION = "0.31.1-beta"
+VERSION = "0.31.2-beta"
 LICENSE = "Apache Software License 2.0"
 
 with open("README.rst") as readme_file:

--- a/xclim/__init__.py
+++ b/xclim/__init__.py
@@ -10,7 +10,7 @@ from xclim.indicators import atmos, land, seaIce  # noqa
 
 __author__ = """Travis Logan"""
 __email__ = "logan.travis@ouranos.ca"
-__version__ = "0.31.1-beta"
+__version__ = "0.31.2-beta"
 
 
 # Load official locales

--- a/xclim/indices/run_length.py
+++ b/xclim/indices/run_length.py
@@ -264,7 +264,7 @@ def windowed_run_events(
 
     if window == 1:
         d = da.pad({dim: (0, 1)}, constant_values=False).astype(int).diff(dim)
-        out = (d == -1).sum()
+        out = (d == -1).sum(dim=dim)
     elif ufunc_1dim:
         out = windowed_run_events_ufunc(da, window, dim)
     else:

--- a/xclim/indices/run_length.py
+++ b/xclim/indices/run_length.py
@@ -263,9 +263,8 @@ def windowed_run_events(
     ufunc_1dim = use_ufunc(ufunc_1dim, da, dim=dim, index=index)
 
     if window == 1:
-        out = (
-            da.pad(x=(0, 1), constant_values=False).astype(int).diff("x") == -1
-        ).sum()
+        d = da.pad({dim: (0, 1)}, constant_values=False).astype(int).diff(dim)
+        out = (d == -1).sum()
     elif ufunc_1dim:
         out = windowed_run_events_ufunc(da, window, dim)
     else:


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #910
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.
- [ ] `bumpversion patch` has been called on this branch
- [x] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

* Adds optimized pathways for the `window=1` cases in `rl.windowed_run_count`, `rl.windowed_run_events` and `rl.first_run` (and thus to most run-length functions using `window`, except `rle_statistics` and `longest_run`).

### Does this PR introduce a breaking change?
No, except that the `ufunc_1dim` argument and the `run_length_ufunc` options are now ignored when `window=1`.

Recall that the `ufunc` version is selected for small arrays that have no chunking along the dimension.

### Other information:
For `windowed_run_count` and `windowed_run_events` the performance gain is clear, see figures in next comments. In both cases, the ufunc version was slower than the optimization but faster then the non-ufunc version. The memory consumption was similar for the optimized and ufunc versions, and horrible for the non-ufunc version.

I also saw that the non-ufunc version triggered many small dask loadings before entering the main computation. I think something is not lazy in `rl.rle`.

For `first_run`, the non-ufunc  version is only slightly slower than the new optimized way, while the ufunc version is much slower. Here, the memory consumption was better in the non-ufunc than in the optimized version.

All tests performed with a 150 years daily datasets of 50 chunks of 65 points.