### PR TITLE
French indicator metadata cleanup

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,19 +7,20 @@ History
 Contributors to this version: Pascal Bourgault (:user:`aulemahal`), Travis Logan (:user:`tlogan2000`), Trevor James Smith (:user:`Zeitsperre`)
 
 New features and enhancements
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 * Added an optimized pathway for ``xclim.indices.run_length`` functions when ``window=1``. (:pull:`911`, :issue:`910`).
-* The data input frequency expected by ``Indicator``s is now in the ``src_freq`` attribute and is thus controlable by subclassing existing indicators. (:issue:`898`, :pull:`927`).
+* The data input frequency expected by ``Indicator``s is now in the ``src_freq`` attribute and is thus controllable by subclassing existing indicators. (:issue:`898`, :pull:`927`).
 
 Internal changes
-~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^
 * Removed some logging configurations in ``dataflags`` that were polluting python's main logging configuration. (:pull:`909`).
 * Synchronized logging formatters in `xclim.ensembles` and `xclim.core.utils`. (:pull:`909`).
 * Added a helper function for generating the release notes with dynamically-generated ReStructuredText or Markdown-formatted hyperlinks (:pull:`922`, :issue:`907`).
 * Split of resampling-related functionality of ``Indicator``s into a new ``ResamplingIndicator`` subclass. The use of new (private) methods makes it easier to inject functionality in indicator subclasses. (:issue:`867`, :pull:`927`).
+* French translation metadata fields are now cleaner and much more internally consistent, and many empty metadata fields (e.g. ``comment_fr``) have been removed. (:pull:`930`, :issue:`929`).
 
 Bug fixes
-~~~~~~~~~
+^^^^^^^^^
 * Fix bugs in the `cf_attrs` and/or `abstract` of `continuous_snow_cover_end` and `continuous_snow_cover_start`. (:pull:`908`).
 
 0.31.0 (2021-11-05)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.31.2-beta
+current_version = 0.31.3-beta
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+).(?P<patch>\d+)(\-(?P<release>[a-z]+))?

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ URL = "https://github.com/Ouranosinc/xclim"
 AUTHOR = "Travis Logan"
 AUTHOR_EMAIL = "logan.travis@ouranos.ca"
 REQUIRES_PYTHON = ">=3.7.0"
-VERSION = "0.31.2-beta"
+VERSION = "0.31.3-beta"
 LICENSE = "Apache Software License 2.0"
 
 with open("README.rst") as readme_file:

--- a/xclim/__init__.py
+++ b/xclim/__init__.py
@@ -10,7 +10,7 @@ from xclim.indicators import atmos, land, seaIce  # noqa
 
 __author__ = """Travis Logan"""
 __email__ = "logan.travis@ouranos.ca"
-__version__ = "0.31.2-beta"
+__version__ = "0.31.3-beta"
 
 
 # Load official locales

--- a/xclim/data/fr.json
+++ b/xclim/data/fr.json
@@ -337,10 +337,10 @@
     "abstract": "Moyenne de la température journalière minimale."
   },
   "TN10P": {
-    "long_name": "Nombre de jours où la température minimale est au-dessous du 10e percentile",
-    "description": "Nombre {freq:m} de jours où la température minimale est au-dessous du 10e percentile. Le 10e percentile est calculé à partir d'une fenêtre de 5 jours centrée sur chaque jour du calendrier à l'intérieur d'une période de référence.",
-    "title": "Nombre de jours où la température minimale est au-dessous du 10e percentile",
-    "abstract": "Nombre de jours où la température minimale est au-dessous du 10e percentile."
+    "long_name": "Nombre de jours où la température minimale est en dessous du 10e percentile",
+    "description": "Nombre {freq:m} de jours où la température minimale est en dessous du 10e percentile. Le 10e percentile est calculé à partir d'une fenêtre de 5 jours centrée sur chaque jour du calendrier à l'intérieur d'une période de référence.",
+    "title": "Nombre de jours où la température minimale est en dessous du 10e percentile",
+    "abstract": "Nombre de jours où la température minimale est en dessous du 10e percentile."
   },
   "TN90P": {
     "long_name": "Nombre de jours où la température minimale est au-dessus du 90e percentile",
@@ -367,10 +367,10 @@
     "abstract": "Moyenne de la température journalière maximale."
   },
   "TX10P": {
-    "long_name": "Nombre de jours où la température maximale est au-dessous du 10e percentile",
-    "description": "Nombre {freq:m} de jours où la température maximale est au-dessous du 10e percentile. Le 10e percentile est calculé à partir d'une fenêtre de 5 jours centrée sur chaque jour du calendrier à l'intérieur d'une période de référence.",
-    "title": "Nombre de jours où la température maximale est au-dessous du 10e percentile",
-    "abstract": "Nombre de jours où la température maximale est au-dessous du 10e percentile."
+    "long_name": "Nombre de jours où la température maximale est en dessous du 10e percentile",
+    "description": "Nombre {freq:m} de jours où la température maximale est en dessous du 10e percentile. Le 10e percentile est calculé à partir d'une fenêtre de 5 jours centrée sur chaque jour du calendrier à l'intérieur d'une période de référence.",
+    "title": "Nombre de jours où la température maximale est en dessous du 10e percentile",
+    "abstract": "Nombre de jours où la température maximale est en dessous du 10e percentile."
   },
   "TX90P": {
     "long_name": "Nombre de jours où la température maximale est au-dessus du 90e percentile",
@@ -431,7 +431,7 @@
     "long_name": "Cycles de gel-dégel",
     "description": "Nombre {freq:m} de jours avec un gel-dégel quotidien : Tmax > {thresh_tasmax} et Tmin <= {thresh_tasmin}.",
     "title": "Nombre de jours avec un cycle de gel-dégel",
-    "abstract": "Le nombre de jours où Tmax est au-dessus d'un seuil et Tmin au-dessous d'un seuil, habituellement 0 °C pour les deux."
+    "abstract": "Le nombre de jours où Tmax est au-dessus d'un seuil et Tmin en dessous d'un seuil, habituellement 0 °C pour les deux."
   },
   "COOLING_DEGREE_DAYS": {
     "long_name": "Degrés-jours de réfrigération (Tmoy > {thresh})",
@@ -441,7 +441,7 @@
   },
   "HEATING_DEGREE_DAYS": {
     "long_name": "Degrés-jours de chauffage (Tmoy < {thresh})",
-    "description": "Cumul {freq:m} des degrés-jours de chauffage (Température au-dessous de {thresh}).",
+    "description": "Cumul {freq:m} des degrés-jours de chauffage (Température en dessous de {thresh}).",
     "title": "Degrés-jours de chauffage",
     "abstract": "Cumul des degrés-jours pour les jours où la température moyenne est sous un seuil et que les immeubles doivent être chauffés."
   },
@@ -453,7 +453,7 @@
   },
   "FREEZING_DEGREE_DAYS": {
     "long_name": "Degrés-jours de gel (Tmoy < {thresh})",
-    "description": "Cumul {freq:m} des degrés-jours de gel (Température au-dessous de {thresh}).",
+    "description": "Cumul {freq:m} des degrés-jours de gel (Température en dessous de {thresh}).",
     "title": "Degrés-jours de gel",
     "abstract": "Cumul des degrés-jours pour les jours où la température moyenne est sous un seuil."
   },
