### PR TITLE
History attribute shows args as kwargs

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,17 @@
 History
 =======
 
+0.34.0 (unreleased)
+-------------------
+Contributors to this version: Pascal Bourgault (:user:`aulemahal`)
+
+Breaking changes
+^^^^^^^^^^^^^^^^
+* The "history" attribute added by xclim will was changed:
+    - The trailing dot was dropped.
+    - ``None`` inputs are now printed as "None" (and not "<NoneType>").
+    - Arguments are always printed as keyword-arguments. This mostly impacts ``sdba`` functions, as it was already the case for ``Indicators``.
+
 0.33.2 (2022-02-09)
 -------------------
 Contributors to this version: Pascal Bourgault (:user:`aulemahal`), Juliette Lavoie (:user:`juliettelavoie`), Trevor James Smith (:user:`Zeitsperre`).

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,7 +8,7 @@ Contributors to this version: Pascal Bourgault (:user:`aulemahal`)
 
 Breaking changes
 ^^^^^^^^^^^^^^^^
-* The "history" attribute added by xclim will was changed:
+* The "history" attribute added by xclim will was changed: (:issue:`963`, :pull:`1018`).
     - The trailing dot was dropped.
     - ``None`` inputs are now printed as "None" (and not "<NoneType>").
     - Arguments are always printed as keyword-arguments. This mostly impacts ``sdba`` functions, as it was already the case for ``Indicators``.

--- a/xclim/core/formatting.py
+++ b/xclim/core/formatting.py
@@ -327,7 +327,7 @@ def update_xclim_history(func):
     """Decorator that auto-generates and fills the history attribute.
 
     The history is generated from the signature of the function and added to the first output.
-    Because of a limiation of boltons wrapper, all arguments passed to the wrapped function
+    Because of a limitation of the `boltons` wrapper, all arguments passed to the wrapped function
     will be printed as keyword arguments.
     """
 

--- a/xclim/core/formatting.py
+++ b/xclim/core/formatting.py
@@ -327,6 +327,8 @@ def update_xclim_history(func):
     """Decorator that auto-generates and fills the history attribute.
 
     The history is generated from the signature of the function and added to the first output.
+    Because of a limiation of boltons wrapper, all arguments passed to the wrapped function
+    will be printed as keyword arguments.
     """
 
     @wraps(func)
