### PR TITLE
ENH: Update percentile dask chunking

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -23,6 +23,7 @@ New features and enhancements
 * New ``xclim.indices.stats.parametric_cdf`` function to facilitate the computation of return periods over DataArrays of statistical distribution parameters (:issue:`876`, :pull:`984`).
 * Add ``copy`` parameter to ``percentile_doy`` to control if the array input can be dumped after computing percentiles (:issue:`932`, :pull:`985`).
 * Added ``properties.py`` and ``measures.py`` in order to perform diagnostic tests of sdba (:issue:`424`, :pull:`967`).
+* Update how ``percentile_doy`` rechunk the input data to preserve the initial chunk size. This should make the computation memory footprint more predictable (:issue:`932`, :pull:`987`).
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/xclim/core/calendar.py
+++ b/xclim/core/calendar.py
@@ -491,7 +491,10 @@ def percentile_doy(
     rrr = rr.assign_coords(time=ind).unstack("time").stack(stack_dim=("year", "window"))
 
     if rrr.chunks is not None and len(rrr.chunks[rrr.get_axis_num("stack_dim")]) > 1:
-        rrr = rrr.chunk(dict(stack_dim=-1))
+        # Preserve chunk size
+        time_chunks_count = len(arr.chunks[arr.get_axis_num("time")])
+        doy_chunk_size = round(len(rrr.dayofyear) / (window * time_chunks_count))
+        rrr = rrr.chunk(dict(stack_dim=-1, dayofyear=doy_chunk_size))
 
     if np.isscalar(per):
         per = [per]

--- a/xclim/core/calendar.py
+++ b/xclim/core/calendar.py
@@ -58,7 +58,6 @@ __all__ = [
     "uniform_calendars",
 ]
 
-
 # Maximum day of year in each calendar.
 max_doy = {
     "default": 366,
@@ -492,9 +491,17 @@ def percentile_doy(
 
     if rrr.chunks is not None and len(rrr.chunks[rrr.get_axis_num("stack_dim")]) > 1:
         # Preserve chunk size
-        time_chunks_count = len(arr.chunks[arr.get_axis_num("time")])
-        doy_chunk_size = round(len(rrr.dayofyear) / (window * time_chunks_count))
-        rrr = rrr.chunk(dict(stack_dim=-1, dayofyear=doy_chunk_size))
+        initial_chunk_count = 1
+        for chunk in arr.chunks:
+            initial_chunk_count *= len(chunk)
+        dims = set(arr.dims) & set(rrr.dims)
+        chunks = {
+            d: (np.ceil(len(arr[d]) / (window * initial_chunk_count / len(rrr.dims))))
+            for d in dims
+        }
+        chunks["stack_dim"] = -1
+        chunks["dayofyear"] = -1
+        rrr = rrr.chunk(chunks)
 
     if np.isscalar(per):
         per = [per]


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR is related to #932 
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.
- [ ] `bumpversion patch` has been called on this branch
- [ ] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?
This PR make sure `percentile_doy` rechunking preserve the initial chunk size.

Currently, ``percentile_doy`` multiply the size of chunks by at least `window` width (default 5).
This size increase can even be larger because the time dimension initial chunking is lost in percentile_doy rechunking.
This PR fix this by chunking ``dayofyear`` dimension in `window * time_chunk_count` chunks.

Using dask dashboard I see the memory peak use being reduced by about 30% for a mono-threaded launch with theses changes,
However, I expected a bigger reduction of memory use.
The performances seems to also improve, even though dask exhibits a new warning: ``PerformanceWarning: Slicing with an out-of-order index is generating 36 times more chunks``
I'm not sure what this warning is about, it comes from [dask slicing].(https://github.com/dask/dask/blob/main/dask/array/slicing.py#L630)

I suspect the performance improvement is mainly due to fewer I/O tasks for spilling and reading memory on disk.

<details>
<summary>Test Script</summary>

```
client = Client(memory_limit='16GB', n_workers=1, threads_per_worker=1)
big_tas_file = "../icclim/netcdf_files/tas_day_INM-CM5-0_ssp585_r1i1p1f1_gr1_20650101-21001231.nc"
da = xr.open_dataset(big_tas_file).tas
dask.config.set({"array.chunk-size": f"{200} MB"})
chunking = {d: "auto" for d in da.dims}
# chunking["time"] = -1
da = da.chunk(chunking)

da_per = da.sel(time=slice("2065-01-01", "2094-12-31"))
tas_per = percentile_doy(da_per, window=5, per=90)
a = xc.atmos.tg90p(tas=da, t90=tas_per, freq="MS", bootstrap=False)
a.compute()
```
</details>

### Does this PR introduce a breaking change?
No.

### Other information:
I'm putting this in draft for now as I would like to do a few more tests.
Any feedback would be also appreciated.