@@ -846,7 +846,7 @@
   "WARM_SPELL_DURATION_INDEX": {
     "title": "Indice de durée des vagues de chaleur",
     "abstract": "Nombre de jours faisant partie de vagues d'une longueur minimale où la température maximale quotidienne excède le 90e percentile. Le 90e percentile des températures devrait être calculé avec une fenêtre mobile de 5 jours.",
-    "description": "Durée totale {freq:m} des vagues de chaleur. Une vague de chaleur se produit lorsque Tmax est au-dessus du 90e percentile, durant au moins {window} jours.",
+    "description": "Durée totale {freq:f} des vagues de chaleur. Une vague de chaleur se produit lorsque Tmax est au-dessus du 90e percentile durant au moins {window} jours.",
     "long_name": "Durée des vagues de chaleur"
   },
   "MAXIMUM_CONSECUTIVE_WARM_DAYS": {
@@ -870,17 +870,17 @@
   "FREEZETHAW_SPELL_FREQUENCY": {
     "title": "Fréquence des événements de gel-dégel quotidien",
     "abstract": "Nombre de périodes de gel-dégel. Ces périodes sont des séries de jours consécutifs où la température minimale quotidienne est sous un seuil et la température maximale quotidienne au-dessus d'un autre. En général, ces deux seuils sont 0°C.",
-    "description": "Fréquence {freq:f} des événements de gel-dégel quotidien : Tmax > {thresh_tasmax} et Tmin <= {thresh_tasmin} pour au moins {window} jour(s) consecutif(s).",
+    "description": "Fréquence {freq:f} des événements de gel-dégel quotidiens : Tmax > {thresh_tasmax} et Tmin <= {thresh_tasmin} pour au moins {window} jour(s) consecutif(s).",
     "long_name": "Fréquence {freq:f} des événements de gel-dégel quotidien"
   },
   "FREEZETHAW_SPELL_MAX_LENGTH": {
-    "title": "Durée maximale du nombre de jours consécutifs avec un gel-dégel",
+    "title": "Durée maximale d'une période de jours consécutifs avec un gel-dégel",
     "abstract": "Durée maximale des périodes de gel-dégel. Ces périodes sont des séries de jours consécutifs où la température minimale quotidienne est sous un seuil et la température maximale quotidienne au-dessus d'un autre. En général, ces deux seuils sont 0°C.",
     "description": "Durée maximale {freq:f} des événements de gel-dégel quotidien : Tmax > {thresh_tasmax} et Tmin <= {thresh_tasmin} pour au moins {window} jour(s) consecutif(s).",
     "long_name": "Durée maximale {freq:f} des événements de gel-dégel quotidien"
   },
   "FREEZETHAW_SPELL_MEAN_LENGTH": {
-    "title": "Durée moyenne du nombre de jours consécutifs avec un gel-dégel",
+    "title": "Durée moyenne d'une période de jours consécutifs avec un gel-dégel",
     "abstract": "Durée moyenne des périodes de gel-dégel. Ces périodes sont des séries de jours consécutifs où la température minimale quotidienne est sous un seuil et la température maximale quotidienne au-dessus d'un autre. En général, ces deux seuils sont 0°C.",
     "description": "Durée moyenne {freq:f} des événements de gel-dégel quotidien : Tmax > {thresh_tasmax} et Tmin <= {thresh_tasmin} pour au moins {window} jour(s) consecutif(s).",
     "long_name": "Durée moyenne {freq:f} des événements de gel-dégel quotidien"

--- a/xclim/data/fr.json
+++ b/xclim/data/fr.json
@@ -434,9 +434,9 @@
     "abstract": "Le nombre de jours où Tmax est au-dessus d'un seuil et Tmin en dessous d'un seuil, habituellement 0 °C pour les deux."
   },
   "COOLING_DEGREE_DAYS": {
-    "long_name": "Degrés-jours de réfrigération (Tmoy > {thresh})",
-    "description": "Cumul {freq:m} des degrés-jours de réfrigération (Température au-dessus de {thresh}).",
-    "title": "Degrés-jours de réfrigération",
+    "long_name": "Degrés-jours de climatisation (Tmoy > {thresh})",
+    "description": "Cumul {freq:m} des degrés-jours de climatisation (Température au-dessus de {thresh}).",
+    "title": "Degrés-jours de climatisation",
     "abstract": "Cumul des degrés-jours pour les jours où la température moyenne est au-dessus d'un seuil et que les immeubles doivent être réfrigérés."
   },
   "HEATING_DEGREE_DAYS": {
@@ -503,9 +503,9 @@
     "abstract": "Nombre de jours où la température journalière minimale est sous un seuil."
   },
   "ICE_DAYS": {
-    "long_name": "Nombre de jours froids (Tmax < {thresh})",
+    "long_name": "Nombre de jours de glace (Tmax < {thresh})",
     "description": "Nombre {freq:m} de jours où la température journalière maximale est sous {thresh}.",
-    "title": "Nombre de jours froids",
+    "title": "Nombre de jours de glace",
     "abstract": "Nombre de jours où la température journalière maximale est sous un seuil."
   },
   "CONSECUTIVE_FROST_DAYS": {

--- a/xclim/data/fr.json
+++ b/xclim/data/fr.json
@@ -150,8 +150,8 @@
     "abstract": "Maximum des précipitations totales quotidiennes pour une période donnée."
   },
   "MAX_N_DAY_PRECIPITATION_AMOUNT": {
-    "long_name": "Précipitation quotidienne maximale sur {window} jours",
-    "description": "Précipitation quotidienne maximale sur {window} jours {freq:f}.",
+    "long_name": "Maximum du cumul sur {window} jours de la précipitation quotidienne",
+    "description": "Maximum {freq:m} du cumul sur {window} jours de la précipitation quotidienne.",
     "title": "Précipitation maximale cumulée sur un nombre de jours donné",
     "abstract": "Maximum de la somme mobile des précipitations quotidiennes pour une période donnée."
   },
@@ -379,22 +379,22 @@
     "abstract": "Nombre de jours où la température maximale est au-dessus du 90e percentile."
   },
   "DTRMAX": {
-    "long_name": "Amplitude maximale de la température diurne",
-    "description": "Maximum {freq:m} de l'amplitude diurne de température.",
-    "title": "Amplitude maxmimale de la température diurne",
-    "abstract": "La différence maximale entre la température journalière maximale et minimale."
+    "long_name": "Amplitude diurne maximale de la température",
+    "description": "Maximum {freq:m} de l'amplitude diurne de la température.",
+    "title": "Amplitude diurne maximale de la température",
+    "abstract": "L'écart maximal entre les températures journalières maximale et minimale."
   },
   "DTR": {
-    "long_name": "Amplitude de la température diurne",
-    "description": "Moyenne {freq:f} de l'amplitude diurne de température.",
-    "title": "Amplitude de la température diurne",
-    "abstract": "La différence moyenne entre la température journalière maximale et minimale."
+    "long_name": "Amplitude diurne de la température",
+    "description": "Moyenne {freq:f} de l'amplitude diurne de la température.",
+    "title": "Amplitude diurne de la température",
+    "abstract": "La différence moyenne entre les températures journalières maximale et minimale."
   },
   "DTRVAR": {
-    "long_name": "Variabilité de l'amplitude de la température diurne",
-    "description": "Variabilité {freq:f} de l'amplitude de la température diurne (définie comme la moyenne de la variation journalière de l'amplitude de température sur une période donnée).",
-    "title": "Variation quotidienne absolue moyenne de l'amplitude de la température diurne",
-    "abstract": "La valeur absolue de la moyenne de l'amplitude de la température diurne."
+    "long_name": "Variabilité de l'amplitude diurne de la température",
+    "description": "Variation interdiurne moyenne {freq:f} de l'amplitude diurne de la température.",
+    "title": "Variation interdiurne moyenne de l'amplitude diurne de la température",
+    "abstract": "Variation interdiurne moyenne de l'amplitude diurne de la température."
   },
   "ETR": {
     "long_name": "Amplitude des températures extrêmes",

--- a/xclim/data/fr.json
+++ b/xclim/data/fr.json
@@ -141,28 +141,24 @@
     "long_name": "Nombre de jours de pluie sur sol gelé",
     "description": "Nombre {freq:m} de jours avec plus de {thresh} de pluie suivant sept jours consécutifs où la température était sous 0°C. Les précipitations sont considérées comme de la pluie lorsque la température moyenne est au-dessus de 0°C.",
     "title": "Nombre de jours de pluie sur sol gelé",
-    "comment": "",
     "abstract": "Nombre de jours avec des précipitations au-dessus d'un certain seuil après 7 jours consécutifs où la température était sous 0°C. Les précipitations sont considérées comme de la pluie lorsque la température moyenne est au-dessus de 0°C."
   },
   "RX1DAY": {
     "long_name": "Précipitation quotidienne maximale",
     "description": "Maximum {freq:m} de la précipitation quotidienne.",
     "title": "Précipitation maximale en 1 jour pour une période donnée",
-    "comment": "",
     "abstract": "Maximum des précipitations totales quotidiennes pour une période donnée."
   },
   "MAX_N_DAY_PRECIPITATION_AMOUNT": {
     "long_name": "Précipitation quotidienne maximale sur {window} jours",
     "description": "Précipitation quotidienne maximale sur {window} jours {freq:f}.",
     "title": "Précipitation maximale cumulée sur un nombre de jours donné",
-    "comment": "",
     "abstract": "Maximum de la somme mobile des précipitations quotidiennes pour une période donnée."
   },
   "MAX_PR_INTENSITY": {
     "long_name": "Intensité maximale de précipitation sur une durée de {window} h",
     "description": "Intensité maximale {freq:f} de précipitation sur une fenêtre mobile de {window} h.",
     "title": "Intensité de précipitation maximale sur une durée et période donnée",
-    "comment": "",
     "keywords": "courbes IDF",
     "abstract": "Maximum de l'intensité de précipitation horaire pour une durée et période donnée."
   },
@@ -170,132 +166,113 @@
     "long_name": "Nombre de jours pluvieux (précip >= {thresh})",
     "description": "Nombre {freq:m} de jours où les précipitations sont au-dessus de {thresh}.",
     "title": "Jours mouillés",
-    "comment": "",
     "abstract": "Nombre de jours où les précipitations sont au-dessus d'un seuil."
   },
   "CDD": {
     "long_name": "Durée maximale d'une période sèche",
     "description": "Nombre {freq:m} maximal de jours consécutifs où les précipitations sont sous {thresh}.",
     "title": "Nombre maximal de jours secs consécutifs",
-    "comment": "",
     "abstract": "Période la plus longue où la précipitation est sous un seuil."
   },
   "CWD": {
     "long_name": "Durée maximale d'une période pluvieuse",
     "description": "Nombre {freq:m} maximal de jours consécutifs où les précipitations sont au-dessus de {thresh}.",
     "title": "Durée de période pluvieuse",
-    "comment": "",
     "abstract": "Période la plus longue où la précipitation est au-dessus d'un seuil."
   },
   "SDII": {
     "long_name": "Indice simple de l'intensité des précipitations",
     "description": "Indice simple d'intensité des précipitations {freq:m} [SDII]. Moyenne {freq:f} de la précipitation journalière pour les jours où la précipitation est au-dessus de {thresh}.",
     "title": "Indice simple de l'intensité des précipitations",
-    "comment": "",
     "abstract": "Moyenne de la précipitation quotidienne pour les jours où la précipitation est au-dessus d'un seuil."
   },
   "PRCPTOT": {
     "long_name": "Précipitation totale",
     "description": "Précipitation totale {freq:f}.",
     "title": "Précipitation accumulée totale (liquide ou solide)",
-    "comment": "",
     "abstract": "Précipitation accumulée totale. Si la température journalière moyenne est donnée, le paramètre phase peut-être utilisé pour restreindre le calcul aux précipitations d'une seule phase (liquide ou solide). Les précipitations sont considérées solides si la température journalière moyenne est sous 0°C (et vice-versa)."
   },
   "WET_PRCPTOT": {
     "long_name": "Précipitation totale lors de jours pluvieux",
     "description": "Précipitation totale {freq:f} lorsque la précipitation journalière excède {thresh}.",
     "title": "Précipitation accumulée totale lors de jours pluvieux",
-    "comment": "",
     "abstract": "Précipitation accumulée totale lors de jours pluvieux. Un jour est considéré pluvieux si la précipitation est supérieure ou égale à un seuil donné."
   },
   "LIQUIDPRCPTOT": {
     "long_name": "Précipitation liquide totale",
     "description": "Précipitation liquide totale {freq:f}, estimée comme la précipitation lorsque la température moyenne est >= 0°C.",
     "title": "Précipitation liquide accumulée totale",
-    "comment": "",
     "abstract": "Précipitation liquide accumulée totale. Les précipitations sont considérées liquides lorsque la température journalière moyenne est au-dessus de 0°C."
   },
   "SOLIDPRCPTOT": {
     "long_name": "Précipitation solide totale",
     "description": "Précipitation solide totale {freq:f}, estimée comme la précipitation lorsque la température moyenne est < 0°C.",
     "title": "Précipitation solide accumulée totale",
-    "comment": "",
     "abstract": "Précipitation liquide accumulée totale. Les précipitations sont considérées liquides lorsque la température journalière moyenne est sous 0°C."
   },
   "DC": {
     "long_name": "Indice de sécheresse",
     "description": "Code numérique estimant la teneur en humidité moyenne de couches organiques. Calculée avec la méthode de mise en route '{start_up_mode}'.",
     "title": "Indice de sécheresse quotidien",
-    "comment": "",
     "abstract": "L'indice de sécheresse fait partie du système canadien des Indices Forêt-Météo. C'est un code numérique estimant la teneur en humidité moyenne de couches organiques."
   },
   "TN_DAYS_ABOVE": {
     "long_name": "Nombre de jours avec Tmin > {thresh}",
     "description": "Nombre {freq:m} de jours où la température journalière minimale est au-dessus de {thresh}.",
     "title": "Nombre de jours avec Tmin au-dessus d'un certain seuil",
-    "comment": "",
     "abstract": "Nombre de jours où la température journalière minimale est au-dessus d'un seuil."
   },
   "TN_DAYS_BELOW": {
     "long_name": "Nombre de jours avec Tmin < {thresh}",
     "description": "Nombre {freq:m} de jours où la température journalière minimale est sous {thresh}.",
     "title": "Nombre de jours avec Tmin sous un certain seuil",
-    "comment": "",
     "abstract": "Nombre de jours où la température journalière minimale est sous un seuil."
   },
   "TG_DAYS_ABOVE": {
     "long_name": "Nombre de jours avec Tmoy > {thresh}",
     "description": "Nombre {freq:m} de jours où la température journalière moyenne est au-dessus de {thresh}.",
     "title": "Nombre de jours avec tmoy au-dessus d'un certain seuil",
-    "comment": "",
     "abstract": "Nombre de jours où la température journalière moyenne est au-dessus d'un seuil."
   },
   "TG_DAYS_BELOW": {
     "long_name": "Nombre de jours avec Tmoy < {thresh}",
     "description": "Nombre {freq:m} de jours où la température journalière moyenne est sous {thresh}.",
     "title": "Nombre de jours avec tmoy sous un certain seuil",
-    "comment": "",
     "abstract": "Nombre de jours où la température journalière moyenne est sous un seuil."
   },
   "TX_DAYS_ABOVE": {
     "long_name": "Nombre de jours avec Tmax > {thresh}",
     "description": "Nombre {freq:m} de jours où la température journalière maximale est au-dessus de {thresh}.",
     "title": "Nombre de jours avec Tmax au-dessus d'un certain seuil",
-    "comment": "",
     "abstract": "Nombre de jours où la température journalière maximale est au-dessus d'un seuil."
   },
   "TX_DAYS_BELOW": {
     "long_name": "Nombre de jours avec Tmax < {thresh}",
     "description": "Nombre {freq:m} de jours où la température journalière maximale est sous {thresh}.",
     "title": "Nombre de jours avec Tmax sous un certain seuil",
-    "comment": "",
     "abstract": "Nombre de jours où la température journalière maximale est sous un seuil."
   },
   "TX_TN_DAYS_ABOVE": {
     "long_name": "Nombre de jours avec Tmax > {thresh_tasmax} et Tmin > {thresh_tasmin}",
     "description": "Nombre {freq:m} de jours où la température journalière maximale excède {thresh_tasmax} et la température journalière minimale excède {thresh_tasmin}.",
     "title": "Nombre de jours avec des températures quotidiennes minimales et maximales chaudes",
-    "comment": "",
     "abstract": "Nombre de jours où les températures journalières maximales et minimales sont au-dessus de seuils donnés."
   },
   "HEAT_WAVE_FREQUENCY": {
     "long_name": "Nombre de vagues de chaleur (Tmin > {thresh_tasmin} et Tmax > {thresh_tasmax} pour {window} jours)",
     "description": "Nombre {freq:m} de vagues de chaleur. Une vague de chaleur se produit lorsque les températures quotidiennes minimales et maximales excèdent {thresh_tasmin} et {thresh_tasmax}, respectivement, durant au moins {window} jours.",
     "title": "Fréquence des vagues de chaleur",
-    "comment": "",
     "abstract": "Nombre de vagues de chaleur. Une vague de chaleur se produit lorsque les températures journalières minimales et maximales excèdent des seuils donnés durant un certain nombre de jours."
   },
   "HEAT_WAVE_TOTAL_LENGTH": {
     "long_name": "Durée totale des vagues de chaleur (Tmin > {thresh_tasmin} et Tmax > {thresh_tasmax} pour >= {window} days)",
     "description": "Durée totale {freq:f} des vagues de chaleur. Une vague de chaleur se produit lorsque les températures quotidiennes minimales et maximales excèdent {thresh_tasmin} et {thresh_tasmax}, respectivement, durant au moins {window} jours.",
-    "comment": "",
     "title": "Durée totale des vagues de chaleur",
     "abstract": "Durée totale des vagues de chaleur. Une vague de chaleur se produit lorsque les températures journalières minimales et maximales excèdent des seuils donnés durant un certain nombre de jours."
   },
   "HEAT_WAVE_MAX_LENGTH": {
     "long_name": "Longueur maximale des vagues de chaleur (Tmin > {thresh_tasmin} et Tmax > {thresh_tasmax} pour {window} jours au moins)",
     "description": "Longueur maximale {freq:f} des vagues de chaleur. Une vague de chaleur se produit lorsque les températures quotidiennes minimales et maximales excèdent {thresh_tasmin} et {thresh_tasmax}, respectivement, durant au moins {window} jours.",
-    "comment": "",
     "title": "Longueur maximale des vagues de chaleur",
     "abstract": "Longueur maximale des vagues de chaleur. Une vague de chaleur se produit lorsque les températures journalières minimales et maximales excèdent des seuils donnés durant un certain nombre de jours."
   },
@@ -303,132 +280,113 @@
     "long_name": "Nombre de jours de vague de chaleur",
     "description": "Nombre {freq:m} de jours de vague de chaleur, définie comme cinq jours consécutifs ou plus où la température est au-dessus de {thresh}.",
     "title": "Indice de vague de chaleur",
