### PR TITLE
Ci coverage adjustments

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,7 +75,7 @@ jobs:
 #        parallel: true
 
   finish:
-    needs: test
+    needs: [test, doctests]
     runs-on: ubuntu-latest
     steps:
     - name: Coveralls Finished

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,12 @@ History
 -------------------
 Contributors to this version: Pascal Bourgault (:user:`aulemahal`), Travis Logan (:user:`tlogan2000`), Trevor James Smith (:user:`Zeitsperre`)
 
+Announcements
+^^^^^^^^^^^^^
+* Code coverage (`coverage/coveralls`) is now a required CI check for merging Pull Requests. Requirements are now:
+    - No individual run may report *<80%* code coverage.
+    - Some drop in coverage is now tolerable, but runs cannot dip below *-0.25%* relative to the main branch.
+
 New features and enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 * Added an optimized pathway for ``xclim.indices.run_length`` functions when ``window=1``. (:pull:`911`, :issue:`910`).
@@ -23,6 +29,7 @@ Internal changes
 * Added a helper function for generating the release notes with dynamically-generated ReStructuredText or Markdown-formatted hyperlinks (:pull:`922`, :issue:`907`).
 * Split of resampling-related functionality of ``Indicator``s into a new ``ResamplingIndicator`` and ``ResamplingIndicatorWithIndexing`` subclasses. The use of new (private) methods makes it easier to inject functionality in indicator subclasses. (:issue:`867`, :pull:`927`, :pull:`934`).
 * French translation metadata fields are now cleaner and much more internally consistent, and many empty metadata fields (e.g. ``comment_fr``) have been removed. (:pull:`930`, :issue:`929`).
+* Adjustments to the `tox` builds so that slow tests are now run alongside standard tests (for more accurate coverage reporting). (:pull:`938`)
 
 Bug fixes
 ^^^^^^^^^

--- a/Makefile
+++ b/Makefile
@@ -50,10 +50,10 @@ clean-test: ## remove test and coverage artifacts
 	rm -fr htmlcov/
 	rm -fr .pytest_cache
 
-lint: ## check style with flake8
+lint: ## check style with flake8 and black
 	pydocstyle --convention=numpy --match='(?!test_).*\.py' xclim
 	flake8 xclim
-	black --check --target-version py36 xclim
+	black --check --target-version py37 xclim
 	pylint --rcfile=setup.cfg --exit-zero xclim
 
 test: ## run tests quickly with the default Python

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ setenv =
 passenv = CI GITHUB_* LD_LIBRARY_PATH
 extras = dev
 deps =
-    coveralls
+    coverage: coveralls
     xarray: setuptools
 install_command = python -m pip install --no-user {opts} {packages}
 download = True

--- a/tox.ini
+++ b/tox.ini
@@ -47,8 +47,8 @@ commands =
 ;    xarray: pip install git+https://github.com/pydata/bottleneck.git@master#egg=bottleneck
     lm3: pip install git+https://github.com/OpenHydrology/lmoments3.git@develop#egg=lmoments3
     doctest: pytest --rootdir xclim/testing/tests/ --xdoctest xclim --ignore=xclim/testing/tests/
-    pytest --cov xclim -m "not slow"
-    slow: pytest --cov xclim -m "slow"
+    !slow: pytest --cov xclim -m "not slow"
+    slow: pytest --cov xclim
     coverage: - coveralls
 ;platform =
 ;    windows: win32


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.
- [ ] `bumpversion patch` has been called on this branch
- [ ] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

* adds the doctests build to the needed builds for CI suite
* slight adjustment to the largely neglected makefile

### Does this PR introduce a breaking change?
No

### Other information:

Coveralls (https://coveralls.io/github/Ouranosinc/xclim) has been adjusted to be a little less discouraging, but a bit more strict (Coveralls will now be a `required` check). PRs now require the following:
- Coverage decreases can be no more than 0.25% from master
- Coverage total must remain above 80% (for individual runs)

Failing either of these conditions means the PR will be blocked from merging.

Additionally, Codefactor is now permanently ignoring "Complex Method" (Flake8: `C901`). This isn't _great_, but we're doing some relatively complex stuff, so let's be easy on ourselves. 