### PR TITLE
[sdba] Fix constant extrapolation for monthly grouping and with interpolation

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -14,7 +14,7 @@ Bug fixes
 ^^^^^^^^^
 * Adjusted behaviour in ``dataflags.ecad_compliant`` to remove `data_vars` of invalids checks that return `None`, causing issues with `dask`. (:pull:`1002`).
 * Temporarily pinned `ipython` below version 8.0 due to behaviour causing hangs in GitHub Actions and ReadTheDocs. (:issue:`1005`, :pull:`1006`).
-* ``sdba.utils.interp_on_quantiles``, with ``extrapolation='constant'``, now interpolates the limits of the interpolation along the time grouping index, fixing a issue with "time.month" grouping. (:issue:`1008`).
+* ``sdba.utils.interp_on_quantiles``, with ``extrapolation='constant'``, now interpolates the limits of the interpolation along the time grouping index, fixing a issue with "time.month" grouping. (:issue:`1008`, :pull:`1009`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -14,12 +14,14 @@ Bug fixes
 ^^^^^^^^^
 * Adjusted behaviour in ``dataflags.ecad_compliant`` to remove `data_vars` of invalids checks that return `None`, causing issues with `dask`. (:pull:`1002`).
 * Temporarily pinned `ipython` below version 8.0 due to behaviour causing hangs in GitHub Actions and ReadTheDocs. (:issue:`1005`, :pull:`1006`).
+* ``sdba.utils.interp_on_quantiles``, with ``extrapolation='constant'``, now interpolates the limits of the interpolation along the time grouping index, fixing a issue with "time.month" grouping. (:issue:`1008`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^
 * `pre-commit` now uses Black 22.1.0 with Python3.8 style conventions. Existing code has been adjusted. (:pull:`1000`).
 * `tox` builds for Python3.7 have been deprecated. (:pull:`1000`).
 * Docstrings and documentation has been adjusted for grammar and typos. (:pull:`1000`).
+* ``sdba.utils.extrapolate_qm`` has been removed, as announced for xclim 0.33.
 
 0.33.0 (2022-01-28)
 -------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.33.1-beta
+current_version = 0.33.2-beta
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+).(?P<patch>\d+)(\-(?P<release>[a-z]+))?

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ URL = "https://github.com/Ouranosinc/xclim"
 AUTHOR = "Travis Logan"
 AUTHOR_EMAIL = "logan.travis@ouranos.ca"
 REQUIRES_PYTHON = ">=3.8.0"
-VERSION = "0.33.1-beta"
+VERSION = "0.33.2-beta"
 LICENSE = "Apache Software License 2.0"
 
 with open("README.rst") as readme_file:

--- a/xclim/__init__.py
+++ b/xclim/__init__.py
@@ -9,7 +9,7 @@ from xclim.indicators import atmos, land, seaIce  # noqa
 
 __author__ = """Travis Logan"""
 __email__ = "logan.travis@ouranos.ca"
-__version__ = "0.33.1-beta"
+__version__ = "0.33.2-beta"
 
 
 # Load official locales

--- a/xclim/sdba/nbutils.py
+++ b/xclim/sdba/nbutils.py
@@ -191,19 +191,17 @@ def _first_and_last_nonnull(arr):
 def _extrapolate_on_quantiles(interp, oldx, oldg, oldy, newx, newg, method="constant"):
     """Apply extrapolation to the output of interpolation on quantiles with a given
     grouping. Arguments are the same as _interp_on_quantiles_2D.
-
-    "constant" extrapolation is done independently for each group.
     """
-    igrp = np.empty_like(newg)
-    np.around(newg, 0, igrp)
-    igrp = igrp.astype(int64)
     bnds = _first_and_last_nonnull(oldx)
-    toolow = newx < bnds[:, 0][igrp]
-    toohigh = newx > bnds[:, 1][igrp]
+    xp = np.arange(bnds.shape[0])
+    toolow = newx < np.interp(newg, xp, bnds[:, 0])
+    toohigh = newx > np.interp(newg, xp, bnds[:, 1])
     if method == "constant":
         constants = _first_and_last_nonnull(oldy)
-        interp[toolow] = constants[igrp, 0][toolow]
-        interp[toohigh] = constants[igrp, 1][toohigh]
+        cnstlow = np.interp(newg, xp, constants[:, 0])
+        cnsthigh = np.interp(newg, xp, constants[:, 1])
+        interp[toolow] = cnstlow[toolow]
+        interp[toohigh] = cnsthigh[toohigh]
     else:  # 'nan'
         interp[toolow] = np.NaN
         interp[toohigh] = np.NaN

--- a/xclim/sdba/nbutils.py
+++ b/xclim/sdba/nbutils.py
@@ -3,7 +3,7 @@ Numba-accelerated utilities
 ---------------------------
 """
 import numpy as np
-from numba import boolean, float32, float64, guvectorize, int64, njit
+from numba import boolean, float32, float64, guvectorize, njit
 from xarray import DataArray
 from xarray.core import utils
 

--- a/xclim/sdba/utils.py
+++ b/xclim/sdba/utils.py
@@ -438,7 +438,6 @@ def _interp_on_quantiles_2D(newx, newg, oldx, oldy, oldg, method, extrap):  # no
             category=RuntimeWarning,
         )
         return out
-
     out[~mask_new] = griddata(
         (oldx[~mask_old], oldg[~mask_old]),
         oldy[~mask_old],
@@ -493,7 +492,7 @@ def interp_on_quantiles(
     - 'nan' : Any value of `newx` outside the range of `xq` is set to NaN.
     - 'constant' : Values of `newx` smaller than the minimum of `xq` are set to the first
       value of `yq` and those larger than the maximum, set to the last one (first and
-      last values along the "quantiles" dimension).
+      last values along the "quantiles" dimension). When the grouping is
     """
     dim = group.dim
     prop = group.prop

--- a/xclim/sdba/utils.py
+++ b/xclim/sdba/utils.py
@@ -3,7 +3,7 @@ sdba utilities
 --------------
 """
 import itertools
-from typing import Callable, List, Mapping, Optional, Tuple, Union
+from typing import Callable, Mapping, Optional, Tuple, Union
 from warnings import warn
 
 import numpy as np
@@ -294,112 +294,6 @@ def add_cyclic_bounds(
         qmf = qmf.assign_coords({att: vals})
         qmf[att].attrs.update(da.coords[att].attrs)
     return ensure_chunk_size(qmf, **{att: -1})
-
-
-def extrapolate_qm(
-    qf: xr.DataArray,
-    xq: xr.DataArray,
-    method: str = "constant",
-    abs_bounds: Optional[tuple] = (-np.inf, np.inf),
-) -> Tuple[xr.DataArray, xr.DataArray]:
-    """Extrapolate quantile adjustment factors beyond the computed quantiles.
-
-    Parameters
-    ----------
-    qf : xr.DataArray
-      Adjustment factors over `quantile` coordinates.
-    xq : xr.DataArray
-      Coordinates of the adjustment factors.
-      For example, in EQM, this are the values at each `quantile`.
-    method : {"constant", "nan"}
-      Extrapolation method. See notes below.
-    abs_bounds : 2-tuple
-      The absolute bounds of `xq`. Defaults to (-inf, inf).
-
-    Returns
-    -------
-    qf: xr.Dataset or xr.DataArray
-        Extrapolated adjustment factors.
-    xq: xr.Dataset or xr.DataArray
-        Extrapolated x-values.
-
-    Notes
-    -----
-    Valid values for `method` are:
-
-    - 'nan'
-
-      Estimating values above or below the computed values will return a NaN.
-
-    - 'constant'
-
-      The adjustment factor above and below the computed values are equal to the last
-      and first values respectively.
-    """
-    warn(
-        (
-            "`extrapolate_qm` is deprecated and will be removed in xclim 0.33. "
-            "Extrapolation is now handled directly in `interp_on_quantiles`."
-        ),
-        DeprecationWarning,
-    )
-    # constant_iqr
-    #   Same as `constant`, but values are set to NaN if farther than one interquartile range from the min and max.
-    q_l, q_r = [0], [1]
-    x_l, x_r = [abs_bounds[0]], [abs_bounds[1]]
-    if method == "nan":
-        qf_l, qf_r = np.NaN, np.NaN
-    elif method == "constant":
-        qf_l = qf.bfill("quantiles").isel(quantiles=0)
-        qf_r = qf.ffill("quantiles").isel(quantiles=-1)
-
-    elif (
-        method == "constant_iqr"
-    ):  # This won't work because add_endpoints does not support mixed y (float and DA)
-        raise NotImplementedError
-        # iqr = np.diff(xq.interp(quantile=[0.25, 0.75]))[0]
-        # ql, qr = [0, 0], [1, 1]
-        # xl, xr = [-np.inf, xq.isel(quantile=0) - iqr], [xq.isel(quantile=-1) + iqr, np.inf]
-        # qml, qmr = [np.nan, qm.isel(quantile=0)], [qm.isel(quantile=-1), np.nan]
-    else:
-        raise ValueError
-
-    qf = add_endpoints(qf, left=[q_l, qf_l], right=[q_r, qf_r])
-    xq = add_endpoints(xq, left=[q_l, x_l], right=[q_r, x_r])
-    return qf, xq
-
-
-def add_endpoints(
-    da: xr.DataArray,
-    left: List[Union[int, float, xr.DataArray, List[int], List[float]]],
-    right: List[Union[int, float, xr.DataArray, List[int], List[float]]],
-    dim: str = "quantiles",
-) -> xr.DataArray:
-    """Add left and right endpoints to a DataArray.
-
-    Parameters
-    ----------
-    da : DataArray
-      Source array.
-    left : [x, y]
-      Values to prepend
-    right : [x, y]
-      Values to append.
-    dim : str
-      Dimension along which to add endpoints.
-    """
-    elems = []
-    for (x, y) in (left, right):
-        if isinstance(y, xr.DataArray):
-            if "quantiles" not in y.dims:
-                y = y.expand_dims("quantiles")
-            y = y.assign_coords(quantiles=x)
-        else:
-            y = xr.DataArray(y, coords={dim: x}, dims=(dim,))
-        elems.append(y)
-    l, r = elems  # pylint: disable=unbalanced-tuple-unpacking
-    out = xr.concat((l, da, r), dim=dim)
-    return ensure_chunk_size(out, **{dim: -1})
 
 
 def _interp_on_quantiles_1D(newx, oldx, oldy, method, extrap):

--- a/xclim/sdba/utils.py
+++ b/xclim/sdba/utils.py
@@ -386,7 +386,8 @@ def interp_on_quantiles(
     - 'nan' : Any value of `newx` outside the range of `xq` is set to NaN.
     - 'constant' : Values of `newx` smaller than the minimum of `xq` are set to the first
       value of `yq` and those larger than the maximum, set to the last one (first and
-      last values along the "quantiles" dimension). When the grouping is
+      last values along the "quantiles" dimension). When the grouping is "time.month",
+      these limits are linearly interpolated along the month dimension.
     """
     dim = group.dim
     prop = group.prop

--- a/xclim/testing/tests/test_sdba/test_utils.py
+++ b/xclim/testing/tests/test_sdba/test_utils.py
@@ -57,7 +57,7 @@ def test_equally_spaced_nodes():
     "interp,expi", [("nearest", 2.9), ("linear", 2.95), ("cubic", 2.95)]
 )
 @pytest.mark.parametrize("extrap,expe", [("constant", 4.4), ("nan", np.NaN)])
-def test_interp_on_quantiles_constant(group, interp, expi, extrap, expe):
+def test_interp_on_quantiles_constant(interp, expi, extrap, expe):
     quantiles = np.linspace(0, 1, num=25)
     xq = xr.DataArray(
         np.linspace(205, 229, num=25),
@@ -83,7 +83,7 @@ def test_interp_on_quantiles_constant(group, interp, expi, extrap, expe):
     newx = newx.expand_dims(lat=[1, 2, 3])
 
     out = u.interp_on_quantiles(
-        newx, xq, yq, group=group, method=interp, extrapolation=extrap
+        newx, xq, yq, group="time", method=interp, extrapolation=extrap
     )
 
     if np.isnan(expe):
@@ -96,7 +96,7 @@ def test_interp_on_quantiles_constant(group, interp, expi, extrap, expe):
     xq = xq.where(xq != 220)
     yq = yq.where(yq != 3)
     out = u.interp_on_quantiles(
-        newx, xq, yq, group=group, method=interp, extrapolation=extrap
+        newx, xq, yq, group="time", method=interp, extrapolation=extrap
     )
 
     if np.isnan(expe):

--- a/xclim/testing/tests/test_sdba/test_utils.py
+++ b/xclim/testing/tests/test_sdba/test_utils.py
@@ -1,11 +1,9 @@
 import numpy as np
-import pandas as pd
 import pytest
 import xarray as xr
 from scipy.stats import norm
 
 from xclim.sdba import utils as u
-from xclim.sdba.base import Grouper
 
 
 def test_ecdf(series):
@@ -51,24 +49,6 @@ def test_equally_spaced_nodes():
 
     x = u.equally_spaced_nodes(1, eps=None)
     np.testing.assert_almost_equal(x[0], 0.5)
-
-
-@pytest.mark.parametrize(
-    "method,exp", [("nan", [np.NaN, -np.inf]), ("constant", [0, -np.inf])]
-)
-def test_extrapolate_qm(make_qm, method, exp):
-    qm = make_qm(np.arange(6).reshape(2, 3))
-    xq = make_qm(np.arange(6).reshape(2, 3))
-
-    q, x = u.extrapolate_qm(qm, xq, method=method)
-
-    assert isinstance(q, xr.DataArray)
-    assert isinstance(x, xr.DataArray)
-    if np.isnan(exp[0]):
-        assert q[0, 0].isnull()
-    else:
-        assert q[0, 0] == exp[0]
-    assert x[0, 0] == exp[1]
 
 
 @pytest.mark.parametrize("group", ["time", "time.month"])


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1008
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.
- [x] `bumpversion patch` has been called on this branch
- [ ] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

Ok, so when doing quantile mapping, the train step will create a 2D map of adjustment factors. The "x" axis are values of the variable, the CDF of the requested quantiles. and the "g" axis is the temporal group (like months or dayofyear). Note that the "x" axis is different for each temporal group. EX: the historical CDF is different for each month.

The adjustment steps takes each value of `sim` and finds the correct factor by interpolating into this map. 

When linear or cubic interpolation is requested with a "time.month" grouping, we use some kind of "decimal" month as the "g" coordinate in the interpolation. Like Jan 15th is 1, Jan 31st is 1.5 and so on.

When the "constant" extrapolation is requested, the previous behaviour was to find the max and min along the historical "x" axis for each given month. For example, if the CDF of july goes from 270 to 330 K, all values of sim in july that are < 270 are given 270 as the output value, thus the extrapolation is "constant".

However, that's not how `griddata` (who does the interpolation) works. Say the hist CDF of June goes from 280 to 330. Now say the sim value on the 1st of July (6.5) is 271. When you think of it, it is outside our 2D map, and thus griddata can't interpolated and puts `NaN`. However, our extrapolation function sees it within the CDF of july and doesn't extrapolate it.

Bam, a NaN that was not expected.

This PR interpolates the bounds linearly so that it uses the same logic that `griddata` uses to determine which value to extrapolate. In fact, it might not be the exact same "convex hull", but it's near enough.

The fix is applied on all cases (not only "time.month"), even if it is not needed. We could say it's a more general version of the previous algorithm, so there shouldn't be any change in the results. Also, the performance seems unchanged (thanks numba!).

### Does this PR introduce a breaking change?
No.