-    "comment": "",
     "abstract": "Nombre de jours de vagues de chaleur. Une vague de chaleur se produit lorsque la température journalière maximale excède un seuil durant au moins 5 jours."
   },
   "TG": {
     "long_name": "température journalière moyenne",
     "description": "température journalière moyenne estimée par la médiane des températures maximales et minimales.",
     "title": "Moyenne des températures maximales et minimales",
-    "comment": "",
     "abstract": "La température journalière moyenne en assumant une distribution symétrique des températures.  Tg = (Tx + Tn) / 2"
   },
   "TG_MIN": {
     "long_name": "Minimum de la température journalière moyenne",
     "description": "Minimum {freq:m} de la température journalière moyenne.",
     "title": "Minimum de la température journalière moyenne",
-    "comment": "",
     "abstract": "Minimum de la température journalière moyenne."
   },
   "TG_MAX": {
     "long_name": "Maximum de la température journalière moyenne",
     "description": "Maximum {freq:m} de la température journalière moyenne.",
     "title": "Maximum de la température journalière moyenne",
-    "comment": "",
     "abstract": "Maximum de la température journalière moyenne."
   },
   "TG_MEAN": {
     "long_name": "Moyenne de la température journalière",
     "description": "Moyenne {freq:f} de la température journalière.",
     "title": "Température journalière moyenne",
-    "comment": "",
     "abstract": "Température journalière moyenne."
   },
   "TG10P": {
     "long_name": "Nombre de jours où la température est au-dessus du 10e percentile",
     "description": "Nombre {freq:m} de jours où la température est au-dessus du 10e percentile. Le 10e percentile est calculé à partir d'une fenêtre de 5 jours centrée sur chaque jour du calendrier à l'intérieur d'une période de référence.",
     "title": "Nombre de jours où la température est au-dessus du 10e percentile",
-    "comment": "",
     "abstract": "Nombre de jours où la température est au-dessus du 10e percentile"
   },
   "TG90P": {
     "long_name": "Nombre de jours où la température est au-dessus du 90e percentile",
     "description": "Nombre {freq:m} de jours où la température est au-dessus du 90e percentile. Le 90e percentile est calculé à partir d'une fenêtre de 5 jours centrée sur chaque jour du calendrier à l'intérieur d'une période de référence.",
     "title": "Nombre de jours où la température est au-dessus du 90e percentile",
-    "comment": "",
     "abstract": "Nombre de jours où la température est au-dessus du 90e percentile."
   },
   "TN_MIN": {
     "long_name": "Minimum de la température journalière",
     "description": "Minimum {freq:m} de la température journalière minimale.",
     "title": "Température journalière minimale",
-    "comment": "",
     "abstract": "Température journalière minimale."
   },
   "TN_MAX": {
     "long_name": "Maximum de la température journalière minimale",
     "description": "Maximum {freq:m} de la température journalière minimale.",
     "title": "Maximum de la température minimale",
-    "comment": "",
     "abstract": "Maximum de la température journalière minimale."
   },
   "TN_MEAN": {
     "long_name": "Moyenne de la température journalière minimale",
     "description": "Moyenne {freq:f} de la température journalière minimale.",
     "title": "Moyenne de la température minimale",
-    "comment": "",
     "abstract": "Moyenne de la température journalière minimale."
   },
   "TN10P": {
     "long_name": "Nombre de jours où la température minimale est au-dessous du 10e percentile",
     "description": "Nombre {freq:m} de jours où la température minimale est au-dessous du 10e percentile. Le 10e percentile est calculé à partir d'une fenêtre de 5 jours centrée sur chaque jour du calendrier à l'intérieur d'une période de référence.",
     "title": "Nombre de jours où la température minimale est au-dessous du 10e percentile",
-    "comment": "",
     "abstract": "Nombre de jours où la température minimale est au-dessous du 10e percentile."
   },
   "TN90P": {
     "long_name": "Nombre de jours où la température minimale est au-dessus du 90e percentile",
     "description": "Nombre {freq:m} de jours où la température minimale est au-dessus du 90e percentile. Le 90e percentile est calculé à partir d'une fenêtre de 5 jours centrée sur chaque jour du calendrier à l'intérieur d'une période de référence.",
     "title": "Nombre de jours où la température minimale est au-dessus du 90e percentile",
-    "comment": "",
     "abstract": "Nombre de jours où la température minimale est au-dessus du 90e percentile."
   },
   "TX_MIN": {
     "long_name": "Minimum de la température journalière maximale",
     "description": "Minimum {freq:m} de la température journalière maximale.",
     "title": "Minimum de la température maximale",
-    "comment": "",
     "abstract": "Minimum de la température journalière maximale."
   },
   "TX_MAX": {
     "long_name": "Maximum de la température journalière",
     "description": "Maximum {freq:m} de la température journalière maximale.",
     "title": "Température journalière maximale",
-    "comment": "",
     "abstract": "Température journalière maximale."
   },
   "TX_MEAN": {
     "long_name": "Moyenne de la température journalière maximale",
     "description": "Moyenne {freq:f} de la température journalière maximale.",
     "title": "Moyenne de la température maximale",
-    "comment": "",
     "abstract": "Moyenne de la température journalière maximale."
   },
   "TX10P": {
     "long_name": "Nombre de jours où la température maximale est au-dessous du 10e percentile",
     "description": "Nombre {freq:m} de jours où la température maximale est au-dessous du 10e percentile. Le 10e percentile est calculé à partir d'une fenêtre de 5 jours centrée sur chaque jour du calendrier à l'intérieur d'une période de référence.",
     "title": "Nombre de jours où la température maximale est au-dessous du 10e percentile",
-    "comment": "",
     "abstract": "Nombre de jours où la température maximale est au-dessous du 10e percentile."
   },
   "TX90P": {
     "long_name": "Nombre de jours où la température maximale est au-dessus du 90e percentile",
     "description": "Nombre {freq:m} de jours où la température maximale est au-dessus du 90e percentile. Le 90e percentile est calculé à partir d'une fenêtre de 5 jours centrée sur chaque jour du calendrier à l'intérieur d'une période de référence.",
     "title": "Nombre de jours où la température maximale est au-dessus du 90e percentile",
-    "comment": "",
     "abstract": "Nombre de jours où la température maximale est au-dessus du 90e percentile."
   },
   "DTRMAX": {
     "long_name": "Amplitude maximale de la température diurne",
     "description": "Maximum {freq:m} de l'amplitude diurne de température.",
-    "comment": "",
     "title": "Amplitude maxmimale de la température diurne",
     "abstract": "La différence maximale entre la température journalière maximale et minimale."
   },
   "DTR": {
     "long_name": "Amplitude de la température diurne",
     "description": "Moyenne {freq:f} de l'amplitude diurne de température.",
-    "comment": "",
     "title": "Amplitude de la température diurne",
     "abstract": "La différence moyenne entre la température journalière maximale et minimale."
   },
@@ -436,35 +394,30 @@
     "long_name": "Variabilité de l'amplitude de la température diurne",
     "description": "Variabilité {freq:f} de l'amplitude de la température diurne (définie comme la moyenne de la variation journalière de l'amplitude de température sur une période donnée).",
     "title": "Variation quotidienne absolue moyenne de l'amplitude de la température diurne",
-    "comment": "",
     "abstract": "La valeur absolue de la moyenne de l'amplitude de la température diurne."
   },
   "ETR": {
     "long_name": "Amplitude des températures extrêmes",
     "description": "Calcul {freq:m} de l'intervalle entre le maximum de la température journalière maximale et le minimum de la température journalière minimale.",
     "title": "Intervalle des températures extrêmes",
-    "comment": "",
     "abstract": "Le maximum de la température maximale moins le minimum de la température minimale."
   },
   "COLD_SPELL_DURATION_INDEX": {
     "long_name": "Indice de durée des vagues de froid",
     "description": "Nombre {freq:m} de jours de vague de froid. Une vague de froid se produit lorsque la température journalière minimale est sous le 10e percentile durant au moins {window} jours consécutifs. Le 10e percentile est calculé à partir d'une fenêtre de 5 jours centrée sur chaque jour du calendrier à l'intérieur d'une période de référence.",
     "title": "Indice de durée des vagues de froid",
-    "comment": "",
     "abstract": "Nombre de jours de vagues de froid. Une vague de froid se produit lorsque la température journalière minimale est sous le 10e percentile durant au moins un certain nombre de jours consécutifs."
   },
   "COLD_SPELL_FREQUENCY": {
     "long_name": "Nombre de vagues de froid",
     "description": "Nombre {freq:m} de vagues de froid. Une vague de froid se produit lorsque la température journalière minimale est sous {thresh} durant au moins {window} jours consécutifs.",
     "title": "Nombre de vagues de froid",
-    "comment": "",
     "abstract": "Nombre de vagues de froid. Une vague de froid se produit lorsque la température journalière minimale est sous un seuil durant au moins un certain nombre de jours consécutifs."
   },
   "COLD_SPELL_DAYS": {
     "long_name": "Jours de vagues de froid",
     "description": "Nombre {freq:m} de jours de vague de froid. Une vague de froid se produit lorsque la température journalière minimale est sous {thresh} durant au moins {window} jours consécutifs.",
     "title": "Jours de vague de froid",
-    "comment": "",
     "abstract": "Nombre de jours de vagues de froid. Une vague de froid se produit lorsque la température journalière minimale est sous un seuil durant au moins un certain nombre de jours consécutifs."
   },
   "COOL_NIGHT_INDEX": {
@@ -478,42 +431,36 @@
     "long_name": "Cycles de gel-dégel",
     "description": "Nombre {freq:m} de jours avec un gel-dégel quotidien : Tmax > {thresh_tasmax} et Tmin <= {thresh_tasmin}.",
     "title": "Nombre de jours avec un cycle de gel-dégel",
-    "comment": "",
     "abstract": "Le nombre de jours où Tmax est au-dessus d'un seuil et Tmin au-dessous d'un seuil, habituellement 0 °C pour les deux."
   },
   "COOLING_DEGREE_DAYS": {
     "long_name": "Degrés-jours de réfrigération (Tmoy > {thresh})",
     "description": "Cumul {freq:m} des degrés-jours de réfrigération (Température au-dessus de {thresh}).",
     "title": "Degrés-jours de réfrigération",
-    "comment": "",
     "abstract": "Cumul des degrés-jours pour les jours où la température moyenne est au-dessus d'un seuil et que les immeubles doivent être réfrigérés."
   },
   "HEATING_DEGREE_DAYS": {
     "long_name": "Degrés-jours de chauffage (Tmoy < {thresh})",
     "description": "Cumul {freq:m} des degrés-jours de chauffage (Température au-dessous de {thresh}).",
     "title": "Degrés-jours de chauffage",
-    "comment": "",
     "abstract": "Cumul des degrés-jours pour les jours où la température moyenne est sous un seuil et que les immeubles doivent être chauffés."
   },
   "GROWING_DEGREE_DAYS": {
     "long_name": "Degrés-jours de croissance (Tmoy > {thresh})",
     "description": "Cumul {freq} des degrés-jours de croissance (Température au-dessus de {thresh}).",
     "title": "Degrés-jours de croissance",
-    "comment": "",
     "abstract": "Cumul des degrés-jours pour les jours où la température moyenne est au-dessus d'un seuil."
   },
   "FREEZING_DEGREE_DAYS": {
     "long_name": "Degrés-jours de gel (Tmoy < {thresh})",
     "description": "Cumul {freq:m} des degrés-jours de gel (Température au-dessous de {thresh}).",
     "title": "Degrés-jours de gel",
-    "comment": "",
     "abstract": "Cumul des degrés-jours pour les jours où la température moyenne est sous un seuil."
   },
   "THAWING_DEGREE_DAYS": {
     "long_name": "Degrés-jours de dégel (Tmoy > {thresh})",
     "description": "Cumul {freq} des degrés-jours de dégel (Température au-dessus de {thresh}).",
     "title": "Degrés-jours de dégel",
-    "comment": "",
     "abstract": "Cumul des degrés-jours pour les jours où la température moyenne est au-dessus d'un seuil."
   },
   "BIOLOGICALLY_EFFECTIVE_DEGREE_DAYS": {
@@ -541,7 +488,6 @@
     "long_name": "Jour de l'année du début de la crue nivale",
     "description": "Jour de l'année du début de la crue nivale, défini comme le {window}e jour consécutif où la température excède {thresh}.",
     "title": "Nième jour consécutif où la température excède un seuil",
-    "comment": "",
     "abstract": "Premier jour où la température excède un certain seuil depuis un certain nombre de jours consécutifs."
   },
   "FROST_SEASON_LENGTH": {
@@ -554,27 +500,23 @@
     "long_name": "Nombre de jours de gel (Tmin < {thresh})",
     "description": "Nombre {freq:m} de jours où la température journalière minimale est sous {thresh}.",
     "title": "Nombre de jours de gel",
-    "comment": "",
     "abstract": "Nombre de jours où la température journalière minimale est sous un seuil."
   },
   "ICE_DAYS": {
     "long_name": "Nombre de jours froids (Tmax < {thresh})",
     "description": "Nombre {freq:m} de jours où la température journalière maximale est sous {thresh}.",
     "title": "Nombre de jours froids",
-    "comment": "",
     "abstract": "Nombre de jours où la température journalière maximale est sous un seuil."
   },
   "CONSECUTIVE_FROST_DAYS": {
     "long_name": "Durée maximale des périodes de gel (Tmin < 0°C)",
     "description": "Durée maximale {freq:f} des périodes où la température journalière minimale est sous 0°C.",
     "title": "Durée maximale des périodes de gel (Tmin < 0°C)",
-    "comment": "",
     "abstract": "Durée maximale des périodes consécutives où la température journalière minimale est sous 0°C."
   },
   "FROST_FREE_SEASON_LENGTH": {
     "long_name": "Durée de la saison sans gel",
     "description": "Nombre {freq:m} de jours entre la première occurrence d'au moins {window} jours consécutifs où la température journalière moyenne dépasse {thresh} et la première occurrence (après le {mid_date}) d'au moins {window} jours consécutifs où la température est sous {thresh}.",
-    "comment": "",
     "title": "Durée de la saison sans gel",
     "abstract": "Nombre de jours entre la première série de N jours avec des températures journalières moyennes au-dessus d'un seuil et la première série de N jours avec des températures journalières moyennes sous ce même seuil."
   },
