### PR TITLE
Suppress pint warnings and pin pandas below v1.4

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -38,7 +38,7 @@ Internal changes
 * `TrainAdjust` and `Adjust` object have a new `skip_input_checks` keyword arg to their `train` and  `adjust` methods. When `True`, all unit-, calendar- and coordinate-related input checks are skipped. This is an ugly solution to disappearing attributes when using `xr.map_blocks` with dask. (:pull:`964`).
 * Some slow tests were marked `slow` to help speed up the standard test ensemble. (:pull:`969`).
     - Tox testing ensemble now also reports slowest tests using the ``--durations`` flag.
-* `pint` no longer emits warnings about redefined units when the `logging` module is loaded.
+* `pint` no longer emits warnings about redefined units when the `logging` module is loaded. (:issue:`990`, :pull:`991`).
 
 0.32.1 (2021-12-17)
 -------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -39,6 +39,7 @@ Internal changes
 * Some slow tests were marked `slow` to help speed up the standard test ensemble. (:pull:`969`).
     - Tox testing ensemble now also reports slowest tests using the ``--durations`` flag.
 * `pint` no longer emits warnings about redefined units when the `logging` module is loaded. (:issue:`990`, :pull:`991`).
+* `pandas` is now temporarily pinned below version 1.4.0. (related: :issue:`992`).
 
 0.32.1 (2021-12-17)
 -------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -38,6 +38,7 @@ Internal changes
 * `TrainAdjust` and `Adjust` object have a new `skip_input_checks` keyword arg to their `train` and  `adjust` methods. When `True`, all unit-, calendar- and coordinate-related input checks are skipped. This is an ugly solution to disappearing attributes when using `xr.map_blocks` with dask. (:pull:`964`).
 * Some slow tests were marked `slow` to help speed up the standard test ensemble. (:pull:`969`).
     - Tox testing ensemble now also reports slowest tests using the ``--durations`` flag.
+* `pint` no longer emits warnings about redefined units when the `logging` module is loaded.
 
 0.32.1 (2021-12-17)
 -------------------

--- a/environment.yml
+++ b/environment.yml
@@ -3,22 +3,22 @@ channels:
     - conda-forge
     - defaults
 dependencies:
-    - numpy>=1.16
-    - xarray>=0.17
-    - cf_xarray>=0.6.1
-    - scipy>=1.2
-    - numba
-    - pandas>=0.23
-    - cftime>=1.4.1
-    - poppler>=0.67
-    - dask>=2.6.0
-    - bottleneck>=1.3.1,<1.4
-    - pint>=0.9
     - boltons>=20.1
-    - scikit-learn>=0.21.3
+    - bottleneck>=1.3.1,<1.4
+    - cf_xarray>=0.6.1
+    - cftime>=1.4.1
     - Click
-    - pyyaml
+    - dask>=2.6.0
     - jsonpickle
+    - numba
+    - numpy>=1.16
+    - pandas>=0.23,<1.4
+    - pint>=0.9
+    - poppler>=0.67
+    - pyyaml
+    - scikit-learn>=0.21.3
+    - scipy>=1.2
+    - xarray>=0.17
     # Testing and development dependencies
     - black
     - bump2version

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ requirements = [
     "numba",
     "numpy>=1.16",
     "packaging>=20.0",
-    "pandas>=0.23",
+    "pandas>=0.23,<1.4",
     "pint>=0.10",
     "pyyaml",
     "scikit-learn>=0.21.3",

--- a/xclim/core/units.py
+++ b/xclim/core/units.py
@@ -37,9 +37,7 @@ __all__ = [
 ]
 
 
-units = pint.UnitRegistry(
-    autoconvert_offset_to_baseunit=True
-)  # , on_redefinition="ignore")
+units = pint.UnitRegistry(autoconvert_offset_to_baseunit=True, on_redefinition="ignore")
 units.define(
     pint.unit.UnitDefinition(
         "percent", "%", ("pct",), pint.converters.ScaleConverter(0.01)


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #990 
    - This PR provides a temporary solution to #992 
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.
- [ ] `bumpversion patch` has been called on this branch
- [ ] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

* Sets `pint` to no longer raise warnings when loading `xclim` with `logging` imported.

### Does this PR introduce a breaking change?
No.

### Other information:
https://github.com/Ouranosinc/PAVICS-landing/pull/40
semi-related: https://github.com/roocs/clisops/issues/144