### PR TITLE
Work around pandas 1.4

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -45,7 +45,6 @@ Internal changes
 * Some slow tests were marked `slow` to help speed up the standard test ensemble. (:pull:`969`).
     - Tox testing ensemble now also reports slowest tests using the ``--durations`` flag.
 * `pint` no longer emits warnings about redefined units when the `logging` module is loaded. (:issue:`990`, :pull:`991`).
-* `pandas` is now temporarily pinned below version 1.4.0. (related: :issue:`992`).
 * Added a CI step for cancelling running workflows in pull requests that receive multiple pushes. (:pull:`988`).
 
 0.32.1 (2021-12-17)

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
     - jsonpickle
     - numba
     - numpy>=1.16
-    - pandas>=0.23,<1.4
+    - pandas>=0.23
     - pint>=0.9
     - poppler>=0.67
     - pyyaml

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ requirements = [
     "numba",
     "numpy>=1.16",
     "packaging>=20.0",
-    "pandas>=0.23,<1.4",
+    "pandas>=0.23",
     "pint>=0.10",
     "pyyaml",
     "scikit-learn>=0.21.3",

--- a/xclim/testing/tests/conftest.py
+++ b/xclim/testing/tests/conftest.py
@@ -19,7 +19,7 @@ def tmp_netcdf_filename(tmpdir):
 @pytest.fixture
 def tas_series():
     def _tas_series(values, start="7/1/2000"):
-        coords = pd.date_range(start, periods=len(values), freq=pd.DateOffset(days=1))
+        coords = pd.date_range(start, periods=len(values), freq="D")
         return xr.DataArray(
             values,
             coords=[coords],
@@ -38,7 +38,7 @@ def tas_series():
 @pytest.fixture
 def tasmax_series():
     def _tasmax_series(values, start="7/1/2000"):
-        coords = pd.date_range(start, periods=len(values), freq=pd.DateOffset(days=1))
+        coords = pd.date_range(start, periods=len(values), freq="D")
         return xr.DataArray(
             values,
             coords=[coords],
@@ -57,7 +57,7 @@ def tasmax_series():
 @pytest.fixture
 def tasmin_series():
     def _tasmin_series(values, start="7/1/2000"):
-        coords = pd.date_range(start, periods=len(values), freq=pd.DateOffset(days=1))
+        coords = pd.date_range(start, periods=len(values), freq="D")
         return xr.DataArray(
             values,
             coords=[coords],
@@ -76,7 +76,7 @@ def tasmin_series():
 @pytest.fixture
 def pr_series():
     def _pr_series(values, start="7/1/2000", units="kg m-2 s-1"):
-        coords = pd.date_range(start, periods=len(values), freq=pd.DateOffset(days=1))
+        coords = pd.date_range(start, periods=len(values), freq="D")
         return xr.DataArray(
             values,
             coords=[coords],
@@ -95,7 +95,7 @@ def pr_series():
 @pytest.fixture
 def prc_series():
     def _prc_series(values, start="7/1/2000", units="kg m-2 s-1"):
-        coords = pd.date_range(start, periods=len(values), freq=pd.DateOffset(days=1))
+        coords = pd.date_range(start, periods=len(values), freq="D")
         return xr.DataArray(
             values,
             coords=[coords],
@@ -117,9 +117,7 @@ def bootstrap_series():
         if cf_time:
             coords = xr.cftime_range(start, periods=len(values), freq="D")
         else:
-            coords = pd.date_range(
-                start, periods=len(values), freq=pd.DateOffset(days=1)
-            )
+            coords = pd.date_range(start, periods=len(values), freq="D")
         return xr.DataArray(
             values,
             coords=[coords],
@@ -138,7 +136,7 @@ def bootstrap_series():
 @pytest.fixture
 def prsn_series():
     def _prsn_series(values, start="7/1/2000"):
-        coords = pd.date_range(start, periods=len(values), freq=pd.DateOffset(days=1))
+        coords = pd.date_range(start, periods=len(values), freq="D")
         return xr.DataArray(
             values,
             coords=[coords],
@@ -159,7 +157,7 @@ def pr_hr_series():
     """Return hourly time series."""
 
     def _pr_hr_series(values, start="1/1/2000"):
-        coords = pd.date_range(start, periods=len(values), freq=pd.DateOffset(hours=1))
+        coords = pd.date_range(start, periods=len(values), freq="1H")
         return xr.DataArray(
             values,
             coords=[coords],
@@ -179,7 +177,7 @@ def pr_hr_series():
 def pr_ndseries():
     def _pr_series(values, start="1/1/2000"):
         nt, nx, ny = np.atleast_3d(values).shape
-        time = pd.date_range(start, periods=nt, freq=pd.DateOffset(days=1))
+        time = pd.date_range(start, periods=nt, freq="D")
         x = np.arange(nx)
         y = np.arange(ny)
         return xr.DataArray(
@@ -200,7 +198,7 @@ def pr_ndseries():
 @pytest.fixture
 def q_series():
     def _q_series(values, start="1/1/2000"):
-        coords = pd.date_range(start, periods=len(values), freq=pd.DateOffset(days=1))
+        coords = pd.date_range(start, periods=len(values), freq="D")
         return xr.DataArray(
             values,
             coords=[coords],
@@ -223,7 +221,7 @@ def ndq_series():
 
     cx = xr.IndexVariable("x", x)
     cy = xr.IndexVariable("y", y)
-    dates = pd.date_range("1900-01-01", periods=nt, freq=pd.DateOffset(days=1))
+    dates = pd.date_range("1900-01-01", periods=nt, freq="D")
 
     time = xr.IndexVariable(
         "time", dates, attrs={"units": "days since 1900-01-01", "calendar": "standard"}
@@ -287,7 +285,7 @@ areacello = areacella
 @pytest.fixture
 def hurs_series():
     def _hurs_series(values, start="7/1/2000"):
-        coords = pd.date_range(start, periods=len(values), freq=pd.DateOffset(days=1))
+        coords = pd.date_range(start, periods=len(values), freq="D")
         return xr.DataArray(
             values,
             coords=[coords],
@@ -305,7 +303,7 @@ def hurs_series():
 @pytest.fixture
 def sfcWind_series():
     def _sfcWind_series(values, start="7/1/2000"):
-        coords = pd.date_range(start, periods=len(values), freq=pd.DateOffset(days=1))
+        coords = pd.date_range(start, periods=len(values), freq="D")
         return xr.DataArray(
             values,
             coords=[coords],
@@ -323,7 +321,7 @@ def sfcWind_series():
 @pytest.fixture
 def huss_series():
     def _huss_series(values, start="7/1/2000"):
-        coords = pd.date_range(start, periods=len(values), freq=pd.DateOffset(days=1))
+        coords = pd.date_range(start, periods=len(values), freq="D")
         return xr.DataArray(
             values,
             coords=[coords],
@@ -341,7 +339,7 @@ def huss_series():
 @pytest.fixture
 def snd_series():
     def _snd_series(values, start="7/1/2000"):
-        coords = pd.date_range(start, periods=len(values), freq=pd.DateOffset(days=1))
+        coords = pd.date_range(start, periods=len(values), freq="D")
         return xr.DataArray(
             values,
             coords=[coords],
@@ -359,7 +357,7 @@ def snd_series():
 @pytest.fixture
 def snw_series():
     def _snw_series(values, start="7/1/2000"):
-        coords = pd.date_range(start, periods=len(values), freq=pd.DateOffset(days=1))
+        coords = pd.date_range(start, periods=len(values), freq="D")
         return xr.DataArray(
             values,
             coords=[coords],
@@ -377,7 +375,7 @@ def snw_series():
 @pytest.fixture
 def ps_series():
     def _ps_series(values, start="7/1/2000"):
-        coords = pd.date_range(start, periods=len(values), freq=pd.DateOffset(days=1))
+        coords = pd.date_range(start, periods=len(values), freq="D")
         return xr.DataArray(
             values,
             coords=[coords],

--- a/xclim/testing/tests/test_indices.py
+++ b/xclim/testing/tests/test_indices.py
@@ -62,9 +62,7 @@ class TestMaxNDayPrecipitationAmount:
 class TestMax1DayPrecipitationAmount:
     @staticmethod
     def time_series(values):
-        coords = pd.date_range(
-            "7/1/2000", periods=len(values), freq=pd.DateOffset(days=1)
-        )
+        coords = pd.date_range("7/1/2000", periods=len(values), freq="D")
         return xr.DataArray(
             values,
             coords=[coords],

--- a/xclim/testing/tests/test_run_length.py
+++ b/xclim/testing/tests/test_run_length.py
@@ -126,9 +126,7 @@ class TestStatisticsRun:
 
     def test_simple(self):
         values = np.zeros(365)
-        time = pd.date_range(
-            "7/1/2000", periods=len(values), freq=pd.DateOffset(days=1)
-        )
+        time = pd.date_range("7/1/2000", periods=len(values), freq="D")
         values[1:11] = 1
         da = xr.DataArray(values != 0, coords={"time": time}, dims="time")
         lt = da.resample(time="M").map(rl.rle_statistics, reducer="max")
@@ -137,9 +135,7 @@ class TestStatisticsRun:
 
     def test_start_at_0(self):
         values = np.zeros(365)
-        time = pd.date_range(
-            "7/1/2000", periods=len(values), freq=pd.DateOffset(days=1)
-        )
+        time = pd.date_range("7/1/2000", periods=len(values), freq="D")
         values[0:10] = 1
         da = xr.DataArray(values != 0, coords={"time": time}, dims="time")
         lt = da.resample(time="M").map(rl.rle_statistics, reducer="max")
@@ -148,9 +144,7 @@ class TestStatisticsRun:
 
     def test_end_start_at_0(self):
         values = np.zeros(365)
-        time = pd.date_range(
-            "7/1/2000", periods=len(values), freq=pd.DateOffset(days=1)
-        )
+        time = pd.date_range("7/1/2000", periods=len(values), freq="D")
         values[-10:] = 1
         da = xr.DataArray(values != 0, coords={"time": time}, dims="time")
 
@@ -160,9 +154,7 @@ class TestStatisticsRun:
 
     def test_all_true(self):
         values = np.ones(365)
-        time = pd.date_range(
-            "7/1/2000", periods=len(values), freq=pd.DateOffset(days=1)
-        )
+        time = pd.date_range("7/1/2000", periods=len(values), freq="D")
         da = xr.DataArray(values != 0, coords={"time": time}, dims="time")
 
         lt = da.resample(time="M").map(rl.rle_statistics, reducer="max")
@@ -171,9 +163,7 @@ class TestStatisticsRun:
     def test_almost_all_true(self):
         values = np.ones(365)
         values[35] = 0
-        time = pd.date_range(
-            "7/1/2000", periods=len(values), freq=pd.DateOffset(days=1)
-        )
+        time = pd.date_range("7/1/2000", periods=len(values), freq="D")
         da = xr.DataArray(values != 0, coords={"time": time}, dims="time")
 
         lt = da.resample(time="M").map(rl.rle_statistics, reducer="max")
@@ -184,9 +174,7 @@ class TestStatisticsRun:
     def test_other_stats(self):
         values = np.ones(365)
         values[35] = 0
-        time = pd.date_range(
-            "1/1/2000", periods=len(values), freq=pd.DateOffset(days=1)
-        )
+        time = pd.date_range("1/1/2000", periods=len(values), freq="D")
         da = xr.DataArray(values != 0, coords={"time": time}, dims="time")
 
         lt = da.resample(time="YS").map(rl.rle_statistics, reducer="min")

--- a/xclim/testing/tests/test_sdba/utils.py
+++ b/xclim/testing/tests/test_sdba/utils.py
@@ -14,7 +14,7 @@ def series(values, name, start="2000-01-01"):
     coords = collections.OrderedDict()
     for dim, n in zip(("time", "lon", "lat"), values.shape):
         if dim == "time":
-            coords[dim] = pd.date_range(start, periods=n, freq=pd.DateOffset(days=1))
+            coords[dim] = pd.date_range(start, periods=n, freq="D")
         else:
             coords[dim] = xr.IndexVariable(dim, np.arange(n))
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #992
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.
- [ ] `bumpversion patch` has been called on this branch
- [ ] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

* Workaround bug pandas-dev/pandas#45595, by using strings instead of `DateOffset` objects in `date_range`.

### Does this PR introduce a breaking change?
Nope.

### Other information:
