### PR TITLE
Fix module loading on pycharm

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -19,6 +19,10 @@ Breaking changes
     - ``None`` inputs are now printed as "None" (and not "<NoneType>").
     - Arguments are now always shown as keyword-arguments. This mostly impacts ``sdba`` functions, as it was already the case for ``Indicators``.
 
+Bug fixes
+^^^^^^^^^
+* Loading virtual python modules with ``build_indicator_module_from_yaml`` is now fixed on some systems where the current directory was not part of python's path. Furthermore, paths of the python and json files can now be passed directly to the ``indices`` and ``translations`` arguments, respectively. (:issue:`1020`, :pull:`1021`).
+
 Internal changes
 ^^^^^^^^^^^^^^^^
 * Due to an upstream bug in `bottleneck`'s support of virtualenv, `tox` builds for Python3.10 now depend on a patched fork of `bottleneck`. This workaround will be removed once the fix is merged upstream. (:pull:`1013`, see: `bottleneck PR/397`_).

--- a/docs/notebooks/example.fr.json
+++ b/docs/notebooks/example.fr.json
@@ -9,7 +9,7 @@
   },
   "R95P.R95p": {
     "long_name": "Accumulation {freq:f} des précipitations lors des jours de fortes pluies (> {perc}e percentile)",
-    "description": "Épaisseur équivalent des précipitations accumulées lors des jours où la pluie est plus forte que le {perc}e percentile de la série."
+    "description": "Épaisseur équivalente des précipitations accumulées lors des jours où la pluie est plus forte que le {perc}e percentile de la série."
   },
   "R95P.R95p_days": {
     "long_name": "Nombre de jours de fortes pluies (> {perc}e percentile)",
@@ -17,7 +17,7 @@
   },
   "R99P.R99p": {
     "long_name": "Accumulation {freq:f} des précipitations lors des jours de fortes pluies (> {perc}e percentile)",
-    "description": "Épaisseur équivalent des précipitations accumulées lors des jours où la pluie est plus forte que le {perc}e percentile de la série."
+    "description": "Épaisseur équivalente des précipitations accumulées lors des jours où la pluie est plus forte que le {perc}e percentile de la série."
   },
   "R99P.R99p_days": {
     "long_name": "Nombre de jours de fortes pluies (> {perc}e percentile)",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.33.3-beta
+current_version = 0.33.4-beta
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+).(?P<patch>\d+)(\-(?P<release>[a-z]+))?

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ URL = "https://github.com/Ouranosinc/xclim"
 AUTHOR = "Travis Logan"
 AUTHOR_EMAIL = "logan.travis@ouranos.ca"
 REQUIRES_PYTHON = ">=3.8.0"
-VERSION = "0.33.3-beta"
+VERSION = "0.33.4-beta"
 LICENSE = "Apache Software License 2.0"
 
 with open("README.rst") as readme_file:

--- a/xclim/__init__.py
+++ b/xclim/__init__.py
@@ -9,7 +9,7 @@ from xclim.indicators import atmos, land, seaIce  # noqa
 
 __author__ = """Travis Logan"""
 __email__ = "logan.travis@ouranos.ca"
-__version__ = "0.33.3-beta"
+__version__ = "0.33.4-beta"
 
 
 # Load official locales

