### PR TITLE
Indexing within indicators

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -13,7 +13,7 @@ New features and enhancements
 * New ``**indexer`` keyword args added to many indicators, it accepts the same arguments as ``xclim.indices.generic.select_time``, which has been improved. Unless otherwise specified, the time selection is done before any computation. (:pull:`934`, :issue:`899`).
 
 Breaking changes
-~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^
 * Following version 1.9 of the CF Conventions, published in September 2021, the calendar name "gregorian" is deprecated. ``core.calendar.get_calendar`` will return "standard", even if the underlying cftime objects still use "gregorian" (cftime <= 1.5.1). (:pull:`935`).
 
 Internal changes

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,7 +10,7 @@ New features and enhancements
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Added an optimized pathway for ``xclim.indices.run_length`` functions when ``window=1``. (:pull:`911`, :issue:`910`).
 * The data input frequency expected by ``Indicator``s is now in the ``src_freq`` attribute and is thus controlable by subclassing existing indicators. (:issue:`898`, :pull:`927`).
-* New ``**indexer`` keyword args added to most indicators, it accepts the same arguments as ``xclim.indices.generic.select_time``, which has been improved. Unless otherwise specified, the time selection is done before any computation. (:pull:`934`, :issue:`899`).
+* New ``**indexer`` keyword args added to many indicators, it accepts the same arguments as ``xclim.indices.generic.select_time``, which has been improved. Unless otherwise specified, the time selection is done before any computation. (:pull:`934`, :issue:`899`).
 
 Internal changes
 ~~~~~~~~~~~~~~~~

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,7 +10,7 @@ New features and enhancements
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Added an optimized pathway for ``xclim.indices.run_length`` functions when ``window=1``. (:pull:`911`, :issue:`910`).
 * The data input frequency expected by ``Indicator``s is now in the ``src_freq`` attribute and is thus controlable by subclassing existing indicators. (:issue:`898`, :pull:`927`).
-* New ``**indexer`` keyword args added to most indicators, it accepts the same arguments as ``xclim.indices.generic.select_time``, which has been improved. Unless otherwise specified, the time selection is done before than any computation. (:pull:`934`, :issue:`899`).
+* New ``**indexer`` keyword args added to most indicators, it accepts the same arguments as ``xclim.indices.generic.select_time``, which has been improved. Unless otherwise specified, the time selection is done before any computation. (:pull:`934`, :issue:`899`).
 
 Internal changes
 ~~~~~~~~~~~~~~~~

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,13 +10,14 @@ New features and enhancements
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Added an optimized pathway for ``xclim.indices.run_length`` functions when ``window=1``. (:pull:`911`, :issue:`910`).
 * The data input frequency expected by ``Indicator``s is now in the ``src_freq`` attribute and is thus controlable by subclassing existing indicators. (:issue:`898`, :pull:`927`).
+* New ``**indexer`` keyword args added to most indicators, it accepts the same arguments as ``xclim.indices.generic.select_time``, which has been improved. Unless otherwise specified, the time selection is done before than any computation. (:pull:`934`, :issue:`899`).
 
 Internal changes
 ~~~~~~~~~~~~~~~~
 * Removed some logging configurations in ``dataflags`` that were polluting python's main logging configuration. (:pull:`909`).
 * Synchronized logging formatters in `xclim.ensembles` and `xclim.core.utils`. (:pull:`909`).
 * Added a helper function for generating the release notes with dynamically-generated ReStructuredText or Markdown-formatted hyperlinks (:pull:`922`, :issue:`907`).
-* Split of resampling-related functionality of ``Indicator``s into a new ``ResamplingIndicator`` subclass. The use of new (private) methods makes it easier to inject functionality in indicator subclasses. (:issue:`867`, :pull:`927`).
+* Split of resampling-related functionality of ``Indicator``s into a new ``ResamplingIndicator`` and ``ResamplingIndicatorWithIndexing`` subclasses. The use of new (private) methods makes it easier to inject functionality in indicator subclasses. (:issue:`867`, :pull:`927`, :pull:`934`).
 
 Bug fixes
 ~~~~~~~~~

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,20 +7,20 @@ History
 Contributors to this version: Pascal Bourgault (:user:`aulemahal`), Travis Logan (:user:`tlogan2000`), Trevor James Smith (:user:`Zeitsperre`)
 
 New features and enhancements
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 * Added an optimized pathway for ``xclim.indices.run_length`` functions when ``window=1``. (:pull:`911`, :issue:`910`).
 * The data input frequency expected by ``Indicator``s is now in the ``src_freq`` attribute and is thus controlable by subclassing existing indicators. (:issue:`898`, :pull:`927`).
 * New ``**indexer`` keyword args added to many indicators, it accepts the same arguments as ``xclim.indices.generic.select_time``, which has been improved. Unless otherwise specified, the time selection is done before any computation. (:pull:`934`, :issue:`899`).
 
 Internal changes
-~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^
 * Removed some logging configurations in ``dataflags`` that were polluting python's main logging configuration. (:pull:`909`).
 * Synchronized logging formatters in `xclim.ensembles` and `xclim.core.utils`. (:pull:`909`).
 * Added a helper function for generating the release notes with dynamically-generated ReStructuredText or Markdown-formatted hyperlinks (:pull:`922`, :issue:`907`).
 * Split of resampling-related functionality of ``Indicator``s into a new ``ResamplingIndicator`` and ``ResamplingIndicatorWithIndexing`` subclasses. The use of new (private) methods makes it easier to inject functionality in indicator subclasses. (:issue:`867`, :pull:`927`, :pull:`934`).
 
 Bug fixes
-~~~~~~~~~
+^^^^^^^^^
 * Fix bugs in the `cf_attrs` and/or `abstract` of `continuous_snow_cover_end` and `continuous_snow_cover_start`. (:pull:`908`).
 
 0.31.0 (2021-11-05)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.31.3-beta
+current_version = 0.31.4-beta
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+).(?P<patch>\d+)(\-(?P<release>[a-z]+))?

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ URL = "https://github.com/Ouranosinc/xclim"
 AUTHOR = "Travis Logan"
 AUTHOR_EMAIL = "logan.travis@ouranos.ca"
 REQUIRES_PYTHON = ">=3.7.0"
