### PR TITLE
Change default quantiles to not include endpoints

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,11 +8,11 @@ Contributors to this version: Pascal Bourgault (:user:`aulemahal`), Juliette Lav
 
 Announcements
 ^^^^^^^^^^^^^
-* `xclim` no longer supports Python3.7. Code conventions and new features for Python3.8 (`PEP 569 <https://www.python.org/dev/peps/pep-0569/>`_) are now accepted. (:issue:`966`, :pull:`1000`).
+* `xclim` no longer supports Python3.7. Code conventions and new features for Python3.8 (`PEP 569`_) are now accepted. (:issue:`966`, :pull:`1000`).
 
 Breaking changes
 ^^^^^^^^^^^^^^^^
-* Python3.7 (`PEP 537 <https://www.python.org/dev/peps/pep-0537/>`_) support has been officially deprecated. Continuous integration testing is no longer run against this version of Python. (:issue:`966`, :pull:`1000`).
+* Python3.7 (`PEP 537`_) support has been officially deprecated. Continuous integration testing is no longer run against this version of Python. (:issue:`966`, :pull:`1000`).
 
 Bug fixes
 ^^^^^^^^^
@@ -27,6 +27,8 @@ Internal changes
 * `tox` builds for Python3.7 have been deprecated. (:pull:`1000`).
 * Docstrings and documentation has been adjusted for grammar and typos. (:pull:`1000`).
 * ``sdba.utils.extrapolate_qm`` has been removed, as announced for xclim 0.33. (:pull:`1009`).
+
+.. _PEP 569: https://www.python.org/dev/peps/pep-0569/
 
 0.33.0 (2022-01-28)
 -------------------
@@ -441,7 +443,7 @@ Internal Changes
 
 Announcements
 ^^^^^^^^^^^^^
-* `xclim` no longer supports Python3.6. Code conventions and new features from Python3.7 (`PEP 537 <https://www.python.org/dev/peps/pep-0537/#features-for-3-7>`_) are now accepted.
+* `xclim` no longer supports Python3.6. Code conventions and new features from Python3.7 (`PEP 537`_) are now accepted.
 
 New features and enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -470,6 +472,8 @@ Internal Changes
 ^^^^^^^^^^^^^^^^
 * `pre-commit` linting checks now run formatting hook `black==21.4b2`.
 * Code cleaning (more accurate call signatures, more use of https links, docstring updates, and typo fixes).
+
+.. _PEP 537:  https://www.python.org/dev/peps/pep-0537/#features-for-3-7
 
 0.25.0 (2021-03-31)
 -------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,22 @@
 History
 =======
 
+0.34.0 (unreleased)
+-------------------
+Contributors to this version: Pascal Bourgault (:user:`aulemahal`).
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+* Quantile mapping adjustment objects (EQM, DQM and QDM) and ``sdba.utils.equally_spaced_nodes`` will not add additionnal endpoints to the quantile range. (:issue:`1015`, :pull:`1016`). To retrieve the same functionality as before use.
+
+.. code-block:: python
+
+    from xclim import sdba
+    # NQ is the the number of equally spaced nodes, the argument previously given to nquantiles directly.
+    EQM = sdba.EmpiricalQuantileMapping.train(ref, hist, nquantiles=sdba.equally_spaced_nodes(NQ, eps=1e-6), ...)
+
+
+
 0.33.2 (2022-02-09)
 -------------------
 Contributors to this version: Pascal Bourgault (:user:`aulemahal`), Juliette Lavoie (:user:`juliettelavoie`), Trevor James Smith (:user:`Zeitsperre`).

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,7 +8,7 @@ Contributors to this version: Pascal Bourgault (:user:`aulemahal`).
 
 Breaking changes
 ~~~~~~~~~~~~~~~~
-* Quantile mapping adjustment objects (EQM, DQM and QDM) and ``sdba.utils.equally_spaced_nodes`` will not add additionnal endpoints to the quantile range. (:issue:`1015`, :pull:`1016`). To retrieve the same functionality as before use.
+* Quantile mapping adjustment objects (EQM, DQM and QDM) and ``sdba.utils.equally_spaced_nodes`` will not add additional endpoints to the quantile range. With those endpoints, variables are capped to the reference's range in the historical period, which can be dangerous with high variability in the extremes (ex: pr), especially if the reference doesn't reproduce those extremes credibly. (:issue:`1015`, :pull:`1016`). To retrieve the same functionality as before use:
 
 .. code-block:: python
 

