### PR TITLE
Enh/map block bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,4 +124,12 @@ ENV/
 /docs/xclim.testing.tests.test_sdba.rst
 
 .vscode
+
+# netCDF
 *.nc
+
+# zarr store
+*.zarr
+
+# dask
+dask-worker-space

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,7 @@ History
 
 0.34.0 (unreleased)
 -------------------
-Contributors to this version: Pascal Bourgault (:user:`aulemahal`), Trevor James Smith (:user:`Zeitsperre`).
+Contributors to this version: Pascal Bourgault (:user:`aulemahal`), Trevor James Smith (:user:`Zeitsperre`), Aoun Abel (:user:`bzah`).
 
 Announcements
 ^^^^^^^^^^^^^
@@ -26,6 +26,10 @@ Internal changes
 * The "is_dayofyear" attribute added by several indices is now a ``numpy.int32`` instance, instead of python's ``int``. This ensures a THREDDS server can read it when the variable is saved to a netCDF file with `xarray`/`netCDF4-python`. (:issue:`980`, :pull:`1019`).
 
 .. _bottleneck PR/397: https://github.com/pydata/bottleneck/pull/397/
+
+New features and enhancements
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+* Improve performances of percentile bootstrap algorithm by using ``xarray.map_block`` (:issue:`932`, :pull:`1017`).
 
 0.33.2 (2022-02-09)
 -------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -25,11 +25,12 @@ Internal changes
 * GitHub CI actions now use the `deadsnakes python PPA Action <https://github.com/deadsnakes/action>`_ for gathering the Python3.10 development headers. (:pull:`1013`).
 * The "is_dayofyear" attribute added by several indices is now a ``numpy.int32`` instance, instead of python's ``int``. This ensures a THREDDS server can read it when the variable is saved to a netCDF file with `xarray`/`netCDF4-python`. (:issue:`980`, :pull:`1019`).
 
-.. _bottleneck PR/397: https://github.com/pydata/bottleneck/pull/397/
-
 New features and enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 * Improve performances of percentile bootstrap algorithm by using ``xarray.map_block`` (:issue:`932`, :pull:`1017`).
+
+.. _bottleneck PR/397: https://github.com/pydata/bottleneck/pull/397/
+
 
 0.33.2 (2022-02-09)
 -------------------

--- a/xclim/core/bootstrapping.py
+++ b/xclim/core/bootstrapping.py
@@ -1,5 +1,5 @@
 from inspect import signature
-from typing import Any, Callable, Dict, Optional, Sequence, Union
+from typing import Any, Callable, Dict, Optional, Sequence, Tuple, Union
 
 import cftime
 import numpy as np
@@ -175,8 +175,11 @@ def bootstrap_func(compute_indice_func: Callable, **kwargs) -> xr.DataArray:
 
     # def bs_percentile_doys(overlapping_da, overlapping_years, pdoy_args):
     #     out = []
-    #     for label, time_slice in overlapping_years.items():
-    #         bda = bootstrap_year(overlapping_da, overlapping_years, label)
+    #     for year, _ in overlapping_years.items():
+    #         bda = build_bootstrap_year_da(overlapping_da,
+    #                                       overlapping_years,
+    #                                       year,
+    #                                       bs_dim_name="_bootstrap")
     #         out.append(percentile_doy(bda, **pdoy_args, copy=False))
     #     return xr.concat(out, dim="time")
     #
@@ -187,8 +190,8 @@ def bootstrap_func(compute_indice_func: Callable, **kwargs) -> xr.DataArray:
     #     obj=overlapping_da,
     #     kwargs={
     #         "overlapping_years": overlapping_years,
-    #         "per_key":       per_key,
-    #         "pdoy_args":     pdoy_args,
+    #         "per_key":           per_key,
+    #         "pdoy_args":         pdoy_args,
     #     },
     #     template=per_template,
     # )
@@ -242,10 +245,49 @@ def bootstrap_year(
     pdoy_args: Dict,
     compute_indice_func: Callable,
 ):