-VERSION = "0.31.3-beta"
+VERSION = "0.31.4-beta"
 LICENSE = "Apache Software License 2.0"
 
 with open("README.rst") as readme_file:

--- a/xclim/__init__.py
+++ b/xclim/__init__.py
@@ -10,7 +10,7 @@ from xclim.indicators import atmos, land, seaIce  # noqa
 
 __author__ = """Travis Logan"""
 __email__ = "logan.travis@ouranos.ca"
-__version__ = "0.31.3-beta"
+__version__ = "0.31.4-beta"
 
 
 # Load official locales

--- a/xclim/core/calendar.py
+++ b/xclim/core/calendar.py
@@ -46,6 +46,9 @@ max_doy = {
     "360_day": 360,
 }
 
+# Names of calendars that have the same number of days for all years
+uniform_calendars = ("noleap", "all_leap", "365_day", "366_day", "360_day")
+
 
 def get_calendar(obj: Any, dim: str = "time") -> str:
     """Return the calendar of an object.

--- a/xclim/core/indicator.py
+++ b/xclim/core/indicator.py
@@ -1348,7 +1348,7 @@ class ResamplingIndicatorWithIndexing(ResamplingIndicator):
 
     @classmethod
     def _injected_parameters(self):
-        return super()._injected_parameters + [
+        return super()._injected_parameters() + [
             (
                 "indexer",
                 Parameter(
@@ -1366,20 +1366,20 @@ class ResamplingIndicatorWithIndexing(ResamplingIndicator):
         """Perform parent's checks and also check if freq is allowed."""
         das, params = super()._preprocess_and_checks(das, params)
 
-        indexer = params.get("indexer")
-        if indexer:
-            # do things
-            pass
+        indxr = params.get("indexer")
+        if indxr:
+            das = {k: indices.generic.select_time(da, **indxr) for k, da in das.items()}
+            print(das)
         return das, params
 
 
-class Daily(ResamplingIndicator):
+class Daily(ResamplingIndicatorWithIndexing):
     """Class for daily inputs and resampling computes."""
 
     src_freq = "D"
 
 
-class Hourly(ResamplingIndicator):
+class Hourly(ResamplingIndicatorWithIndexing):
     """Class for hourly inputs and resampling computes."""
 
     src_freq = "H"
@@ -1387,6 +1387,7 @@ class Hourly(ResamplingIndicator):
 
 base_registry["Indicator"] = Indicator
 base_registry["ResamplingIndicator"] = ResamplingIndicator
+base_registry["ResamplingIndicatorWithIndexing"] = ResamplingIndicatorWithIndexing
 base_registry["Hourly"] = Hourly
 base_registry["Daily"] = Daily
 

--- a/xclim/core/indicator.py
+++ b/xclim/core/indicator.py
@@ -1339,7 +1339,9 @@ class ResamplingIndicator(Indicator):
             )
             # Reduce by or and broadcast to ensure the same length in time
             # When indexing is used and there are no valid points in the last period, mask will not include it
-            mask = reduce(np.logical_or, miss).reindex_like(outs[0], fill_value=True)
+            mask = reduce(np.logical_or, miss)
+            if isinstance(mask, DataArray) and mask.time.size < outs[0].time.size:
+                mask = mask.reindex(time=outs[0].time, fill_value=True)
             outs = [out.where(~mask) for out in outs]
 
         return outs
@@ -1357,8 +1359,8 @@ class ResamplingIndicatorWithIndexing(ResamplingIndicator):
                     kind=InputKind.KWARGS,
                     description=(
                         "Indexing parameters to compute the indicator on a temporal "
-                        "subset of the data, see ... for details on how to use this "
-                        "parameter."
+                        "subset of the data. It accepts the same arguments as "
+                        ":py:func:`xclim.indices.generic.select_time`."
                     ),
                 ),
             )

--- a/xclim/core/indicator.py
+++ b/xclim/core/indicator.py
@@ -1154,7 +1154,7 @@ class Indicator(IndicatorRegistrar):
                 mba[k] = "{:g}".format(v)
             # TODO: What about InputKind.NUMBER_SEQUENCE
             elif k == "indexer":
-                if v:
+                if v and v is not _empty:
                     dk, dv = v.copy().popitem()
                     if dk == "month":
                         dv = f"m{dv}"

--- a/xclim/core/indicator.py
+++ b/xclim/core/indicator.py
@@ -1153,15 +1153,20 @@ class Indicator(IndicatorRegistrar):
             elif isinstance(v, (int, float)):
                 mba[k] = "{:g}".format(v)
             # TODO: What about InputKind.NUMBER_SEQUENCE
+            elif k == "indexer":
+                if v:
+                    dk, dv = v.copy().popitem()
+                    if dk == "month":
+                        dv = f"m{dv}"
+                    elif dk in ("doy_bounds", "date_bounds"):
+                        dv = f"{dv[0]} to {dv[1]}"
+                    mba["indexer"] = dv
+                else:
+                    mba["indexer"] = args.get("freq") or indices.generic.default_freq(
+                        **v
+                    )
             else:
                 mba[k] = v
-        # if indexer:
-        #     dk, dv = indexer.copy().popitem()
-        #     if dk == "month":
-        #         dv = "m{}".format(dv)
-        #     mba["indexer"] = dv
-        # else:
-        #     mba["indexer"] = "annual"
 
         out = {}
         for key, val in attrs.items():

--- a/xclim/core/indicator.py
+++ b/xclim/core/indicator.py
@@ -770,8 +770,7 @@ class Indicator(IndicatorRegistrar):
         """Call function of Indicator class."""
         # Put the variables in `das`, parse them according to the annotations
         # das : OrderedDict of variables (required + non-None optionals)
-        # params : OrderedDict of parameters INCLUDING unpacked kwargs and injected EXCLUDING indexer
-        # indexer: If present, the "indexer" kwargs <- this is needed by _update_attrs and _mask
+        # params : OrderedDict of parameters (var_kwargs as a single argument, if any)
         das, params = self._parse_variables_from_call(args, kwds)
 
         das, params = self._preprocess_and_checks(das, params)