@@ -582,13 +524,11 @@
     "long_name": "Jour de l'année du début de la saison sans gel",
     "description": "Jour de l'année du début de la saison sans gel, défini comme le {window}e jour consécutif où la température excède {thresh}.",
     "title": "Nième jour consécutif où la température excède un seuil",
-    "comment": "",
     "abstract": "Premier jour où la température excède un certain seuil depuis un certain nombre de jours consécutifs."
   },
   "GROWING_SEASON_LENGTH": {
     "long_name": "Durée de la saison de croissance",
     "description": "Nombre {freq:m} de jours entre la première occurrence d'au moins {window} jours consécutifs où la température journalière moyenne dépasse {thresh} et la première occurrence (après le {mid_date}) d'au moins {window} jours consécutifs où la température est sous {thresh}.",
-    "comment": "",
     "title": "Durée de la saison de croissance",
     "abstract": "Nombre de jours entre la première série de N jours avec des températures journalières moyennes au-dessus d'un seuil et la première série de N jours avec des températures journalières moyennes sous ce même seuil."
   },
@@ -596,125 +536,107 @@
     "long_name": "Jour de l'année du début de la saison de croissance",
     "description": "Jour de l'année du début de la saison de croissance, défini comme le {window}e jour consécutif où la température excède {thresh}.",
     "title": "Nième jour consécutif où la température excède un seuil",
-    "comment": "",
     "abstract": "Premier jour où la température excède un certain seuil depuis un certain nombre de jours consécutifs."
   },
   "TROPICAL_NIGHTS": {
     "long_name": "Nombre de nuits tropicales (Tmin > {thresh})",
     "description": "Nombre {freq:m} de nuits tropicales : définies comme des jours avec une température minimale au-dessus de {thresh}.",
     "title": "Nombre de nuits tropicales",
-    "comment": "",
     "abstract": "Nombre de jours où la température minimale est au-dessus d'un seuil."
   },
   "BASE_FLOW_INDEX": {
     "long_name": "Flux de base",
     "description": "Minimum de la moyenne mobile sur 7 jours du flux moyen divisé par le flux moyen.",
     "title": "Flux de base",
-    "comment": "",
     "abstract": "Minimum de la moyenne mobile sur 7 jours du flux moyen divisé par le flux moyen."
   },
   "RB_FLASHINESS_INDEX": {
     "long_name": "Indice Richards-Baker de torrentialité",
     "description": "Indice Richards-Baker mesurant le caractère torrentiel d'un débit de rivière.",
     "title": "Indice Richards-Baker de torrentialité",
-    "comment": "",
     "abstract": "Mesure des oscillations du débit relatif au débit moyen, quantifiant la fréquence et la rapidité des changements de débits."
   },
   "FREQ_ANALYSIS": {
     "long_name": "Période de retour {mode} {indexer} du flux de {window} jours",
     "description": "Analyse de fréquence pour le {mode} {indexer} du flux de {window} jours, estimé avec la distribution {dist:f}.",
     "title": "Période de retour",
-    "comment": "",
     "abstract": "Analyse de fréquence selon un mode et une distribution."
   },
   "STATS": {
     "long_name": "{op} du {indexer} {freq:m} du flux journalier",
     "description": "{op} du {indexer} {freq:m} du flux journalier.",
     "title": "Calcul de statistiques sur des sous-périodes.",
-    "comment": "",
     "abstract": ""
   },
   "FIT": {
     "long_name": "Paramètres d'une distribution {dist:f}",
     "description": "Paramètres d'une distribution {dist:f}.",
     "title": "Calcul les paramètres d'une distribution univariée pour un ensemble de données",
-    "comment": "",
     "abstract": ""
   },
   "DOY_QMAX": {
     "long_name": "Jour de l'année du maximum le long de {indexer}",
     "description": "Jour de l'année du maximum le long de {indexer}.",
-    "comment": "",
     "title": "Jour de l'année du maximum",
     "abstract": ""
   },
   "DOY_QMIN": {
     "long_name": "Jour de l'année du minimum le long de {indexer}",
     "description": "Jour de l'année du minimum le long de {indexer}.",
-    "comment": "",
     "title": "Jour de l'année du minimum",
     "abstract": ""
   },
   "SEA_ICE_AREA": {
     "long_name": "Surface de la banquise",
     "description": "La somme des surfaces recouvertes de glace de mer là où sa concentration est d'au moins {thresh}.",
-    "comment": "",
     "title": "Surface de la banquise",
     "abstract": "Mesure de surface totale des océans couverte de glace de mer."
   },
   "SEA_ICE_EXTENT": {
     "long_name": "Étendue de banquise",
     "description": "L'aire totale de toutes les régions où la concentration de glace de mer est d'au moins {thresh}.",
-    "comment": "",
     "title": "Étendue de la banquise",
     "abstract": "Mesure de l'étendue de toutes les régions où la concentration de glace de mer excède un seuil."
   },
   "DRY_DAYS": {
     "long_name": "Nombre de jours secs (precip < {thresh})",
     "description": "Nombre {freq} de jours où la précipitation journalière est sous {thresh}.",
-    "comment": "",
     "title": "Jours secs",
     "abstract": "Nombre de jours où la précipitation journalière est sous un seuil."
   },
   "HOT_SPELL_FREQUENCY": {
     "long_name": "Nombre de périodes chaudes (Tmax > {thresh_tasmax} durant >= {window} jours)",
     "description": "Nombre {freq} de périodes chaudes. Une période chaude se produit lorsque la température journalière maximale excède {thresh_tasmax} durant au moins {window} jours.",
-    "comment": "",
     "title": "Fréquences des périodes chaudes",
     "abstract": "Nombre de périodes chaudes dans un période donnée. Une période chaude se produit lorsque la température journalière maximale excède un seuil spécifique durant un minimum de jours."
   },
   "LAST_SPRING_FROST": {
     "long_name": "Jour de l'année du dernier gel printanier",
     "description": "Jour de l'année du dernier gel printanier, defini comme le dernier jour où la température journalière moyenne reste sous {thresh} durant au moins {window} jours avant une certaine date.",
-    "comment": "",
     "title": "Jour de l'année du dernier gel printanier",
     "abstract": "Dernier jour où la température est inférieur à un seuil durant un certain nombre de jours, limité par une date finale."
   },
   "HOT_SPELL_MAX_LENGTH": {
     "long_name": "Longueur maximale des périodes chaudes (Tmax > {thresh_tasmax} durant >= {window} jours)",
     "description": "Longueur maximale {freq:f} des périodes chaudes. Une période chaude se produit lorsque la température journalière maximale excède {thresh_tasmax} durant au moins {window} jours.",
-    "comment": "",
     "title": "Longueur maximale des périodes chaudes",
     "abstract": "Longueur maximale des périodes chaudes dans une période donnée. Une période chaude se produit lorsque la température journalière maximale excède un seuil spécifique durant un minimum de jours."
   },
   "CONSECUTIVE_FROST_FREE_DAYS": {
     "long_name": "Nombre maximal de jours consécutifs avec Tmin >= {thresh}",
     "description": "Nombre maximal {freq} de jours consécutifs où la température journalière minimale excède ou est égale à {thresh}.",
-    "comment": "",
     "title": "Nombre maximal de jours consécutifs sans gel (Tmin >= 0℃)",
     "abstract": "La nombre maximal de jours consécutifs sans gel: où la température journalière minimale est au-dessus ou égale à un seuil."
   },
   "GROWING_SEASON_END": {
     "long_name": "Jour de l'année de la fin de la saison de croissance",
     "description": "Jour de l'année de la fin de la saison de croissance. La saison de croissance est définie comme l'intervalle entre la première série de {window} jours où la température journalière est au-dessus de {thresh} et la première série (après le {mid_date}) de {window} jours où elle est sous {thresh}.",
-    "comment": "",
     "title": "Fin de la saison de croissance",
     "abstract": "Jour de l'année de la fin de la saison de croissance. La saison de croissance est définie comme l'intervalle entre la première série de N jours où la température journalière est au-dessus d'un seuil et la première série (après une certaine date) de N jours où elle est sous ce même seuil."
   },
   "FROST_FREE_SEASON_END": {
     "long_name": "Jour de l'année de la fin de la saison sans gel",
     "description": "Jour de l'année de la fin de la saison sans gel. La saison sans gel est définie comme l'intervalle entre la première série de {window} jours où la température journalière est au-dessus de {thresh} et la première série (après le {mid_date}) de {window} jours où elle est sous {thresh}.",
-    "comment": "",
     "title": "Fin de la saison sans gel",
     "abstract": "Jour de l'année de la fin de la saison sans gél. La saison sans gel est définie comme l'intervalle entre la première série de N jours où la température journalière est au-dessus d'un seuil et la première série (après une certaine date) de N jours où elle est sous ce même seuil."
   },

