### PR TITLE
Adapt to CF conventions 1.9 - remove gregorian calendar

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -13,7 +13,7 @@ New features and enhancements
 
 Breaking changes
 ~~~~~~~~~~~~~~~~
-* Following version 1.9 of the CF Conventions, publised in September 2021, the calendar name "gregorian" is deprecated. ``core.calendar.get_calendar`` will return "standard", even if the underlying cftime objects still use "gregorian" (cftime <= 1.5.1).
+* Following version 1.9 of the CF Conventions, publised in September 2021, the calendar name "gregorian" is deprecated. ``core.calendar.get_calendar`` will return "standard", even if the underlying cftime objects still use "gregorian" (cftime <= 1.5.1). (:pull:`935`).
 
 Internal changes
 ~~~~~~~~~~~~~~~~

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,10 @@ New features and enhancements
 * Added an optimized pathway for ``xclim.indices.run_length`` functions when ``window=1``. (:pull:`911`, :issue:`910`).
 * The data input frequency expected by ``Indicator``s is now in the ``src_freq`` attribute and is thus controlable by subclassing existing indicators. (:issue:`898`, :pull:`927`).
 
+Breaking changes
+~~~~~~~~~~~~~~~~
+* Following version 1.9 of the CF Conventions, publised in September 2021, the calendar name "gregorian" is deprecated. ``core.calendar.get_calendar`` will return "standard", even if the underlying cftime objects still use "gregorian" (cftime <= 1.5.1).
+
 Internal changes
 ~~~~~~~~~~~~~~~~
 * Removed some logging configurations in ``dataflags`` that were polluting python's main logging configuration. (:pull:`909`).

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -13,7 +13,7 @@ New features and enhancements
 
 Breaking changes
 ~~~~~~~~~~~~~~~~
-* Following version 1.9 of the CF Conventions, publised in September 2021, the calendar name "gregorian" is deprecated. ``core.calendar.get_calendar`` will return "standard", even if the underlying cftime objects still use "gregorian" (cftime <= 1.5.1). (:pull:`935`).
+* Following version 1.9 of the CF Conventions, published in September 2021, the calendar name "gregorian" is deprecated. ``core.calendar.get_calendar`` will return "standard", even if the underlying cftime objects still use "gregorian" (cftime <= 1.5.1). (:pull:`935`).
 
 Internal changes
 ~~~~~~~~~~~~~~~~

--- a/xclim/core/calendar.py
+++ b/xclim/core/calendar.py
@@ -451,7 +451,7 @@ def _convert_datetime(
 
 def ensure_cftime_array(
     time: Sequence,
-) -> Union[CFTimeIndex, np.ndarray]:
+) -> np.ndarray:
     """Convert an input 1D array to an array of cftime objects.
 
     Python's datetime are converted to cftime.DatetimeGregorian ("standard" calendar).

--- a/xclim/core/calendar.py
+++ b/xclim/core/calendar.py
@@ -70,19 +70,23 @@ def get_calendar(obj: Any, dim: str = "time") -> str:
     -------
     str
       The cftime calendar name or "default" when the data is using numpy's or python's datetime types.
+      Will always return "standard" instead of "gregorian", following CF conventions 1.9.
     """
     if isinstance(obj, (xr.DataArray, xr.Dataset)):
         if obj[dim].dtype == "O":
             obj = obj[dim].where(obj[dim].notnull(), drop=True)[0].item()
         elif "datetime64" in obj[dim].dtype.name:
             return "default"
-
-    obj = np.take(
-        obj, 0
-    )  # Take zeroth element, overcome cases when arrays or lists are passed.
+    elif isinstance(obj, xr.CFTimeIndex):
+        obj = obj.values[0]
+    else:
+        obj = np.take(obj, 0)
+        # Take zeroth element, overcome cases when arrays or lists are passed.
     if isinstance(obj, pydt.datetime):  # Also covers pandas Timestamp
         return "default"
     if isinstance(obj, cftime.datetime):
+        if obj.calendar == "gregorian":
+            return "standard"
         return obj.calendar
 
     raise ValueError(f"Calendar could not be inferred from object of type {type(obj)}.")
@@ -450,7 +454,7 @@ def ensure_cftime_array(
 ) -> Union[CFTimeIndex, np.ndarray]:
     """Convert an input 1D array to an array of cftime objects.
 
-    Python's datetime are converted to cftime.DatetimeGregorian.
+    Python's datetime are converted to cftime.DatetimeGregorian ("standard" calendar).
 
     Raises ValueError when unable to cast the input.
     """
@@ -458,6 +462,8 @@ def ensure_cftime_array(
         time = time.indexes["time"]
     elif isinstance(time, np.ndarray):
         time = pd.DatetimeIndex(time)
+    if isinstance(time, xr.CFTimeIndex):
+        return time.values
     if isinstance(time[0], cftime.datetime):
         return time
     if isinstance(time[0], pydt.datetime):

--- a/xclim/core/calendar.py
+++ b/xclim/core/calendar.py
@@ -449,10 +449,8 @@ def _convert_datetime(
         return np.nan
 
 
-def ensure_cftime_array(
-    time: Sequence,
-) -> np.ndarray:
-    """Convert an input 1D array to an array of cftime objects.
+def ensure_cftime_array(time: Sequence) -> np.ndarray:
+    """Convert an input 1D array to a numpy array of cftime objects.
 
     Python's datetime are converted to cftime.DatetimeGregorian ("standard" calendar).
 

--- a/xclim/testing/tests/test_calendar.py
+++ b/xclim/testing/tests/test_calendar.py
@@ -331,7 +331,7 @@ def test_convert_calendar_missing(source, target, freq):
         ("standard", "noleap"),
         ("noleap", "default"),
         ("standard", "360_day"),
-        ("360_day", "gregorian"),
+        ("360_day", "standard"),
         ("noleap", "all_leap"),
         ("360_day", "noleap"),
     ],
@@ -368,20 +368,20 @@ def test_interp_calendar(source, target):
                 dims=("time",),
                 name="time",
             ),
-            "gregorian",
+            "standard",
         ),
-        (date_range("2004-01-01", "2004-01-10", freq="D"), "gregorian"),
+        (date_range("2004-01-01", "2004-01-10", freq="D"), "standard"),
         (
             xr.DataArray(date_range("2004-01-01", "2004-01-10", freq="D")).values,
-            "gregorian",
+            "standard",
         ),
-        (date_range("2004-01-01", "2004-01-10", freq="D"), "gregorian"),
+        (date_range("2004-01-01", "2004-01-10", freq="D"), "standard"),
         (date_range("2004-01-01", "2004-01-10", freq="D", calendar="julian"), "julian"),
     ],
 )
 def test_ensure_cftime_array(inp, calout):
     out = ensure_cftime_array(inp)
-    assert out[0].calendar == calout
+    assert get_calendar(out) == calout
 
 
 @pytest.mark.parametrize(
@@ -391,7 +391,7 @@ def test_ensure_cftime_array(inp, calout):
         (2004, "noleap", 365),
         (2004, "all_leap", 366),
         (1500, "default", 365),
-        (1500, "gregorian", 366),
+        (1500, "standard", 366),
         (1500, "proleptic_gregorian", 365),
         (2030, "360_day", 360),
     ],

--- a/xclim/testing/tests/test_calendar.py
+++ b/xclim/testing/tests/test_calendar.py
@@ -168,6 +168,7 @@ def test_get_calendar(file, cal, maxdoy):
         (pd.Timestamp.now(), "default"),
         (cftime.DatetimeAllLeap(2000, 1, 1), "all_leap"),
         (np.array([cftime.DatetimeNoLeap(2000, 1, 1)]), "noleap"),
+        (xr.cftime_range("2000-01-01", periods=4, freq="D"), "standard"),
     ],
 )
 def test_get_calendar_nonxr(obj, cal):

--- a/xclim/testing/tests/test_calendar.py
+++ b/xclim/testing/tests/test_calendar.py
@@ -175,6 +175,12 @@ def test_get_calendar_nonxr(obj, cal):
     assert get_calendar(obj) == cal
 
 
+@pytest.mark.parametrize("obj", ["astring", {"a": "dict"}, lambda x: x])
+def test_get_calendar_errors(obj):
+    with pytest.raises(ValueError, match="Calendar could not be inferred from object"):
+        get_calendar(obj)
+
+
 @pytest.mark.parametrize(
     "source,target,target_as_str,freq",
     [
@@ -376,7 +382,7 @@ def test_interp_calendar(source, target):
             xr.DataArray(date_range("2004-01-01", "2004-01-10", freq="D")).values,
             "standard",
         ),
-        (date_range("2004-01-01", "2004-01-10", freq="D"), "standard"),
+        (date_range("2004-01-01", "2004-01-10", freq="D").values, "standard"),
         (date_range("2004-01-01", "2004-01-10", freq="D", calendar="julian"), "julian"),
     ],
 )


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.
- [ ] `bumpversion patch` has been called on this branch
- [ ] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

* Deprecates the calendar name "gregorian". Uses "standard" instead, as stated in the version 1.9 of the CF conventions (Sept 2021). In this we simply follow `cftime` that made this change yesterday (Unidata/cftime#257).
* Changes to `get_calendar` and `ensure_ctime_array` to fix a bug I saw while making this change. Both were failing in some edgecases involving `xr.CFTimeIndex` objects.

### Does this PR introduce a breaking change?
Yes, `get_calendar` will never return "gregorian", but "standard".