--- a/docs/notebooks/cli.ipynb
+++ b/docs/notebooks/cli.ipynb
@@ -153,7 +153,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!xclim -i example_data.nc -o out1.nc solidprcptot --pr pr --tas tasmin --freq MS"
+    "!xclim -i example_data.nc -o out1.nc solidprcptot --pr pr --tas tasmin --freq MS\n",
+    "from pathlib import Path\n",
+    "\n",
+    "if Path(\"out2.nc\").is_file():\n",
+    "    print(\"ok\")\n",
+    "else:\n",
+    "    raise ValueError(\"Cell failed.\")"
    ]
   },
   {
@@ -398,7 +404,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.9.6"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/cli.ipynb
+++ b/docs/notebooks/cli.ipynb
@@ -153,13 +153,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!xclim -i example_data.nc -o out1.nc solidprcptot --pr pr --tas tasmin --freq MS\n",
-    "from pathlib import Path\n",
-    "\n",
-    "if Path(\"out2.nc\").is_file():\n",
-    "    print(\"ok\")\n",
-    "else:\n",
-    "    raise ValueError(\"Cell failed.\")"
+    "!xclim -i example_data.nc -o out1.nc solidprcptot --pr pr --tas tasmin --freq MS"
    ]
   },
   {

--- a/xclim/sdba/adjustment.py
+++ b/xclim/sdba/adjustment.py
@@ -318,7 +318,7 @@ class EmpiricalQuantileMapping(TrainAdjust):
 
     nquantiles : int or 1d array of floats
       The number of quantiles to use. Two endpoints at 1e-6 and 1 - 1e-6 will be added.
-      An array of quantiles [0, 1] can also be passed. Defaults to 20 quantiles (+2 endpoints).
+      An array of quantiles [0, 1] can also be passed. Defaults to 20 quantiles.
     kind : {'+', '*'}
       The adjustment kind, either additive or multiplicative. Defaults to "+".
     group : Union[str, Grouper]
@@ -348,14 +348,14 @@ class EmpiricalQuantileMapping(TrainAdjust):
         ref: xr.DataArray,
         hist: xr.DataArray,
         *,
-        nquantiles: int = 20,
+        nquantiles: Union[int, np.ndarray] = 20,
         kind: str = ADDITIVE,
         group: Union[str, Grouper] = "time",
     ):
         if np.isscalar(nquantiles):
-            quantiles = equally_spaced_nodes(nquantiles, eps=1e-6).astype(ref.dtype)
+            quantiles = equally_spaced_nodes(nquantiles).astype(ref.dtype)
         else:
-            quantiles = nquantiles
+            quantiles = nquantiles.astype(ref.dtype)
 
         ds = eqm_train(
             xr.Dataset({"ref": ref, "hist": hist}),
@@ -409,8 +409,8 @@ class DetrendedQuantileMapping(TrainAdjust):
     Train step:
 
     nquantiles : int or 1d array of floats
-      The number of quantiles to use. Two endpoints at 1e-6 and 1 - 1e-6 will be added.
-      An array of quantiles [0, 1] can also be passed. Defaults to 20 quantiles (+2 endpoints).
+      The number of quantiles to use. See :py:func:`~xclim.sdba.utils.equally_spaced_nodes`.
+      An array of quantiles [0, 1] can also be passed. Defaults to 20 quantiles.
     kind : {'+', '*'}
       The adjustment kind, either additive or multiplicative. Defaults to "+".
     group : Union[str, Grouper]
@@ -440,7 +440,7 @@ class DetrendedQuantileMapping(TrainAdjust):
         ref: xr.DataArray,
         hist: xr.DataArray,
         *,
-        nquantiles: int = 20,
+        nquantiles: Union[int, np.ndarray] = 20,
         kind: str = ADDITIVE,
         group: Union[str, Grouper] = "time",
     ):
@@ -450,9 +450,9 @@ class DetrendedQuantileMapping(TrainAdjust):
             )
 
         if np.isscalar(nquantiles):
-            quantiles = equally_spaced_nodes(nquantiles, eps=1e-6).astype(ref.dtype)
+            quantiles = equally_spaced_nodes(nquantiles).astype(ref.dtype)
         else:
-            quantiles = nquantiles
+            quantiles = nquantiles.astype(ref.dtype)
 
         ds = dqm_train(
             xr.Dataset({"ref": ref, "hist": hist}),
@@ -514,8 +514,8 @@ class QuantileDeltaMapping(EmpiricalQuantileMapping):
     Train step:
 
     nquantiles : int or 1d array of floats
-      The number of quantiles to use. Two endpoints at 1e-6 and 1 - 1e-6 will be added.
-      An array of quantiles [0, 1] can also be passed. Defaults to 20 quantiles (+2 endpoints).
+      The number of quantiles to use. See :py:func:`~xclim.sdba.utils.equally_spaced_nodes`.
+      An array of quantiles [0, 1] can also be passed. Defaults to 20 quantiles.
     kind : {'+', '*'}
       The adjustment kind, either additive or multiplicative. Defaults to "+".
     group : Union[str, Grouper]

--- a/xclim/sdba/utils.py
+++ b/xclim/sdba/utils.py
@@ -239,9 +239,10 @@ def broadcast(
 def equally_spaced_nodes(n: int, eps: Optional[float] = None) -> np.array:
     """Return nodes with `n` equally spaced points within [0, 1], optionally adding two end-points.
 
-    .. warning:: Passing a small `eps` will effectively clip the scenario to the bounds of the reference
-    on the historical period in most cases. With normal quantile mapping algorithms, this can
-    give strange result when the reference does not show as many extremes as the simulation does.
+    .. warning:: 
+        Passing a small `eps` will effectively clip the scenario to the bounds of the reference
+        on the historical period in most cases. With normal quantile mapping algorithms, this can
+        give strange result when the reference does not show as many extremes as the simulation does.
 
     Parameters
     ----------

--- a/xclim/sdba/utils.py
+++ b/xclim/sdba/utils.py
@@ -239,11 +239,6 @@ def broadcast(
 def equally_spaced_nodes(n: int, eps: Optional[float] = None) -> np.array:
     """Return nodes with `n` equally spaced points within [0, 1], optionally adding two end-points.
 
-    .. warning::
-        Passing a small `eps` will effectively clip the scenario to the bounds of the reference
-        on the historical period in most cases. With normal quantile mapping algorithms, this can
-        give strange result when the reference does not show as many extremes as the simulation does.
-
     Parameters
     ----------
     n : int
@@ -255,6 +250,12 @@ def equally_spaced_nodes(n: int, eps: Optional[float] = None) -> np.array:
     -------
     np.array
       Nodes between 0 and 1. Nodes can be seen as the middle points of `n` equal bins.
+
+    Warnings
+    --------
+    Passing a small `eps` will effectively clip the scenario to the bounds of the reference
+    on the historical period in most cases. With normal quantile mapping algorithms, this can
+    give strange result when the reference does not show as many extremes as the simulation does.
 
     Notes
     -----

--- a/xclim/sdba/utils.py
+++ b/xclim/sdba/utils.py
@@ -236,20 +236,24 @@ def broadcast(
     return grouped
 
 
-def equally_spaced_nodes(n: int, eps: Union[float, None] = 1e-4) -> np.array:
-    """Return nodes with `n` equally spaced points within [0, 1] plus two end-points.
+def equally_spaced_nodes(n: int, eps: Optional[float] = None) -> np.array:
+    """Return nodes with `n` equally spaced points within [0, 1], optionally adding two end-points.
+
+    WARNING: Passing a small `eps` will effectively clip the scenario to the bounds of the reference
+    on the historical period in most cases. With normal quantile mapping algorithms, this can
+    give strange result when the reference does not show as many extremes as the simulation does.
 
     Parameters
     ----------
     n : int
       Number of equally spaced nodes.
-    eps : float, None
-      Distance from 0 and 1 of end nodes. If None, do not add endpoints.
+    eps : float, optional
+      Distance from 0 and 1 of added end nodes. If None (default), do not add endpoints.
 
     Returns
     -------
     np.array
-      Nodes between 0 and 1.
+      Nodes between 0 and 1. Nodes can be seen as the middle points of `n` equal bins.
 
     Notes
     -----

--- a/xclim/sdba/utils.py
+++ b/xclim/sdba/utils.py
@@ -239,7 +239,7 @@ def broadcast(
 def equally_spaced_nodes(n: int, eps: Optional[float] = None) -> np.array:
     """Return nodes with `n` equally spaced points within [0, 1], optionally adding two end-points.
 
-    .. warning:: 
+    .. warning::
         Passing a small `eps` will effectively clip the scenario to the bounds of the reference
         on the historical period in most cases. With normal quantile mapping algorithms, this can
         give strange result when the reference does not show as many extremes as the simulation does.

--- a/xclim/sdba/utils.py
+++ b/xclim/sdba/utils.py
@@ -239,7 +239,7 @@ def broadcast(
 def equally_spaced_nodes(n: int, eps: Optional[float] = None) -> np.array:
     """Return nodes with `n` equally spaced points within [0, 1], optionally adding two end-points.
 
-    WARNING: Passing a small `eps` will effectively clip the scenario to the bounds of the reference
+    .. warning:: Passing a small `eps` will effectively clip the scenario to the bounds of the reference
     on the historical period in most cases. With normal quantile mapping algorithms, this can
     give strange result when the reference does not show as many extremes as the simulation does.
 

--- a/xclim/testing/tests/test_sdba/test_utils.py
+++ b/xclim/testing/tests/test_sdba/test_utils.py
@@ -44,12 +44,12 @@ def test_map_cdf(series):
 
 
 def test_equally_spaced_nodes():
-    x = u.equally_spaced_nodes(5)
+    x = u.equally_spaced_nodes(5, eps=1e-4)
     assert len(x) == 7
     d = np.diff(x)
     np.testing.assert_almost_equal(d[0], d[1] / 2, 3)
 
-    x = u.equally_spaced_nodes(1, eps=None)
+    x = u.equally_spaced_nodes(1)
     np.testing.assert_almost_equal(x[0], 0.5)
 
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1015
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.
- [ ] `bumpversion patch` has been called on this branch
- [ ] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

* Change the default behaviour of QM algos to not include endpoints in the quantile vector.
The documentation was changed accordingly and a warning was added in the docstring of `sdba.utils.equally_spaced_nodes`.

### Does this PR introduce a breaking change?
Yes. The way to get back to the previous behaviour is documented in the history entry.


### Other information:
Should I add a warning?