@@ -1367,7 +1366,7 @@ class ResamplingIndicatorWithIndexing(ResamplingIndicator):
         """Perform parent's checks and also check if freq is allowed."""
         das, params = super()._preprocess_and_checks(das, params)
 
-        indexer = params.pop("indexer")
+        indexer = params.get("indexer")
         if indexer:
             # do things
             pass

--- a/xclim/core/indicator.py
+++ b/xclim/core/indicator.py
@@ -1376,13 +1376,13 @@ class ResamplingIndicatorWithIndexing(ResamplingIndicator):
         return das, params
 
 
-class Daily(ResamplingIndicatorWithIndexing):
+class Daily(ResamplingIndicator):
     """Class for daily inputs and resampling computes."""
 
     src_freq = "D"
 
 
-class Hourly(ResamplingIndicatorWithIndexing):
+class Hourly(ResamplingIndicator):
     """Class for hourly inputs and resampling computes."""
 
     src_freq = "H"

--- a/xclim/core/indicator.py
+++ b/xclim/core/indicator.py
@@ -1337,7 +1337,9 @@ class ResamplingIndicator(Indicator):
                 for da in das.values()
                 if "time" in da.coords
             )
-            mask = reduce(np.logical_or, miss)
+            # Reduce by or and broadcast to ensure the same length in time
+            # When indexing is used and there are no valid points in the last period, mask will not include it
+            mask = reduce(np.logical_or, miss).reindex_like(outs[0], fill_value=True)
             outs = [out.where(~mask) for out in outs]
 
         return outs
@@ -1369,7 +1371,6 @@ class ResamplingIndicatorWithIndexing(ResamplingIndicator):
         indxr = params.get("indexer")
         if indxr:
             das = {k: indices.generic.select_time(da, **indxr) for k, da in das.items()}
-            print(das)
         return das, params
 
 

--- a/xclim/core/indicator.py
+++ b/xclim/core/indicator.py
@@ -1162,7 +1162,7 @@ class Indicator(IndicatorRegistrar):
                         dv = f"{dv[0]} to {dv[1]}"
                     mba["indexer"] = dv
                 else:
-                    mba["indexer"] = args.get("freq") or indices.generic.default_freq()
+                    mba["indexer"] = args.get("freq") or "YS"
             else:
                 mba[k] = v
 

--- a/xclim/core/indicator.py
+++ b/xclim/core/indicator.py
@@ -1154,7 +1154,7 @@ class Indicator(IndicatorRegistrar):
                 mba[k] = "{:g}".format(v)
             # TODO: What about InputKind.NUMBER_SEQUENCE
             elif k == "indexer":
-                if v and v is not _empty:
+                if v and v not in [_empty, _empty_default]:
                     dk, dv = v.copy().popitem()
                     if dk == "month":
                         dv = f"m{dv}"
@@ -1162,9 +1162,7 @@ class Indicator(IndicatorRegistrar):
                         dv = f"{dv[0]} to {dv[1]}"
                     mba["indexer"] = dv
                 else:
-                    mba["indexer"] = args.get("freq") or indices.generic.default_freq(
-                        **v
-                    )
+                    mba["indexer"] = args.get("freq") or indices.generic.default_freq()
             else:
                 mba[k] = v
 

--- a/xclim/core/missing.py
+++ b/xclim/core/missing.py
@@ -88,7 +88,7 @@ class MissingBase:
     @staticmethod
     def is_null(da, freq, **indexer):
         """Return a boolean array indicating which values are null."""
-        selected = generic.select_time(da, **indexer)
+        selected = generic.select_time(da, drop=True, **indexer)
         if selected.time.size == 0:
             raise ValueError("No data for selected period.")
 
@@ -154,7 +154,7 @@ class MissingBase:
             )
 
             sda = xr.DataArray(data=np.ones(len(t)), coords={"time": t}, dims=("time",))
-            st = generic.select_time(sda, **indexer)
+            st = generic.select_time(sda, drop=True, **indexer)
             if freq:
                 count = st.notnull().resample(time=freq).sum(dim="time")
             else:

--- a/xclim/indicators/atmos/_temperature.py
+++ b/xclim/indicators/atmos/_temperature.py
@@ -5,7 +5,7 @@ from inspect import _empty  # noqa
 
 from xclim import indices
 from xclim.core import cfchecks
