### PR TITLE
[sdba] Refactor interp_on_quantiles

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -36,6 +36,7 @@ Bug fixes
 ^^^^^^^^^
 * Fix bugs in the `cf_attrs` and/or `abstract` of `continuous_snow_cover_end` and `continuous_snow_cover_start`. (:pull:`908`).
 * Remove unnecessary `keep_attrs` from `resample` call which would raise an error in futur Xarray version. (:pull:`937`).
+* Skip all missing values in ``xclim.sdba.utils.interp_on_quantiles``, drop them from both the old and new coordinates, as well as from the old values.
 
 0.31.0 (2021-11-05)
 -------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -25,6 +25,7 @@ New features and enhancements
 Breaking changes
 ^^^^^^^^^^^^^^^^
 * Following version 1.9 of the CF Conventions, published in September 2021, the calendar name "gregorian" is deprecated. ``core.calendar.get_calendar`` will return "standard", even if the underlying cftime objects still use "gregorian" (cftime <= 1.5.1). (:pull:`935`).
+* ``sdba.utils.extrapolate_qm`` is now deprecated and will be removed in version 0.33. (:pull:`941`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -36,7 +36,7 @@ Bug fixes
 ^^^^^^^^^
 * Fix bugs in the `cf_attrs` and/or `abstract` of `continuous_snow_cover_end` and `continuous_snow_cover_start`. (:pull:`908`).
 * Remove unnecessary `keep_attrs` from `resample` call which would raise an error in futur Xarray version. (:pull:`937`).
-* Skip all missing values in ``xclim.sdba.utils.interp_on_quantiles``, drop them from both the old and new coordinates, as well as from the old values.
+* Skip all missing values in ``xclim.sdba.utils.interp_on_quantiles``, drop them from both the old and new coordinates, as well as from the old values. (:pull:`941`).
 
 0.31.0 (2021-11-05)
 -------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -35,6 +35,7 @@ Internal changes
 * French translation metadata fields are now cleaner and much more internally consistent, and many empty metadata fields (e.g. ``comment_fr``) have been removed. (:pull:`930`, :issue:`929`).
 * Adjustments to the `tox` builds so that slow tests are now run alongside standard tests (for more accurate coverage reporting). (:pull:`938`)
 * Use ``xarray.apply_ufunc`` to vectorize statistical functions. (:pull:`943`)
+* Refactor of ``xclim.sdba.utils.interp_on_quantiles`` so that it now handles the extrapolation directly and to better handle missing values. (:pull:`941`).
 
 Bug fixes
 ^^^^^^^^^

--- a/xclim/sdba/utils.py
+++ b/xclim/sdba/utils.py
@@ -334,6 +334,13 @@ def extrapolate_qm(
       The adjustment factor above and below the computed values are equal to the last
       and first values respectively.
     """
+    warn(
+        (
+            "`extrapolate_qm` is deprecated and will be removed in xclim 0.33. "
+            "Extrapolation is now handled directly in `interp_on_quantiles`."
+        ),
+        DeprecationWarning,
+    )
     # constant_iqr
     #   Same as `constant`, but values are set to NaN if farther than one interquartile range from the min and max.
     q_l, q_r = [0], [1]

--- a/xclim/sdba/utils.py
+++ b/xclim/sdba/utils.py
@@ -404,7 +404,7 @@ def interp_on_quantiles(
     """Interpolate values of yq on new values of x.
 
     Interpolate in 2D with :py:func:`~scipy.interpolate.griddata` if grouping is used,
-    in 1D otherwise, with :py:func:`~scipy.interpolate.interp1d`. Except for the
+    in 1D otherwise, with :py:class:`~scipy.interpolate.interp1d`. Except for the
     boundaries as added by :py:func:`~xclim.sdba.utils.extrapolate_qm`, any NaNs in xq
     or yq are removed from the input map. Similarly, NaNs in newx are left NaNs.
 

--- a/xclim/sdba/utils.py
+++ b/xclim/sdba/utils.py
@@ -441,7 +441,7 @@ def interp_on_quantiles(
             mask_old = mask_old | np.isnan(oldx)
 
             mask_new = np.isnan(newx)
-            out = np.full_like(newx, np.NaN)
+            out = np.full_like(newx, np.NaN, dtype=oldy.dtype)
             out[~mask_new] = interp1d(
                 oldx[~mask_old],
                 oldy[~mask_old],
@@ -483,7 +483,7 @@ def interp_on_quantiles(
         mask_old = mask_old | np.isnan(_oldx) | np.isnan(_oldg)
 
         mask_new = np.isnan(_newx) | np.isnan(_newg)
-        out = np.full_like(_newx, np.NaN)
+        out = np.full_like(_newx, np.NaN, dtype=_oldy.dtype)
         out[~mask_new] = griddata(
             (_oldx[~mask_old], _oldg[~mask_old]),
             _oldy[~mask_old],

--- a/xclim/sdba/utils.py
+++ b/xclim/sdba/utils.py
@@ -449,6 +449,7 @@ def interp_on_quantiles(
                 kind=method,
                 fill_value=fill_value,
             )(newx[~mask_new])
+            return out
 
         if "group" in xq.dims:
             xq = xq.squeeze("group", drop=True)
@@ -462,7 +463,7 @@ def interp_on_quantiles(
             output_core_dims=[[dim]],
             vectorize=True,
             dask="parallelized",
-            output_dtypes=[float],
+            output_dtypes=[yq.dtype],
         )
     # else:
 
@@ -484,11 +485,12 @@ def interp_on_quantiles(
         mask_new = np.isnan(_newx) | np.isnan(_newg)
         out = np.full_like(_newx, np.NaN)
         out[~mask_new] = griddata(
-            (_oldx[~mask], _oldg[~mask]),
-            _oldy[~mask],
+            (_oldx[~mask_old], _oldg[~mask_old]),
+            _oldy[~mask_old],
             (_newx[~mask_new], _newg[~mask_new]),
             method=method,
         )
+        return out
 
     xq = add_cyclic_bounds(xq, prop, cyclic_coords=False)
     yq = add_cyclic_bounds(yq, prop, cyclic_coords=False)

--- a/xclim/testing/tests/test_sdba/test_base.py
+++ b/xclim/testing/tests/test_sdba/test_base.py
@@ -51,8 +51,8 @@ def test_grouper_group(tas_series, group, window, nvals):
 )
 def test_grouper_get_index(tas_series, group, interp, val90):
     tas = tas_series(np.ones(366), start="2000-01-01")
-    grouper = Grouper(group, interp=interp)
-    indx = grouper.get_index(tas)
+    grouper = Grouper(group)
+    indx = grouper.get_index(tas, interp=interp)
     # 90 is March 31st
     assert indx[90] == val90
 

--- a/xclim/testing/tests/test_sdba/test_utils.py
+++ b/xclim/testing/tests/test_sdba/test_utils.py
@@ -103,14 +103,11 @@ def test_interp_on_quantiles(shape, group, method):
         *("time", "lat", "lon")[: len(shape)]
     )
 
-    if method == "nearest":
-        np.testing.assert_allclose(fut_corr.values, obs.values, rtol=0.3)
-        assert fut_corr.isnull().sum() == 0
-    else:
-        np.testing.assert_allclose(
-            fut_corr.values, obs.where(fut != 1000).values, rtol=2e-3
-        )
-        xr.testing.assert_equal(fut_corr.isnull(), fut == 1000)
+    rtol = 0.02 if method == "nearest" else 0.002
+    np.testing.assert_allclose(
+        fut_corr.values, obs.where(fut != 1000).values, rtol=rtol
+    )
+    xr.testing.assert_equal(fut_corr.isnull(), fut == 1000)
 
 
 @pytest.mark.parametrize("group", ["time", "time.month"])

--- a/xclim/testing/tests/test_utils.py
+++ b/xclim/testing/tests/test_utils.py
@@ -6,7 +6,6 @@ from inspect import signature
 import numpy as np
 import xarray as xr
 
-from xclim.core.indicator import Daily
 from xclim.core.utils import (
     ensure_chunk_size,
     nan_calc_percentiles,


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.
- [ ] `bumpversion patch` has been called on this branch
- [ ] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

I though the changes in #914 would address a bug I saw while computing ESPO-R. However, I had forgotten about the splitting pathways for `group='time'` vs `group='time.prop'`. That also meant testing was not sufficient.  This PR changes `xclim.sdba.utils.interp_on_quantiles` so that:

* All NaNs in the coordinates are dropped. Minor modification from the Extremes' PR, but dropping everything explicitly, instead of relying on `interp1d`, has the advantage that NaNs in the new coord are not considered "out of bounds", but NaNs. They return NaN in the output, not an extrapolated value.
* All NaNs in the new coordinates are dropped. In the 2D case, with 'nearest', NaNs would cause QHull errors.

### Does this PR introduce a breaking change?
* Not really.

### Other information:
The docstring was improved.

I realized that `method='cubic'` does not respect the constant extrapolation as set by `extrapolate_qm`... I added a note to the doc, but I'm not sure what to do here. @huard ?  The logic we used works well with 'nearest' and 'linear', but as 'cubic' fetches a third point it estimates something else.

EDIT:
I compared the performance before and after the change and it is insignificant. `griddata` and `interp1d` are much slower than any numpy overhead I added, so I did not see any timing difference.
