### PR TITLE
Improve rxxp indices

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,7 @@ New features and enhancements
 * Added an optimized pathway for ``xclim.indices.run_length`` functions when ``window=1``. (:pull:`911`, :issue:`910`).
 * The data input frequency expected by ``Indicator``s is now in the ``src_freq`` attribute and is thus controllable by subclassing existing indicators. (:issue:`898`, :pull:`927`).
 * New ``**indexer`` keyword args added to many indicators, it accepts the same arguments as ``xclim.indices.generic.select_time``, which has been improved. Unless otherwise specified, the time selection is done before any computation. (:pull:`934`, :issue:`899`).
+* Added `days_over_precip_doy_thresh` indicator to distinguish between WMO and ECAD definition of the Rxxp indices.
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -18,7 +18,7 @@ New features and enhancements
 * The data input frequency expected by ``Indicator``s is now in the ``src_freq`` attribute and is thus controllable by subclassing existing indicators. (:issue:`898`, :pull:`927`).
 * New ``**indexer`` keyword args added to many indicators, it accepts the same arguments as ``xclim.indices.generic.select_time``, which has been improved. Unless otherwise specified, the time selection is done before any computation. (:pull:`934`, :issue:`899`).
 * Rewrite of ``xclim.sdba.ExtremeValues``, now fixed with a correct algorithm. It has not been tested extensively and should be considered experimental. (:pull:`914`, :issue:`789`, :issue:`790`).
-* Added `days_over_precip_doy_thresh` indicator to distinguish between WMO and ECAD definition of the Rxxp indices.
+* Added `days_over_precip_doy_thresh` and `fraction_over_precip_doy_thresh` indicators to distinguish between WMO and ECAD definition of the Rxxp and RxxpTot indices. (:issue:`931`, :pull:`940`)
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/xclim/core/bootstrapping.py
+++ b/xclim/core/bootstrapping.py
@@ -1,5 +1,5 @@
 from inspect import signature
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, Optional
 
 import cftime
 import numpy as np
@@ -93,6 +93,7 @@ def bootstrap_func(compute_indice_func: Callable, **kwargs) -> xarray.DataArray:
 
     """
     # Identify the input and the percentile arrays from the bound arguments
+    per_key = None
     for name, val in kwargs.items():
         if isinstance(val, DataArray):
             if "percentile_doy" in val.attrs.get("history", ""):
@@ -102,7 +103,12 @@ def bootstrap_func(compute_indice_func: Callable, **kwargs) -> xarray.DataArray:
 
     # Extract the DataArray inputs from the arguments
     da: DataArray = kwargs.pop(da_key)
-    per: DataArray = kwargs.pop(per_key)
+    per: Optional[DataArray] = kwargs.pop(per_key, None)
+    if per is None:
+        # per may be empty on non doy percentiles
+        raise KeyError(
+            "`bootstrap` can only be used with percentiles computed using `percentile_doy`"
+        )
 
     # List of years in base period
     clim = per.attrs["climatology_bounds"]

--- a/xclim/data/icclim.yml
+++ b/xclim/data/icclim.yml
@@ -221,20 +221,20 @@ indicators:
     parameters:
       thresh: 1 mm/day
       per:
-        description: Daily 75th percentile of wet day precipitation flux.
+        description: 75th percentile of wet day precipitation flux.
 
   R95p:
     base: days_over_precip_thresh
     parameters:
       thresh: 1 mm/day
       per:
-        description: Daily 95th percentile of wet day precipitation flux.
+        description: 95th percentile of wet day precipitation flux.
   R99p:
     base: days_over_precip_thresh
     parameters:
       thresh: 1 mm/day
       per:
-        description: Daily 99th percentile of wet day precipitation flux.
+        description: 99th percentile of wet day precipitation flux.
   R75pTOT:
     base: fraction_over_precip_thresh
     cf_attrs:
@@ -242,7 +242,7 @@ indicators:
     parameters:
       thresh: 1 mm/day
       per:
-        description: Daily 75th percentile of wet day precipitation flux.
+        description: 75th percentile of wet day precipitation flux.
 
   R95pTOT:
     base: fraction_over_precip_thresh
@@ -251,7 +251,7 @@ indicators:
     parameters:
       thresh: 1 mm/day
       per:
-        description: Daily 95th percentile of wet day precipitation flux.
+        description: 95th percentile of wet day precipitation flux.
   R99pTOT:
     base: fraction_over_precip_thresh
     cf_attrs:
@@ -259,7 +259,7 @@ indicators:
     parameters:
       thresh: 1 mm/day
       per:
-        description: Daily 99th percentile of wet day precipitation flux.
+        description: 99th percentile of wet day precipitation flux.
   SD:
     realm: land
     base: snow_depth

--- a/xclim/indicators/atmos/_precip.py
+++ b/xclim/indicators/atmos/_precip.py
@@ -316,7 +316,7 @@ high_precip_low_temp = PrTasx(
 )
 
 
-fraction_over_precip_thresh = Precip(
+fraction_over_precip_doy_thresh = Precip(
     identifier="fraction_over_precip_thresh",
     description="{freq} fraction of total precipitation due to days with precipitation above a daily percentile."
     " Only days with at least {thresh} are included in the total.",
@@ -325,6 +325,14 @@ fraction_over_precip_thresh = Precip(
     compute=indices.fraction_over_precip_thresh,
 )
 
+fraction_over_precip_thresh = Precip(
+    identifier="fraction_over_precip_thresh",
+    description="{freq} fraction of total precipitation due to days with precipitation above percentile."
+    " Only days with at least {thresh} are included in the total.",
+    units="",
+    cell_methods="",
+    compute=indices.fraction_over_precip_thresh,
+)
 
 liquid_precip_ratio = PrTasx(
     identifier="liquid_precip_ratio",

--- a/xclim/indicators/atmos/_precip.py
+++ b/xclim/indicators/atmos/_precip.py
@@ -290,13 +290,22 @@ days_with_snow = Precip(
 days_over_precip_thresh = Precip(
     identifier="days_over_precip_thresh",
     standard_name="number_of_days_with_lwe_thickness_of_precipitation_amount_above_threshold",
-    description="{freq} number of days with precipitation above a daily percentile."
+    description="{freq} number of days with precipitation above percentile."
     " Only days with at least {thresh} are counted.",
     units="days",
     cell_methods="time: sum over days",
     compute=indices.days_over_precip_thresh,
 )
 
+days_over_precip_doy_thresh = Precip(
+    identifier="days_over_precip_doy_thresh",
+    standard_name="number_of_days_with_lwe_thickness_of_precipitation_amount_above_daily_threshold",
+    description="{freq} number of days with precipitation above a daily percentile."
+    " Only days with at least {thresh} are counted.",
+    units="days",
+    cell_methods="time: sum over days",
+    compute=indices.days_over_precip_thresh,
+)
 
 high_precip_low_temp = PrTasx(
     identifier="high_precip_low_temp",

--- a/xclim/indices/_multivariate.py
+++ b/xclim/indices/_multivariate.py
@@ -1168,7 +1168,8 @@ def fraction_over_precip_thresh(
     pr : xarray.DataArray
       Mean daily precipitation flux.
     per : xarray.DataArray
-      Daily percentile of wet day precipitation flux.
+      Percentile of wet day precipitation flux. Either computed daily (one value per day
+      of year) or computed over a period (one value per spatial point).
     thresh : str
        Precipitation value over which a day is considered wet.
     freq : str

--- a/xclim/indices/_multivariate.py
+++ b/xclim/indices/_multivariate.py
@@ -1106,7 +1106,8 @@ def days_over_precip_thresh(
     pr : xarray.DataArray
       Mean daily precipitation flux.
     per : xarray.DataArray
-      Daily percentile of wet day precipitation flux.
+      Percentile of wet day precipitation flux. Either computed daily (one value per day
+      of year) or computed over a period (one value per spatial point).
     thresh : str
        Precipitation value over which a day is considered wet.
     freq : str
@@ -1138,6 +1139,10 @@ def days_over_precip_thresh(
     if "dayofyear" in per.coords:
         # Create time series out of doy values.
         tp = resample_doy(tp, pr)
+    elif bootstrap:
+        raise KeyError(
+            "`bootstrap` can only be used with percentiles computed on day of year."
+        )
 
     # Compute the days where precip is both over the wet day threshold and the percentile threshold.
     out = threshold_count(pr, ">", tp, freq)
@@ -1189,6 +1194,10 @@ def fraction_over_precip_thresh(
     if "dayofyear" in per.coords:
         # Create time series out of doy values.
         tp = resample_doy(tp, pr)
+    else:
+        raise KeyError(
+            "`bootstrap` can only be used with percentiles computed on day of year."
+        )
 
     # Total precip during wet days over period
     total = pr.where(pr > thresh).resample(time=freq).sum(dim="time")

--- a/xclim/indices/generic.py
+++ b/xclim/indices/generic.py
@@ -271,7 +271,7 @@ def compare(da: xr.DataArray, op: str, thresh: Union[float, int]) -> xr.DataArra
 
 
 def threshold_count(
-    da: xr.DataArray, op: str, thresh: Union[float, int], freq: str
+    da: xr.DataArray, op: str, thresh: Union[float, int, xr.DataArray], freq: str
 ) -> xr.DataArray:
     """Count number of days where value is above or below threshold.
 