--- a/xclim/data/fr.json
+++ b/xclim/data/fr.json
@@ -145,15 +145,15 @@
     "abstract": "Nombre de jours avec des précipitations au-dessus d'un certain seuil après 7 jours consécutifs où la température était sous 0°C. Les précipitations sont considérées comme de la pluie lorsque la température moyenne est au-dessus de 0°C."
   },
   "RX1DAY": {
-    "long_name": "Précipitation maximale en 1 jour",
-    "description": "Précipitation maximale en 1 jour {freq:f}.",
-    "title": "Précipitation maximale en 1 jour dans une période donnée",
+    "long_name": "Précipitation quotidienne maximale",
+    "description": "Maximum {freq:m} de la précipitation quotidienne.",
+    "title": "Précipitation maximale en 1 jour pour une période donnée",
     "comment": "",
     "abstract": "Maximum des précipitations totales quotidiennes pour une période donnée."
   },
   "MAX_N_DAY_PRECIPITATION_AMOUNT": {
-    "long_name": "Précipitation maximale sur {window} jours",
-    "description": "Précipitation maximale sur {window} jours {freq:f}.",
+    "long_name": "Précipitation quotidienne maximale sur {window} jours",
+    "description": "Précipitation quotidienne maximale sur {window} jours {freq:f}.",
     "title": "Précipitation maximale cumulée sur un nombre de jours donné",
     "comment": "",
     "abstract": "Maximum de la somme mobile des précipitations quotidiennes pour une période donnée."
@@ -232,14 +232,14 @@
   "TN_DAYS_ABOVE": {
     "long_name": "Nombre de jours avec Tmin > {thresh}",
     "description": "Nombre {freq:m} de jours où la température journalière minimale est au-dessus de {thresh}.",
-    "title": "Nombre de jours avec tmin au-dessus d'un certain seuil",
+    "title": "Nombre de jours avec Tmin au-dessus d'un certain seuil",
     "comment": "",
     "abstract": "Nombre de jours où la température journalière minimale est au-dessus d'un seuil."
   },
   "TN_DAYS_BELOW": {
     "long_name": "Nombre de jours avec Tmin < {thresh}",
     "description": "Nombre {freq:m} de jours où la température journalière minimale est sous {thresh}.",
-    "title": "Nombre de jours avec tmin sous un certain seuil",
+    "title": "Nombre de jours avec Tmin sous un certain seuil",
     "comment": "",
     "abstract": "Nombre de jours où la température journalière minimale est sous un seuil."
   },
@@ -260,14 +260,14 @@
   "TX_DAYS_ABOVE": {
     "long_name": "Nombre de jours avec Tmax > {thresh}",
     "description": "Nombre {freq:m} de jours où la température journalière maximale est au-dessus de {thresh}.",
-    "title": "Nombre de jours avec tmax au-dessus d'un certain seuil",
+    "title": "Nombre de jours avec Tmax au-dessus d'un certain seuil",
     "comment": "",
     "abstract": "Nombre de jours où la température journalière maximale est au-dessus d'un seuil."
   },
   "TX_DAYS_BELOW": {
     "long_name": "Nombre de jours avec Tmax < {thresh}",
     "description": "Nombre {freq:m} de jours où la température journalière maximale est sous {thresh}.",
-    "title": "Nombre de jours avec tmax sous un certain seuil",
+    "title": "Nombre de jours avec Tmax sous un certain seuil",
     "comment": "",
     "abstract": "Nombre de jours où la température journalière maximale est sous un seuil."
   },
@@ -328,11 +328,11 @@
     "abstract": "Maximum de la température journalière moyenne."
   },
   "TG_MEAN": {
-    "long_name": "Moyenne de la température journalière moyenne",
-    "description": "Moyenne {freq:f} de la température journalière moyenne.",
-    "title": "Moyenne de la température journalière moyenne",
+    "long_name": "Moyenne de la température journalière",
+    "description": "Moyenne {freq:f} de la température journalière.",
+    "title": "Température journalière moyenne",
     "comment": "",
-    "abstract": "Moyenne de la température journalière moyenne."
+    "abstract": "Température journalière moyenne."
   },
   "TG10P": {
     "long_name": "Nombre de jours où la température est au-dessus du 10e percentile",
@@ -346,14 +346,14 @@
     "description": "Nombre {freq:m} de jours où la température est au-dessus du 90e percentile. Le 90e percentile est calculé à partir d'une fenêtre de 5 jours centrée sur chaque jour du calendrier à l'intérieur d'une période de référence.",
     "title": "Nombre de jours où la température est au-dessus du 90e percentile",
     "comment": "",
-    "abstract": "Number of days with daily mean temperature over the 90th percentile."
+    "abstract": "Nombre de jours où la température est au-dessus du 90e percentile."
   },
   "TN_MIN": {
-    "long_name": "Minimum de la température journalière minimale",
+    "long_name": "Minimum de la température journalière",
     "description": "Minimum {freq:m} de la température journalière minimale.",
-    "title": "Minimum de la température minimale",
+    "title": "Température journalière minimale",
     "comment": "",
-    "abstract": "Minimum de la température journalière minimale."
+    "abstract": "Température journalière minimale."
   },
   "TN_MAX": {
     "long_name": "Maximum de la température journalière minimale",
@@ -370,11 +370,11 @@
     "abstract": "Moyenne de la température journalière minimale."
   },
   "TN10P": {
-    "long_name": "Nombre de jours où la température minimale est au-dessus du 10e percentile",
-    "description": "Nombre {freq:m} de jours où la température minimale est au-dessus du 10e percentile. Le 10e percentile est calculé à partir d'une fenêtre de 5 jours centrée sur chaque jour du calendrier à l'intérieur d'une période de référence.",
-    "title": "Nombre de jours où la température minimale est au-dessus du 10e percentile",
+    "long_name": "Nombre de jours où la température minimale est au-dessous du 10e percentile",
+    "description": "Nombre {freq:m} de jours où la température minimale est au-dessous du 10e percentile. Le 10e percentile est calculé à partir d'une fenêtre de 5 jours centrée sur chaque jour du calendrier à l'intérieur d'une période de référence.",
+    "title": "Nombre de jours où la température minimale est au-dessous du 10e percentile",
     "comment": "",
-    "abstract": "Nombre de jours où la température minimale est au-dessus du 10e percentile."
+    "abstract": "Nombre de jours où la température minimale est au-dessous du 10e percentile."
   },
   "TN90P": {
     "long_name": "Nombre de jours où la température minimale est au-dessus du 90e percentile",
@@ -391,11 +391,11 @@
     "abstract": "Minimum de la température journalière maximale."
   },
   "TX_MAX": {
-    "long_name": "Maximum de la température journalière maximale",
+    "long_name": "Maximum de la température journalière",
     "description": "Maximum {freq:m} de la température journalière maximale.",
-    "title": "Maximum de la température maximale",
+    "title": "Température journalière maximale",
     "comment": "",
-    "abstract": "Maximum de la température journalière maximale."
+    "abstract": "Température journalière maximale."
   },
   "TX_MEAN": {
     "long_name": "Moyenne de la température journalière maximale",
@@ -405,11 +405,11 @@
     "abstract": "Moyenne de la température journalière maximale."
   },
   "TX10P": {
-    "long_name": "Nombre de jours où la température maximale est au-dessus du 10e percentile",
-    "description": "Nombre {freq:m} de jours où la température maximale est au-dessus du 10e percentile. Le 10e percentile est calculé à partir d'une fenêtre de 5 jours centrée sur chaque jour du calendrier à l'intérieur d'une période de référence.",
-    "title": "Nombre de jours où la température maximale est au-dessus du 10e percentile",
+    "long_name": "Nombre de jours où la température maximale est au-dessous du 10e percentile",
+    "description": "Nombre {freq:m} de jours où la température maximale est au-dessous du 10e percentile. Le 10e percentile est calculé à partir d'une fenêtre de 5 jours centrée sur chaque jour du calendrier à l'intérieur d'une période de référence.",
+    "title": "Nombre de jours où la température maximale est au-dessous du 10e percentile",
     "comment": "",
-    "abstract": "Nombre de jours où la température maximale est au-dessus du 10e percentile."
+    "abstract": "Nombre de jours où la température maximale est au-dessous du 10e percentile."
   },
   "TX90P": {
     "long_name": "Nombre de jours où la température maximale est au-dessus du 90e percentile",
@@ -423,14 +423,14 @@
     "description": "Maximum {freq:m} de l'amplitude diurne de température.",
     "comment": "",
     "title": "Amplitude maxmimale de la température diurne",
-    "abstract": "La différence maximale entre la température journalière maximale et la température journalière minimale."
+    "abstract": "La différence maximale entre la température journalière maximale et minimale."
   },
   "DTR": {
     "long_name": "Amplitude de la température diurne",
     "description": "Moyenne {freq:f} de l'amplitude diurne de température.",
     "comment": "",
     "title": "Amplitude de la température diurne",
-    "abstract": "La différence moyenne entre la température journalière maximale et la température journalière minimale."
+    "abstract": "La différence moyenne entre la température journalière maximale et minimale."
   },
   "DTRVAR": {
     "long_name": "Variabilité de l'amplitude de la température diurne",
@@ -475,44 +475,44 @@
     "abstract": "Indicateur des conditions nycthermiques de maturation, qui correspond à la valeur moyenne de la température minimale de l'air sur les 30 jours précédant la date de récolte potentielle."
   },
   "DLYFRZTHW": {
-    "long_name": "Cycles de gel-dégel quotidien",
-    "description": "Nombre {freq:m} de jours avec un gel-dégel : Tmax > {thresh_tasmax} et Tmin <= {thresh_tasmin}.",
+    "long_name": "Cycles de gel-dégel",
+    "description": "Nombre {freq:m} de jours avec un gel-dégel quotidien : Tmax > {thresh_tasmax} et Tmin <= {thresh_tasmin}.",
     "title": "Nombre de jours avec un cycle de gel-dégel",
     "comment": "",
-    "abstract": "Le nombre de jours où Tmax est au-dessus d'un seuil et Tmin sous un seuil, habituellement 0°C pour les deux."
+    "abstract": "Le nombre de jours où Tmax est au-dessus d'un seuil et Tmin au-dessous d'un seuil, habituellement 0 °C pour les deux."
   },
   "COOLING_DEGREE_DAYS": {
-    "long_name": "Degré-jour de réfrigération (Tmoy > {thresh})",
+    "long_name": "Degrés-jours de réfrigération (Tmoy > {thresh})",
     "description": "Cumul {freq:m} des degrés-jours de réfrigération (Température au-dessus de {thresh}).",
-    "title": "Degré-jour de réfrigération",
+    "title": "Degrés-jours de réfrigération",
     "comment": "",
     "abstract": "Cumul des degrés-jours pour les jours où la température moyenne est au-dessus d'un seuil et que les immeubles doivent être réfrigérés."
   },
   "HEATING_DEGREE_DAYS": {
-    "long_name": "Degré-jour de chauffage (Tmoy < {thresh})",
-    "description": "Cumul {freq:m} des degrés-jours de chauffage (Température au-dessus de {thresh}).",
-    "title": "Degré-jour de chauffage",
+    "long_name": "Degrés-jours de chauffage (Tmoy < {thresh})",
+    "description": "Cumul {freq:m} des degrés-jours de chauffage (Température au-dessous de {thresh}).",
+    "title": "Degrés-jours de chauffage",
     "comment": "",
     "abstract": "Cumul des degrés-jours pour les jours où la température moyenne est sous un seuil et que les immeubles doivent être chauffés."
   },
   "GROWING_DEGREE_DAYS": {
-    "long_name": "Degré-jour de croissance (Tmoy > {thresh})",
+    "long_name": "Degrés-jours de croissance (Tmoy > {thresh})",
     "description": "Cumul {freq} des degrés-jours de croissance (Température au-dessus de {thresh}).",
-    "title": "Degré-jour de croissance",
+    "title": "Degrés-jours de croissance",
     "comment": "",
     "abstract": "Cumul des degrés-jours pour les jours où la température moyenne est au-dessus d'un seuil."
   },
   "FREEZING_DEGREE_DAYS": {
-    "long_name": "Degré-jour de gel (Tmoy < {thresh})",
-    "description": "Cumul {freq:m} des degrés-jours de gel (Température au-dessus de {thresh}).",
-    "title": "Degré-jour de gel",
+    "long_name": "Degrés-jours de gel (Tmoy < {thresh})",
+    "description": "Cumul {freq:m} des degrés-jours de gel (Température au-dessous de {thresh}).",
+    "title": "Degrés-jours de gel",
     "comment": "",
     "abstract": "Cumul des degrés-jours pour les jours où la température moyenne est sous un seuil."
   },
   "THAWING_DEGREE_DAYS": {
-    "long_name": "Degré-jour de dégel (Tmoy > {thresh})",
+    "long_name": "Degrés-jours de dégel (Tmoy > {thresh})",
     "description": "Cumul {freq} des degrés-jours de dégel (Température au-dessus de {thresh}).",
-    "title": "Degré-jour de dégel",
+    "title": "Degrés-jours de dégel",
     "comment": "",
     "abstract": "Cumul des degrés-jours pour les jours où la température moyenne est au-dessus d'un seuil."
   },
