### PR TITLE
Count cold spell days first, then resample.

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -69,6 +69,15 @@
       "affiliation": "Ouranos",
       "name": "Lavoie, Juliette",
       "orcid": "0000-0002-4708-5182"
+    },
+    {
+      "affiliation": "UCL",
+      "name": "Quinn, Jamie",
+      "orcid": "0000-0002-0268-7032"
+    },
+    {
+      "affiliation": "UCL",
+      "name": "Alegre, Raquel"
     }
   ],
   "keywords": [

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -27,4 +27,5 @@ Contributors
 * Jeremy Fyke `@jeremyfyke <https://github.com/jeremyfyke>`_
 * Clair Barnes <clair.barnes.16@ucl.ac.uk> `@clairbarnes <https://github.com/clairbarnes>`_
 * Raquel Alegre <raquel.alegre@gmail.com> `@raquel-ucl <https://github.com/raquel-ucl>`_
+* Jamie Quinn <jamiejquinn@jamiejquinn.com> `@jamiejquinn <https://github.com/jamiejquinn>`_
 * Abel Aoun <aoun.abel@gmail.com> `@bzah <https://github.com/bzah>`_

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -18,6 +18,7 @@ Internal changes
 Bug fixes
 ~~~~~~~~~
 * Fix bugs in the `cf_attrs` and/or `abstract` of `continuous_snow_cover_end` and `continuous_snow_cover_start`. (:pull:`908`).
+* Fix counting of cold spells when split across two time periods. (:pull:`917`, :issue:`916`)
 
 0.31.0 (2021-11-05)
 -------------------

--- a/xclim/indices/_threshold.py
+++ b/xclim/indices/_threshold.py
@@ -200,14 +200,9 @@ def cold_spell_frequency(
     t = convert_units_to(thresh, tas)
     over = tas < t
 
-    group = over.resample(time=freq)
-
-    out = group.map(rl.windowed_run_events, window=window, dim="time")
-
-    # runs = rl.rle(over, index=index)
-    # cold_spells = runs >= window
-
-    # out = cold_spells.resample(time="AS-JUL").sum()
+    runs = rl.rle(over, index=index)
+    cold_spells = runs >= window
+    out = cold_spells.resample(time=freq).sum()
 
     out.attrs["units"] = ""
     return out

--- a/xclim/indices/_threshold.py
+++ b/xclim/indices/_threshold.py
@@ -156,9 +156,11 @@ def cold_spell_days(
     """
     t = convert_units_to(thresh, tas)
     over = tas < t
-    group = over.resample(time=freq)
 
-    out = group.map(rl.windowed_run_count, window=window, dim="time")
+    runs = rl.rle(over)
+    cold_spells = runs.ffill(dim="time") >= window
+    out = cold_spells.resample(time=freq).sum().rename(cold_spell_days)
+
     return to_agg_units(out, tas, "count")
 
 

--- a/xclim/indices/_threshold.py
+++ b/xclim/indices/_threshold.py
@@ -157,13 +157,9 @@ def cold_spell_days(
     t = convert_units_to(thresh, tas)
     over = tas < t
 
-    group = over.resample(time=freq)
-
-    out = group.map(rl.windowed_run_count, window=window, dim="time")
-
-    # runs = rl.rle(over)
-    # cold_spells = runs.ffill(dim="time") >= window
-    # out = cold_spells.resample(time=freq).sum()
+    runs = rl.rle(over)
+    cold_spells = runs.ffill(dim="time") >= window
+    out = cold_spells.resample(time=freq).sum()
 
     return to_agg_units(out, tas, "count")
 

--- a/xclim/indices/_threshold.py
+++ b/xclim/indices/_threshold.py
@@ -187,7 +187,7 @@ def cold_spell_frequency(
       Minimum number of days with temperature below threshold to qualify as a cold spell.
     freq : str
       Resampling frequency.
-    index : str
+    index : {"first", "last"}
       If ‘first’, the run length is indexed at the first element in the run. If ‘last’, at the last element in the run.
 
     Returns

--- a/xclim/indices/_threshold.py
+++ b/xclim/indices/_threshold.py
@@ -159,7 +159,7 @@ def cold_spell_days(
 
     runs = rl.rle(over)
     cold_spells = runs.ffill(dim="time") >= window
-    out = cold_spells.resample(time=freq).sum().rename(cold_spell_days)
+    out = cold_spells.resample(time=freq).sum()
 
     return to_agg_units(out, tas, "count")
 

--- a/xclim/testing/tests/test_indices.py
+++ b/xclim/testing/tests/test_indices.py
@@ -124,10 +124,11 @@ class TestColdSpellDays:
         a[10:20] -= 15  # 10 days
         a[40:43] -= 50  # too short -> 0
         a[80:100] -= 30  # at the end and beginning
+        a[150:156] -= 50  # short cold spell spanning two months
         da = tas_series(a + K2C)
 
         out = xci.cold_spell_days(da, thresh="-10. C", freq="M")
-        np.testing.assert_array_equal(out, [10, 0, 12, 8, 0, 0, 0, 0, 0, 0, 0, 0])
+        np.testing.assert_array_equal(out, [10, 0, 12, 8, 3, 3, 0, 0, 0, 0, 0, 0])
         assert out.units == "d"
 
 

--- a/xclim/testing/tests/test_indices.py
+++ b/xclim/testing/tests/test_indices.py
@@ -139,14 +139,15 @@ class TestColdSpellFreq:
         a[40:43] -= 50  # too short -> 0
         a[80:86] -= 30
         a[95:101] -= 30
+        a[150:156] -= 50  # short cold spell spanning two months
         da = tas_series(a + K2C, start="1971-01-01")
 
         out = xci.cold_spell_frequency(da, thresh="-10. C", freq="M")
-        np.testing.assert_array_equal(out, [1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0])
+        np.testing.assert_array_equal(out, [1, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0])
         assert out.units == ""
 
         out = xci.cold_spell_frequency(da, thresh="-10. C", freq="YS")
-        np.testing.assert_array_equal(out, 3)
+        np.testing.assert_array_equal(out, 4)
         assert out.units == ""
 
 

--- a/xclim/testing/tests/test_temperature.py
+++ b/xclim/testing/tests/test_temperature.py
@@ -387,11 +387,12 @@ class TestColdSpellDays:
         a[10:20] -= 15  # 10 days
         a[40:43] -= 50  # too short -> 0
         a[80:100] -= 30  # at the end and beginning
+        a[148:154] -= 50  # short cold spell spanning two months
         ts = tas_series(a)
         out = atmos.cold_spell_days(ts, thresh="-10 C", freq="MS")
-        np.testing.assert_array_equal(out, [10, 0, 12, 8, 0, 0, 0, 0, 0, 0, 0, 0])
+        np.testing.assert_array_equal(out, [10, 0, 12, 8, 3, 3, 0, 0, 0, 0, 0, 0])
         out = atmos.cold_spell_frequency(ts, thresh="-10 C", freq="MS")
-        np.testing.assert_array_equal(out, [1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0])
+        np.testing.assert_array_equal(out, [1, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0])
 
     def test_convert_units(self, tas_series):
         a = np.zeros(365)

--- a/xclim/testing/tests/test_temperature.py
+++ b/xclim/testing/tests/test_temperature.py
@@ -387,12 +387,11 @@ class TestColdSpellDays:
         a[10:20] -= 15  # 10 days
         a[40:43] -= 50  # too short -> 0
         a[80:100] -= 30  # at the end and beginning
-        a[148:154] -= 50  # short cold spell spanning two months
         ts = tas_series(a)
         out = atmos.cold_spell_days(ts, thresh="-10 C", freq="MS")
-        np.testing.assert_array_equal(out, [10, 0, 12, 8, 3, 3, 0, 0, 0, 0, 0, 0])
+        np.testing.assert_array_equal(out, [10, 0, 12, 8, 0, 0, 0, 0, 0, 0, 0, 0])
         out = atmos.cold_spell_frequency(ts, thresh="-10 C", freq="MS")
-        np.testing.assert_array_equal(out, [1, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0])
+        np.testing.assert_array_equal(out, [1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0])
 
     def test_convert_units(self, tas_series):
         a = np.zeros(365)

--- a/xclim/testing/tests/test_temperature.py
+++ b/xclim/testing/tests/test_temperature.py
@@ -391,7 +391,7 @@ class TestColdSpellDays:
         out = atmos.cold_spell_days(ts, thresh="-10 C", freq="MS")
         np.testing.assert_array_equal(out, [10, 0, 12, 8, 0, 0, 0, 0, 0, 0, 0, 0])
         out = atmos.cold_spell_frequency(ts, thresh="-10 C", freq="MS")
-        np.testing.assert_array_equal(out, [1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0])
+        np.testing.assert_array_equal(out, [1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0])
 
     def test_convert_units(self, tas_series):
         a = np.zeros(365)
@@ -403,7 +403,7 @@ class TestColdSpellDays:
         out = atmos.cold_spell_days(ts, thresh="-10 C", freq="MS")
         np.testing.assert_array_equal(out, [10, 0, 12, 8, 0, 0, 0, 0, 0, 0, 0, 0])
         out = atmos.cold_spell_frequency(ts, thresh="-10 C", freq="MS")
-        np.testing.assert_array_equal(out, [1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0])
+        np.testing.assert_array_equal(out, [1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0])
 
     def test_nan_presence(self, tas_series):
         a = np.zeros(365) + K2C
@@ -416,7 +416,7 @@ class TestColdSpellDays:
         out = atmos.cold_spell_days(ts, thresh="-10 C", freq="MS")
         np.testing.assert_array_equal(out, [10, 0, 12, 8, 0, 0, 0, 0, 0, 0, 0, np.nan])
         out = atmos.cold_spell_frequency(ts, thresh="-10 C", freq="MS")
-        np.testing.assert_array_equal(out, [1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, np.nan])
+        np.testing.assert_array_equal(out, [1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, np.nan])
 
 
 class TestFrostDays:


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #916 
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.
- [ ] `bumpversion patch` has been called on this branch
- [x] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

* The original method divided the time series into periods, then counted run lengths contained within each period. This means that spells that span two periods are treated as two separate cold spells: particularly when handling data at monthly frequency this can mean that cold spells are not identified. This PR is the proposed alternative.

### Does this PR introduce a breaking change?
 

### Other information:
- [ ] Although there are already tests for this method, we still need to add tests for edge cases (ie periods that used to be counted twice are counted once correctly now, and periods that were not counted at all now are).