### PR TITLE
Allow a few more special chars in username regex

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -38,6 +38,7 @@ Bug fixes
 ^^^^^^^^^
 * Fix bugs in the `cf_attrs` and/or `abstract` of `continuous_snow_cover_end` and `continuous_snow_cover_start`. (:pull:`908`).
 * Remove unnecessary `keep_attrs` from `resample` call which would raise an error in futur Xarray version. (:pull:`937`).
+* Fixed a bug in the regex that parses usernames in the history. (:pull:`945`)
 
 0.31.0 (2021-11-05)
 -------------------

--- a/xclim/testing/_utils.py
+++ b/xclim/testing/_utils.py
@@ -423,13 +423,13 @@ def publish_release_notes(style: str = "md") -> str:
         hyperlink_replacements = {
             r":issue:`([0-9]+)`": r"`GH/\1 <https://github.com/Ouranosinc/xclim/issues/\1>`_",
             r":pull:`([0-9]+)`": r"`PR/\1 <https://github.com/Ouranosinc/xclim/pull/\>`_",
-            r":user:`([a-zA-Z0-9_]+)`": r"`@\1 <https://github.com/\1>`_",
+            r":user:`([a-zA-Z0-9_.-]+)`": r"`@\1 <https://github.com/\1>`_",
         }
     elif style == "md":
         hyperlink_replacements = {
             r":issue:`([0-9]+)`": r"[GH/\1](https://github.com/Ouranosinc/xclim/issues/\1)",
             r":pull:`([0-9]+)`": r"[PR/\1](https://github.com/Ouranosinc/xclim/pull/\1)",
-            r":user:`([a-zA-Z0-9_]+)`": r"[@\1](https://github.com/\1)",
+            r":user:`([a-zA-Z0-9_.-]+)`": r"[@\1](https://github.com/\1)",
         }
     else:
         raise NotImplementedError()


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes a bug found in #915 
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.
- [ ] `bumpversion patch` has been called on this branch
- [ ] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

* Allows for two special characters found in GitHub usernames to be parsed when generating the docs 

### Does this PR introduce a breaking change?

Nope.

### Other information:

This regex is not as in-depth as it could be (see: https://github.com/shinnn/github-username-regex), as starting/ending with a dash isn't allowed and some names are reserved, but we don't need this level of complexity here.