### PR TITLE
ENH: Add option to avoid array copy

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,7 @@ History
 
 0.33.0 (unreleased)
 -------------------
-Contributors to this version: Trevor James Smith (:user:`Zeitsperre`), Pascal Bourgault (:user:`aulemahal`), Tom Keel (:user:`Thomasjkeel`), Jeremy Fyke (:user:`JeremyFyke`), David Huard (:user:`huard`).
+Contributors to this version: Trevor James Smith (:user:`Zeitsperre`), Pascal Bourgault (:user:`aulemahal`), Tom Keel (:user:`Thomasjkeel`), Jeremy Fyke (:user:`JeremyFyke`), David Huard (:user:`huard`), Abel Aoun (:user:`bzah`).
 
 Announcements
 ^^^^^^^^^^^^^
@@ -21,7 +21,7 @@ New features and enhancements
     - ``xclim.sdba.processing.normalize`` now also returns the norm. ``xclim.sdba.processing.jitter`` was created by combining the "under" and "over" methods.
     - ``xclim.sdba.adjustment.PrincipalComponent`` was modified to have a simpler signature. The "full" method for finding the best PC orientation was added. (:issue:`697`).
 * New ``xclim.indices.stats.parametric_cdf`` function to facilitate the computation of return periods over DataArrays of statistical distribution parameters (:issue:`876`, :pull:`984`).
-* Add ``copy`` parameter to ``percentile_doy`` to control if the array input can be dumped after computing percentiles (:pull:``, :issue:`932`).
+* Add ``copy`` parameter to ``percentile_doy`` to control if the array input can be dumped after computing percentiles (:issue:`932`, :pull:`985`).
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -21,6 +21,7 @@ New features and enhancements
     - ``xclim.sdba.processing.normalize`` now also returns the norm. ``xclim.sdba.processing.jitter`` was created by combining the "under" and "over" methods.
     - ``xclim.sdba.adjustment.PrincipalComponent`` was modified to have a simpler signature. The "full" method for finding the best PC orientation was added. (:issue:`697`).
 * New ``xclim.indices.stats.parametric_cdf`` function to facilitate the computation of return periods over DataArrays of statistical distribution parameters (:issue:`876`, :pull:`984`).
+* Add ``copy`` parameter to ``percentile_doy`` to control if the array input can be dumped after computing percentiles (:pull:``, :issue:`932`).
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/xclim/core/bootstrapping.py
+++ b/xclim/core/bootstrapping.py
@@ -149,7 +149,7 @@ def bootstrap_func(compute_indice_func: Callable, **kwargs) -> xarray.DataArray:
         # If the group year is in the base period, run the bootstrap
         if year in per_clim_years:
             bda = bootstrap_year(da_base, in_base_years, label)
-            kw[per_key] = percentile_doy(bda, **pdoy_args)
+            kw[per_key] = percentile_doy(bda, **pdoy_args, copy=False)
             value = compute_indice_func(**kw).mean(dim="_bootstrap", keep_attrs=True)
 
         # Otherwise run the normal computation using the original percentile

--- a/xclim/core/calendar.py
+++ b/xclim/core/calendar.py
@@ -439,6 +439,7 @@ def percentile_doy(
     per: Union[float, Sequence[float]] = 10.0,
     alpha: float = 1.0 / 3.0,
     beta: float = 1.0 / 3.0,
+    copy: bool = True,
 ) -> xr.DataArray:
     """Percentile value for each day of the year.
 
@@ -457,6 +458,12 @@ def percentile_doy(
         Plotting position parameter.
     beta: float
         Plotting position parameter.
+    copy: bool
+        If True (default) the input array will be deep copied. It's a necessary step
+        to keep the data integrity but it can be costly.
+        If False, no copy is made of the input array. It will be mutated and rendered
+        unusable but performances may significantly improve.
+        Put this flag to False only if you understand the consequences.
 
     Returns
     -------
@@ -495,7 +502,7 @@ def percentile_doy(
         input_core_dims=[["stack_dim"]],
         output_core_dims=[["percentiles"]],
         keep_attrs=True,
-        kwargs=dict(percentiles=per, alpha=alpha, beta=beta),
+        kwargs=dict(percentiles=per, alpha=alpha, beta=beta, copy=copy),
         dask="parallelized",
         output_dtypes=[rrr.dtype],
         dask_gufunc_kwargs=dict(output_sizes={"percentiles": len(per)}),

--- a/xclim/core/utils.py
+++ b/xclim/core/utils.py
@@ -215,13 +215,14 @@ def calc_perc(
     percentiles: Sequence[float] = [50.0],
     alpha: float = 1.0,
     beta: float = 1.0,
+    copy: bool = True,
 ) -> np.ndarray:
     """
     Compute percentiles using nan_calc_percentiles and move the percentiles axis to the end.
     """
     return np.moveaxis(
         nan_calc_percentiles(
-            arr=arr, percentiles=percentiles, axis=-1, alpha=alpha, beta=beta
+            arr=arr, percentiles=percentiles, axis=-1, alpha=alpha, beta=beta, copy=copy
         ),
         source=0,
         destination=-1,
@@ -234,13 +235,17 @@ def nan_calc_percentiles(
     axis=-1,
     alpha=1.0,
     beta=1.0,
+    copy=True,
 ) -> np.ndarray:
     """
     Convert the percentiles to quantiles and compute them using _nan_quantile.
     """
-    arr_copy = arr.copy()
+    if copy:
+        # bootstrapping already works on a data's copy
+        # doing it again is extremely costly, especially with dask.
+        arr = arr.copy()
     quantiles = np.array([per / 100.0 for per in percentiles])
-    return _nan_quantile(arr_copy, quantiles, axis, alpha, beta)
+    return _nan_quantile(arr, quantiles, axis, alpha, beta)
 
 
 def _compute_virtual_index(


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #932
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.
- [ ] `bumpversion patch` has been called on this branch
- [x] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

When computing percentiles there is a huge performance bottleneck due to the array copy.
However, when bootstrapping the percentiles, we are already working on a deep copy of the array. 
Thus, it's unnecessary and costly to copy it once again.

related to gh #932

### Does this PR introduce a breaking change?
No, default behavior is unchanged.

### Other information:
~I'm interested to know when is schedule the next release of xclim to include this in icc.~