@@ -558,9 +558,9 @@
     "abstract": "Nombre de jours où la température journalière minimale est sous un seuil."
   },
   "ICE_DAYS": {
-    "long_name": "Nombre de jours de givre (Tmax < {thresh})",
+    "long_name": "Nombre de jours froids (Tmax < {thresh})",
     "description": "Nombre {freq:m} de jours où la température journalière maximale est sous {thresh}.",
-    "title": "Nombre de jours de givre",
+    "title": "Nombre de jours froids",
     "comment": "",
     "abstract": "Nombre de jours où la température journalière maximale est sous un seuil."
   },
@@ -586,15 +586,15 @@
     "abstract": "Premier jour où la température excède un certain seuil depuis un certain nombre de jours consécutifs."
   },
   "GROWING_SEASON_LENGTH": {
-    "long_name": "Durée de la saison de végétation",
+    "long_name": "Durée de la saison de croissance",
     "description": "Nombre {freq:m} de jours entre la première occurrence d'au moins {window} jours consécutifs où la température journalière moyenne dépasse {thresh} et la première occurrence (après le {mid_date}) d'au moins {window} jours consécutifs où la température est sous {thresh}.",
     "comment": "",
     "title": "Durée de la saison de croissance",
     "abstract": "Nombre de jours entre la première série de N jours avec des températures journalières moyennes au-dessus d'un seuil et la première série de N jours avec des températures journalières moyennes sous ce même seuil."
   },
   "GROWING_SEASON_START": {
-    "long_name": "Jour de l'année du début de la saison de végétation",
-    "description": "Jour de l'année du début de la saison de végétation, défini comme le {window}e jour consécutif où la température excède {thresh}.",
+    "long_name": "Jour de l'année du début de la saison de croissance",
+    "description": "Jour de l'année du début de la saison de croissance, défini comme le {window}e jour consécutif où la température excède {thresh}.",
     "title": "Nième jour consécutif où la température excède un seuil",
     "comment": "",
     "abstract": "Premier jour où la température excède un certain seuil depuis un certain nombre de jours consécutifs."
@@ -705,11 +705,11 @@
     "abstract": "La nombre maximal de jours consécutifs sans gel: où la température journalière minimale est au-dessus ou égale à un seuil."
   },
   "GROWING_SEASON_END": {
-    "long_name": "Jour de l'année de la fin de la saison de végétation",
-    "description": "Jour de l'année de la fin de la saison de végétation. La saison de végétation est définie comme l'intervalle entre la première série de {window} jours où la température journalière est au-dessus de {thresh} et la première série (après le {mid_date}) de {window} jours où elle est sous {thresh}.",
+    "long_name": "Jour de l'année de la fin de la saison de croissance",
+    "description": "Jour de l'année de la fin de la saison de croissance. La saison de croissance est définie comme l'intervalle entre la première série de {window} jours où la température journalière est au-dessus de {thresh} et la première série (après le {mid_date}) de {window} jours où elle est sous {thresh}.",
     "comment": "",
-    "title": "Fin de la saison de végétation",
-    "abstract": "Jour de l'année de la fin de la saison de végétation. La saison de végétation est définie comme l'intervalle entre la première série de N jours où la température journalière est au-dessus d'un seuil et la première série (après une certaine date) de N jours où elle est sous ce même seuil."
+    "title": "Fin de la saison de croissance",
+    "abstract": "Jour de l'année de la fin de la saison de croissance. La saison de croissance est définie comme l'intervalle entre la première série de N jours où la température journalière est au-dessus d'un seuil et la première série (après une certaine date) de N jours où elle est sous ce même seuil."
   },
   "FROST_FREE_SEASON_END": {
     "long_name": "Jour de l'année de la fin de la saison sans gel",
@@ -924,8 +924,8 @@
   "WARM_SPELL_DURATION_INDEX": {
     "title": "Indice de durée des vagues de chaleur",
     "abstract": "Nombre de jours faisant partie de vagues d'une longueur minimale où la température maximale quotidienne excède le 90e percentile. Le 90e percentile des températures devrait être calculé avec une fenêtre mobile de 5 jours.",
-    "description": "Nombre {freq:m} total de jours faisant parties de vagues de chaleur d'au moins {window} jours consécutifs où tmax est au-dessus du 90e percentile.",
-    "long_name": "Indice de durée des vagues de chaleur"
+    "description": "Durée totale {freq:m} des vagues de chaleur. Une vague de chaleur se produit lorsque Tmax est au-dessus du 90e percentile, durant au moins {window} jours.",
+    "long_name": "Durée des vagues de chaleur"
   },
   "MAXIMUM_CONSECUTIVE_WARM_DAYS": {
     "title": "Nombre maximal de jours chauds consécutifs",
@@ -948,23 +948,23 @@
   "FREEZETHAW_SPELL_FREQUENCY": {
     "title": "Fréquence des événements de gel-dégel quotidien",
     "abstract": "Nombre de périodes de gel-dégel. Ces périodes sont des séries de jours consécutifs où la température minimale quotidienne est sous un seuil et la température maximale quotidienne au-dessus d'un autre. En général, ces deux seuils sont 0°C.",
-    "description": "Fréquence {freq:f} des événements de gel-dégel quotidien : Tmax > {thresh_tasmax} and Tmin <= {thresh_tasmin} pour au moins {window} jour(s) consecutif(s).",
+    "description": "Fréquence {freq:f} des événements de gel-dégel quotidien : Tmax > {thresh_tasmax} et Tmin <= {thresh_tasmin} pour au moins {window} jour(s) consecutif(s).",
     "long_name": "Fréquence {freq:f} des événements de gel-dégel quotidien"
   },
   "FREEZETHAW_SPELL_MAX_LENGTH": {
-    "title": "Longueur maximale des événements de gel-dégel quotidien",
-    "abstract": "Longueur maximale des périodes de gel-dégel. Ces périodes sont des séries de jours consécutifs où la température minimale quotidienne est sous un seuil et la température maximale quotidienne au-dessus d'un autre. En général, ces deux seuils sont 0°C.",
-    "description": "Longueur maximale {freq:f} des événements de gel-dégel quotidien : Tmax > {thresh_tasmax} and Tmin <= {thresh_tasmin} pour au moins {window} jour(s) consecutif(s).",
-    "long_name": "Longueur maximale {freq:f} des événements de gel-dégel quotidien"
+    "title": "Durée maximale du nombre de jours consécutifs avec un gel-dégel",
+    "abstract": "Durée maximale des périodes de gel-dégel. Ces périodes sont des séries de jours consécutifs où la température minimale quotidienne est sous un seuil et la température maximale quotidienne au-dessus d'un autre. En général, ces deux seuils sont 0°C.",
+    "description": "Durée maximale {freq:f} des événements de gel-dégel quotidien : Tmax > {thresh_tasmax} et Tmin <= {thresh_tasmin} pour au moins {window} jour(s) consecutif(s).",
+    "long_name": "Durée maximale {freq:f} des événements de gel-dégel quotidien"
   },
   "FREEZETHAW_SPELL_MEAN_LENGTH": {
-    "title": "Longueur moyenne des événements de gel-dégel quotidien",
-    "abstract": "Longueur moyenne des périodes de gel-dégel. Ces périodes sont des séries de jours consécutifs où la température minimale quotidienne est sous un seuil et la température maximale quotidienne au-dessus d'un autre. En général, ces deux seuils sont 0°C.",
-    "description": "Longueur moyenne {freq:f} des événements de gel-dégel quotidien : Tmax > {thresh_tasmax} and Tmin <= {thresh_tasmin} pour au moins {window} jour(s) consecutif(s).",
-    "long_name": "Longueur moyenne {freq:f} des événements de gel-dégel quotidien"
+    "title": "Durée moyenne du nombre de jours consécutifs avec un gel-dégel",
+    "abstract": "Durée moyenne des périodes de gel-dégel. Ces périodes sont des séries de jours consécutifs où la température minimale quotidienne est sous un seuil et la température maximale quotidienne au-dessus d'un autre. En général, ces deux seuils sont 0°C.",
+    "description": "Durée moyenne {freq:f} des événements de gel-dégel quotidien : Tmax > {thresh_tasmax} et Tmin <= {thresh_tasmin} pour au moins {window} jour(s) consecutif(s).",
+    "long_name": "Durée moyenne {freq:f} des événements de gel-dégel quotidien"
   },
   "WIND_CHILL": {
-    "title": "Facteur éolien.",
+    "title": "Facteur éolien",
     "abstract": "Le facteur éolien est un indice qui équivaut à la sensation du froid par un individu moyen. Il est calculé à partir de la température et de la vitesse du vent à 10 m. Tel que définit par Environnement et Changement Climatique Canada, une seconde formule est utilisé pour les vents faibles. La formule standard est sinon la même qu'utilisée aux États-Unis.",
     "description": "Refroiddissement éolien, équivalent à la sensation du froid due au vent par in individu moyen.",
     "long_name": "Facteur éolien"
@@ -976,25 +976,25 @@
     "long_name": "indice humidex"
   },
   "POTENTIAL_EVAPOTRANSPIRATION": {
-    "title": "Évapotranspiration potentielle.",
+    "title": "Évapotranspiration potentielle",
     "abstract": "Le potentiel d'évaporation de l'eau du sol et de transpiration par les plantes si l'approvisionnement en eau est suffisant, avec une méthode donnée.",
     "description": "Le potentiel d'évaporation de l'eau du sol et de transpiration par les plantes si l'approvisionnement en eau est suffisant, avec la méthode de {method}.",
     "long_name": "Évapotranspiration potentielle"
   },
   "WATER_BUDGET": {
-    "title": "Bilan hydrique.",
+    "title": "Bilan hydrique",
     "abstract": "Précipitations moins l'évapotranspiration potentielle en tant que mesure approximative d'un bilan hydrique de surface, où l'évapotranspiration potentielle est calculée avec une méthode donnée.",
     "description": "Précipitations moins l'évapotranspiration potentielle en tant que mesure approximative d'un bilan hydrique de surface, où l'évapotranspiration potentielle est calculée avec la méthode {method}.",
     "long_name": "Bilan hydrique"
   },
   "DRY_SPELL_FREQUENCY": {
-    "title": "Fréquence des périodes sèches.",
+    "title": "Fréquence des périodes sèches",
     "abstract": "Fréquence des périodes sèches de n jours et plus, pendant lesquelles les précipitations accumulées ou maximales sur une fenêtre de n jours sont inférieures à un seuil donné.",
     "description": "Fréquence {freq:f} des périodes sèches de {window} jours et plus, pendant lesquelles les précipitations {op:fpl} sur une fenêtre de {window} jours sont inférieures à {thresh}.",
     "long_name": "Fréquence {freq:f} des périodes sèches de {window} jours et plus"
   },
   "DRY_SPELL_TOTAL_LENGTH": {
-    "title": "Durée totale en jours des périodes séches.",
+    "title": "Durée totale en jours des périodes séches",
     "abstract": "Durée totale en jours des périodes séches de n jours et plus, pendant lesquelles les précipitations accumulées sur une fenêtre de n jours sont inférieures à un seuil donné.",
     "description": "Durée totale {freq:f} en jours des périodes séches de {window} jours et plus, pendant lesquelles les précipitations accumulées sur une fenêtre de {window} jours sont inférieures à {thresh}.",
     "long_name": "Durée totale {freq:f} en jours des périodes sèches de {window} jours et plus"

--- a/xclim/testing/tests/test_locales.py
+++ b/xclim/testing/tests/test_locales.py
@@ -43,7 +43,7 @@ def test_local_dict(tmp_path):
     loc, dic = xloc.get_local_dict("fr")
     assert loc == "fr"
     assert (
-        dic["TG_MEAN"]["long_name"] == "Moyenne de la température journalière moyenne"
+        dic["TG_MEAN"]["long_name"] == "Moyenne de la température journalière"
     )
 
     loc, dic = xloc.get_local_dict(esperanto)
@@ -64,7 +64,7 @@ def test_local_dict(tmp_path):
     assert loc == "fr"
     assert dic["TX_MAX"]["long_name"] == "Fait chaud."
     assert (
-        dic["TG_MEAN"]["long_name"] == "Moyenne de la température journalière moyenne"
+        dic["TG_MEAN"]["long_name"] == "Moyenne de la température journalière"
     )
 
 
@@ -112,7 +112,7 @@ def test_indicator_output(tas_series):
     assert "long_name_fr" in tgmean.attrs
     assert (
         tgmean.attrs["description_fr"]
-        == "Moyenne annuelle de la température journalière moyenne."
+        == "Moyenne annuelle de la température journalière."
     )
 
 

--- a/xclim/testing/tests/test_locales.py
+++ b/xclim/testing/tests/test_locales.py
@@ -42,9 +42,7 @@ russian = (
 def test_local_dict(tmp_path):
     loc, dic = xloc.get_local_dict("fr")
     assert loc == "fr"
-    assert (
-        dic["TG_MEAN"]["long_name"] == "Moyenne de la température journalière"
-    )
+    assert dic["TG_MEAN"]["long_name"] == "Moyenne de la température journalière"
 
     loc, dic = xloc.get_local_dict(esperanto)
     assert loc == "eo"
@@ -63,9 +61,7 @@ def test_local_dict(tmp_path):
     loc, dic = xloc.get_local_dict(("fr", {"TX_MAX": {"long_name": "Fait chaud."}}))
     assert loc == "fr"
     assert dic["TX_MAX"]["long_name"] == "Fait chaud."
-    assert (
-        dic["TG_MEAN"]["long_name"] == "Moyenne de la température journalière"
-    )
+    assert dic["TG_MEAN"]["long_name"] == "Moyenne de la température journalière"
 
 
 def test_local_attrs_sing():


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #929
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.
- [x] `bumpversion patch` has been called on this branch
- [x] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

* removed a bunch of empty comment strings among the French translations
* lots of grammar and phrasing changes to

### Does this PR introduce a breaking change?
Yes. Many indicators translated to French will no longer have the same spelling/phrasing in their metadata fields.

### Other information:
