### PR TITLE
Remove unnecessary keep_attrs

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -26,6 +26,7 @@ Internal changes
 Bug fixes
 ^^^^^^^^^
 * Fix bugs in the `cf_attrs` and/or `abstract` of `continuous_snow_cover_end` and `continuous_snow_cover_start`. (:pull:`908`).
+* Remove unnecessary `keep_attrs` from `resample` call which would raise an error in futur Xarray version. (:pull:`937`).
 
 0.31.0 (2021-11-05)
 -------------------

--- a/xclim/indices/generic.py
+++ b/xclim/indices/generic.py
@@ -107,7 +107,7 @@ def select_resample_op(da: xr.DataArray, op: str, freq: str = "YS", **indexer):
       The maximum value for each period.
     """
     da = select_time(da, **indexer)
-    r = da.resample(time=freq, keep_attrs=True)
+    r = da.resample(time=freq)
     if isinstance(op, str):
         return getattr(r, op)(dim="time", keep_attrs=True)
 


### PR DESCRIPTION
On resample `keep_attrs` has no effect and xarray shows a warning.

<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.
- [ ] `bumpversion patch` has been called on this branch
- [ ] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

When calling `xclim.generic.select_resample_op`, Xarray raises the following warning:
> UserWarning: Passing ``keep_attrs`` to ``resample`` has no effect and will raise an error in xarray 0.20. Pass ``keep_attrs`` directly to the applied function, e.g. ``resample(...).mean(keep_attrs=True)``.

This pr remove the `resample(..., keep_attrs=True)` of `select_resample_op`, it seems to be the only place in Xclim where this happens. 

### Does this PR introduce a breaking change?
No.