-from xclim.core.indicator import Daily, Indicator
+from xclim.core.indicator import Daily, Indicator, ResamplingIndicatorWithIndexing
 from xclim.core.utils import InputKind
 
 __all__ = [
@@ -85,7 +85,13 @@ class Temp(Daily):
     """Indicators involving daily temperature."""
 
 
-tn_days_above = Temp(
+class TempWithIndexing(ResamplingIndicatorWithIndexing):
+    """Indicators involving daily temperature and adding an indexing possibility."""
+
+    src_freq = "D"
+
+
+tn_days_above = TempWithIndexing(
     identifier="tn_days_above",
     units="days",
     standard_name="number_of_days_with_air_temperature_above_threshold",
@@ -95,7 +101,7 @@ tn_days_above = Temp(
     compute=indices.tn_days_above,
 )
 
-tn_days_below = Temp(
+tn_days_below = TempWithIndexing(
     identifier="tn_days_below",
     units="days",
     standard_name="number_of_days_with_air_temperature_below_threshold",
@@ -105,7 +111,7 @@ tn_days_below = Temp(
     compute=indices.tn_days_below,
 )
 
-tg_days_above = Temp(
+tg_days_above = TempWithIndexing(
     identifier="tg_days_above",
     units="days",
     standard_name="number_of_days_with_air_temperature_above_threshold",
@@ -115,7 +121,7 @@ tg_days_above = Temp(
     compute=indices.tg_days_above,
 )
 
-tg_days_below = Temp(
+tg_days_below = TempWithIndexing(
     identifier="tg_days_below",
     units="days",
     standard_name="number_of_days_with_air_temperature_below_threshold",
@@ -125,7 +131,7 @@ tg_days_below = Temp(
     compute=indices.tg_days_below,
 )
 
-tx_days_above = Temp(
+tx_days_above = TempWithIndexing(
     identifier="tx_days_above",
     units="days",
     standard_name="number_of_days_with_air_temperature_above_threshold",
@@ -135,7 +141,7 @@ tx_days_above = Temp(
     compute=indices.tx_days_above,
 )
 
-tx_days_below = Temp(
+tx_days_below = TempWithIndexing(
     identifier="tx_days_below",
     units="days",
     standard_name="number_of_days_with_air_temperature_below_threshold",
@@ -145,7 +151,7 @@ tx_days_below = Temp(
     compute=indices.tx_days_below,
 )
 
-tx_tn_days_above = Temp(
+tx_tn_days_above = TempWithIndexing(
     identifier="tx_tn_days_above",
     units="days",
     standard_name="number_of_days_with_air_temperature_above_threshold",
@@ -244,7 +250,7 @@ hot_spell_max_length = Temp(
     compute=indices.hot_spell_max_length,
 )
 
-tg_mean = Temp(
+tg_mean = TempWithIndexing(
     identifier="tg_mean",
     units="K",
     standard_name="air_temperature",
@@ -254,7 +260,7 @@ tg_mean = Temp(
     compute=indices.tg_mean,
 )
 
-tg_max = Temp(
+tg_max = TempWithIndexing(
     identifier="tg_max",
     units="K",
     standard_name="air_temperature",
@@ -264,7 +270,7 @@ tg_max = Temp(
     compute=indices.tg_max,
 )
 
-tg_min = Temp(
+tg_min = TempWithIndexing(
     identifier="tg_min",
     units="K",
     standard_name="air_temperature",
@@ -274,7 +280,7 @@ tg_min = Temp(
     compute=indices.tg_min,
 )
 
-tx_mean = Temp(
+tx_mean = TempWithIndexing(
     identifier="tx_mean",
     units="K",
     standard_name="air_temperature",
@@ -284,7 +290,7 @@ tx_mean = Temp(
     compute=indices.tx_mean,
 )
 
-tx_max = Temp(
+tx_max = TempWithIndexing(
     identifier="tx_max",
     units="K",
     standard_name="air_temperature",
@@ -294,7 +300,7 @@ tx_max = Temp(
     compute=indices.tx_max,
 )
 
-tx_min = Temp(
+tx_min = TempWithIndexing(
     identifier="tx_min",
     units="K",
     standard_name="air_temperature",
@@ -304,7 +310,7 @@ tx_min = Temp(
     compute=indices.tx_min,
 )
 
-tn_mean = Temp(
+tn_mean = TempWithIndexing(
     identifier="tn_mean",
     units="K",
     standard_name="air_temperature",
@@ -314,7 +320,7 @@ tn_mean = Temp(
     compute=indices.tn_mean,
 )
 
-tn_max = Temp(
+tn_max = TempWithIndexing(
     identifier="tn_max",
     units="K",
     standard_name="air_temperature",
@@ -324,7 +330,7 @@ tn_max = Temp(
     compute=indices.tn_max,
 )
 
-tn_min = Temp(
+tn_min = TempWithIndexing(
     identifier="tn_min",
     units="K",
     standard_name="air_temperature",
@@ -334,7 +340,7 @@ tn_min = Temp(
     compute=indices.tn_min,
 )
 
-daily_temperature_range = Temp(
+daily_temperature_range = TempWithIndexing(
     title="Mean of daily temperature range.",
     identifier="dtr",
     units="K",
@@ -346,7 +352,7 @@ daily_temperature_range = Temp(
     parameters=dict(op="mean"),
 )
 
-max_daily_temperature_range = Temp(
+max_daily_temperature_range = TempWithIndexing(
     title="Maximum of daily temperature range.",
     identifier="dtrmax",
     units="K",
@@ -358,7 +364,7 @@ max_daily_temperature_range = Temp(
     parameters=dict(op="max"),
 )
 
-daily_temperature_range_variability = Temp(
+daily_temperature_range_variability = TempWithIndexing(
     identifier="dtrvar",
     units="K",
     standard_name="air_temperature",
@@ -372,7 +378,7 @@ daily_temperature_range_variability = Temp(
     compute=indices.daily_temperature_range_variability,
 )
 
-extreme_temperature_range = Temp(
+extreme_temperature_range = TempWithIndexing(
     identifier="etr",
     units="K",
     standard_name="air_temperature",
@@ -432,7 +438,7 @@ cool_night_index = Temp(
     compute=indices.cool_night_index,
 )
 
-daily_freezethaw_cycles = Temp(
+daily_freezethaw_cycles = TempWithIndexing(
     identifier="dlyfrzthw",
     units="days",
     long_name="daily freezethaw cycles",
@@ -503,7 +509,7 @@ freezethaw_spell_max_length = Temp(
 )
 
 
-cooling_degree_days = Temp(
+cooling_degree_days = TempWithIndexing(
     identifier="cooling_degree_days",
     units="K days",
     standard_name="integral_of_air_temperature_excess_wrt_time",
@@ -514,7 +520,7 @@ cooling_degree_days = Temp(
     parameters={"thresh": {"default": "18.0 degC"}},
 )
 
-heating_degree_days = Temp(
+heating_degree_days = TempWithIndexing(
     identifier="heating_degree_days",
     units="K days",
     standard_name="integral_of_air_temperature_deficit_wrt_time",
@@ -525,7 +531,7 @@ heating_degree_days = Temp(
     parameters={"thresh": {"default": "17.0 degC"}},
 )
 
-growing_degree_days = Temp(
+growing_degree_days = TempWithIndexing(
     identifier="growing_degree_days",
     units="K days",
     standard_name="integral_of_air_temperature_excess_wrt_time",
@@ -536,7 +542,7 @@ growing_degree_days = Temp(
     parameters={"thresh": {"default": "4.0 degC"}},
 )
 
-freezing_degree_days = Temp(
+freezing_degree_days = TempWithIndexing(
     identifier="freezing_degree_days",
     units="K days",
     standard_name="integral_of_air_temperature_deficit_wrt_time",
@@ -547,7 +553,7 @@ freezing_degree_days = Temp(
     parameters={"thresh": {"default": "0 degC"}},
 )
 
-thawing_degree_days = Temp(
+thawing_degree_days = TempWithIndexing(
     identifier="thawing_degree_days",
     units="K days",
     standard_name="integral_of_air_temperature_excess_wrt_time",
@@ -568,7 +574,7 @@ freshet_start = Temp(
     compute=indices.freshet_start,
 )
 
-frost_days = Temp(
+frost_days = TempWithIndexing(
     identifier="frost_days",
     units="days",
     standard_name="days_with_air_temperature_below_threshold",
@@ -621,7 +627,7 @@ first_day_above = Temp(
 )
 
 
-ice_days = Temp(
+ice_days = TempWithIndexing(
     identifier="ice_days",
     standard_name="days_with_air_temperature_below_threshold",
     units="days",
@@ -730,7 +736,7 @@ growing_season_end = Temp(
     parameters={"thresh": {"default": "5.0 degC"}},
 )
 
-tropical_nights = Temp(
+tropical_nights = TempWithIndexing(
     identifier="tropical_nights",
     units="days",
     standard_name="number_of_days_with_air_temperature_above_threshold",

--- a/xclim/indicators/atmos/_wind.py
+++ b/xclim/indicators/atmos/_wind.py
@@ -1,11 +1,13 @@
 from xclim import indices
-from xclim.core.indicator import Daily
+from xclim.core.indicator import ResamplingIndicatorWithIndexing
 
 __all__ = ["calm_days", "windy_days"]
 
 
-class Wind(Daily):
+class Wind(ResamplingIndicatorWithIndexing):
     """Indicator involving daily sfcWind series."""
+
+    src_freq = "D"
 
 
 calm_days = Wind(

--- a/xclim/indicators/land/_streamflow.py
+++ b/xclim/indicators/land/_streamflow.py
@@ -1,7 +1,7 @@
 """Streamflow indicator definitions."""
 
 from xclim.core.cfchecks import check_valid
-from xclim.core.indicator import Daily, Indicator
+from xclim.core.indicator import Indicator, ResamplingIndicator
 from xclim.core.units import declare_units
 from xclim.indices import base_flow_index, generic, rb_flashiness_index
 from xclim.indices.stats import fit as _fit
@@ -18,8 +18,9 @@ __all__ = [
 ]
 
 
-class Streamflow(Daily):
+class Streamflow(ResamplingIndicator):
     context = "hydro"
+    src_freq = "D"
 
     @staticmethod
     def cfcheck(q):

--- a/xclim/indices/generic.py
+++ b/xclim/indices/generic.py
@@ -89,11 +89,11 @@ def select_time(
       The bounds as (start, end) of the period of interest expressed in day-of-year,
       integers going from 1 (January 1st) to 365 or 366 (December 31st). If calendar
       awareness is needed, consider using ``date_bounds`` instead.
-      Bounds are included in the result.
+      Bounds are inclusive.
     date_bounds: 2-tuple of strings
       The bounds as (start, end) of the period of interest expressed as dates in the
       month-day (%m-%d) format.
-      Bounds are included in the result.
+      Bounds are inclusive.
 
     Returns
     -------

--- a/xclim/indices/generic.py
+++ b/xclim/indices/generic.py
@@ -7,17 +7,19 @@ Generic indices submodule
 Helper functions for common generic actions done in the computation of indices.
 """
 from collections.abc import Iterable
-from typing import Optional, Union
+from typing import Optional, Sequence, Tuple, Union
 
 import numpy as np
 import xarray
 import xarray as xr
+from xarray.coding.cftime_offsets import to_cftime_datetime
 
 from xclim.core.calendar import (
     convert_calendar,
     days_in_year,
     doy_to_days_since,
     get_calendar,
+    uniform_calendars,
 )
 from xclim.core.units import (
     convert_units_to,
@@ -57,31 +59,120 @@ __all__ = [
 binary_ops = {">": "gt", "<": "lt", ">=": "ge", "<=": "le", "==": "eq", "!=": "ne"}
 
 
-def select_time(da: xr.DataArray, **indexer):
+def select_time(
+    da: Union[xr.DataArray, xr.Dataset],
+    drop: bool = True,
+    season: Union[str, Sequence[str]] = None,
+    month: Union[int, Sequence[int]] = None,
+    doy_bounds: Tuple[int, int] = None,
+    date_bounds: Tuple[str, str] = None,
+):
     """Select entries according to a time period.
+
+    This conveniently improves xarray's :py:meth:`xarray.DataArray.where` and
+    :py:meth:`xarray.DataArray.sel` with fancier ways of indexing over time elements.
+    In addition to the data `da` and argument `drop`, only one of `season`, `month`,
+    `doy_bounds` or `date_bounds` may be passed.
 
     Parameters
     ----------
-    da : xr.DataArray
+    da : xr.DataArray or xr.Dataset
       Input data.
-    **indexer : {dim: indexer, }, optional
-      Time attribute and values over which to subset the array. For example, use season='DJF' to select winter values,
-      month=1 to select January, or month=[6,7,8] to select summer months. If not indexer is given, all values are
-      considered.
+    drop: boolean
+      Whether to drop elements outside the period of interest (default) or
+      to simply mask them.
+    season: string or sequence of strings
+      One or more of 'DJF', 'MAM', 'JJA' and 'SON'.
+    month: integer or sequence of integers
+      Sequence of month numbers (January = 1 ... December = 12)
+    doy_bounds: 2-tuple of integers
+      The bounds as (start, end) of the period of interest expressed in day-of-year,
+      integers going from 1 (January 1st) to 365 or 366 (December 31st). If calendar
+      awareness is needed, consider using ``date_bounds`` instead.
+      Bounds are included in the result.
+    date_bounds: 2-tuple of strings
+      The bounds as (start, end) of the period of interest expressed as dates in the
+      month-day (%m-%d) format.
+      Bounds are included in the result.
 
     Returns
     -------
-    xr.DataArray
-      Selected input values.
-    """
-    if not indexer:
-        selected = da
-    else:
-        key, val = indexer.popitem()
-        time_att = getattr(da.time.dt, key)
-        selected = da.sel(time=time_att.isin(val)).dropna(dim="time")
+    xr.DataArray or xr.Dataset
+      Selected input values. If ``drop=False``, this has the same length as ``da``
+      (along dimension 'time'), but with masked (NaN) values outside the period of
+      interest.
 
-    return selected
+    Examples
+    --------
+    Keep only the values of fall and spring.
+
+    >>> ds = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc")
+    >>> ds.time.size
+    1461
+    >>> out = select_time(ds, season=['MAM', 'SON'])
+    >>> out.time.size
+    732
+
+    Or all values between two dates (included).
+
+    >>> out = select_time(ds, date_bounds=('02-29', '03-02'))
+    >>> out.time.values
+    array(['1990-03-01T00:00:00.000000000', '1990-03-02T00:00:00.000000000',
+           '1991-03-01T00:00:00.000000000', '1991-03-02T00:00:00.000000000',
+           '1992-02-29T00:00:00.000000000', '1992-03-01T00:00:00.000000000',
+           '1992-03-02T00:00:00.000000000', '1993-03-01T00:00:00.000000000',
+           '1993-03-02T00:00:00.000000000'], dtype='datetime64[ns]')
+    """
+    N = sum(arg is not None for arg in [season, month, doy_bounds, date_bounds])
+    if N > 1:
+        raise ValueError(f"Only one method of indexing may be given, got {N}.")
+
+    if N == 0:
+        return da
+
+    if season is not None:
+        if isinstance(season, str):
+            season = [season]
+        mask = da.time.dt.season.isin(season)
+
+    elif month is not None:
+        if isinstance(month, int):
+            month = [month]
+        mask = da.time.dt.month.isin(month)
+
+    elif doy_bounds is not None:
+        start, end = doy_bounds
+        if start <= end:
+            doys = np.arange(start, end + 1)
+        else:
+            doys = np.concatenate((np.arange(start, 367), np.arange(0, end + 1)))
+        mask = da.time.dt.dayofyear.isin(doys)
+
+    elif date_bounds is not None:
+        # This one is a bit trickier.
+        start, end = date_bounds
+        time = da.time
+        calendar = get_calendar(time)
+        if calendar not in uniform_calendars:
+            # For non-uniform calendars, we can't simply convert dates to doys
+            # conversion to all_leap is safe for all non-uniform calendar as it doesn't remove any date.
+            time = convert_calendar(time, "all_leap")
+            # values of time are the _old_ calendar
+            # and the new calendar is in the coordinate
+            calendar = "all_leap"
+
+        # Get doy of date, this is now safe because the calendar is uniform.
+        start = to_cftime_datetime("2000-" + start, calendar).dayofyr
+        end = to_cftime_datetime("2000-" + end, calendar).dayofyr
+
+        if start <= end:
+            doys = np.arange(start, end + 1)
+        else:
+            doys = np.concatenate((np.arange(start, 367), np.arange(0, end + 1)))
+        mask = time.time.dt.dayofyear.isin(doys)
+        mask["time"] = da.time  # If we converted, this puts back the correct coord.
+
+    return da.where(mask, drop=drop)
 
 
 def select_resample_op(da: xr.DataArray, op: str, freq: str = "YS", **indexer):

--- a/xclim/indices/generic.py
+++ b/xclim/indices/generic.py
@@ -61,7 +61,7 @@ binary_ops = {">": "gt", "<": "lt", ">=": "ge", "<=": "le", "==": "eq", "!=": "n
 
 def select_time(
     da: Union[xr.DataArray, xr.Dataset],
-    drop: bool = True,
+    drop: bool = False,
     season: Union[str, Sequence[str]] = None,
     month: Union[int, Sequence[int]] = None,
     doy_bounds: Tuple[int, int] = None,

--- a/xclim/indices/generic.py
+++ b/xclim/indices/generic.py
@@ -109,13 +109,13 @@ def select_time(
     >>> ds = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc")
     >>> ds.time.size
     1461
-    >>> out = select_time(ds, season=['MAM', 'SON'])
+    >>> out = select_time(ds, drop=True, season=['MAM', 'SON'])
     >>> out.time.size
     732
 
     Or all values between two dates (included).
 
-    >>> out = select_time(ds, date_bounds=('02-29', '03-02'))
+    >>> out = select_time(ds, drop=True, date_bounds=('02-29', '03-02'))
     >>> out.time.values
     array(['1990-03-01T00:00:00.000000000', '1990-03-02T00:00:00.000000000',
            '1991-03-01T00:00:00.000000000', '1991-03-02T00:00:00.000000000',

--- a/xclim/indices/generic.py
+++ b/xclim/indices/generic.py
@@ -130,6 +130,11 @@ def select_time(
     if N == 0:
         return da
 
+    def get_doys(start, end):
+        if start <= end:
+            return np.arange(start, end + 1)
+        return np.concatenate((np.arange(start, 367), np.arange(0, end + 1)))
+
     if season is not None:
         if isinstance(season, str):
             season = [season]
@@ -139,6 +144,9 @@ def select_time(
         if isinstance(month, int):
             month = [month]
         mask = da.time.dt.month.isin(month)
+
+    elif doy_bounds is not None:
+        mask = da.time.dt.dayofyear.isin(get_doys(*doy_bounds))
 
     elif date_bounds is not None:
         # This one is a bit trickier.
@@ -154,21 +162,14 @@ def select_time(
             calendar = "all_leap"
 
         # Get doy of date, this is now safe because the calendar is uniform.
-        doy_bounds = (
+        doys = get_doys(
             to_cftime_datetime("2000-" + start, calendar).dayofyr,
             to_cftime_datetime("2000-" + end, calendar).dayofyr,
         )
+        mask = time.time.dt.dayofyear.isin(doys)
+        # Needed if we converted calendar, this puts back the correct coord
+        mask["time"] = da.time
 
-    if doy_bounds is not None:
-        start, end = doy_bounds
-        if start <= end:
-            doys = np.arange(start, end + 1)
-        else:
-            doys = np.concatenate((np.arange(start, 367), np.arange(0, end + 1)))
-        mask = da.time.dt.dayofyear.isin(doys)
-
-    # Needed if we converted calendar in date_bounds, this puts back the correct coord, useless and inoffensive otherwise
-    mask["time"] = da.time
     return da.where(mask, drop=drop)
 
 

--- a/xclim/testing/tests/test_cli.py
+++ b/xclim/testing/tests/test_cli.py
@@ -56,7 +56,7 @@ def test_indicator_help(indicator, indname):
     results = runner.invoke(cli, [indname, "--help"])
 
     for name in indicator.parameters.keys():
-        if name != "ds":
+        if name not in ["ds", "indexer"]:
             assert name in results.output
 
 

--- a/xclim/testing/tests/test_formatting.py
+++ b/xclim/testing/tests/test_formatting.py
@@ -26,7 +26,7 @@ def test_indicator_docstring():
     )
     assert doc[6] == "Keywords : health,."
     assert doc[12] == "  Default : `ds.tasmin`. [Required units : [temperature]]"
-    assert doc[38] == (
+    assert doc[35] == (
         "  Number of heat wave events (Tmin > {thresh_tasmin} and Tmax > "
         "{thresh_tasmax} for >= {window} days) (heat_wave_events)"
     )

--- a/xclim/testing/tests/test_formatting.py
+++ b/xclim/testing/tests/test_formatting.py
@@ -26,9 +26,9 @@ def test_indicator_docstring():
     )
     assert doc[6] == "Keywords : health,."
     assert doc[12] == "  Default : `ds.tasmin`. [Required units : [temperature]]"
-    assert (
-        doc[35]
-        == "  Number of heat wave events (Tmin > {thresh_tasmin} and Tmax > {thresh_tasmax} for >= {window} days) (heat_wave_events)"
+    assert doc[38] == (
+        "  Number of heat wave events (Tmin > {thresh_tasmin} and Tmax > "
+        "{thresh_tasmax} for >= {window} days) (heat_wave_events)"
     )
 
     doc = degree_days_exceedance_date.__doc__.split("\n")

--- a/xclim/testing/tests/test_generic.py
+++ b/xclim/testing/tests/test_generic.py
@@ -316,7 +316,7 @@ def series(start, end, calendar):
 def test_select_time_month():
     da = series("1993-01-05", "1994-12-31", "default")
 
-    out = generic.select_time(da, month=1)
+    out = generic.select_time(da, drop=True, month=1)
     exp = xr.concat(
         (
             series("1993-01-05", "1993-01-31", "default"),
@@ -326,12 +326,12 @@ def test_select_time_month():
     )
     xr.testing.assert_equal(out, exp)
 
-    out = generic.select_time(da, month=1, drop=False)
+    out = generic.select_time(da, month=1)
     xr.testing.assert_equal(out.time, da.time)
     assert out.sum() == 58
 
     da = series("1993-01-05", "1994-12-30", "360_day")
-    out = generic.select_time(da, month=[3, 6])
+    out = generic.select_time(da, drop=True, month=[3, 6])
     exp = xr.concat(
         (
             series("1993-03-01", "1993-03-30", "360_day"),
@@ -347,7 +347,7 @@ def test_select_time_month():
 def test_select_time_season():
     da = series("1993-01-05", "1994-12-31", "default")
 
-    out = generic.select_time(da, season="DJF")
+    out = generic.select_time(da, drop=True, season="DJF")
     exp = xr.concat(
         (
             series("1993-01-05", "1993-02-28", "default"),
@@ -359,7 +359,7 @@ def test_select_time_season():
     xr.testing.assert_equal(out, exp)
 
     da = series("1993-01-05", "1994-12-31", "365_day")
-    out = generic.select_time(da, season=["MAM", "SON"])
+    out = generic.select_time(da, drop=True, season=["MAM", "SON"])
     exp = xr.concat(
         (
             series("1993-03-01", "1993-05-31", "365_day"),
@@ -375,7 +375,7 @@ def test_select_time_season():
 def test_select_time_doys():
     da = series("2003-02-13", "2004-12-31", "default")
 
-    out = generic.select_time(da, doy_bounds=(360, 75))
+    out = generic.select_time(da, drop=True, doy_bounds=(360, 75))
     exp = xr.concat(
         (
             series("2003-02-13", "2003-03-16", "default"),
@@ -388,7 +388,7 @@ def test_select_time_doys():
 
     da = series("2003-02-13", "2004-12-31", "proleptic_gregorian")
 
-    out = generic.select_time(da, doy_bounds=(25, 80))
+    out = generic.select_time(da, drop=True, doy_bounds=(25, 80))
     exp = xr.concat(
         (
             series("2003-02-13", "2003-03-21", "proleptic_gregorian"),
@@ -403,7 +403,7 @@ def test_select_time_dates():
     da = series("2003-02-13", "2004-11-01", "all_leap")
     da = da.where(da.time.dt.dayofyear != 92, drop=True)  # no 04-01
 
-    out = generic.select_time(da, date_bounds=("04-01", "12-04"))
+    out = generic.select_time(da, drop=True, date_bounds=("04-01", "12-04"))
     exp = xr.concat(
         (
             series("2003-04-02", "2003-12-04", "all_leap"),
@@ -415,7 +415,7 @@ def test_select_time_dates():
 
     da = series("2003-02-13", "2005-11-01", "standard")
 
-    out = generic.select_time(da, date_bounds=("10-05", "02-29"))
+    out = generic.select_time(da, drop=True, date_bounds=("10-05", "02-29"))
     exp = xr.concat(
         (
             series("2003-02-13", "2003-02-28", "standard"),

--- a/xclim/testing/tests/test_generic.py
+++ b/xclim/testing/tests/test_generic.py
@@ -442,5 +442,5 @@ def test_select_time_errors():
     with pytest.raises(ValueError):
         generic.select_time(da, date_bounds=("02-30",))
 
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         generic.select_time(da, doy_bounds=(300, 203, 202))

--- a/xclim/testing/tests/test_indicators.py
+++ b/xclim/testing/tests/test_indicators.py
@@ -20,7 +20,7 @@ from xclim.core.formatting import (
     parse_doc,
     update_history,
 )
-from xclim.core.indicator import Daily, Indicator, registry
+from xclim.core.indicator import Daily, Indicator, ResamplingIndicator, registry
 from xclim.core.units import convert_units_to, declare_units, units
 from xclim.core.utils import InputKind, MissingVariableError
 from xclim.indices import tg_mean
@@ -77,7 +77,8 @@ def uniclim_compute(da: xr.DataArray, freq="YS", **indexer):
     return select.mean(dim="time", keep_attrs=True)
 
 
-uniClim = Daily(
+uniClim = ResamplingIndicator(
+    src_freq="D",
     realm="atmos",
     identifier="clim",
     cf_attrs=[dict(units="K")],
@@ -417,7 +418,14 @@ def test_all_parameters_understood(official_indicators):
 
 def test_signature():
     sig = signature(xclim.atmos.solid_precip_accumulation)
-    assert list(sig.parameters.keys()) == ["pr", "tas", "thresh", "freq", "ds"]
+    assert list(sig.parameters.keys()) == [
+        "pr",
+        "tas",
+        "thresh",
+        "freq",
+        "ds",
+        "indexer",
+    ]
     assert sig.parameters["pr"].annotation == Union[xr.DataArray, str]
     assert sig.parameters["tas"].default == "tas"
     assert sig.parameters["tas"].kind == sig.parameters["tas"].POSITIONAL_OR_KEYWORD
@@ -725,3 +733,19 @@ def test_resamplingIndicator_new_error():
             module="test",
             compute=multioptvar_compute,
         )
+
+
+def test_resampling_indicator_with_indexing(pr_series):
+    pr = pr_series(np.ones(731), start="2003-01-01", units="mm/d")
+
+    out = xclim.atmos.precip_accumulation(pr, freq="YS")
+    np.testing.assert_allclose(out, [365, 366])
+
+    out = xclim.atmos.precip_accumulation(pr, freq="YS", month=2)
+    np.testing.assert_allclose(out, [28, 29])
+
+    out = xclim.atmos.precip_accumulation(pr, freq="AS-JUL", doy_bounds=(1, 50))
+    np.testing.assert_allclose(out, [50, 50, np.NaN])
+
+    out = xclim.atmos.precip_accumulation(pr, freq="YS", date_bounds=("02-29", "04-01"))
+    np.testing.assert_allclose(out, [32, 33])

--- a/xclim/testing/tests/test_indicators.py
+++ b/xclim/testing/tests/test_indicators.py
@@ -74,7 +74,7 @@ uniIndPr = Daily(
 @declare_units(da="[temperature]")
 def uniclim_compute(da: xr.DataArray, freq="YS", **indexer):
     select = select_time(da, **indexer)
-    return select.mean(dim="time", keep_attrs=True)
+    return select.mean(dim="time", keep_attrs=True).expand_dims("time")
 
 
 uniClim = ResamplingIndicator(

--- a/xclim/testing/tests/test_indicators.py
+++ b/xclim/testing/tests/test_indicators.py
@@ -418,14 +418,7 @@ def test_all_parameters_understood(official_indicators):
 
 def test_signature():
     sig = signature(xclim.atmos.solid_precip_accumulation)
-    assert list(sig.parameters.keys()) == [
-        "pr",
-        "tas",
-        "thresh",
-        "freq",
-        "ds",
-        "indexer",
-    ]
+    assert list(sig.parameters.keys()) == ["pr", "tas", "thresh", "freq", "ds"]
     assert sig.parameters["pr"].annotation == Union[xr.DataArray, str]
     assert sig.parameters["tas"].default == "tas"
     assert sig.parameters["tas"].kind == sig.parameters["tas"].POSITIONAL_OR_KEYWORD
@@ -735,17 +728,21 @@ def test_resamplingIndicator_new_error():
         )
 
 
-def test_resampling_indicator_with_indexing(pr_series):
-    pr = pr_series(np.ones(731), start="2003-01-01", units="mm/d")
+def test_resampling_indicator_with_indexing(tas_series):
+    tas = tas_series(np.ones(731) + 273.15, start="2003-01-01")
 
-    out = xclim.atmos.precip_accumulation(pr, freq="YS")
+    out = xclim.atmos.tx_days_above(tas, thresh="0 degC", freq="YS")
     np.testing.assert_allclose(out, [365, 366])
 
-    out = xclim.atmos.precip_accumulation(pr, freq="YS", month=2)
+    out = xclim.atmos.tx_days_above(tas, thresh="0 degC", freq="YS", month=2)
     np.testing.assert_allclose(out, [28, 29])
 
-    out = xclim.atmos.precip_accumulation(pr, freq="AS-JUL", doy_bounds=(1, 50))
+    out = xclim.atmos.tx_days_above(
+        tas, thresh="0 degC", freq="AS-JUL", doy_bounds=(1, 50)
+    )
     np.testing.assert_allclose(out, [50, 50, np.NaN])
 
-    out = xclim.atmos.precip_accumulation(pr, freq="YS", date_bounds=("02-29", "04-01"))
+    out = xclim.atmos.tx_days_above(
+        tas, thresh="0 degC", freq="YS", date_bounds=("02-29", "04-01")
+    )
     np.testing.assert_allclose(out, [32, 33])


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #899
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.
- [x] `bumpversion patch` has been called on this branch
- [x] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

* Creates another base Indicator class, `ResamplingIndicatorWithIndexing`, that injects the `indexer` kwargs, as it was done in some "stats" function. The indexing is done in the `preprocess_and_check` function, so the indice (`compute`) receives an input where values outside the select period are **masked**.
* Expand `generic.select_time` with `doy_bounds` and `date_bounds`. The first takes in bounds as day-of-year integers and the second takes in dates in the month-day format (`%m-%d`). 

### Does this PR introduce a breaking change?

* Indexing now _masks_ values by default, instead of dropping them. There are issues when values are dropped, some indices do not expect those gaps. The principal culprit is `units.rate2amount` which converts by multiplying the rate by the timestep length, which is inferred from the coordinate itself. In case of a gap, the rate is assumed constant on the whole gap...
* Most indicators now have the new `**indexer`  in their signature.

### Other information:
An indice may add an `**indexer` var_keyword and handle the time selecting itself. If the indicator is constructed from `ResamplingIndicator` (the one that _doesn't_ inject this new param), the missing values handling will still understand the passed indexing parameter. This can be useful when the order between indexing and computing is important (like for #884 and many others).
This means that the order is currently "wrong" for many cases: i.e. indexing is done before computation. In a way, if it is made clear what the default order is, I think it's ok to have this caveat temporarily. But should we: 
1. Implement these cases now, in this PR.
2. Let them be wrong for now and correct them later.
3. Revert injecting `**indexer` everywhere and slowly implement it where it makes most sense afterwards.
?
