### PR TITLE
Change is_dayofyear to np.int32

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,14 @@
 History
 =======
 
+0.34.0 (unreleased)
+-------------------
+Contributors to this version: Pascal Bourgault (:user:`aulemahal`)
+
+Internal changes
+^^^^^^^^^^^^^^^^
+* The "is_dayofyear" attribute added by several indices is now a ``numpy.int32`` instance, instead of python's ``int``. This ensures a THREDDS server can read it when the variableis saved to a netCDF file with xarray/netCDF4. (:issue:`980`, :pull:`1019`).
+
 0.33.2 (2022-02-09)
 -------------------
 Contributors to this version: Pascal Bourgault (:user:`aulemahal`), Juliette Lavoie (:user:`juliettelavoie`), Trevor James Smith (:user:`Zeitsperre`).

--- a/xclim/indices/_hydrology.py
+++ b/xclim/indices/_hydrology.py
@@ -131,7 +131,7 @@ def snd_max_doy(snd: xarray.DataArray, freq: str = "AS-JUL") -> xarray.DataArray
 
     # Compute doymax. Will return first time step if all snow depths are 0.
     out = generic.select_resample_op(snd, op=generic.doymax, freq=freq)
-    out.attrs.update(units="", is_dayofyear=1, calendar=get_calendar(snd))
+    out.attrs.update(units="", is_dayofyear=np.int32(1), calendar=get_calendar(snd))
 
     # Mask arrays that miss at least one non-null snd.
     return out.where(~valid)
@@ -183,7 +183,7 @@ def snw_max_doy(snw: xarray.DataArray, freq: str = "AS-JUL") -> xarray.DataArray
 
     # Compute doymax. Will return first time step if all snow depths are 0.
     out = generic.select_resample_op(snw, op=generic.doymax, freq=freq)
-    out.attrs.update(units="", is_dayofyear=1, calendar=get_calendar(snw))
+    out.attrs.update(units="", is_dayofyear=np.int32(1), calendar=get_calendar(snw))
 
     # Mask arrays that miss at least one non-null snd.
     return out.where(~valid)

--- a/xclim/indices/_threshold.py
+++ b/xclim/indices/_threshold.py
@@ -244,7 +244,7 @@ def continuous_snow_cover_end(
         .map(rl.season, window=window, dim="time", coord="dayofyear")
         .end
     )
-    out.attrs.update(units="", is_dayofyear=1, calendar=get_calendar(snd))
+    out.attrs.update(units="", is_dayofyear=np.int32(1), calendar=get_calendar(snd))
     return out
 
 
@@ -292,7 +292,7 @@ def continuous_snow_cover_start(
         )
         .start
     )
-    out.attrs.update(units="", is_dayofyear=1, calendar=get_calendar(snd))
+    out.attrs.update(units="", is_dayofyear=np.int32(1), calendar=get_calendar(snd))
     return out
 
 