--- a/xclim/testing/tests/test_bootstrapping.py
+++ b/xclim/testing/tests/test_bootstrapping.py
@@ -136,6 +136,28 @@ class Test_bootstrap:
             use_dask=False,
         )
 
+    @pytest.mark.slow
+    def test_bootstrap_fraction_over_precip_error_no_doy(self, pr_series):
+        with pytest.raises(KeyError):
+            # no "dayofyear" coords on per
+            fraction_over_precip_thresh(
+                pr_series([1, 2]), pr_series([1, 2]), bootstrap=True
+            )
+
+    @pytest.mark.slow
+    def test_bootstrap_days_over_precip_thresh_error_no_doy(self, pr_series):
+        with pytest.raises(KeyError):
+            # no "dayofyear" coords on per
+            days_over_precip_thresh(
+                pr_series([1, 2]), pr_series([1, 2]), bootstrap=True
+            )
+
+    @pytest.mark.slow
+    def test_bootstrap_no_doy(self, tas_series):
+        # no "dayofyear" coords on per
+        with pytest.raises(KeyError):
+            tg10p(tas_series([42]), tas_series([42]), freq="MS", bootstrap=True)
+
     def bootstrap_testor(
         self,
         series,


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #931
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.
- [ ] `bumpversion patch` has been called on this branch
- [x] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?
- Add new indicator `days_over_precip_doy_thresh` for the WMO definition of Rxxp indices.
The existing `days_over_precip_thresh` (notice ~doy~) description is now made for the ECA&D definiton of Rxxp indices.
Note that both indicators call the same **indice** function, only the description is changed.
- Also added some error handling when non doy percentiles are used in BS.


### Does this PR introduce a breaking change?
Not a breaking change, but those who calls `days_over_precip_thresh` with `per` computed using doy values will receive an improper description for the indicator. 
They should start using `days_over_precip_doy_thresh` for this purpose.

### Other information:
ECAD (pdf): https://www.ecad.eu/documents/atbd.pdf
WMO: https://library.wmo.int/index.php?lvl=notice_display&id=138#.YUBV6CVS9ZI