--- a/xclim/core/indicator.py
+++ b/xclim/core/indicator.py
@@ -1459,8 +1459,8 @@ def build_indicator_module(
 def build_indicator_module_from_yaml(
     filename: PathLike,
     name: Optional[str] = None,
-    indices: Optional[Union[Mapping[str, Callable], ModuleType]] = None,
-    translations: Optional[Mapping[str, dict]] = None,
+    indices: Optional[Union[Mapping[str, Callable], ModuleType, PathLike]] = None,
+    translations: Optional[Dict[str, Union[dict, PathLike]]] = None,
     mode: str = "raise",
     encoding: str = "UTF8",
 ) -> ModuleType:
@@ -1476,12 +1476,14 @@ def build_indicator_module_from_yaml(
     name: str, optional
       The name of the new or existing module, defaults to the basename of the file.
       (e.g: `atmos.yml` -> `atmos`)
-    indices : Mapping of callables or module, optional
-      A mapping or module of indice functions. When creating the indicator, the name in the `index_function` field is
-      first sought here, then in xclim.indices.generic and finally in xclim.indices.
-    translations  : Mapping of dicts, optional
+    indices : Mapping of callables or module or path, optional
+      A mapping or module of indice functions or a python file declaring such a file.
+      When creating the indicator, the name in the `index_function` field is first sought
+      here, then the indicator class will search in xclim.indices.generic and finally in xclim.indices.
+    translations  : Mapping of dicts or path, optional
       Translated metadata for the new indicators. Keys of the mapping must be 2-char language tags.
-      See Notes and :ref:`Internationalization` for more details.
+      Values can be translations dictionaries as defined in :ref:`Internationalization`.
+      They can also be a path to a json file defining the translations.
     mode: {'raise', 'warn', 'ignore'}
       How to deal with broken indice definitions.
     encoding: str
@@ -1530,21 +1532,33 @@ def build_indicator_module_from_yaml(
     )
     doc = yml.get("doc")
 
-    # When given as a stem, we try to load indices and translations
-    if not filepath.suffix:
-        if indices is None:
-            try:
-                indices = load_module(filepath.with_suffix(".py"))
-            except ModuleNotFoundError:
-                pass
+    if (
+        not filepath.suffix
+        and indices is None
+        and (indfile := filepath.with_suffix(".py")).is_file()
+    ):
+        # No suffix means we try to automatically detect the python file
+        indices = indfile
 
-        if translations is None:
-            translations = {}
-            for locfile in filepath.parent.glob(filepath.stem + ".*.json"):
-                locale = locfile.suffixes[0][1:]
-                translations[locale] = read_locale_file(
-                    locfile, module=module_name, encoding=encoding
-                )
+    if isinstance(indices, (str, Path)):
+        indices = load_module(indices, name=module_name)
+
+    if not filepath.suffix and translations is None:
+        # No suffix mean we try to automatically detect the json files.
+        translations = {}
+        for locfile in filepath.parent.glob(filepath.stem + ".*.json"):
+            locale = locfile.suffixes[0][1:]
+            translations[locale] = read_locale_file(
+                locfile, module=module_name, encoding=encoding
+            )
+    elif translations is not None:
+        # A mapping was passed, we read paths is any.
+        translations = {
+            lng: read_locale_file(trans, module=module_name, encoding=encoding)
+            if isinstance(trans, (str, Path))
+            else trans
+            for lng, trans in translations.items()
+        }
 
     # Module-wide default values for some attributes
     defkwargs = {

--- a/xclim/core/utils.py
+++ b/xclim/core/utils.py
@@ -5,13 +5,13 @@ Miscellaneous indices utilities
 
 Helper functions for the indices computation, indicator construction and other things.
 """
+import importlib.util
 import logging
 import os
 import warnings
 from collections import defaultdict
 from enum import IntEnum
 from functools import partial
-from importlib import import_module
 from importlib.resources import open_text
 from inspect import Parameter
 from pathlib import Path
@@ -108,19 +108,19 @@ def walk_map(d: dict, func: FunctionType) -> dict:
     return out
 
 
-def load_module(path: os.PathLike):
-    """Load a python module from a single .py file.
+def load_module(path: os.PathLike, name: Optional[str] = None):
+    """Load a python module from a python file, optionally changing its name.
 
     Examples
     --------
     Given a path to a module file (.py)
 
+    >>> # xdoctest: +SKIP
     >>> from pathlib import Path
-    >>> path = Path(path_to_example_py)
+    >>> path = Path("path/to/example.py")
 
     The two following imports are equivalent, the second uses this method.
 
-    >>> # xdoctest: +SKIP
     >>> os.chdir(path.parent)
     >>> import example as mod1
     >>> os.chdir(previous_working_dir)
@@ -128,14 +128,9 @@ def load_module(path: os.PathLike):
     >>> mod1 == mod2
     """
     path = Path(path)
-    pwd = Path(os.getcwd())
-    os.chdir(path.parent)
-    try:
-        mod = import_module(path.stem)
-    except ModuleNotFoundError as err:
-        raise err
-    finally:
-        os.chdir(pwd)
+    spec = importlib.util.spec_from_file_location(name or path.stem, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # This executes code, effectively loading the module
     return mod
 
 

--- a/xclim/testing/tests/test_modules.py
+++ b/xclim/testing/tests/test_modules.py
@@ -1,4 +1,3 @@
-import sys
 from inspect import _empty
 from pathlib import Path
 
@@ -8,8 +7,9 @@ import yamale
 
 from xclim import indicators
 from xclim.core.indicator import build_indicator_module_from_yaml
+from xclim.core.locales import read_locale_file
 from xclim.core.options import set_options
-from xclim.core.utils import InputKind
+from xclim.core.utils import InputKind, load_module
 from xclim.testing import open_dataset
 
 
@@ -67,9 +67,8 @@ def test_custom_indices():
 
     pr = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc").pr
 
-    sys.path.insert(1, str(nbpath.absolute()))
-
-    import example  # noqa
+    # This tests load_module with a python file that is _not_ on the PATH
+    example = load_module(nbpath / "example.py")
 
     # Fron module
     ex1 = build_indicator_module_from_yaml(
@@ -84,11 +83,6 @@ def test_custom_indices():
         nbpath / "example.yml", name="ex2", indices=exinds
     )
 
-    # Error when missing
-    with pytest.raises(ImportError, match="extreme_precip_accumulation_and_days"):
-        build_indicator_module_from_yaml(nbpath / "example.yml", name="ex3")
-    build_indicator_module_from_yaml(nbpath / "example.yml", name="ex4", mode="ignore")
-
     assert ex1.R95p.__doc__ == ex2.R95p.__doc__  # noqa
 
     out1 = ex1.R95p(pr=pr)  # noqa
@@ -98,6 +92,39 @@ def test_custom_indices():
 
     # Check that missing was not modified even with injecting `freq`.
     assert ex1.RX5day.missing == indicators.atmos.max_n_day_precipitation_amount.missing
+
+    # Error when missing
+    with pytest.raises(ImportError, match="extreme_precip_accumulation_and_days"):
+        build_indicator_module_from_yaml(nbpath / "example.yml", name="ex3")
+    build_indicator_module_from_yaml(nbpath / "example.yml", name="ex4", mode="ignore")
+
+
+@pytest.mark.requires_docs
+def test_build_indicator_module_from_yaml_edge_cases():
+    # Use the example in the Extending Xclim notebook for testing.
+    nbpath = Path(__file__).parent.parent.parent.parent / "docs" / "notebooks"
+
+    # All from paths but one
+    ex5 = build_indicator_module_from_yaml(
+        nbpath / "example.yml",
+        indices=nbpath / "example.py",
+        translations={
+            "fr": nbpath / "example.fr.json",
+            "tlh": str(nbpath / "example.fr.json"),
+            "eo": read_locale_file(nbpath / "example.fr.json", module="ex5"),
+        },
+        name="ex5",
+    )
+    assert hasattr(indicators, "ex5")
+    assert ex5.R95p.translate_attrs("fr")["cf_attrs"][0]["description"].startswith(
+        "Épaisseur équivalente"
+    )
+    assert ex5.R95p.translate_attrs("tlh")["cf_attrs"][0]["description"].startswith(
+        "Épaisseur équivalente"
+    )
+    assert ex5.R95p.translate_attrs("eo")["cf_attrs"][0]["description"].startswith(
+        "Épaisseur équivalente"
+    )
 
 
 class TestOfficalYaml(yamale.YamaleTestCase):

--- a/xclim/testing/tests/test_modules.py
+++ b/xclim/testing/tests/test_modules.py
@@ -110,7 +110,7 @@ def test_build_indicator_module_from_yaml_edge_cases():
         indices=nbpath / "example.py",
         translations={
             "fr": nbpath / "example.fr.json",
-            "tlh": str(nbpath / "example.fr.json"),
+            "ru": str(nbpath / "example.fr.json"),
             "eo": read_locale_file(nbpath / "example.fr.json", module="ex5"),
         },
         name="ex5",
@@ -119,7 +119,7 @@ def test_build_indicator_module_from_yaml_edge_cases():
     assert ex5.R95p.translate_attrs("fr")["cf_attrs"][0]["description"].startswith(
         "Épaisseur équivalente"
     )
-    assert ex5.R95p.translate_attrs("tlh")["cf_attrs"][0]["description"].startswith(
+    assert ex5.R95p.translate_attrs("ru")["cf_attrs"][0]["description"].startswith(
         "Épaisseur équivalente"
     )
     assert ex5.R95p.translate_attrs("eo")["cf_attrs"][0]["description"].startswith(


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1020
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.
- [ ] `bumpversion patch` has been called on this branch
- [ ] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

* Changes the way `xclim.core.utils.load_module` works completely. Following https://stackoverflow.com/a/70757718/9291575
* Changes the way `build_indicator_module_from_yaml` handles the "stem" cases, i.e. when all files have the same name with different extensions. Now, if a .py file exists and can't be loaded, an explicit exception is raised. It previously failed silently, only to fail further with a less clear error about a missing indice function.
* Add some flexibility in `build_indicator_module_from_yaml` : 
    - `indices` can now be a path to a python file to load as indice module. The name of the file is not important.
    - Values of `translations` can now be paths to json file containing the correct translations. The name of the files are not important.
    
### Does this PR introduce a breaking change?
No.

### Other information:
This is my first real-world use of the walrus operator, omg so cool I can't even.

More seriously, if someone could test this with pycharm, it would be neat. Do something like :
```python3
import xclim as xc

mod = xc.build_indicator_module_from_yaml(`path/to/xclim/docs/notebooks/example')
assert mod.R95p.translate_attrs('fr')['cf_attrs'][0]['description'].startswith('Épaisseur')
```
I added a tests where the module to load is not on `path`, but still.