### PR TITLE
Handle dask in indices.stats

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -14,6 +14,7 @@ Bug fixes
 ^^^^^^^^^
 * Adjusted behaviour in ``dataflags.ecad_compliant`` to remove `data_vars` of invalids checks that return `None`, causing issues with `dask`. (:pull:`1002`).
 * Temporarily pinned `ipython` below version 8.0 due to behaviour causing hangs in GitHub Actions and ReadTheDocs. (:issue:`1005`, :pull:`1006`).
+* ``indices.stats`` methods where adapted to handle dask-backed arrays. (:issue:`1007`, :`pull:`1011`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1007
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.
- [ ] `bumpversion patch` has been called on this branch
- [ ] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

* Fixes uses of `xr.apply_ufunc` in `xclim.indices.stats` that were missing an argument to properly handle dask arrays.
* Convert tests in `test_stats` to a more pytest-like structure and adds dask testing for all functions.

### Does this PR introduce a breaking change?
No.

### Other information:
I added an on-the-fly rechunking operation in `frequency_analysis`. I usually don't like doing this, but at the moment of the rechunking, the data has been reduced considerably by a resampling operation, so I assume the array being rechunked is a lot smaller than the input (and thus the new chunk is not huge). 