-    bda = build_bootstrap_year_da(
-        overlapping_da, overlapping_years, year, bs_dim_name="_bootstrap"
+    # bda = build_bootstrap_year_da(
+    #     overlapping_da, overlapping_years, year, bs_dim_name="_bootstrap"
+    # )
+    gr = overlapping_years.copy()
+    da_copy = overlapping_da.copy(deep=True)
+    bloc = overlapping_da["time"][gr.pop(year)]
+    da_copy.loc[{"time": bloc}] = np.NAN
+    out_accumulator = []
+    for i, (key, group_slice) in enumerate(gr.items()):
+        out_accumulator.append(overlapping_da.isel({"time": group_slice}))
+    bs_arr = xr.concat(out_accumulator, dim="bdim")
+    bs_arr = bs_arr.rolling(min_periods=1, center=True, time=5).construct("window")
+    bs_arr = (
+        bs_arr.assign_coords(
+            time=pd.MultiIndex.from_arrays(
+                (bs_arr.time.dt.year.values, bs_arr.time.dt.dayofyear.values),
+                names=("year", "dayofyear"),
+            )
+        )
+        .unstack("time")
+        .stack(stack_dim=("year", "window"))
     )
-    initial_kwargs[per_key] = percentile_doy(bda, **pdoy_args, copy=False)
+    rr = da_copy.rolling(min_periods=1, center=True, time=5).construct("window")
+    ind = pd.MultiIndex.from_arrays(
+        (rr.time.dt.year.values, rr.time.dt.dayofyear.values),
+        names=("year", "dayofyear"),
+    )
+    rr = rr.assign_coords(time=ind).unstack("time").stack(stack_dim=("year", "window"))
+    per = [90]
+    p = xr.apply_ufunc(
+        calc_perc,
+        rr,
+        input_core_dims=[["stack_dim"]],
+        output_core_dims=[["percentiles"]],
+        keep_attrs=True,
+        kwargs=dict(
+            percentiles=per, bs_arr=bs_arr.values, alpha=1 / 3, beta=1 / 3, copy=False
+        ),
+        dask="parallelized",
+        output_dtypes=[rr.dtype],
+        dask_gufunc_kwargs=dict(output_sizes={"percentiles": len(per)}),
+    )
+    initial_kwargs[per_key] = p
     return compute_indice_func(**initial_kwargs).mean(dim="_bootstrap", keep_attrs=True)
 
 
@@ -276,13 +318,14 @@ def build_bootstrap_year_da(
       Array where one group is replaced by values from every other group along the `bootstrap` dimension.
     """
     gr = groups.copy()
+    da_copy = da.copy(deep=True)
 
     # Location along dim that must be replaced
     bloc = da[dim][gr.pop(label)]
 
     # Initialize output array with new bootstrap dimension
     bdim = bs_dim_name
-    out = da.expand_dims({bdim: np.arange(len(gr))}).copy(deep=True)
+    out = da_copy.expand_dims({bdim: np.arange(len(gr))})
     # With dask, mutating the views of out is not working, thus the accumulator
     out_accumulator = []
     # Replace `bloc` by every other group
@@ -310,7 +353,7 @@ def build_bootstrap_year_da(
     return xr.concat(out_accumulator, dim=bdim)
 
 
-# def percentile_doy(
+# def bs_percentile_doy(
 #     arr: xr.DataArray,
 #     window: int = 5,
 #     per: Union[float, Sequence[float]] = 10.0,
@@ -318,7 +361,6 @@ def build_bootstrap_year_da(
 #     beta: float = 1.0 / 3.0,
 #     copy: bool = True,
 # ) -> xr.DataArray:
-#     from .utils import calc_perc
 #     rr = arr.rolling(min_periods=1, center=True, time=window).construct("window")
 #     ind = pd.MultiIndex.from_arrays(
 #         (rr.time.dt.year.values, rr.time.dt.dayofyear.values),
@@ -327,6 +369,7 @@ def build_bootstrap_year_da(
 #     rr = rr.assign_coords(time=ind).unstack("time").stack(stack_dim=("year", "window"))
 #     if np.isscalar(per):
 #         per = [per]
+#
 #     p = xr.apply_ufunc(
 #         calc_perc,
 #         rr,
@@ -340,3 +383,232 @@ def build_bootstrap_year_da(
 #     )
 #     p = p.assign_coords(percentiles=xr.DataArray(per, dims=("percentiles",)))
 #     return p.rename("per")
+
+
+def calc_perc(
+    arr: np.ndarray,
+    bs_arr,
+    percentiles: Sequence[float] = [50.0],
+    alpha: float = 1.0,
+    beta: float = 1.0,
+    copy: bool = True,
+) -> np.ndarray:
+    """
+    Compute percentiles using nan_calc_percentiles and move the percentiles axis to the end.
+    """
+    return np.moveaxis(
+        nan_calc_percentiles(
+            arr=arr,
+            bs_arr=bs_arr,
+            percentiles=percentiles,
+            axis=-1,
+            alpha=alpha,
+            beta=beta,
+            copy=copy,
+        ),
+        source=0,
+        destination=-1,
+    )
+
+
+def nan_calc_percentiles(
+    arr: np.ndarray,
+    bs_arr,
+    percentiles: Sequence[float] = [50.0],
+    axis=-1,
+    alpha=1.0,
+    beta=1.0,
+    copy=True,
+) -> np.ndarray:
+    """
+    Convert the percentiles to quantiles and compute them using _nan_quantile.
+    """
+    if copy:
+        # bootstrapping already works on a data's copy
+        # doing it again is extremely costly, especially with dask.
+        arr = arr.copy()
+    quantiles = np.array([per / 100.0 for per in percentiles])
+    return _nan_quantile(arr, quantiles, bs_arr, axis, alpha, beta)
+
+
+def _compute_virtual_index(
+    n: np.ndarray, quantiles: np.ndarray, alpha: float, beta: float
+):
+    """
+    Compute the floating point indexes of an array for the linear
+    interpolation of quantiles.
+    n : array_like
+        The sample sizes.
+    quantiles : array_like
+        The quantiles values.
+    alpha : float
+        A constant used to correct the index computed.
+    beta : float
+        A constant used to correct the index computed.
+
+    alpha and beta values depend on the chosen method
+    (see quantile documentation)
+
+    Reference:
+    Hyndman&Fan paper "Sample Quantiles in Statistical Packages",
+    DOI: 10.1080/00031305.1996.10473566
+    """
+    return n * quantiles + (alpha + quantiles * (1 - alpha - beta)) - 1
+
+
+def _get_gamma(virtual_indexes: np.ndarray, previous_indexes: np.ndarray):
+    """
+    Compute gamma (a.k.a 'm' or 'weight') for the linear interpolation
+    of quantiles.
+
+    virtual_indexes : array_like
+        The indexes where the percentile is supposed to be found in the sorted
+        sample.
+    previous_indexes : array_like
+        The floor values of virtual_indexes.
+
+    gamma is usually the fractional part of virtual_indexes but can be modified
+    by the interpolation method.
+    """
+    gamma = np.asanyarray(virtual_indexes - previous_indexes)
+    return np.asanyarray(gamma)
+
+
+def _get_indexes(
+    arr: np.ndarray, virtual_indexes: np.ndarray, valid_values_count: np.ndarray
+) -> Tuple[np.ndarray, np.ndarray]:
+    """
+    Get the valid indexes of arr neighbouring virtual_indexes.
+
+    Notes:
+    This is a companion function to linear interpolation of quantiles
+
+    Returns
+    -------
+    (previous_indexes, next_indexes): Tuple
+        A Tuple of virtual_indexes neighbouring indexes
+    """
+    previous_indexes = np.asanyarray(np.floor(virtual_indexes))
+    next_indexes = np.asanyarray(previous_indexes + 1)
+    indexes_above_bounds = virtual_indexes >= valid_values_count - 1
+    # When indexes is above max index, take the max value of the array
+    if indexes_above_bounds.any():
+        previous_indexes[indexes_above_bounds] = -1
+        next_indexes[indexes_above_bounds] = -1
+    # When indexes is below min index, take the min value of the array
+    indexes_below_bounds = virtual_indexes < 0
+    if indexes_below_bounds.any():
+        previous_indexes[indexes_below_bounds] = 0
+        next_indexes[indexes_below_bounds] = 0
+    if np.issubdtype(arr.dtype, np.inexact):
+        # After the sort, slices having NaNs will have for last element a NaN
+        virtual_indexes_nans = np.isnan(virtual_indexes)
+        if virtual_indexes_nans.any():
+            previous_indexes[virtual_indexes_nans] = -1
+            next_indexes[virtual_indexes_nans] = -1
+    previous_indexes = previous_indexes.astype(np.intp)
+    next_indexes = next_indexes.astype(np.intp)
+    return previous_indexes, next_indexes
+
+
+def _linear_interpolation(
+    left: np.ndarray,
+    right: np.ndarray,
+    gamma: np.ndarray,
+) -> np.ndarray:
+    """
+    Compute the linear interpolation weighted by gamma on each point of
+    two same shape arrays.
+
+    left : array_like
+        Left bound.
+    right : array_like
+        Right bound.
+    gamma : array_like
+        The interpolation weight.
+    """
+    diff_b_a = np.subtract(right, left)
+    lerp_interpolation = np.asanyarray(np.add(left, diff_b_a * gamma))
+    np.subtract(
+        right, diff_b_a * (1 - gamma), out=lerp_interpolation, where=gamma >= 0.5
+    )
+    if lerp_interpolation.ndim == 0:
+        lerp_interpolation = lerp_interpolation[()]  # unpack 0d arrays
+    return lerp_interpolation
+
+
+def _nan_quantile(
+    arr: np.ndarray,
+    quantiles: np.ndarray,
+    bs_arr: np.ndarray,
+    axis: int = 0,
+    alpha: float = 1.0,
+    beta: float = 1.0,
+) -> Union[float, np.ndarray]:
+    """
+    Get the quantiles of the array for the given axis.
+    A linear interpolation is performed using alpha and beta.
+
+    By default alpha == beta == 1 which performs the 7th method of Hyndman&Fan.
+    with alpha == beta == 1/3 we get the 8th method.
+    """
+    # --- Setup
+    data_axis_length = arr.shape[axis] + bs_arr.shape[axis]
+    if data_axis_length == 0:
+        return np.NAN
+    if data_axis_length == 1:
+        result = np.take(arr, 0, axis=axis)
+        return np.broadcast_to(result, (quantiles.size,) + result.shape)
+    # The dimensions of `q` are prepended to the output shape, so we need the
+    # axis being sampled from `arr` to be last.
+    DATA_AXIS = -1
+    if axis != DATA_AXIS:  # But moveaxis is slow, so only call it if axis!=0.
+        arr = np.moveaxis(arr, axis, destination=DATA_AXIS)
+    # nan_count is not a scalar
+    nan_count = np.isnan(arr).sum(axis=DATA_AXIS).astype(float)
+    bs_nan_count = np.isnan(bs_arr).sum(axis=DATA_AXIS).astype(float)
+    valid_values_count = data_axis_length - nan_count - bs_nan_count
+    # We need at least two values to do an interpolation
+    too_few_values = valid_values_count < 2
+    if too_few_values.any():
+        # This will result in getting the only available value if it exist
+        valid_values_count[too_few_values] = np.NaN
+    # --- Computation of indexes
+    # Add axis for quantiles
+    valid_values_count = valid_values_count[..., np.newaxis]
+    virtual_indexes = _compute_virtual_index(valid_values_count, quantiles, alpha, beta)
+    virtual_indexes = np.asanyarray(virtual_indexes)
+    previous_indexes, next_indexes = _get_indexes(
+        arr, virtual_indexes, valid_values_count
+    )
+    # --- Sorting
+    arr.sort(axis=DATA_AXIS)
+    # Add bootstrap axis
+    # Fixme, broadcast here may exhaust memory...
+    arr = np.broadcast_to(arr, (bs_arr.shape[0],) + arr.shape)
+    data_arr = np.concatenate([arr, bs_arr], axis=DATA_AXIS)
+    data_arr.sort(axis=DATA_AXIS)
+    # --- Get values from indexes
+    data_arr = data_arr[..., np.newaxis]
+    previous = np.squeeze(
+        np.take_along_axis(
+            data_arr, previous_indexes.astype(int)[np.newaxis, ...], axis=0
+        ),
+        axis=0,
+    )
+    next_elements = np.squeeze(
+        np.take_along_axis(data_arr, next_indexes.astype(int)[np.newaxis, ...], axis=0),
+        axis=0,
+    )
+    # --- Linear interpolation
+    gamma = _get_gamma(virtual_indexes, previous_indexes)
+    interpolation = _linear_interpolation(previous, next_elements, gamma)
+    # When an interpolation is in Nan range, (near the end of the sorted array) it means
+    # we can clip to the array max value.
+    result = np.where(
+        np.isnan(interpolation), np.nanmax(data_arr, axis=0), interpolation
+    )
+    # Move quantile axis in front
+    result = np.moveaxis(result, axis, 0)
+    np.mean(data_arr, axis=-1)
+    return result

--- a/xclim/core/bootstrapping.py
+++ b/xclim/core/bootstrapping.py
@@ -162,24 +162,21 @@ def bootstrap_func(compute_indice_func: Callable, **kwargs) -> xr.DataArray:
     kw = {da_key: out_of_base_da, **kwargs}
     kw[per_key] = per
     out.append(compute_indice_func(**kw))
-    template = out[0]
+    # template = out[0]
 
     if xclim.core.utils.uses_dask(overlapping_da):
         chunking = {d: "auto" for d in da.dims}
         chunking["time"] = -1  # no chunking on time to use map_block
         overlapping_da = overlapping_da.chunk(chunking)
-        # TODO, 1. would be better with xr.chunksizes be it needs xarray>=20
-        # TODO, 2. make sure time is always the first dimension
-        a = (len(out[0].time),) + overlapping_da.chunks[1:]
-        template = out[0].chunk(a)
+    #     # TODO, 1. would be better with xr.chunksizes be it needs xarray>=20
+    #     # TODO, 2. make sure time is always the first dimension
+    #     a = (len(out[0].time),) + overlapping_da.chunks[1:]
+    #     template = out[0].chunk(a)
 
     # def bs_percentile_doys(overlapping_da, overlapping_years, pdoy_args):
     #     out = []
-    #     for year, _ in overlapping_years.items():
-    #         bda = build_bootstrap_year_da(overlapping_da,
-    #                                       overlapping_years,
-    #                                       year,
-    #                                       bs_dim_name="_bootstrap")
+    #     for label, time_slice in overlapping_years.items():
+    #         bda = bootstrap_year(overlapping_da, overlapping_years, label)
     #         out.append(percentile_doy(bda, **pdoy_args, copy=False))
     #     return xr.concat(out, dim="time")
     #
@@ -190,35 +187,48 @@ def bootstrap_func(compute_indice_func: Callable, **kwargs) -> xr.DataArray:
     #     obj=overlapping_da,
     #     kwargs={
     #         "overlapping_years": overlapping_years,
-    #         "per_key":           per_key,
-    #         "pdoy_args":         pdoy_args,
+    #         "per_key":       per_key,
+    #         "pdoy_args":     pdoy_args,
     #     },
     #     template=per_template,
     # )
-
+    template = per.copy(deep=True)
     # Compute bootstrapped index on each year
     overlapping_da_years = overlapping_da.resample(time=bfreq).groups.items()
     for year_label, _ in overlapping_da_years:
         da_year = da.sel(time=str(get_year(year_label)))
         kw = {da_key: da_year, **kwargs}
-        template.coords["time"] = pd.date_range(
-            start=da_year.time[0].dt.date.values[()],
-            periods=len(template["time"]),
-            freq=freq,
+        # template.coords["time"] = pd.date_range(
+        #     start=da_year.time[0].dt.date.values[()],
+        #     periods=len(template["time"]),
+        #     freq=freq,
+        # )
+        bda = build_bootstrap_year_da(
+            overlapping_da, overlapping_years, year_label, bs_dim_name="_bootstrap"
         )
-        value = xr.map_blocks(
-            bootstrap_year,
-            obj=overlapping_da,
-            kwargs={
-                "overlapping_years": overlapping_years,
-                "year": year_label,
-                "initial_kwargs": kw,
-                "per_key": per_key,
-                "pdoy_args": pdoy_args,
-                "compute_indice_func": compute_indice_func,
-            },
+        if "_bootstrap" not in template.dims:
+            template = template.expand_dims(_bootstrap=len(bda._bootstrap))
+            template["_bootstrap"] = bda._bootstrap
+            # TODO: fill a bug on gh-xarray to make the indexing automatic ?
+            #       (without this reindex, the expect of check_result_variables in parallel.py is not properly computed)
+            template = template.reindex(
+                {
+                    "_bootstrap": pd.RangeIndex(
+                        start=0, stop=len(bda._bootstrap), step=1, name="_bootstrap"
+                    )
+                }
+            )
+            for d in set(bda.dims).intersection(set(template.dims)):
+                template = template.chunk({d: bda.chunks[bda.get_axis_num(d)]})
+
+        # initial_kwargs[per_key] = percentile_doy(bda, **pdoy_args, copy=False)
+        kw[per_key] = xr.map_blocks(
+            bs_percentile_doy,
+            obj=bda,
+            kwargs={**pdoy_args, "copy": False},
             template=template,
-        )
+        )  # noqa
+        value = compute_indice_func(**kw).mean(dim="_bootstrap", keep_attrs=True)
         out.append(value)
     out = xr.concat(out, dim="time")
     duplications = out.get_index("time").duplicated()
@@ -234,61 +244,6 @@ def get_year(label):
     else:
         year = label.astype("datetime64[Y]").astype(int) + 1970
     return year
-
-
-def bootstrap_year(
-    overlapping_da,
-    overlapping_years: Dict[Any, slice],
-    year: str,
-    initial_kwargs: Dict,
-    per_key: str,
-    pdoy_args: Dict,
-    compute_indice_func: Callable,
-):
-    # bda = build_bootstrap_year_da(
-    #     overlapping_da, overlapping_years, year, bs_dim_name="_bootstrap"
-    # )
-    gr = overlapping_years.copy()
-    da_copy = overlapping_da.copy(deep=True)
-    bloc = overlapping_da["time"][gr.pop(year)]
-    da_copy.loc[{"time": bloc}] = np.NAN
-    out_accumulator = []
-    for i, (key, group_slice) in enumerate(gr.items()):
-        out_accumulator.append(overlapping_da.isel({"time": group_slice}))
-    bs_arr = xr.concat(out_accumulator, dim="bdim")
-    bs_arr = bs_arr.rolling(min_periods=1, center=True, time=5).construct("window")
-    bs_arr = (
-        bs_arr.assign_coords(
-            time=pd.MultiIndex.from_arrays(
-                (bs_arr.time.dt.year.values, bs_arr.time.dt.dayofyear.values),
-                names=("year", "dayofyear"),
-            )
-        )
-        .unstack("time")
-        .stack(stack_dim=("year", "window"))
-    )
-    rr = da_copy.rolling(min_periods=1, center=True, time=5).construct("window")
-    ind = pd.MultiIndex.from_arrays(
-        (rr.time.dt.year.values, rr.time.dt.dayofyear.values),
-        names=("year", "dayofyear"),
-    )
-    rr = rr.assign_coords(time=ind).unstack("time").stack(stack_dim=("year", "window"))
-    per = [90]
-    p = xr.apply_ufunc(
-        calc_perc,
-        rr,
-        input_core_dims=[["stack_dim"]],
-        output_core_dims=[["percentiles"]],
-        keep_attrs=True,
-        kwargs=dict(
-            percentiles=per, bs_arr=bs_arr.values, alpha=1 / 3, beta=1 / 3, copy=False
-        ),
-        dask="parallelized",
-        output_dtypes=[rr.dtype],
-        dask_gufunc_kwargs=dict(output_sizes={"percentiles": len(per)}),
-    )
-    initial_kwargs[per_key] = p
-    return compute_indice_func(**initial_kwargs).mean(dim="_bootstrap", keep_attrs=True)
 
 
 # TODO: Return a generator instead and assess performance
@@ -318,14 +273,13 @@ def build_bootstrap_year_da(
       Array where one group is replaced by values from every other group along the `bootstrap` dimension.
     """
     gr = groups.copy()
-    da_copy = da.copy(deep=True)
 
     # Location along dim that must be replaced
     bloc = da[dim][gr.pop(label)]
 
     # Initialize output array with new bootstrap dimension
     bdim = bs_dim_name
-    out = da_copy.expand_dims({bdim: np.arange(len(gr))})
+    out = da.expand_dims({bdim: np.arange(len(gr))}).copy(deep=True)
     # With dask, mutating the views of out is not working, thus the accumulator
     out_accumulator = []
     # Replace `bloc` by every other group
@@ -353,7 +307,7 @@ def build_bootstrap_year_da(
     return xr.concat(out_accumulator, dim=bdim)
 
 
-# def bs_percentile_doy(
+# def percentile_doy(
 #     arr: xr.DataArray,
 #     window: int = 5,
 #     per: Union[float, Sequence[float]] = 10.0,
@@ -361,6 +315,7 @@ def build_bootstrap_year_da(
 #     beta: float = 1.0 / 3.0,
 #     copy: bool = True,
 # ) -> xr.DataArray:
+#     from .utils import calc_perc
 #     rr = arr.rolling(min_periods=1, center=True, time=window).construct("window")
 #     ind = pd.MultiIndex.from_arrays(
 #         (rr.time.dt.year.values, rr.time.dt.dayofyear.values),
@@ -369,7 +324,6 @@ def build_bootstrap_year_da(
 #     rr = rr.assign_coords(time=ind).unstack("time").stack(stack_dim=("year", "window"))
 #     if np.isscalar(per):
 #         per = [per]
-#
 #     p = xr.apply_ufunc(
 #         calc_perc,
 #         rr,
@@ -385,230 +339,84 @@ def build_bootstrap_year_da(
 #     return p.rename("per")
 
 
-def calc_perc(
-    arr: np.ndarray,
-    bs_arr,
-    percentiles: Sequence[float] = [50.0],
-    alpha: float = 1.0,
-    beta: float = 1.0,
+def bs_percentile_doy(
+    arr: xr.DataArray,
+    window: int = 5,
+    per: Union[float, Sequence[float]] = 10.0,
+    alpha: float = 1.0 / 3.0,
+    beta: float = 1.0 / 3.0,
     copy: bool = True,
-) -> np.ndarray:
-    """
-    Compute percentiles using nan_calc_percentiles and move the percentiles axis to the end.
-    """
-    return np.moveaxis(
-        nan_calc_percentiles(
-            arr=arr,
-            bs_arr=bs_arr,
-            percentiles=percentiles,
-            axis=-1,
-            alpha=alpha,
-            beta=beta,
-            copy=copy,
-        ),
-        source=0,
-        destination=-1,
-    )
+) -> xr.DataArray:
+    """Percentile value for each day of the year.
 
+    Return the climatological percentile over a moving window around each day of the year.
+    Different quantile estimators can be used by specifying `alpha` and `beta` according to specifications given by [HyndmanFan]_. The default definition corresponds to method 8, which meets multiple desirable statistical properties for sample quantiles. Note that `numpy.percentile` corresponds to method 7, with alpha and beta set to 1.
 
-def nan_calc_percentiles(
-    arr: np.ndarray,
-    bs_arr,
-    percentiles: Sequence[float] = [50.0],
-    axis=-1,
-    alpha=1.0,
-    beta=1.0,
-    copy=True,
-) -> np.ndarray:
-    """
-    Convert the percentiles to quantiles and compute them using _nan_quantile.
-    """
-    if copy:
-        # bootstrapping already works on a data's copy
-        # doing it again is extremely costly, especially with dask.
-        arr = arr.copy()
-    quantiles = np.array([per / 100.0 for per in percentiles])
-    return _nan_quantile(arr, quantiles, bs_arr, axis, alpha, beta)
-
-
-def _compute_virtual_index(
-    n: np.ndarray, quantiles: np.ndarray, alpha: float, beta: float
-):
-    """
-    Compute the floating point indexes of an array for the linear
-    interpolation of quantiles.
-    n : array_like
-        The sample sizes.
-    quantiles : array_like
-        The quantiles values.
-    alpha : float
-        A constant used to correct the index computed.
-    beta : float
-        A constant used to correct the index computed.
-
-    alpha and beta values depend on the chosen method
-    (see quantile documentation)
-
-    Reference:
-    Hyndman&Fan paper "Sample Quantiles in Statistical Packages",
-    DOI: 10.1080/00031305.1996.10473566
-    """
-    return n * quantiles + (alpha + quantiles * (1 - alpha - beta)) - 1
-
-
-def _get_gamma(virtual_indexes: np.ndarray, previous_indexes: np.ndarray):
-    """
-    Compute gamma (a.k.a 'm' or 'weight') for the linear interpolation
-    of quantiles.
-
-    virtual_indexes : array_like
-        The indexes where the percentile is supposed to be found in the sorted
-        sample.
-    previous_indexes : array_like
-        The floor values of virtual_indexes.
-
-    gamma is usually the fractional part of virtual_indexes but can be modified
-    by the interpolation method.
-    """
-    gamma = np.asanyarray(virtual_indexes - previous_indexes)
-    return np.asanyarray(gamma)
-
-
-def _get_indexes(
-    arr: np.ndarray, virtual_indexes: np.ndarray, valid_values_count: np.ndarray
-) -> Tuple[np.ndarray, np.ndarray]:
-    """
-    Get the valid indexes of arr neighbouring virtual_indexes.
-
-    Notes:
-    This is a companion function to linear interpolation of quantiles
+    Parameters
+    ----------
+    arr : xr.DataArray
+      Input data, a daily frequency (or coarser) is required.
+    window : int
+      Number of time-steps around each day of the year to include in the calculation.
+    per : float or sequence of floats
+      Percentile(s) between [0, 100]
+    alpha: float
+        Plotting position parameter.
+    beta: float
+        Plotting position parameter.
+    copy: bool
+        If True (default) the input array will be deep copied. It's a necessary step
+        to keep the data integrity but it can be costly.
+        If False, no copy is made of the input array. It will be mutated and rendered
+        unusable but performances may significantly improve.
+        Put this flag to False only if you understand the consequences.
 
     Returns
     -------
-    (previous_indexes, next_indexes): Tuple
-        A Tuple of virtual_indexes neighbouring indexes
+    xr.DataArray
+      The percentiles indexed by the day of the year.
+      For calendars with 366 days, percentiles of doys 1-365 are interpolated to the 1-366 range.
+
+    References
+    ----------
+    .. [HyndmanFan] Hyndman, R. J., & Fan, Y. (1996). Sample quantiles in statistical packages. The American Statistician, 50(4), 361-365.
     """
-    previous_indexes = np.asanyarray(np.floor(virtual_indexes))
-    next_indexes = np.asanyarray(previous_indexes + 1)
-    indexes_above_bounds = virtual_indexes >= valid_values_count - 1
-    # When indexes is above max index, take the max value of the array
-    if indexes_above_bounds.any():
-        previous_indexes[indexes_above_bounds] = -1
-        next_indexes[indexes_above_bounds] = -1
-    # When indexes is below min index, take the min value of the array
-    indexes_below_bounds = virtual_indexes < 0
-    if indexes_below_bounds.any():
-        previous_indexes[indexes_below_bounds] = 0
-        next_indexes[indexes_below_bounds] = 0
-    if np.issubdtype(arr.dtype, np.inexact):
-        # After the sort, slices having NaNs will have for last element a NaN
-        virtual_indexes_nans = np.isnan(virtual_indexes)
-        if virtual_indexes_nans.any():
-            previous_indexes[virtual_indexes_nans] = -1
-            next_indexes[virtual_indexes_nans] = -1
-    previous_indexes = previous_indexes.astype(np.intp)
-    next_indexes = next_indexes.astype(np.intp)
-    return previous_indexes, next_indexes
+    from .utils import calc_perc
 
+    rr = arr.rolling(min_periods=1, center=True, time=window).construct("window")
 
-def _linear_interpolation(
-    left: np.ndarray,
-    right: np.ndarray,
-    gamma: np.ndarray,
-) -> np.ndarray:
-    """
-    Compute the linear interpolation weighted by gamma on each point of
-    two same shape arrays.
-
-    left : array_like
-        Left bound.
-    right : array_like
-        Right bound.
-    gamma : array_like
-        The interpolation weight.
-    """
-    diff_b_a = np.subtract(right, left)
-    lerp_interpolation = np.asanyarray(np.add(left, diff_b_a * gamma))
-    np.subtract(
-        right, diff_b_a * (1 - gamma), out=lerp_interpolation, where=gamma >= 0.5
+    ind = pd.MultiIndex.from_arrays(
+        (rr.time.dt.year.values, rr.time.dt.dayofyear.values),
+        names=("year", "dayofyear"),
     )
-    if lerp_interpolation.ndim == 0:
-        lerp_interpolation = lerp_interpolation[()]  # unpack 0d arrays
-    return lerp_interpolation
+    rrr = rr.assign_coords(time=ind).unstack("time").stack(stack_dim=("year", "window"))
 
+    if rrr.chunks is not None and len(rrr.chunks[rrr.get_axis_num("stack_dim")]) > 1:
+        # # Preserve chunk size
+        time_chunks_count = len(arr.chunks[arr.get_axis_num("time")])
+        doy_chunk_size = np.ceil(len(rrr.dayofyear) / (window * time_chunks_count))
+        rrr = rrr.chunk(dict(stack_dim=-1, dayofyear=doy_chunk_size))
 
-def _nan_quantile(
-    arr: np.ndarray,
-    quantiles: np.ndarray,
-    bs_arr: np.ndarray,
-    axis: int = 0,
-    alpha: float = 1.0,
-    beta: float = 1.0,
-) -> Union[float, np.ndarray]:
-    """
-    Get the quantiles of the array for the given axis.
-    A linear interpolation is performed using alpha and beta.
+    if np.isscalar(per):
+        per = [per]
 
-    By default alpha == beta == 1 which performs the 7th method of Hyndman&Fan.
-    with alpha == beta == 1/3 we get the 8th method.
-    """
-    # --- Setup
-    data_axis_length = arr.shape[axis] + bs_arr.shape[axis]
-    if data_axis_length == 0:
-        return np.NAN
-    if data_axis_length == 1:
-        result = np.take(arr, 0, axis=axis)
-        return np.broadcast_to(result, (quantiles.size,) + result.shape)
-    # The dimensions of `q` are prepended to the output shape, so we need the
-    # axis being sampled from `arr` to be last.
-    DATA_AXIS = -1
-    if axis != DATA_AXIS:  # But moveaxis is slow, so only call it if axis!=0.
-        arr = np.moveaxis(arr, axis, destination=DATA_AXIS)
-    # nan_count is not a scalar
-    nan_count = np.isnan(arr).sum(axis=DATA_AXIS).astype(float)
-    bs_nan_count = np.isnan(bs_arr).sum(axis=DATA_AXIS).astype(float)
-    valid_values_count = data_axis_length - nan_count - bs_nan_count
-    # We need at least two values to do an interpolation
-    too_few_values = valid_values_count < 2
-    if too_few_values.any():
-        # This will result in getting the only available value if it exist
-        valid_values_count[too_few_values] = np.NaN
-    # --- Computation of indexes
-    # Add axis for quantiles
-    valid_values_count = valid_values_count[..., np.newaxis]
-    virtual_indexes = _compute_virtual_index(valid_values_count, quantiles, alpha, beta)
-    virtual_indexes = np.asanyarray(virtual_indexes)
-    previous_indexes, next_indexes = _get_indexes(
-        arr, virtual_indexes, valid_values_count
+    p = xr.apply_ufunc(
+        calc_perc,
+        rrr,
+        input_core_dims=[["stack_dim"]],
+        output_core_dims=[["percentiles"]],
+        keep_attrs=True,
+        kwargs=dict(percentiles=per, alpha=alpha, beta=beta, copy=copy),
+        dask="parallelized",
+        output_dtypes=[rrr.dtype],
+        dask_gufunc_kwargs=dict(output_sizes={"percentiles": len(per)}),
     )
-    # --- Sorting
-    arr.sort(axis=DATA_AXIS)
-    # Add bootstrap axis
-    # Fixme, broadcast here may exhaust memory...
-    arr = np.broadcast_to(arr, (bs_arr.shape[0],) + arr.shape)
-    data_arr = np.concatenate([arr, bs_arr], axis=DATA_AXIS)
-    data_arr.sort(axis=DATA_AXIS)
-    # --- Get values from indexes
-    data_arr = data_arr[..., np.newaxis]
-    previous = np.squeeze(
-        np.take_along_axis(
-            data_arr, previous_indexes.astype(int)[np.newaxis, ...], axis=0
-        ),
-        axis=0,
-    )
-    next_elements = np.squeeze(
-        np.take_along_axis(data_arr, next_indexes.astype(int)[np.newaxis, ...], axis=0),
-        axis=0,
-    )
-    # --- Linear interpolation
-    gamma = _get_gamma(virtual_indexes, previous_indexes)
-    interpolation = _linear_interpolation(previous, next_elements, gamma)
-    # When an interpolation is in Nan range, (near the end of the sorted array) it means
-    # we can clip to the array max value.
-    result = np.where(
-        np.isnan(interpolation), np.nanmax(data_arr, axis=0), interpolation
-    )
-    # Move quantile axis in front
-    result = np.moveaxis(result, axis, 0)
-    np.mean(data_arr, axis=-1)
-    return result
+    p = p.assign_coords(percentiles=xr.DataArray(per, dims=("percentiles",)))
+
+    # The percentile for the 366th day has a sample size of 1/4 of the other days.
+    # To have the same sample size, we interpolate the percentile from 1-365 doy range to 1-366
+    if p.dayofyear.max() == 366:
+        p = xclim.core.calendar.adjust_doy_calendar(
+            p.sel(dayofyear=(p.dayofyear < 366)), arr
+        )
+    return p.rename("per")

--- a/xclim/core/bootstrapping.py
+++ b/xclim/core/bootstrapping.py
@@ -162,15 +162,16 @@ def bootstrap_func(compute_index_func: Callable, **kwargs) -> xr.DataArray:
                         for d in set(bda.dims).intersection(set(per_template.dims))
                     }
                     per_template = per_template.chunk(chunking)
-            kw[per_key] = xr.map_blocks(
+            per = xr.map_blocks(
                 percentile_doy.__wrapped__,  # strip history update from percentile_doy
                 obj=bda,
                 kwargs={**pdoy_args, "copy": False},
                 template=per_template,
             )
-            value = compute_index_func(**kw).mean(dim="_bootstrap", keep_attrs=True)
             if "percentiles" not in per_da.dims:
-                value = value.squeeze("percentiles")
+                per = per.squeeze("percentiles")
+            kw[per_key] = per
+            value = compute_index_func(**kw).mean(dim="_bootstrap", keep_attrs=True)
         else:
             # Otherwise, run the normal computation using the original percentile
             kw[per_key] = per_da

--- a/xclim/core/bootstrapping.py
+++ b/xclim/core/bootstrapping.py
@@ -171,7 +171,7 @@ def bootstrap_func(compute_index_func: Callable, **kwargs) -> xr.DataArray:
             if "percentiles" not in per_da.dims:
                 per = per.squeeze("percentiles")
             kw[per_key] = per
-            value = compute_index_func(**kw).mean(dim="_bootstrap", keep_attrs=True)
+            value = compute_index_func(**kw).mean(dim=BOOTSTRAP_DIM, keep_attrs=True)
         else:
             # Otherwise, run the normal computation using the original percentile
             kw[per_key] = per_da

--- a/xclim/core/bootstrapping.py
+++ b/xclim/core/bootstrapping.py
@@ -117,10 +117,9 @@ def bootstrap_func(compute_indice_func: Callable, **kwargs) -> xr.DataArray:
 
     # List of years in base period
     clim = per.attrs["climatology_bounds"]
-    per_clim_years = xr.cftime_range(*clim, freq="YS").year
 
     # `da` over base period used to compute percentile
-    in_base_da = da.sel(time=slice(*clim))
+    overlapping_da = da.sel(time=slice(*clim))
 
     # Arguments used to compute percentile
     percentile = per.percentiles.data.tolist()  # Can be a list or scalar
@@ -139,48 +138,78 @@ def bootstrap_func(compute_indice_func: Callable, **kwargs) -> xr.DataArray:
         bfreq += "S"
     if base in ["A", "Q"] and anchor is not None:
         bfreq = f"{bfreq}-{anchor}"
-    da_years = da.resample(time=bfreq).groups
-    no_overlap_years = list(
-        filter(lambda x: get_year(x[0]) not in per_clim_years, da_years.items())
-    )
-    if len(no_overlap_years) == 0:
-        raise KeyError(
-            "`bootstrap` is unnecessary when all years between in_base and out_of_base are overlapping"
-        )
-    in_base_years = in_base_da.resample(time=bfreq).groups
+    # overlap_da = da.sel(time=slice(str(min(per_clim_years)), str(max(per_clim_years))))
+    # for item in da_years.items():
+    #     year = get_year(item[0])
+    #     if year in per_clim_years:
+    #         overlap_years.append(year)
+    #     else:
+    #         no_overlap_years.append(year)
+    # if len(no_overlap_years) == 0:
+    #     raise KeyError(
+    #         "`bootstrap` is unnecessary when all years between in_base (percentiles period) and out_of_base (index period) are overlapping"
+    #     )
+    # if len(overlap_years) == 0 :
+    #     raise KeyError(
+    #         "`bootstrap` is unnecessary when no year overlap between in_base (percentiles period) and out_of_base (index period)."
+    #     )
+    overlapping_years = overlapping_da.resample(time=bfreq).groups
     out = []
 
-    for label, time_slice in no_overlap_years:
-        kw = {da_key: da.isel(time=time_slice), **kwargs}
-        kw[per_key] = per
-        value = compute_indice_func(**kw)
-        out.append(value)
+    out_of_base_da = da.sel(
+        time=da.indexes["time"].difference(overlapping_da.indexes["time"])
+    )
+    kw = {da_key: out_of_base_da, **kwargs}
+    kw[per_key] = per
+    out.append(compute_indice_func(**kw))
+    template = out[0]
 
-    if xclim.core.utils.uses_dask(in_base_da):
+    if xclim.core.utils.uses_dask(overlapping_da):
         chunking = {d: "auto" for d in da.dims}
-        chunking["time"] = -1  # no chunking on time for percentile_doy in map_block
-        in_base_da = in_base_da.chunk(chunking)
+        chunking["time"] = -1  # no chunking on time to use map_block
+        overlapping_da = overlapping_da.chunk(chunking)
+        # TODO, 1. would be better with xr.chunksizes be it needs xarray>=20
+        # TODO, 2. make sure time is always the first dimension
+        a = (len(out[0].time),) + overlapping_da.chunks[1:]
+        template = out[0].chunk(a)
 
-    # TODO, would be better with xr.chunksizes be it needs xarray>=20
-    # TODO, make sure time is always the first dimension
-    a = (len(out[0].time),) + in_base_da.chunks[1:]
-    template = out[0].chunk(a)
+    # def bs_percentile_doys(overlapping_da, overlapping_years, pdoy_args):
+    #     out = []
+    #     for label, time_slice in overlapping_years.items():
+    #         bda = bootstrap_year(overlapping_da, overlapping_years, label)
+    #         out.append(percentile_doy(bda, **pdoy_args, copy=False))
+    #     return xr.concat(out, dim="time")
+    #
+    # per_template: DataArray = kwargs[per_key]  # noqa
+    # per_template.expand_dims(time=)
+    # per_doys = xr.map_blocks(
+    #     bs_percentile_doys,
+    #     obj=overlapping_da,
+    #     kwargs={
+    #         "overlapping_years": overlapping_years,
+    #         "per_key":       per_key,
+    #         "pdoy_args":     pdoy_args,
+    #     },
+    #     template=per_template,
+    # )
+
     # Compute bootstrapped index on each year
-    for label, time_slice in in_base_years.items():
-        da_year = da.isel(time=time_slice)
+    overlapping_da_years = overlapping_da.resample(time=bfreq).groups.items()
+    for year_label, _ in overlapping_da_years:
+        da_year = da.sel(time=str(get_year(year_label)))
         kw = {da_key: da_year, **kwargs}
         template.coords["time"] = pd.date_range(
             start=da_year.time[0].dt.date.values[()],
-            end=da_year.time[-1].dt.date.values[()],
+            periods=len(template["time"]),
             freq=freq,
         )
         value = xr.map_blocks(
-            yolo,
-            obj=in_base_da,
+            bootstrap_year,
+            obj=overlapping_da,
             kwargs={
-                "in_base_years": in_base_years,
-                "label": label,
-                "kw": kw,
+                "overlapping_years": overlapping_years,
+                "year": year_label,
+                "initial_kwargs": kw,
                 "per_key": per_key,
                 "pdoy_args": pdoy_args,
                 "compute_indice_func": compute_indice_func,
@@ -204,15 +233,29 @@ def get_year(label):
     return year
 
 
-def yolo(in_base_da, in_base_years, label, kw, per_key, pdoy_args, compute_indice_func):
-    bda = bootstrap_year(in_base_da, in_base_years, label)
-    kw[per_key] = percentile_doy(bda, **pdoy_args, copy=False)
-    return compute_indice_func(**kw).mean(dim="_bootstrap", keep_attrs=True)
+def bootstrap_year(
+    overlapping_da,
+    overlapping_years: Dict[Any, slice],
+    year: str,
+    initial_kwargs: Dict,
+    per_key: str,
+    pdoy_args: Dict,
+    compute_indice_func: Callable,
+):
+    bda = build_bootstrap_year_da(
+        overlapping_da, overlapping_years, year, bs_dim_name="_bootstrap"
+    )
+    initial_kwargs[per_key] = percentile_doy(bda, **pdoy_args, copy=False)
+    return compute_indice_func(**initial_kwargs).mean(dim="_bootstrap", keep_attrs=True)
 
 
 # TODO: Return a generator instead and assess performance
-def bootstrap_year(
-    da: DataArray, groups: Dict[Any, slice], label: Any, dim: str = "time"
+def build_bootstrap_year_da(
+    da: DataArray,
+    groups: Dict[Any, slice],
+    label: Any,
+    bs_dim_name: str,
+    dim: str = "time",
 ) -> DataArray:
     """Return an array where a group in the original is replaced by every other groups along a new dimension.
 
@@ -238,7 +281,7 @@ def bootstrap_year(
     bloc = da[dim][gr.pop(label)]
 
     # Initialize output array with new bootstrap dimension
-    bdim = "_bootstrap"
+    bdim = bs_dim_name
     out = da.expand_dims({bdim: np.arange(len(gr))}).copy(deep=True)
     # With dask, mutating the views of out is not working, thus the accumulator
     out_accumulator = []
@@ -275,90 +318,25 @@ def bootstrap_year(
 #     beta: float = 1.0 / 3.0,
 #     copy: bool = True,
 # ) -> xr.DataArray:
-#     """Percentile value for each day of the year.
-#
-#     Return the climatological percentile over a moving window around each day of the year.
-#     Different quantile estimators can be used by specifying `alpha` and `beta` according to specifications given by [HyndmanFan]_. The default definition corresponds to method 8, which meets multiple desirable statistical properties for sample quantiles. Note that `numpy.percentile` corresponds to method 7, with alpha and beta set to 1.
-#
-#     Parameters
-#     ----------
-#     arr : xr.DataArray
-#       Input data, a daily frequency (or coarser) is required.
-#     window : int
-#       Number of time-steps around each day of the year to include in the calculation.
-#     per : float or sequence of floats
-#       Percentile(s) between [0, 100]
-#     alpha: float
-#         Plotting position parameter.
-#     beta: float
-#         Plotting position parameter.
-#     copy: bool
-#         If True (default) the input array will be deep copied. It's a necessary step
-#         to keep the data integrity but it can be costly.
-#         If False, no copy is made of the input array. It will be mutated and rendered
-#         unusable but performances may significantly improve.
-#         Put this flag to False only if you understand the consequences.
-#
-#     Returns
-#     -------
-#     xr.DataArray
-#       The percentiles indexed by the day of the year.
-#       For calendars with 366 days, percentiles of doys 1-365 are interpolated to the 1-366 range.
-#
-#     References
-#     ----------
-#     .. [HyndmanFan] Hyndman, R. J., & Fan, Y. (1996). Sample quantiles in statistical packages. The American Statistician, 50(4), 361-365.
-#     """
 #     from .utils import calc_perc
-#
-#     # Ensure arr sampling frequency is daily or coarser
-#     # but cowardly escape the non-inferrable case.
-#     if compare_offsets(xr.infer_freq(arr.time) or "D", "<", "D"):
-#         raise ValueError("input data should have daily or coarser frequency")
-#
 #     rr = arr.rolling(min_periods=1, center=True, time=window).construct("window")
-#
 #     ind = pd.MultiIndex.from_arrays(
 #         (rr.time.dt.year.values, rr.time.dt.dayofyear.values),
 #         names=("year", "dayofyear"),
 #     )
-#     rrr = rr.assign_coords(time=ind).unstack("time").stack(stack_dim=("year", "window"))
-#
-#     if rrr.chunks is not None and len(rrr.chunks[rrr.get_axis_num("stack_dim")]) > 1:
-#         # Preserve chunk size
-#         time_chunks_count = len(arr.chunks[arr.get_axis_num("time")])
-#         doy_chunk_size = np.ceil(len(rrr.dayofyear) / (window * time_chunks_count))
-#         rrr = rrr.chunk(dict(stack_dim=-1, dayofyear=doy_chunk_size))
-#
+#     rr = rr.assign_coords(time=ind).unstack("time").stack(stack_dim=("year", "window"))
 #     if np.isscalar(per):
 #         per = [per]
-#
 #     p = xr.apply_ufunc(
 #         calc_perc,
-#         rrr,
+#         rr,
 #         input_core_dims=[["stack_dim"]],
 #         output_core_dims=[["percentiles"]],
 #         keep_attrs=True,
 #         kwargs=dict(percentiles=per, alpha=alpha, beta=beta, copy=copy),
 #         dask="parallelized",
-#         output_dtypes=[rrr.dtype],
+#         output_dtypes=[rr.dtype],
 #         dask_gufunc_kwargs=dict(output_sizes={"percentiles": len(per)}),
 #     )
 #     p = p.assign_coords(percentiles=xr.DataArray(per, dims=("percentiles",)))
-#
-#     # The percentile for the 366th day has a sample size of 1/4 of the other days.
-#     # To have the same sample size, we interpolate the percentile from 1-365 doy range to 1-366
-#     if p.dayofyear.max() == 366:
-#         p = adjust_doy_calendar(p.sel(dayofyear=(p.dayofyear < 366)), arr)
-#
-#     p.attrs.update(arr.attrs.copy())
-#
-#     # Saving percentile attributes
-#     n = len(arr.time)
-#     p.attrs["climatology_bounds"] = (
-#         arr.time[0 :: n - 1].dt.strftime("%Y-%m-%d").values.tolist()
-#     )
-#     p.attrs["window"] = window
-#     p.attrs["alpha"] = alpha
-#     p.attrs["beta"] = beta
 #     return p.rename("per")

--- a/xclim/core/calendar.py
+++ b/xclim/core/calendar.py
@@ -440,6 +440,7 @@ def percentile_doy(
     alpha: float = 1.0 / 3.0,
     beta: float = 1.0 / 3.0,
     copy: bool = True,
+    keep_chunk_size: bool = True,
 ) -> xr.DataArray:
     """Percentile value for each day of the year.
 
@@ -464,6 +465,10 @@ def percentile_doy(
         If False, no copy is made of the input array. It will be mutated and rendered
         unusable but performances may significantly improve.
         Put this flag to False only if you understand the consequences.
+    keep_chunk_size: bool
+        If True will rechunk dayofyear into len(time) * windows chunks, this preserves
+        the initial chunk size.
+        Otherwise, it will not rechunk.
 
     Returns
     -------
@@ -491,10 +496,13 @@ def percentile_doy(
     rrr = rr.assign_coords(time=ind).unstack("time").stack(stack_dim=("year", "window"))
 
     if rrr.chunks is not None and len(rrr.chunks[rrr.get_axis_num("stack_dim")]) > 1:
-        # Preserve chunk size
-        time_chunks_count = len(arr.chunks[arr.get_axis_num("time")])
-        doy_chunk_size = np.ceil(len(rrr.dayofyear) / (window * time_chunks_count))
-        rrr = rrr.chunk(dict(stack_dim=-1, dayofyear=doy_chunk_size))
+        chunking = {"stack_dim": -1}
+        if keep_chunk_size:
+            # Preserve chunk size
+            time_chunks_count = len(arr.chunks[arr.get_axis_num("time")])
+            doy_chunk_size = np.ceil(len(rrr.dayofyear) / (window * time_chunks_count))
+            chunking["dayofyear"] = doy_chunk_size
+        rrr = rrr.chunk(chunking)
 
     if np.isscalar(per):
         per = [per]

--- a/xclim/indices/_threshold.py
+++ b/xclim/indices/_threshold.py
@@ -1885,7 +1885,7 @@ def maximum_consecutive_dry_days(
     -----
     Let :math:`\mathbf{p}=p_0, p_1, \ldots, p_n` be a daily precipitation series and :math:`thresh` the threshold
     under which a day is considered dry. Then let :math:`\mathbf{s}` be the sorted vector of indices :math:`i` where
-    :math:`[p_i < thresh] \neq [p_{i+1} < thresh]`, that is, the days when the temperature crosses the threshold.
+    :math:`[p_i < thresh] \neq [p_{i+1} < thresh]`, that is, the days when the precipitation crosses the threshold.
     Then the maximum number of consecutive dry days is given by
 
     .. math::

--- a/xclim/testing/tests/test_bootstrapping.py
+++ b/xclim/testing/tests/test_bootstrapping.py
@@ -225,15 +225,15 @@ class Test_bootstrap:
         # Bootstrapping should increase the computed index values within the overlapping
         # period. However, this will not work on unrealistic values such as a constant
         # temperature.
-        # Beside, bootstrapping is particularly effective on extreme percentiles, the
-        # closer the target percentile(s) is to the median the less bootstrapping is
-        # effective.
-        # The following assertions may even fail if the chosen percentile is close to 50
+        # Beside, bootstrapping is particularly effective on extreme percentiles, but
+        # the closer the target percentile is to the median the less bootstrapping is
+        # necessary.
+        # Following assertions may even fail if chosen percentile is close to 50.
         assert np.count_nonzero(
             bootstrapped_in_base > no_bs_in_base
         ) > np.count_nonzero(bootstrapped_in_base < no_bs_in_base)
-        # bootstrapping should let the out of base unchanged,
-        # precision above 15th decimal might differ though
+        # bootstrapping should leave the out of base unchanged,
+        # but precision above 15th decimal might differ.
         np.testing.assert_array_almost_equal(no_bs_out_base, bs_out_base, 15)
 
     def ar1(self, alpha, n, positive_values=False):

--- a/xclim/testing/tests/test_bootstrapping.py
+++ b/xclim/testing/tests/test_bootstrapping.py
@@ -144,7 +144,6 @@ class Test_bootstrap:
                 pr_series([1, 2]), pr_series([1, 2]), bootstrap=True
             )
 
-    @pytest.mark.slow
     def test_bootstrap_days_over_precip_thresh_error_no_doy(self, pr_series):
         with pytest.raises(KeyError):
             # no "dayofyear" coords on per
@@ -152,61 +151,95 @@ class Test_bootstrap:
                 pr_series([1, 2]), pr_series([1, 2]), bootstrap=True
             )
 
-    @pytest.mark.slow
     def test_bootstrap_no_doy(self, tas_series):
         # no "dayofyear" coords on per
         with pytest.raises(KeyError):
             tg10p(tas_series([42]), tas_series([42]), freq="MS", bootstrap=True)
 
-    # @pytest.mark.slow
-    # def test_bootstrap_full_overlap(self, tas_series):
-    #     # bootstrap is unnecessary when in base and out of base fully overlap
-    #     with pytest.raises(KeyError):
-    #         tg10p(tas_series([42]), tas_series([42]), freq="MS", bootstrap=True)
+    def test_bootstrap_full_overlap(self, tas_series):
+        # bootstrap is unnecessary when in base and out of base fully overlap
+        # -- GIVEN
+        tas = tas_series(self.ar1(alpha=0.8, n=int(4 * 365.25)), start="2000-01-01")
+        per = percentile_doy(tas, per=90)
+        # -- THEN
+        with pytest.raises(KeyError):
+            # -- WHEN
+            tg10p(tas, per, freq="YS", bootstrap=True)
+
+    @pytest.mark.slow
+    def test_bootstrap_no_overlap(self, tas_series):
+        # bootstrap is unnecessary when in base and out of base fully overlap
+        # -- GIVEN
+        tas = tas_series(self.ar1(alpha=0.8, n=int(4 * 365.25)), start="2000-01-01")
+        tas_in_base = tas.sel(time=slice("2000-01-01", "2001-12-31"))
+        tas_out_base = tas.sel(time=slice("2002-01-01", "2001-12-31"))
+        per = percentile_doy(tas_in_base, per=90)
+        # -- THEN
+        with pytest.raises(KeyError):
+            # -- WHEN
+            tg10p(tas_out_base, per, freq="MS", bootstrap=True)
+
+    @pytest.mark.slow
+    def test_multi_per(self):
+        tas = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc").tas
+        t90 = percentile_doy(
+            tas.sel(time=slice("1990-01-01", "1991-12-31")), window=5, per=[90, 91]
+        )
+        res = tg90p(tas=tas, t90=t90, freq="YS", bootstrap=True)
+        np.testing.assert_array_equal([90, 91], res.percentiles)
+
+    @pytest.mark.slow
+    def test_doctest_ndims(self):
+        """Replicates doctest to facilitate debugging."""
+        tas = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc").tas
+        t90 = percentile_doy(
+            tas.sel(time=slice("1990-01-01", "1991-12-31")), window=5, per=90
+        )
+        tg90p(tas=tas, t90=t90.isel(percentiles=0), freq="YS", bootstrap=True)
+        tg90p(tas=tas, t90=t90, freq="YS", bootstrap=True)
 
     def bootstrap_testor(
         self,
         series,
         per: int,
-        index_fun: Callable[[DataArray, DataArray], DataArray],
+        index_fun: Callable[[DataArray, DataArray, bool], DataArray],
         positive_values=False,
         use_dask=False,
     ):
-        # GIVEN
-        n = int(4 * 365.25)
-        alpha = 0.8
-        arr = self.ar1(alpha, n, positive_values)
+        # -- GIVEN
+        arr = self.ar1(alpha=0.8, n=int(4 * 365.25), positive_values=positive_values)
         climat_variable = series(arr, start="2000-01-01")
         if use_dask:
             climat_variable = climat_variable.chunk(dict(time=50))
         in_base_slice = slice("2000-01-01", "2001-12-31")
         out_base_slice = slice("2002-01-01", "2003-12-31")
         per = percentile_doy(climat_variable.sel(time=in_base_slice), per=per)
-        # WHEN
+        # -- WHEN
         no_bootstrap = index_fun(climat_variable, per, False)
         no_bs_in_base = no_bootstrap.sel(time=in_base_slice)
         no_bs_out_base = no_bootstrap.sel(time=out_base_slice)
         bootstrap = index_fun(climat_variable, per, True)
         bootstrapped_in_base = bootstrap.sel(time=in_base_slice)
         bs_out_base = bootstrap.sel(time=out_base_slice)
-        # THEN
-        # bootstrapping should increase the indices values within the in_base
-        # will not work on unrealistic values such as a constant temperature
-        # However, the closer the targeted percentile is to the median
-        # the less bootstrapping makes sense to use.
-        # The tests may even fail if the chosen percentile is close to 50
+        # -- THEN
+        # Bootstrapping should increase the computed index values within the overlapping
+        # period. However, this will not work on unrealistic values such as a constant
+        # temperature.
+        # Beside, bootstrapping is particularly effective on extreme percentiles, the
+        # closer the target percentile(s) is to the median the less bootstrapping is
+        # effective.
+        # The following assertions may even fail if the chosen percentile is close to 50
         assert np.count_nonzero(
             bootstrapped_in_base > no_bs_in_base
         ) > np.count_nonzero(bootstrapped_in_base < no_bs_in_base)
-        # bootstrapping should let the out of base unchanged
-        assert np.count_nonzero(no_bs_out_base != bs_out_base) == 0
+        # bootstrapping should let the out of base unchanged,
+        # precision above 15th decimal might differ though
+        np.testing.assert_array_almost_equal(no_bs_out_base, bs_out_base, 15)
 
     def ar1(self, alpha, n, positive_values=False):
         """Return random AR1 DataArray."""
-
         # White noise
         wn = np.random.randn(n - 1) * np.sqrt(1 - alpha**2)
-
         # Autoregressive series of order 1
         out = np.empty(n)
         out[0] = np.random.randn()
@@ -215,14 +248,4 @@ class Test_bootstrap:
                 out[i + 1] = np.abs(alpha * out[i] + w)
             else:
                 out[i + 1] = alpha * out[i] + w
-
         return out
-
-
-def test_doctest_ndims():
-    """Replicates doctest to facilitate debugging."""
-    tas = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc").tas
-    t90 = percentile_doy(tas, window=5, per=90)
-    tg90p(tas=tas, t90=t90, freq="YS", bootstrap=True)
-
-    tg90p(tas=tas, t90=t90.isel(percentiles=0), freq="YS", bootstrap=True)


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #932 
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.
- [ ] `bumpversion patch` has been called on this branch
- [x] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?
This PR make an optimization to dask graph when bootstrapping percentiles using `xarray.map_block`.
There are also a few refactorings to clarify the code.


#### Before
The main concern was the intermediary results stored on disk by dasks.
In a large dataset, It was generating up 150Go of data on disk.
This had two consequences:
- Computation is slow down by i/o operations, which may even idle all worker's threads while the i/o is in progress.
- The OS may not allow an application to write so much data on disk, especially if there is no such space...
I suspect dask was storing the data broadcasted to window size which could effectively be reused in multiple steps of bootstrapping algorithm.  
The other concern was the high memory (RAM) use. This lead dask to spill even more on disk and also limited the number of threads concurrently running.
For example, on dask default scheduler the OS would often kill the python process due to the amount of memory being use.
Finally on large dataset the dask graph could be populated with a lot of tasks.


#### Now
When running bootstrap algorithm on a single file of shape `time: 3653, lat: 128, lon: 256` and stored in chunks: `chunksizes': (1, 128, 256)`, there are approximately the same number of dask tasks created as before.
However, on a zarr store of shape `lat: 256, lon: 512, time: 38716` and stored in chunks `(38716, 3, 512)`, when 10 years are bootstrapped on a 20 years study, it was generating 1M tasks where now it "only" generates 250K tasks.

Plus, there is **much** less spilling on disk going on and the memory use always stays at a very manageable level.

### Does this PR introduce a breaking change?
No.

### Other information:
There was also some cases where years were duplicated and an (ugly) post-processing was filtering them out.
The root cause was the object used to iterates. We were using the whole da instead of the overlapping da in between reference period and studied period.

Two more errors can now be raised to avoid starting bootstrap when it's unnecessary:
- When the reference period and the studied period don't overlap.
- When the reference period and the studied period **fully** overlap.
This last case may seem counterintuitive. The bootstrap algorithm is used to avoid the inhomogeneity of percentile comparison between the period where both the index and the daily percentiles are computed (reference period) and the period where **only** the index is computed.
Thus, when reference period is equal to the study period there is no inhomogeneity.

All tests were done on my laptop. CPU: i5 2GHz 4 cores (x2) ; RAM: 16GB (dask is configured to use this as a limit)