@@ -367,8 +369,9 @@ def update_xclim_history(func):
 def gen_call_string(funcname: str, *args, **kwargs):
     """Generate a signature string for use in the history attribute.
 
-    DataArrays and Dataset are replaced with their name, floats, ints and strings are
-    printed directly, all other objects have their type printed between < >.
+    DataArrays and Dataset are replaced with their name, while Nones, floats,
+    ints and strings are printed directly.
+    All other objects have their type printed between < >.
 
     Arguments given through positional arguments are printed positionnally and those
     given through keywords are printed prefixed by their name.

--- a/xclim/testing/tests/test_formatting.py
+++ b/xclim/testing/tests/test_formatting.py
@@ -47,7 +47,7 @@ def test_update_xclim_history(atmosds):
     out = func(atmosds.tas, 1, arg2=[1, 2], arg3=None)
 
     matches = re.match(
-        r"\[([0-9-:\s]*)\]\s(\w*):\s(\w*)\((.*)\)\s-\sxclim\sversion:\s(\d*\.\d*\.\d*)[a-zA-Z-]*",
+        r"\[([0-9-:\s]*)\]\s(\w*):\s(\w*)\((.*)\)\s-\sxclim\sversion:\s(\d*\.\d*\.\d*[a-zA-Z-]*)",
         out.attrs["history"],
     ).groups()
 

--- a/xclim/testing/tests/test_formatting.py
+++ b/xclim/testing/tests/test_formatting.py
@@ -1,3 +1,7 @@
+import datetime as dt
+import re
+
+from xclim import __version__
 from xclim.core import formatting as fmt
 from xclim.indicators.atmos import degree_days_exceedance_date, heat_wave_frequency
 
@@ -33,3 +37,23 @@ def test_indicator_docstring():
 
     doc = degree_days_exceedance_date.__doc__.split("\n")
     assert doc[20] == "  Default : >. "
+
+
+def test_update_xclim_history(atmosds):
+    @fmt.update_xclim_history
+    def func(da, arg1, arg2=None, arg3=None):
+        return da
+
+    out = func(atmosds.tas, 1, arg2=[1, 2], arg3=None)
+
+    matches = re.match(
+        r"\[([0-9-:\s]*)\]\s(\w*):\s(\w*)\((.*)\)\s-\sxclim\sversion:\s([0-9\.]*)",
+        out.attrs["history"],
+    ).groups()
+
+    date = dt.datetime.fromisoformat(matches[0])
+    assert dt.timedelta(0) < (dt.datetime.now() - date) < dt.timedelta(seconds=3)
+    assert matches[1] == "tas"
+    assert matches[2] == "func"
+    assert matches[3] == "da=tas, arg1=1, arg2=<list>, arg3=None"
+    assert matches[4] == __version__

--- a/xclim/testing/tests/test_formatting.py
+++ b/xclim/testing/tests/test_formatting.py
@@ -47,7 +47,7 @@ def test_update_xclim_history(atmosds):
     out = func(atmosds.tas, 1, arg2=[1, 2], arg3=None)
 
     matches = re.match(
-        r"\[([0-9-:\s]*)\]\s(\w*):\s(\w*)\((.*)\)\s-\sxclim\sversion:\s([0-9\.]*)",
+        r"\[([0-9-:\s]*)\]\s(\w*):\s(\w*)\((.*)\)\s-\sxclim\sversion:\s(\d*\.\d*\.\d*)[a-zA-Z-]*",
         out.attrs["history"],
     ).groups()
 

--- a/xclim/testing/tests/test_indicators.py
+++ b/xclim/testing/tests/test_indicators.py
@@ -145,7 +145,7 @@ def test_attrs(tas_series):
     assert txm.cell_methods == "time: mean within days time: mean within years"
     assert f"{dt.datetime.now():%Y-%m-%d %H}" in txm.attrs["history"]
     assert "TMIN(da=tas, thresh='5 degC', freq='YS')" in txm.attrs["history"]
-    assert f"xclim version: {__version__}." in txm.attrs["history"]
+    assert f"xclim version: {__version__}" in txm.attrs["history"]
     assert txm.name == "tmin5 degC"
     assert uniIndTemp.standard_name == "{freq} mean temperature"
     assert uniIndTemp.cf_attrs[0]["another_attr"] == "With a value."

--- a/xclim/testing/tests/test_sdba/test_processing.py
+++ b/xclim/testing/tests/test_sdba/test_processing.py
@@ -45,7 +45,7 @@ def test_jitter_under_thresh():
     assert da[0] > 0
     np.testing.assert_allclose(da[1:], out[1:])
     assert (
-        "jitter(<array>, '1 K', <NoneType>, <NoneType>, <NoneType>) - xclim version"
+        "jitter(x=<array>, lower='1 K', upper=None, minimum=None, maximum=None) - xclim version"
         in out.attrs["history"]
     )
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #963
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.
- [ ] `bumpversion patch` has been called on this branch
- [ ] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

* The "history" attribute added by xclim will was changed:
    - The trailing dot was dropped.
    - ``None`` inputs are now printed as "None" (and not "\<NoneType\>").
    - Arguments are always printed as keyword-arguments. This mostly impacts ``sdba`` functions, as it was already the case for ``Indicators``.

Example: 
```python3
from xclim.core.formatting import update_xclim_history
from xclim.testing import open_dataset

@update_xclim_history
def func(da, arg1, arg2=None, arg3=None):
    return da

ds = open_dataset('ERA5/daily_surface_cancities_1990-1993.nc')
out = func(ds.tas, 1, arg2=[2, 2], arg3=None)

print(out.attrs['history'])
```
Before: `[2021-12-20 10:38:35] tas: func(tas, 1, <list>, <NoneType>) - xclim version: 0.32.1.`
Now: `[2022-02-16 14:58:50] tas: func(da=tas, arg1=1, arg2=<list>, arg3=None) - xclim version: 0.33.2`

### Does this PR introduce a breaking change?
I guess that it does, if anyone was parsing that string.