@@ -521,7 +521,7 @@ def freshet_start(
     thresh = convert_units_to(thresh, tas)
     over = tas > thresh
     out = over.resample(time=freq).map(rl.first_run, window=window, coord="dayofyear")
-    out.attrs.update(units="", is_dayofyear=1, calendar=get_calendar(tas))
+    out.attrs.update(units="", is_dayofyear=np.int32(1), calendar=get_calendar(tas))
     return out
 
 
@@ -602,7 +602,7 @@ def growing_season_start(
     thresh = convert_units_to(thresh, tas)
     over = tas >= thresh
     out = over.resample(time=freq).map(rl.first_run, window=window, coord="dayofyear")
-    out.attrs.update(units="", is_dayofyear=1, calendar=get_calendar(tas))
+    out.attrs.update(units="", is_dayofyear=np.int32(1), calendar=get_calendar(tas))
     return out
 
 
@@ -649,7 +649,7 @@ def growing_season_end(
         dim="time",
         coord="dayofyear",
     )
-    out.attrs.update(units="", is_dayofyear=1, calendar=get_calendar(tas))
+    out.attrs.update(units="", is_dayofyear=np.int32(1), calendar=get_calendar(tas))
     return out
 
 
@@ -845,7 +845,7 @@ def frost_free_season_start(
     thresh = convert_units_to(thresh, tasmin)
     over = tasmin >= thresh
     out = over.resample(time=freq).map(rl.first_run, window=window, coord="dayofyear")
-    out.attrs.update(units="", is_dayofyear=1, calendar=get_calendar(tasmin))
+    out.attrs.update(units="", is_dayofyear=np.int32(1), calendar=get_calendar(tasmin))
     return out
 
 
@@ -893,7 +893,7 @@ def frost_free_season_end(
         dim="time",
         coord="dayofyear",
     )
-    out.attrs.update(units="", is_dayofyear=1, calendar=get_calendar(tasmin))
+    out.attrs.update(units="", is_dayofyear=np.int32(1), calendar=get_calendar(tasmin))
     return out
 
 
@@ -1012,7 +1012,7 @@ def last_spring_frost(
         dim="time",
         coord="dayofyear",
     )
-    out.attrs.update(units="", is_dayofyear=1, calendar=get_calendar(tas))
+    out.attrs.update(units="", is_dayofyear=np.int32(1), calendar=get_calendar(tas))
     return out
 
 
@@ -1060,7 +1060,7 @@ def first_day_below(
         dim="time",
         coord="dayofyear",
     )
-    out.attrs.update(units="", is_dayofyear=1, calendar=get_calendar(tasmin))
+    out.attrs.update(units="", is_dayofyear=np.int32(1), calendar=get_calendar(tasmin))
     return out
 
 
@@ -1108,7 +1108,7 @@ def first_day_above(
         dim="time",
         coord="dayofyear",
     )
-    out.attrs.update(units="", is_dayofyear=1, calendar=get_calendar(tasmin))
+    out.attrs.update(units="", is_dayofyear=np.int32(1), calendar=get_calendar(tasmin))
     return out
 
 
@@ -1152,7 +1152,7 @@ def first_snowfall(
         dim="time",
         coord="dayofyear",
     )
-    out.attrs.update(units="", is_dayofyear=1, calendar=get_calendar(prsn))
+    out.attrs.update(units="", is_dayofyear=np.int32(1), calendar=get_calendar(prsn))
     return out
 
 
@@ -2271,7 +2271,7 @@ def degree_days_exceedance_date(
         )
 
     out = c.clip(0).resample(time=freq).map(_exceedance_date)
-    out.attrs.update(units="", is_dayofyear=1, calendar=get_calendar(tas))
+    out.attrs.update(units="", is_dayofyear=np.int32(1), calendar=get_calendar(tas))
     return out
 
 

--- a/xclim/indices/generic.py
+++ b/xclim/indices/generic.py
@@ -118,7 +118,7 @@ def doymax(da: xr.DataArray) -> xr.DataArray:
     """Return the day of year of the maximum value."""
     i = da.argmax(dim="time")
     out = da.time.dt.dayofyear.isel(time=i, drop=True)
-    out.attrs.update(units="", is_dayofyear=1, calendar=get_calendar(da))
+    out.attrs.update(units="", is_dayofyear=np.int32(1), calendar=get_calendar(da))
     return out
 
 
@@ -126,7 +126,7 @@ def doymin(da: xr.DataArray) -> xr.DataArray:
     """Return the day of year of the minimum value."""
     i = da.argmin(dim="time")
     out = da.time.dt.dayofyear.isel(time=i, drop=True)
-    out.attrs.update(units="", is_dayofyear=1, calendar=get_calendar(da))
+    out.attrs.update(units="", is_dayofyear=np.int32(1), calendar=get_calendar(da))
     return out
 
 

--- a/xclim/testing/tests/test_indices.py
+++ b/xclim/testing/tests/test_indices.py
@@ -496,6 +496,7 @@ class TestLastSpringFrost:
             assert attr in lsf.attrs.keys()
         assert lsf.attrs["units"] == ""
         assert lsf.attrs["is_dayofyear"] == 1
+        assert lsf.attrs["is_dayofyear"].dtype == np.int32
 
 
 class TestFirstDayBelow:


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #980
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.
- [ ] `bumpversion patch` has been called on this branch
- [ ] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?
* The "is_dayofyear" attribute added by several indices is now a ``numpy.int32`` instance, instead of python's ``int``. This ensures a THREDDS server can read it when the variableis saved to a netCDF file with xarray/netCDF4.

### Does this PR introduce a breaking change?
No.