### PR TITLE
Remove extra cell_methods from indicator metadata

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -26,7 +26,7 @@ Breaking changes
     - The trailing dot (``.``) was dropped.
     - ``None`` inputs are now printed as "None" (and not "<NoneType>").
     - Arguments are now always shown as keyword-arguments. This mostly impacts ``sdba`` functions, as it was already the case for ``Indicators``.
-* The `cell_methods` string attribute appends only the operation from the indicator itself. In previous version, some indicators also appended the input data's own `cell_method`. The clix-meta importer has been modified to follow the same convention. (:issue:`983`)
+* The `cell_methods` string attribute appends only the operation from the indicator itself. In previous version, some indicators also appended the input data's own `cell_method`. The clix-meta importer has been modified to follow the same convention. (:issue:`983`, :pull:`1022`)
 
 Bug fixes
 ^^^^^^^^^

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,7 @@ History
 
 0.34.0 (unreleased)
 -------------------
-Contributors to this version: Pascal Bourgault (:user:`aulemahal`), Trevor James Smith (:user:`Zeitsperre`).
+Contributors to this version: Pascal Bourgault (:user:`aulemahal`), Trevor James Smith (:user:`Zeitsperre`), David Huard (:user:`huard`).
 
 Announcements
 ^^^^^^^^^^^^^
@@ -26,6 +26,7 @@ Breaking changes
     - The trailing dot (``.``) was dropped.
     - ``None`` inputs are now printed as "None" (and not "<NoneType>").
     - Arguments are now always shown as keyword-arguments. This mostly impacts ``sdba`` functions, as it was already the case for ``Indicators``.
+* The `cell_methods` string attribute appends only the operation from the indicator itself. In previous version, some indicators also appended the input data's own `cell_method`. The clix-meta importer has been modified to follow the same convention. (:issue:`983`)
 
 Bug fixes
 ^^^^^^^^^

--- a/xclim/core/utils.py
+++ b/xclim/core/utils.py
@@ -752,5 +752,7 @@ def adapt_clix_meta_yaml(raw: os.PathLike, adapted: os.PathLike):
     for cmid in remove_ids:
         del yml["indices"][cmid]
 
+    yml["indicators"] = yml.pop("indices")
+
     with open(adapted, "w") as f:
         safe_dump(yml, f)

--- a/xclim/core/utils.py
+++ b/xclim/core/utils.py
@@ -36,6 +36,14 @@ DayOfYearStr = NewType("DayOfYearStr", str)
 # Official variables definitions
 VARIABLES = safe_load(open_text("xclim.data", "variables.yml"))["variables"]
 
+# Input cell methods
+ICM = {
+    "tasmin": "time: minimum within days",
+    "tasmax": "time: maximum within days",
+    "tas": "time: mean within days",
+    "pr": "time: sum within days",
+}
+
 
 def wrapped_partial(
     func: FunctionType, suggested: Optional[dict] = None, **fixed
@@ -614,7 +622,7 @@ def adapt_clix_meta_yaml(raw: os.PathLike, adapted: os.PathLike):
     """Reads in a clix-meta yaml and refactors it to fit xclim's yaml specifications."""
     from xclim.indices import generic
 
-    freq_names = {"annual": "A", "seasonal": "Q", "monthly": "M", "weekly": "W"}
+    # freq_names = {"annual": "A", "seasonal": "Q", "monthly": "M", "weekly": "W"}
     freq_defs = {"annual": "YS", "seasonal": "QS-DEC", "monthly": "MS", "weekly": "W"}
 
     with open(raw) as f:
@@ -706,23 +714,32 @@ def adapt_clix_meta_yaml(raw: os.PathLike, adapted: os.PathLike):
                         # Value
                         data["parameters"][name] = f"{param['data']} {param['units']}"
 
-        period = data.pop("period")
-        data["allowed_periods"] = [freq_names[per] for per in period["allowed"].keys()]
-        data.setdefault("parameters", {})["freq"] = {
-            "default": freq_defs[period["default"]]
-        }
+        period = data.pop("default_period")
+        # data["allowed_periods"] = [freq_names[per] for per in period["allowed"].keys()]
+        data.setdefault("parameters", {})["freq"] = {"default": freq_defs[period]}
 
         attrs = {}
-        for attr, val in data.pop("output").items():
+        output = data.pop("output")
+        for attr, val in output.items():
             if val is None:
                 continue
             if attr == "cell_methods":
                 methods = []
-                for cell_method in val:
-                    methods.append(
-                        "".join([f"{dim}: {meth}" for dim, meth in cell_method.items()])
+                for i, cell_method in enumerate(val):
+                    # Construct cell_method string
+                    cm = "".join(
+                        [f"{dim}: {meth}" for dim, meth in cell_method.items()]
                     )
+
+                    # If cell_method seems to be describing input data, and not the operation, skip.
+                    if i == 0:
+                        if cm in [ICM.get(v) for v in data["input"].values()]:
+                            continue
+
+                    methods.append(cm)
+
                 val = " ".join(methods)
+
             elif attr in ["var_name", "long_name"]:
                 for new, old in rename_params.items():
                     val = val.replace(old, new)

--- a/xclim/data/cf.yml
+++ b/xclim/data/cf.yml
@@ -10,12 +10,15 @@ doc: "  ===================\n  CF Standard indices\n  ===================\n\n  I
   \ that are currently not well covered by the\n  CF Conventions. Currently identified\
   \ issues frequently relate to standard_name or/and cell_methods\n  which both are\
   \ controlled vocabularies of the CF Conventions.\n\n  .. _clix-meta: https://github.com/clix-meta/clix-meta\n"
-indicators:
+indices:
   cdd:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: sum over days'
+      long_name: Maximum consecutive dry days (Precip < 1mm)
+      proposed_standard_name: spell_length_with_lwe_thickness_of_precipitation_amount_below_threshold
+      standard_name: spell_length_of_days_with_lwe_thickness_of_precipitation_amount_below_threshold
+      units: day
+      var_name: cdd
     compute: spell_length
     input:
       data: pr
@@ -26,18 +29,13 @@ indicators:
       reducer: max
       threshold: 1 mm day-1
     references: ETCCDI
-    cf_attrs:
-      - cell_methods: 'time: sum within days time: sum over days'
-        long_name: Maximum consecutive dry days (Precip < 1mm)
-        proposed_standard_name: spell_length_with_lwe_thickness_of_precipitation_amount_below_threshold
-        standard_name: spell_length_of_days_with_lwe_thickness_of_precipitation_amount_below_threshold
-        units: day
-        var_name: cdd
   cddcoldTT:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: sum over days'
+      long_name: Cooling Degree Days (Tmean > {threshold}C)
+      standard_name: integral_wrt_time_of_air_temperature_excess
+      units: degree_Celsius day
+      var_name: cddcold{threshold}
     compute: temperature_sum
     input:
       data: tas
@@ -49,17 +47,14 @@ indicators:
         description: air temperature
         units: degree_Celsius
     references: ET-SCI
-    cf_attrs:
-      - cell_methods: 'time: mean within days time: sum over days'
-        long_name: Cooling Degree Days (Tmean > {threshold}C)
-        standard_name: integral_wrt_time_of_air_temperature_excess
-        units: degree_Celsius day
-        var_name: cddcold{threshold}
   cfd:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: maximum over days'
+      long_name: Maximum number of consecutive frost days (Tmin < 0 C)
+      proposed_standard_name: spell_length_with_air_temperature_below_threshold
+      standard_name: spell_length_of_days_with_air_temperature_below_threshold
+      units: day
+      var_name: cfd
     compute: count_occurrences
     input:
       data: tasmin
@@ -69,18 +64,14 @@ indicators:
         default: YS
       threshold: 0 degree_Celsius
     references: ECA&D
-    cf_attrs:
-      - cell_methods: 'time: minimum within days time: maximum over days'
-        long_name: Maximum number of consecutive frost days (Tmin < 0 C)
-        proposed_standard_name: spell_length_with_air_temperature_below_threshold
-        standard_name: spell_length_of_days_with_air_temperature_below_threshold
-        units: day
-        var_name: cfd
   csu:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: maximum over days'
+      long_name: Maximum number of consecutive summer days (Tmax >25 C)
+      proposed_standard_name: spell_length_with_air_temperature_above_threshold
+      standard_name: spell_length_of_days_with_air_temperature_above_threshold
+      units: day
+      var_name: csu
     compute: count_occurrences
     input:
       data: tasmax
@@ -90,18 +81,14 @@ indicators:
         default: YS
       threshold: 25 degree_Celsius
     references: ECA&D
-    cf_attrs:
-      - cell_methods: 'time: maximum within days time: maximum over days'
-        long_name: Maximum number of consecutive summer days (Tmax >25 C)
-        proposed_standard_name: spell_length_with_air_temperature_above_threshold
-        standard_name: spell_length_of_days_with_air_temperature_above_threshold
-        units: day
-        var_name: csu
   ctmgeTT:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: maximum over days'
+      long_name: Maximum number of consequtive days with Tmean >= {threshold}C
+      proposed_standard_name: spell_length_with_air_temperature_at_or_above_threshold
+      standard_name: spell_length_of_days_with_air_temperature_above_threshold
+      units: day
+      var_name: ctmge{threshold}
     compute: spell_length
     input:
       data: tas
@@ -114,18 +101,14 @@ indicators:
         description: air temperature
         units: degree_Celsius
     references: CLIPC
-    cf_attrs:
-      - cell_methods: 'time: mean within days time: maximum over days'
-        long_name: Maximum number of consequtive days with Tmean >= {threshold}C
-        proposed_standard_name: spell_length_with_air_temperature_at_or_above_threshold
-        standard_name: spell_length_of_days_with_air_temperature_above_threshold
-        units: day
-        var_name: ctmge{threshold}
   ctmgtTT:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: maximum over days'
+      long_name: Maximum number of consequtive days with Tmean > {threshold}C
+      proposed_standard_name: spell_length_with_air_temperature_above_threshold
+      standard_name: spell_length_of_days_with_air_temperature_above_threshold
+      units: day
+      var_name: ctmgt{threshold}
     compute: spell_length
     input:
       data: tas
@@ -138,18 +121,14 @@ indicators:
         description: air temperature
         units: degree_Celsius
     references: CLIPC
-    cf_attrs:
-      - cell_methods: 'time: mean within days time: maximum over days'
-        long_name: Maximum number of consequtive days with Tmean > {threshold}C
-        proposed_standard_name: spell_length_with_air_temperature_above_threshold
-        standard_name: spell_length_of_days_with_air_temperature_above_threshold
-        units: day
-        var_name: ctmgt{threshold}
   ctmleTT:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: maximum over days'
+      long_name: Maximum number of consequtive days with Tmean <= {threshold}C
+      proposed_standard_name: spell_length_with_air_temperature_at_or_below_threshold
+      standard_name: spell_length_of_days_with_air_temperature_below_threshold
+      units: day
+      var_name: ctmle{threshold}
     compute: spell_length
     input:
       data: tas
@@ -162,18 +141,14 @@ indicators:
         description: air temperature
         units: degree_Celsius
     references: CLIPC
-    cf_attrs:
-      - cell_methods: 'time: mean within days time: maximum over days'
-        long_name: Maximum number of consequtive days with Tmean <= {threshold}C
-        proposed_standard_name: spell_length_with_air_temperature_at_or_below_threshold
-        standard_name: spell_length_of_days_with_air_temperature_below_threshold
-        units: day
-        var_name: ctmle{threshold}
   ctmltTT:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: maximum over days'
+      long_name: Maximum number of consequtive days with Tmean < {threshold}C
+      proposed_standard_name: spell_length_with_air_temperature_below_threshold
+      standard_name: spell_length_of_days_with_air_temperature_below_threshold
+      units: day
+      var_name: ctmlt{threshold}
     compute: spell_length
     input:
       data: tas
@@ -186,18 +161,14 @@ indicators:
         description: air temperature
         units: degree_Celsius
     references: CLIPC
-    cf_attrs:
-      - cell_methods: 'time: mean within days time: maximum over days'
-        long_name: Maximum number of consequtive days with Tmean < {threshold}C
-        proposed_standard_name: spell_length_with_air_temperature_below_threshold
-        standard_name: spell_length_of_days_with_air_temperature_below_threshold
-        units: day
-        var_name: ctmlt{threshold}
   ctngeTT:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: maximum over days'
+      long_name: Maximum number of consequtive days with Tmin >= {threshold}C
+      proposed_standard_name: spell_length_with_air_temperature_at_or_above_threshold
+      standard_name: spell_length_of_days_with_air_temperature_above_threshold
+      units: day
+      var_name: ctnge{threshold}
     compute: spell_length
     input:
       data: tasmin
@@ -210,18 +181,14 @@ indicators:
         description: air temperature
         units: degree_Celsius
     references: CLIPC
-    cf_attrs:
-      - cell_methods: 'time: minimum within days time: maximum over days'
-        long_name: Maximum number of consequtive days with Tmin >= {threshold}C
-        proposed_standard_name: spell_length_with_air_temperature_at_or_above_threshold
-        standard_name: spell_length_of_days_with_air_temperature_above_threshold
-        units: day
-        var_name: ctnge{threshold}
   ctngtTT:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: maximum over days'
+      long_name: Maximum number of consequtive days with Tmin > {threshold}C
+      proposed_standard_name: spell_length_with_air_temperature_above_threshold
+      standard_name: spell_length_of_days_with_air_temperature_above_threshold
+      units: day
+      var_name: ctngt{threshold}
     compute: spell_length
     input:
       data: tasmin
@@ -234,18 +201,14 @@ indicators:
         description: air temperature
         units: degree_Celsius
     references: CLIPC
-    cf_attrs:
-      - cell_methods: 'time: minimum within days time: maximum over days'
-        long_name: Maximum number of consequtive days with Tmin > {threshold}C
-        proposed_standard_name: spell_length_with_air_temperature_above_threshold
-        standard_name: spell_length_of_days_with_air_temperature_above_threshold
-        units: day
-        var_name: ctngt{threshold}
   ctnleTT:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: maximum over days'
+      long_name: Maximum number of consequtive days with Tmin <= {threshold}C
+      proposed_standard_name: spell_length_with_air_temperature_at_or_below_threshold
+      standard_name: spell_length_of_days_with_air_temperature_below_threshold
+      units: day
+      var_name: ctnle{threshold}
     compute: spell_length
     input:
       data: tasmin
@@ -258,18 +221,14 @@ indicators:
         description: air temperature
         units: degree_Celsius
     references: CLIPC
-    cf_attrs:
-      - cell_methods: 'time: minimum within days time: maximum over days'
-        long_name: Maximum number of consequtive days with Tmin <= {threshold}C
-        proposed_standard_name: spell_length_with_air_temperature_at_or_below_threshold
-        standard_name: spell_length_of_days_with_air_temperature_below_threshold
-        units: day
-        var_name: ctnle{threshold}
   ctnltTT:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: maximum over days'
+      long_name: Maximum number of consequtive days with Tmin < {threshold}C
+      proposed_standard_name: spell_length_with_air_temperature_below_threshold
+      standard_name: spell_length_of_days_with_air_temperature_below_threshold
+      units: day
+      var_name: ctnlt{threshold}
     compute: spell_length
     input:
       data: tasmin
@@ -282,18 +241,14 @@ indicators:
         description: air temperature
         units: degree_Celsius
     references: CLIPC
-    cf_attrs:
-      - cell_methods: 'time: minimum within days time: maximum over days'
-        long_name: Maximum number of consequtive days with Tmin < {threshold}C
-        proposed_standard_name: spell_length_with_air_temperature_below_threshold
-        standard_name: spell_length_of_days_with_air_temperature_below_threshold
-        units: day
-        var_name: ctnlt{threshold}
   ctxgeTT:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: maximum over days'
+      long_name: Maximum number of consequtive days with Tmax >= {threshold}C
+      proposed_standard_name: spell_length_with_air_temperature_at_or_above_threshold
+      standard_name: spell_length_of_days_with_air_temperature_above_threshold
+      units: day
+      var_name: ctxge{threshold}
     compute: spell_length
     input:
       data: tasmax
@@ -306,18 +261,14 @@ indicators:
         description: air temperature
         units: degree_Celsius
     references: CLIPC
-    cf_attrs:
-      - cell_methods: 'time: maximum within days time: maximum over days'
-        long_name: Maximum number of consequtive days with Tmax >= {threshold}C
-        proposed_standard_name: spell_length_with_air_temperature_at_or_above_threshold
-        standard_name: spell_length_of_days_with_air_temperature_above_threshold
-        units: day
-        var_name: ctxge{threshold}
   ctxgtTT:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: maximum over days'
+      long_name: Maximum number of consequtive days with Tmax > {threshold}C
+      proposed_standard_name: spell_length_with_air_temperature_above_threshold
+      standard_name: spell_length_of_days_with_air_temperature_above_threshold
+      units: day
+      var_name: ctxgt{threshold}
     compute: spell_length
     input:
       data: tasmax
@@ -330,18 +281,14 @@ indicators:
         description: air temperature
         units: degree_Celsius
     references: CLIPC
-    cf_attrs:
-      - cell_methods: 'time: maximum within days time: maximum over days'
-        long_name: Maximum number of consequtive days with Tmax > {threshold}C
-        proposed_standard_name: spell_length_with_air_temperature_above_threshold
-        standard_name: spell_length_of_days_with_air_temperature_above_threshold
-        units: day
-        var_name: ctxgt{threshold}
   ctxleTT:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: maximum over days'
+      long_name: Maximum number of consequtive days with Tmax <= {threshold}C
+      proposed_standard_name: spell_length_with_air_temperature_at_or_below_threshold
+      standard_name: spell_length_of_days_with_air_temperature_below_threshold
+      units: day
+      var_name: ctxle{threshold}
     compute: spell_length
     input:
       data: tasmax
@@ -354,18 +301,14 @@ indicators:
         description: air temperature
         units: degree_Celsius
     references: CLIPC
-    cf_attrs:
-      - cell_methods: 'time: maximum within days time: maximum over days'
-        long_name: Maximum number of consequtive days with Tmax <= {threshold}C
-        proposed_standard_name: spell_length_with_air_temperature_at_or_below_threshold
-        standard_name: spell_length_of_days_with_air_temperature_below_threshold
-        units: day
-        var_name: ctxle{threshold}
   ctxltTT:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: maximum over days'
+      long_name: Maximum number of consequtive days with Tmax < {threshold}C
+      proposed_standard_name: spell_length_with_air_temperature_below_threshold
+      standard_name: spell_length_of_days_with_air_temperature_below_threshold
+      units: day
+      var_name: ctxlt{threshold}
     compute: spell_length
     input:
       data: tasmax
@@ -378,18 +321,14 @@ indicators:
         description: air temperature
         units: degree_Celsius
     references: CLIPC
-    cf_attrs:
-      - cell_methods: 'time: maximum within days time: maximum over days'
-        long_name: Maximum number of consequtive days with Tmax < {threshold}C
-        proposed_standard_name: spell_length_with_air_temperature_below_threshold
-        standard_name: spell_length_of_days_with_air_temperature_below_threshold
-        units: day
-        var_name: ctxlt{threshold}
   cwd:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: sum over days'
+      long_name: Maximum consecutive wet days (Precip >= 1mm)
+      proposed_standard_name: spell_length_with_lwe_thickness_of_precipitation_amount_at_or_above_threshold
+      standard_name: spell_length_of_days_with_lwe_thickness_of_precipitation_amount_above_threshold
+      units: day
+      var_name: cwd
     compute: spell_length
     input:
       data: pr
@@ -400,18 +339,13 @@ indicators:
       reducer: max
       threshold: 1 mm day-1
     references: ETCCDI
-    cf_attrs:
-      - cell_methods: 'time: sum within days time: sum over days'
-        long_name: Maximum consecutive wet days (Precip >= 1mm)
-        proposed_standard_name: spell_length_with_lwe_thickness_of_precipitation_amount_at_or_above_threshold
-        standard_name: spell_length_of_days_with_lwe_thickness_of_precipitation_amount_above_threshold
-        units: day
-        var_name: cwd
   ddgtTT:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: sum over days'
+      long_name: Degree Days (Tmean > {threshold}C)
+      standard_name: integral_wrt_time_of_air_temperature_excess
+      units: degree_Celsius day
+      var_name: ddgt{threshold}
     compute: temperature_sum
     input:
       data: tas
@@ -423,17 +357,13 @@ indicators:
         description: air temperature
         units: degree_Celsius
     references: CLIPC
-    cf_attrs:
-      - cell_methods: 'time: mean within days time: sum over days'
-        long_name: Degree Days (Tmean > {threshold}C)
-        standard_name: integral_wrt_time_of_air_temperature_excess
-        units: degree_Celsius day
-        var_name: ddgt{threshold}
   ddltTT:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: sum over days'
+      long_name: Degree Days (Tmean < {threshold}C)
+      standard_name: integral_wrt_time_of_air_temperature_deficit
+      units: degree_Celsius day
+      var_name: ddlt{threshold}
     compute: temperature_sum
     input:
       data: tas
@@ -445,17 +375,13 @@ indicators:
         description: air temperature
         units: degree_Celsius
     references: CLIPC
-    cf_attrs:
-      - cell_methods: 'time: mean within days time: sum over days'
-        long_name: Degree Days (Tmean < {threshold}C)
-        standard_name: integral_wrt_time_of_air_temperature_deficit
-        units: degree_Celsius day
-        var_name: ddlt{threshold}
   dtr:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: range within days time: mean over days'
+      long_name: Mean Diurnal Temperature Range
+      proposed_standard_name: air_temperature_range
+      units: degree_Celsius
+      var_name: dtr
     compute: diurnal_temperature_range
     input:
       high_data: tasmax
@@ -465,17 +391,13 @@ indicators:
         default: MS
       reducer: mean
     references: ETCCDI
-    cf_attrs:
-      - cell_methods: 'time: range within days time: mean over days'
-        long_name: Mean Diurnal Temperature Range
-        proposed_standard_name: air_temperature_range
-        units: degree_Celsius
-        var_name: dtr
   etr:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: range'
+      long_name: Intra-period extreme temperature range
+      proposed_standard_name: air_temperature_range
+      units: degree_Celsius
+      var_name: etr
     compute: extreme_temperature_range
     input:
       high_data: tasmax
@@ -484,17 +406,13 @@ indicators:
       freq:
         default: MS
     references: ECA&D
-    cf_attrs:
-      - cell_methods: 'time: range'
-        long_name: Intra-period extreme temperature range
-        proposed_standard_name: air_temperature_range
-        units: degree_Celsius
-        var_name: etr
   fg:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: mean'
+      long_name: Mean of daily mean wind strength
+      standard_name: wind_speed
+      units: meter second-1
+      var_name: fg
     compute: statistics
     input:
       data: sfcWind
@@ -503,17 +421,13 @@ indicators:
         default: MS
       reducer: mean
     references: ECA&D
-    cf_attrs:
-      - cell_methods: 'time: mean'
-        long_name: Mean of daily mean wind strength
-        standard_name: wind_speed
-        units: meter second-1
-        var_name: fg
   fxx:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: maximum'
+      long_name: Maximum value of daily maximum wind gust strength
+      standard_name: wind_speed_of_gust
+      units: meter second-1
+      var_name: fxx
     compute: statistics
     input:
       data: wsgsmax
@@ -522,17 +436,13 @@ indicators:
         default: MS
       reducer: max
     references: ECA&D
-    cf_attrs:
-      - cell_methods: 'time: maximum'
-        long_name: Maximum value of daily maximum wind gust strength
-        standard_name: wind_speed_of_gust
-        units: meter second-1
-        var_name: fxx
   gd4:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: sum over days'
+      long_name: Growing degree days (sum of Tmean > 4 C)
+      standard_name: integral_wrt_time_of_air_temperature_excess
+      units: degree_Celsius day
+      var_name: gd4
     compute: temperature_sum
     input:
       data: tas
@@ -542,15 +452,13 @@ indicators:
         default: YS
       threshold: 4 degree_Celsius
     references: ECA&D
-    cf_attrs:
-      - cell_methods: 'time: mean within days time: sum over days'
-        long_name: Growing degree days (sum of Tmean > 4 C)
-        standard_name: integral_wrt_time_of_air_temperature_excess
-        units: degree_Celsius day
-        var_name: gd4
   gddgrowTT:
-    allowed_periods:
-      - A
+    cf_attrs:
+    - cell_methods: 'time: sum over days'
+      long_name: Annual Growing Degree Days (Tmean > {threshold}C)
+      standard_name: integral_wrt_time_of_air_temperature_excess
+      units: degree_Celsius day
+      var_name: gddgrow{threshold}
     compute: temperature_sum
     input:
       data: tas
@@ -562,17 +470,13 @@ indicators:
         description: air temperature
         units: degree_Celsius
     references: ET-SCI
-    cf_attrs:
-      - cell_methods: 'time: mean within days time: sum over days'
-        long_name: Annual Growing Degree Days (Tmean > {threshold}C)
-        standard_name: integral_wrt_time_of_air_temperature_excess
-        units: degree_Celsius day
-        var_name: gddgrow{threshold}
   hd17:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: sum over days'
+      long_name: Heating degree days (sum of Tmean < 17 C)
+      standard_name: integral_wrt_time_of_air_temperature_excess
+      units: degree_Celsius day
+      var_name: hd17
     compute: temperature_sum
     input:
       data: tas
@@ -582,17 +486,13 @@ indicators:
         default: YS
       threshold: 17 degree_Celsius
     references: ECA&D
-    cf_attrs:
-      - cell_methods: 'time: mean within days time: sum over days'
-        long_name: Heating degree days (sum of Tmean < 17 C)
-        standard_name: integral_wrt_time_of_air_temperature_excess
-        units: degree_Celsius day
-        var_name: hd17
   hddheatTT:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: sum over days'
+      long_name: Heating Degree Days (Tmean < {threshold}C)
+      standard_name: integral_wrt_time_of_air_temperature_deficit
+      units: degree_Celsius day
+      var_name: hddheat{threshold}
     compute: temperature_sum
     input:
       data: tas
@@ -604,17 +504,13 @@ indicators:
         description: air temperature
         units: degree_Celsius
     references: ET-SCI
-    cf_attrs:
-      - cell_methods: 'time: mean within days time: sum over days'
-        long_name: Heating Degree Days (Tmean < {threshold}C)
-        standard_name: integral_wrt_time_of_air_temperature_deficit
-        units: degree_Celsius day
-        var_name: hddheat{threshold}
   maxdtr:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: range within days time: maximum over days'
+      long_name: Maximum Diurnal Temperature Range
+      proposed_standard_name: air_temperature_range
+      units: degree_Celsius
+      var_name: maxdtr
     compute: diurnal_temperature_range
     input:
       high_data: tasmax
@@ -624,17 +520,13 @@ indicators:
         default: MS
       reducer: max
     references: SMHI
-    cf_attrs:
-      - cell_methods: 'time: range within days time: maximum over days'
-        long_name: Maximum Diurnal Temperature Range
-        proposed_standard_name: air_temperature_range
-        units: degree_Celsius
-        var_name: maxdtr
   pp:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: mean'
+      long_name: Mean of daily sea level pressure
+      standard_name: air_pressure_at_sea_level
+      units: hPa
+      var_name: pp
     compute: statistics
     input:
       data: psl
@@ -643,17 +535,13 @@ indicators:
         default: MS
       reducer: mean
     references: ECA&D
-    cf_attrs:
-      - cell_methods: 'time: mean'
-        long_name: Mean of daily sea level pressure
-        standard_name: air_pressure_at_sea_level
-        units: hPa
-        var_name: pp
   rh:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: mean'
+      long_name: Mean of daily relative humidity
+      standard_name: relative_humidity
+      units: '%'
+      var_name: rh
     compute: statistics
     input:
       data: hurs
@@ -662,17 +550,13 @@ indicators:
         default: MS
       reducer: mean
     references: ECA&D
-    cf_attrs:
-      - cell_methods: 'time: mean'
-        long_name: Mean of daily relative humidity
-        standard_name: relative_humidity
-        units: '%'
-        var_name: rh
   sd:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: mean'
+      long_name: Mean of daily snow depth
+      standard_name: surface_snow_thickness
+      units: cm
+      var_name: sd
     compute: statistics
     input:
       data: snd
@@ -681,17 +565,13 @@ indicators:
         default: MS
       reducer: mean
     references: ECA&D
-    cf_attrs:
-      - cell_methods: 'time: mean'
-        long_name: Mean of daily snow depth
-        standard_name: surface_snow_thickness
-        units: cm
-        var_name: sd
   sdii:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: mean over days'
+      long_name: Average precipitation during Wet Days (SDII)
+      standard_name: lwe_precipitation_rate
+      units: mm day-1
+      var_name: sdii
     compute: thresholded_statistics
     input:
       data: pr
@@ -702,17 +582,12 @@ indicators:
       reducer: mean
       threshold: 1 mm day-1
     references: ETCCDI
-    cf_attrs:
-      - cell_methods: 'time: sum within days time: mean over days'
-        long_name: Average precipitation during Wet Days (SDII)
-        standard_name: lwe_precipitation_rate
-        units: mm day-1
-        var_name: sdii
   ss:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - long_name: Sunshine duration, sum
+      standard_name: duration_of_sunshine
+      units: hour
+      var_name: ss
     compute: statistics
     input:
       data: sund
@@ -721,16 +596,13 @@ indicators:
         default: MS
       reducer: sum
     references: ECA&D
-    cf_attrs:
-      - long_name: Sunshine duration, sum
-        standard_name: duration_of_sunshine
-        units: hour
-        var_name: ss
   tg:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: mean'
+      long_name: Mean of daily mean temperature
+      standard_name: air_temperature
+      units: degree_Celsius
+      var_name: tg
     compute: statistics
     input:
       data: tas
@@ -739,17 +611,13 @@ indicators:
         default: MS
       reducer: mean
     references: ECA&D
-    cf_attrs:
-      - cell_methods: 'time: mean'
-        long_name: Mean of daily mean temperature
-        standard_name: air_temperature
-        units: degree_Celsius
-        var_name: tg
   tmm:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: mean over days'
+      long_name: Mean daily mean temperature
+      standard_name: air_temperature
+      units: degree_Celsius
+      var_name: tmm
     compute: statistics
     input:
       data: tas
@@ -758,17 +626,13 @@ indicators:
         default: YS
       reducer: mean
     references: null
-    cf_attrs:
-      - cell_methods: 'time: mean within days time: mean over days'
-        long_name: Mean daily mean temperature
-        standard_name: air_temperature
-        units: degree_Celsius
-        var_name: tmm
   tmmax:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: maximum over days'
+      long_name: Maximum daily mean temperature
+      standard_name: air_temperature
+      units: degree_Celsius
+      var_name: tmmax
     compute: statistics
     input:
       data: tas
@@ -777,17 +641,13 @@ indicators:
         default: YS
       reducer: max
     references: CLIPC
-    cf_attrs:
-      - cell_methods: 'time: mean within days time: maximum over days'
-        long_name: Maximum daily mean temperature
-        standard_name: air_temperature
-        units: degree_Celsius
-        var_name: tmmax
   tmmean:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: mean over days'
+      long_name: Mean daily mean temperature
+      standard_name: air_temperature
+      units: degree_Celsius
+      var_name: tmmean
     compute: statistics
     input:
       data: tas
@@ -796,17 +656,13 @@ indicators:
         default: YS
       reducer: mean
     references: CLIPC
-    cf_attrs:
-      - cell_methods: 'time: mean within days time: mean over days'
-        long_name: Mean daily mean temperature
-        standard_name: air_temperature
-        units: degree_Celsius
-        var_name: tmmean
   tmmin:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: maximum over days'
+      long_name: Minimum daily mean temperature
+      standard_name: air_temperature
+      units: degree_Celsius
+      var_name: tmmin
     compute: statistics
     input:
       data: tas
@@ -815,17 +671,13 @@ indicators:
         default: YS
       reducer: min
     references: CLIPC
-    cf_attrs:
-      - cell_methods: 'time: mean within days time: maximum over days'
-        long_name: Minimum daily mean temperature
-        standard_name: air_temperature
-        units: degree_Celsius
-        var_name: tmmin
   tmn:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: minimum over days'
+      long_name: Minimum daily mean temperature
+      standard_name: air_temperature
+      units: degree_Celsius
+      var_name: tmn
     compute: statistics
     input:
       data: tas
@@ -834,17 +686,13 @@ indicators:
         default: YS
       reducer: min
     references: null
-    cf_attrs:
-      - cell_methods: 'time: mean within days time: minimum over days'
-        long_name: Minimum daily mean temperature
-        standard_name: air_temperature
-        units: degree_Celsius
-        var_name: tmn
   tmx:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: maximum over days'
+      long_name: Maximum daily mean temperature
+      standard_name: air_temperature
+      units: degree_Celsius
+      var_name: tmx
     compute: statistics
     input:
       data: tas
@@ -853,17 +701,13 @@ indicators:
         default: YS
       reducer: max
     references: null
-    cf_attrs:
-      - cell_methods: 'time: mean within days time: maximum over days'
-        long_name: Maximum daily mean temperature
-        standard_name: air_temperature
-        units: degree_Celsius
-        var_name: tmx
   tn:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: mean'
+      long_name: Mean of daily minimum temperature
+      standard_name: air_temperature
+      units: degree_Celsius
+      var_name: tn
     compute: statistics
     input:
       data: tasmin
@@ -872,17 +716,13 @@ indicators:
         default: MS
       reducer: mean
     references: ECA&D
-    cf_attrs:
-      - cell_methods: 'time: mean'
-        long_name: Mean of daily minimum temperature
-        standard_name: air_temperature
-        units: degree_Celsius
-        var_name: tn
   tnm:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: mean over days'
+      long_name: Mean daily minimum temperature
+      standard_name: air_temperature
+      units: degree_Celsius
+      var_name: tnm
     compute: statistics
     input:
       data: tasmin
@@ -891,17 +731,13 @@ indicators:
         default: YS
       reducer: mean
     references: null
-    cf_attrs:
-      - cell_methods: 'time: minimum within days time: mean over days'
-        long_name: Mean daily minimum temperature
-        standard_name: air_temperature
-        units: degree_Celsius
-        var_name: tnm
   tnmax:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: maximum over days'
+      long_name: Maximum daily minimum temperature
+      standard_name: air_temperature
+      units: degree_Celsius
+      var_name: tnmax
     compute: statistics
     input:
       data: tasmin
@@ -910,17 +746,13 @@ indicators:
         default: YS
       reducer: max
     references: CLIPC
-    cf_attrs:
-      - cell_methods: 'time: minimum within days time: maximum over days'
-        long_name: Maximum daily minimum temperature
-        standard_name: air_temperature
-        units: degree_Celsius
-        var_name: tnmax
   tnmean:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: mean over days'
+      long_name: Mean daily minimum temperature
+      standard_name: air_temperature
+      units: degree_Celsius
+      var_name: tnmean
     compute: statistics
     input:
       data: tasmin
@@ -929,17 +761,13 @@ indicators:
         default: YS
       reducer: mean
     references: CLIPC
-    cf_attrs:
-      - cell_methods: 'time: minimum within days time: mean over days'
-        long_name: Mean daily minimum temperature
-        standard_name: air_temperature
-        units: degree_Celsius
-        var_name: tnmean
   tnmin:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: minimum over days'
+      long_name: Minimum daily minimum temperature
+      standard_name: air_temperature
+      units: degree_Celsius
+      var_name: tnmin
     compute: statistics
     input:
       data: tasmin
@@ -948,17 +776,13 @@ indicators:
         default: YS
       reducer: min
     references: CLIPC
-    cf_attrs:
-      - cell_methods: 'time: minimum within days time: minimum over days'
-        long_name: Minimum daily minimum temperature
-        standard_name: air_temperature
-        units: degree_Celsius
-        var_name: tnmin
   tnn:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: minimum over days'
+      long_name: Minimum daily minimum temperature
+      standard_name: air_temperature
+      units: degree_Celsius
+      var_name: tnn
     compute: statistics
     input:
       data: tasmin
@@ -967,17 +791,13 @@ indicators:
         default: YS
       reducer: min
     references: ETCCDI
-    cf_attrs:
-      - cell_methods: 'time: minimum within days time: minimum over days'
-        long_name: Minimum daily minimum temperature
-        standard_name: air_temperature
-        units: degree_Celsius
-        var_name: tnn
   tnx:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: maximum over days'
+      long_name: Maximum daily minimum temperature
+      standard_name: air_temperature
+      units: degree_Celsius
+      var_name: tnx
     compute: statistics
     input:
       data: tasmin
@@ -986,17 +806,13 @@ indicators:
         default: YS
       reducer: max
     references: ETCCDI
-    cf_attrs:
-      - cell_methods: 'time: minimum within days time: maximum over days'
-        long_name: Maximum daily minimum temperature
-        standard_name: air_temperature
-        units: degree_Celsius
-        var_name: tnx
   tx:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: mean'
+      long_name: Mean of daily maximum temperature
+      standard_name: air_temperature
+      units: degree_Celsius
+      var_name: tx
     compute: statistics
     input:
       data: tasmax
@@ -1005,17 +821,13 @@ indicators:
         default: MS
       reducer: mean
     references: ECA&D
-    cf_attrs:
-      - cell_methods: 'time: mean'
-        long_name: Mean of daily maximum temperature
-        standard_name: air_temperature
-        units: degree_Celsius
-        var_name: tx
   txm:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: mean over days'
+      long_name: Mean daily maximum temperature
+      standard_name: air_temperature
+      units: degree_Celsius
+      var_name: txm
     compute: statistics
     input:
       data: tasmax
@@ -1024,17 +836,13 @@ indicators:
         default: YS
       reducer: mean
     references: null
-    cf_attrs:
-      - cell_methods: 'time: maximum within days time: mean over days'
-        long_name: Mean daily maximum temperature
-        standard_name: air_temperature
-        units: degree_Celsius
-        var_name: txm
   txmax:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: maximum over days'
+      long_name: Maximum daily maximum temperature
+      standard_name: air_temperature
+      units: degree_Celsius
+      var_name: txmax
     compute: statistics
     input:
       data: tasmax
@@ -1043,17 +851,13 @@ indicators:
         default: YS
       reducer: max
     references: CLIPC
-    cf_attrs:
-      - cell_methods: 'time: maximum within days time: maximum over days'
-        long_name: Maximum daily maximum temperature
-        standard_name: air_temperature
-        units: degree_Celsius
-        var_name: txmax
   txmean:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: mean over days'
+      long_name: Mean daily maximum temperature
+      standard_name: air_temperature
+      units: degree_Celsius
+      var_name: txmean
     compute: statistics
     input:
       data: tasmax
@@ -1062,17 +866,13 @@ indicators:
         default: YS
       reducer: mean
     references: CLIPC
-    cf_attrs:
-      - cell_methods: 'time: maximum within days time: mean over days'
-        long_name: Mean daily maximum temperature
-        standard_name: air_temperature
-        units: degree_Celsius
-        var_name: txmean
   txmin:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: minimum over days'
+      long_name: Minimum daily maximum temperature
+      standard_name: air_temperature
+      units: degree_Celsius
+      var_name: txmin
     compute: statistics
     input:
       data: tasmax
@@ -1081,17 +881,13 @@ indicators:
         default: YS
       reducer: min
     references: CLIPC
-    cf_attrs:
-      - cell_methods: 'time: maximum within days time: minimum over days'
-        long_name: Minimum daily maximum temperature
-        standard_name: air_temperature
-        units: degree_Celsius
-        var_name: txmin
   txn:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: minimum over days'
+      long_name: Minimum daily maximum temperature
+      standard_name: air_temperature
+      units: degree_Celsius
+      var_name: txn
     compute: statistics
     input:
       data: tasmax
@@ -1100,17 +896,13 @@ indicators:
         default: YS
       reducer: min
     references: ETCCDI
-    cf_attrs:
-      - cell_methods: 'time: maximum within days time: minimum over days'
-        long_name: Minimum daily maximum temperature
-        standard_name: air_temperature
-        units: degree_Celsius
-        var_name: txn
   txx:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - cell_methods: 'time: maximum over days'
+      long_name: Maximum daily maximum temperature
+      standard_name: air_temperature
+      units: degree_Celsius
+      var_name: txx
     compute: statistics
     input:
       data: tasmax
@@ -1119,17 +911,12 @@ indicators:
         default: YS
       reducer: max
     references: ETCCDI
-    cf_attrs:
-      - cell_methods: 'time: maximum within days time: maximum over days'
-        long_name: Maximum daily maximum temperature
-        standard_name: air_temperature
-        units: degree_Celsius
-        var_name: txx
   vdtr:
-    allowed_periods:
-      - A
-      - Q
-      - M
+    cf_attrs:
+    - long_name: Mean day-to-day variation in Diurnal Temperature Range
+      proposed_standard_name: air_temperature_difference
+      units: degree_Celsius
+      var_name: vdtr
     compute: interday_diurnal_temperature_range
     input:
       high_data: tasmax
@@ -1138,10 +925,5 @@ indicators:
       freq:
         default: MS
     references: ECA&D
-    cf_attrs:
-      - long_name: Mean day-to-day variation in Diurnal Temperature Range
-        proposed_standard_name: air_temperature_difference
-        units: degree_Celsius
-        var_name: vdtr
 realm: atmos
 references: clix-meta https://github.com/clix-meta/clix-meta

--- a/xclim/data/cf.yml
+++ b/xclim/data/cf.yml
@@ -10,7 +10,7 @@ doc: "  ===================\n  CF Standard indices\n  ===================\n\n  I
   \ that are currently not well covered by the\n  CF Conventions. Currently identified\
   \ issues frequently relate to standard_name or/and cell_methods\n  which both are\
   \ controlled vocabularies of the CF Conventions.\n\n  .. _clix-meta: https://github.com/clix-meta/clix-meta\n"
-indices:
+indicators:
   cdd:
     cf_attrs:
     - cell_methods: 'time: sum over days'

--- a/xclim/indicators/atmos/_precip.py
+++ b/xclim/indicators/atmos/_precip.py
@@ -88,7 +88,7 @@ max_1day_precipitation_amount = Precip(
     standard_name="lwe_thickness_of_precipitation_amount",
     long_name="maximum 1-day total precipitation",
     description="{freq} maximum 1-day total precipitation",
-    cell_methods="time: sum within days time: maximum over days",
+    cell_methods="time: maximum over days",
     compute=indices.max_1day_precipitation_amount,
 )
 
@@ -99,7 +99,7 @@ max_n_day_precipitation_amount = Precip(
     standard_name="lwe_thickness_of_precipitation_amount",
     long_name="maximum {window}-day total precipitation",
     description="{freq} maximum {window}-day total precipitation.",
-    cell_methods="time: sum within days time: maximum over days",
+    cell_methods="time: maximum over days",
     compute=indices.max_n_day_precipitation_amount,
 )
 
@@ -109,7 +109,7 @@ wetdays = Precip(
     standard_name="number_of_days_with_lwe_thickness_of_precipitation_amount_at_or_above_threshold",
     long_name="Number of wet days (precip >= {thresh})",
     description="{freq} number of days with daily precipitation over {thresh}.",
-    cell_methods="time: sum within days time: sum over days",
+    cell_methods="time: sum over days",
     compute=indices.wetdays,
 )
 
@@ -118,7 +118,7 @@ wetdays_prop = Precip(
     units="1",
     long_name="Proportion of wet days (precip >= {thresh})",
     description="{freq} proportion of days with precipitation over {thresh}.",
-    cell_methods="time: sum within days time: sum over days",
+    cell_methods="time: sum over days",
     compute=indices.wetdays_prop,
 )
 
@@ -128,7 +128,7 @@ dry_days = Precip(
     standard_name="number_of_days_with_lwe_thickness_of_precipitation_amount_below_threshold",
     long_name="Number of dry days (precip < {thresh})",
     description="{freq} number of days with daily precipitation under {thresh}.",
-    cell_methods="time: sum within days time: sum over days",
+    cell_methods="time: sum over days",
     compute=indices.dry_days,
 )
 
@@ -140,7 +140,7 @@ maximum_consecutive_wet_days = Precip(
     long_name="Maximum consecutive wet days (Precip >= {thresh})",
     description="{freq} maximum number of consecutive days with daily "
     "precipitation over {thresh}.",
-    cell_methods="time: sum within days time: sum over days",
+    cell_methods="time: sum over days",
     compute=indices.maximum_consecutive_wet_days,
 )
 
@@ -152,7 +152,7 @@ maximum_consecutive_dry_days = Precip(
     long_name="Maximum consecutive dry days (Precip < {thresh})",
     description="{freq} maximum number of consecutive days with daily "
     "precipitation below {thresh}.",
-    cell_methods="time: sum within days time: sum over days",
+    cell_methods="time: sum over days",
     compute=indices.maximum_consecutive_dry_days,
 )
 
@@ -187,7 +187,7 @@ precip_accumulation = Precip(
     standard_name="lwe_thickness_of_precipitation_amount",
     long_name="Total precipitation",
     description="{freq} total precipitation",
-    cell_methods="time: sum within days time: sum over days",
+    cell_methods="time: sum over days",
     compute=indices.precip_accumulation,
     parameters=dict(tas=None, phase=None),
 )
@@ -199,7 +199,7 @@ wet_precip_accumulation = Precip(
     standard_name="lwe_thickness_of_precipitation_amount",
     long_name="Total precipitation",
     description="{freq} total precipitation over wet days, defined as days where precipitation exceeds {thresh}.",
-    cell_methods="time: sum within days time: sum over days",
+    cell_methods="time: sum over days",
     compute=indices.prcptot,
     parameters={"thresh": {"default": "1 mm/day"}},
 )
@@ -211,7 +211,7 @@ liquid_precip_accumulation = PrTasx(
     standard_name="lwe_thickness_of_liquid_precipitation_amount",
     long_name="Total liquid precipitation",
     description="{freq} total {phase} precipitation, estimated as precipitation when temperature >= {thresh}",
-    cell_methods="time: sum within days time: sum over days",
+    cell_methods="time: sum over days",
     compute=indices.precip_accumulation,
     parameters={"tas": {"kind": InputKind.VARIABLE}, "phase": "liquid"},
 )
@@ -223,7 +223,7 @@ solid_precip_accumulation = PrTasx(
     standard_name="lwe_thickness_of_snowfall_amount",
     long_name="Total solid precipitation",
     description="{freq} total solid precipitation, estimated as precipitation when temperature < {thresh}",
-    cell_methods="time: sum within days time: sum over days",
+    cell_methods="time: sum over days",
     compute=indices.precip_accumulation,
     parameters={"tas": {"kind": InputKind.VARIABLE}, "phase": "solid"},
 )

--- a/xclim/indicators/atmos/_preciptemp.py
+++ b/xclim/indicators/atmos/_preciptemp.py
@@ -21,7 +21,7 @@ cold_and_dry_days = PrecipTemp(
     long_name="Cold and dry days",
     title="Cold and dry days",
     description="{freq} number of days where tas < 25th percentile and pr < 25th percentile",
-    cell_methods="time: mean within days time: sum over days",
+    cell_methods="time: sum over days",
     compute=indices.cold_and_dry_days,
 )
 
@@ -31,7 +31,7 @@ warm_and_dry_days = PrecipTemp(
     long_name="warm and dry days",
     title="warm and dry days",
     description="{freq} number of days where tas > 75th percentile and pr < 25th percentile",
-    cell_methods="time: mean within days time: sum over days",
+    cell_methods="time: sum over days",
     compute=indices.warm_and_dry_days,
 )
 
@@ -41,7 +41,7 @@ warm_and_wet_days = PrecipTemp(
     long_name="warm and wet days",
     title="warm and wet days",
     description="{freq} number of days where tas > 75th percentile and pr > 75th percentile",
-    cell_methods="time: mean within days time: sum over days",
+    cell_methods="time: sum over days",
     compute=indices.warm_and_wet_days,
 )
 
@@ -51,6 +51,6 @@ cold_and_wet_days = PrecipTemp(
     long_name="cold and wet days",
     title="cold and wet days",
     description="{freq} number of days where tas < 25th percentile and pr > 75th percentile",
-    cell_methods="time: mean within days time: sum over days",
+    cell_methods="time: sum over days",
     compute=indices.cold_and_wet_days,
 )

--- a/xclim/indicators/atmos/_temperature.py
+++ b/xclim/indicators/atmos/_temperature.py
@@ -96,7 +96,7 @@ tn_days_above = TempWithIndexing(
     standard_name="number_of_days_with_air_temperature_above_threshold",
     long_name="Number of days with Tmin > {thresh}",
     description="{freq} number of days where daily minimum temperature exceeds {thresh}.",
-    cell_methods="time: minimum within days time: sum over days",
+    cell_methods="time: sum over days",
     compute=indices.tn_days_above,
 )
 
@@ -106,7 +106,7 @@ tn_days_below = TempWithIndexing(
     standard_name="number_of_days_with_air_temperature_below_threshold",
     long_name="Number of days with Tmin < {thresh}",
     description="{freq} number of days where daily minimum temperature is below {thresh}.",
-    cell_methods="time: minimum within days time: sum over days",
+    cell_methods="time: sum over days",
     compute=indices.tn_days_below,
 )
 
@@ -116,7 +116,7 @@ tg_days_above = TempWithIndexing(
     standard_name="number_of_days_with_air_temperature_above_threshold",
     long_name="Number of days with Tavg > {thresh}",
     description="{freq} number of days where daily mean temperature exceeds {thresh}.",
-    cell_methods="time: mean within days time: sum over days",
+    cell_methods="time: sum over days",
     compute=indices.tg_days_above,
 )
 
@@ -126,7 +126,7 @@ tg_days_below = TempWithIndexing(
     standard_name="number_of_days_with_air_temperature_below_threshold",
     long_name="Number of days with Tavg < {thresh}",
     description="{freq} number of days where daily mean temperature is below {thresh}.",
-    cell_methods="time: mean within days time: sum over days",
+    cell_methods="time: sum over days",
     compute=indices.tg_days_below,
 )
 
@@ -136,7 +136,7 @@ tx_days_above = TempWithIndexing(
     standard_name="number_of_days_with_air_temperature_above_threshold",
     long_name="Number of days with Tmax > {thresh}",
     description="{freq} number of days where daily maximum temperature exceeds {thresh}.",
-    cell_methods="time: maximum within days time: sum over days",
+    cell_methods="time: sum over days",
     compute=indices.tx_days_above,
 )
 
@@ -146,7 +146,7 @@ tx_days_below = TempWithIndexing(
     standard_name="number_of_days_with_air_temperature_below_threshold",
     long_name="Number of days with Tmax < {thresh}",
     description="{freq} number of days where daily max temperature is below {thresh}.",
-    cell_methods="time: max within days time: sum over days",
+    cell_methods="time: sum over days",
     compute=indices.tx_days_below,
 )
 
@@ -255,7 +255,7 @@ tg_mean = TempWithIndexing(
     standard_name="air_temperature",
     long_name="Mean daily mean temperature",
     description="{freq} mean of daily mean temperature.",
-    cell_methods="time: mean within days time: mean over days",
+    cell_methods="time: mean over days",
     compute=indices.tg_mean,
 )
 
@@ -265,7 +265,7 @@ tg_max = TempWithIndexing(
     standard_name="air_temperature",
     long_name="Maximum daily mean temperature",
     description="{freq} maximum of daily mean temperature.",
-    cell_methods="time: mean within days time: maximum over days",
+    cell_methods="time: maximum over days",
     compute=indices.tg_max,
 )
 
@@ -275,7 +275,7 @@ tg_min = TempWithIndexing(
     standard_name="air_temperature",
     long_name="Minimum daily mean temperature",
     description="{freq} minimum of daily mean temperature.",
-    cell_methods="time: mean within days time: minimum over days",
+    cell_methods="time: minimum over days",
     compute=indices.tg_min,
 )
 
@@ -285,7 +285,7 @@ tx_mean = TempWithIndexing(
     standard_name="air_temperature",
     long_name="Mean daily maximum temperature",
     description="{freq} mean of daily maximum temperature.",
-    cell_methods="time: maximum within days time: mean over days",
+    cell_methods="time: mean over days",
     compute=indices.tx_mean,
 )
 
@@ -295,7 +295,7 @@ tx_max = TempWithIndexing(
     standard_name="air_temperature",
     long_name="Maximum daily maximum temperature",
     description="{freq} maximum of daily maximum temperature.",
-    cell_methods="time: maximum within days time: maximum over days",
+    cell_methods="time: maximum over days",
     compute=indices.tx_max,
 )
 
@@ -305,7 +305,7 @@ tx_min = TempWithIndexing(
     standard_name="air_temperature",
     long_name="Minimum daily maximum temperature",
     description="{freq} minimum of daily maximum temperature.",
-    cell_methods="time: maximum within days time: minimum over days",
+    cell_methods="time: minimum over days",
     compute=indices.tx_min,
 )
 
@@ -315,7 +315,7 @@ tn_mean = TempWithIndexing(
     standard_name="air_temperature",
     long_name="Mean daily minimum temperature",
     description="{freq} mean of daily minimum temperature.",
-    cell_methods="time: minimum within days time: mean over days",
+    cell_methods="time: mean over days",
     compute=indices.tn_mean,
 )
 
@@ -325,7 +325,7 @@ tn_max = TempWithIndexing(
     standard_name="air_temperature",
     long_name="Maximum daily minimum temperature",
     description="{freq} maximum of daily minimum temperature.",
-    cell_methods="time: minimum within days time: maximum over days",
+    cell_methods="time: maximum over days",
     compute=indices.tn_max,
 )
 
@@ -335,7 +335,7 @@ tn_min = TempWithIndexing(
     standard_name="air_temperature",
     long_name="Minimum daily minimum temperature",
     description="{freq} minimum of daily minimum temperature.",
-    cell_methods="time: minimum within days time: minimum over days",
+    cell_methods="time: minimum over days",
     compute=indices.tn_min,
 )
 
@@ -430,7 +430,7 @@ cool_night_index = Temp(
     units="degC",
     long_name="cool night index",
     description="Mean minimum temperature for September (northern hemisphere) or March (southern hemisphere).",
-    cell_methods="time: min within days time: mean over days",
+    cell_methods="time: mean over days",
     abstract="A night coolness variable which takes into account the mean minimum night temperatures during the "
     "month when ripening usually occurs beyond the ripening period.",
     allowed_periods=["A"],
@@ -514,7 +514,7 @@ cooling_degree_days = TempWithIndexing(
     standard_name="integral_of_air_temperature_excess_wrt_time",
     long_name="Cooling degree days (Tmean > {thresh})",
     description="{freq} cooling degree days above {thresh}.",
-    cell_methods="time: mean within days time: sum over days",
+    cell_methods="time: sum over days",
     compute=indices.cooling_degree_days,
     parameters={"thresh": {"default": "18.0 degC"}},
 )
@@ -525,7 +525,7 @@ heating_degree_days = TempWithIndexing(
     standard_name="integral_of_air_temperature_deficit_wrt_time",
     long_name="Heating degree days (Tmean < {thresh})",
     description="{freq} heating degree days below {thresh}.",
-    cell_methods="time: mean within days time: sum over days",
+    cell_methods="time: sum over days",
     compute=indices.heating_degree_days,
     parameters={"thresh": {"default": "17.0 degC"}},
 )
@@ -536,7 +536,7 @@ growing_degree_days = TempWithIndexing(
     standard_name="integral_of_air_temperature_excess_wrt_time",
     long_name="Growing degree days above {thresh}",
     description="{freq} growing degree days above {thresh}.",
-    cell_methods="time: mean within days time: sum over days",
+    cell_methods="time: sum over days",
     compute=indices.growing_degree_days,
     parameters={"thresh": {"default": "4.0 degC"}},
 )
@@ -547,7 +547,7 @@ freezing_degree_days = TempWithIndexing(
     standard_name="integral_of_air_temperature_deficit_wrt_time",
     long_name="Freezing degree days (Tmean < {thresh})",
     description="{freq} freezing degree days below {thresh}.",
-    cell_methods="time: mean within days time: sum over days",
+    cell_methods="time: sum over days",
     compute=indices.heating_degree_days,
     parameters={"thresh": {"default": "0 degC"}},
 )
@@ -558,7 +558,7 @@ thawing_degree_days = TempWithIndexing(
     standard_name="integral_of_air_temperature_excess_wrt_time",
     long_name="Thawing degree days (degree days above 0°C)",
     description="{freq} thawing degree days above 0°C.",
-    cell_methods="time: mean within days time: sum over days",
+    cell_methods="time: sum over days",
     compute=indices.growing_degree_days,
     parameters={"thresh": {"default": "0 degC"}},
 )
@@ -579,7 +579,7 @@ frost_days = TempWithIndexing(
     standard_name="days_with_air_temperature_below_threshold",
     long_name="Number of frost days (Tmin < {thresh})",
     description="{freq} number of days with minimum daily temperature below {thresh}.",
-    cell_methods="time: minimum within days time: sum over days",
+    cell_methods="time: sum over days",
     compute=indices.frost_days,
 )
 
@@ -592,7 +592,7 @@ frost_season_length = Temp(
     "{window} consecutive days with minimum daily temperature below freezing and "
     "the first occurrence of at least {window} consecutive days with "
     "minimuim daily temperature above freezing after {mid_date}.",
-    cell_methods="time: minimum within days time: sum over days",
+    cell_methods="time: sum over days",
     compute=indices.frost_season_length,
     parameters=dict(thresh="0 degC"),
 )
@@ -632,7 +632,7 @@ ice_days = TempWithIndexing(
     units="days",
     long_name="Number of ice days (Tmax < {thresh})",
     description="{freq} number of days with maximum daily temperature below {thresh}.",
-    cell_methods="time: maximum within days time: sum over days",
+    cell_methods="time: sum over days",
     compute=indices.ice_days,
 )
 
@@ -643,7 +643,7 @@ consecutive_frost_days = Temp(
     long_name="Maximum number of consecutive days with Tmin < {thresh}",
     description="{freq} maximum number of consecutive days with "
     "minimum daily temperature below {thresh}.",
-    cell_methods="time: min within days time: maximum over days",
+    cell_methods="time: maximum over days",
     compute=indices.maximum_consecutive_frost_days,
 )
 
@@ -656,7 +656,7 @@ frost_free_season_length = Temp(
     "{window} consecutive days with minimum daily temperature above or at the freezing point and "
     "the first occurrence of at least {window} consecutive days with "
     "minimum daily temperature below freezing after {mid_date}.",
-    cell_methods="time: minimum within days time: sum over days",
+    cell_methods="time: sum over days",
     compute=indices.frost_free_season_length,
     parameters={"thresh": {"default": "0 degC"}},
 )
@@ -691,7 +691,7 @@ maximum_consecutive_frost_free_days = Temp(
     long_name="Maximum number of consecutive days with Tmin >= {thresh}",
     description="{freq} maximum number of consecutive days with "
     "minimum daily temperature above or equal to {thresh}.",
-    cell_methods="time: min within days time: maximum over days",
+    cell_methods="time: maximum over days",
     compute=indices.maximum_consecutive_frost_free_days,
 )
 
@@ -742,7 +742,7 @@ tropical_nights = TempWithIndexing(
     long_name="Number of Tropical Nights (Tmin > {thresh})",
     description="{freq} number of Tropical Nights : defined as days with minimum daily temperature"
     " above {thresh}.",
-    cell_methods="time: minimum within days time: sum over days",
+    cell_methods="time: sum over days",
     compute=indices.tn_days_above,
     parameters={"thresh": {"default": "20.0 degC"}},
 )
@@ -755,7 +755,7 @@ tg90p = Temp(
     description="{freq} number of days with mean daily temperature above the 90th percentile."
     "The 90th percentile is to be computed for a 5 day moving window centered on each calendar day "
     "for a reference period.",
-    cell_methods="time: mean within days time: sum over days",
+    cell_methods="time: sum over days",
     compute=indices.tg90p,
 )
 
@@ -767,7 +767,7 @@ tg10p = Temp(
     description="{freq} number of days with mean daily temperature below the 10th percentile."
     "The 10th percentile is to be computed for a 5 day moving window centered on each calendar day "
     "for a reference period.",
-    cell_methods="time: mean within days time: sum over days",
+    cell_methods="time: sum over days",
     compute=indices.tg10p,
 )
 
@@ -779,7 +779,7 @@ tx90p = Temp(
     description="{freq} number of days with maximum daily temperature above the 90th percentile."
     "The 90th percentile is to be computed for a 5 day moving window centered on each calendar day "
     "for a reference period.",
-    cell_methods="time: maximum within days time: sum over days",
+    cell_methods="time: sum over days",
     compute=indices.tx90p,
 )
 
@@ -791,7 +791,7 @@ tx10p = Temp(
     description="{freq} number of days with maximum daily temperature below the 10th percentile."
     "The 10th percentile is to be computed for a 5 day moving window centered on each calendar day "
     "for a reference period.",
-    cell_methods="time: maximum within days time: sum over days",
+    cell_methods="time: sum over days",
     compute=indices.tx10p,
 )
 
@@ -803,7 +803,7 @@ tn90p = Temp(
     description="{freq} number of days with minimum daily temperature above the 90th percentile."
     "The 90th percentile is to be computed for a 5 day moving window centered on each calendar day "
     "for a reference period.",
-    cell_methods="time: minimum within days time: sum over days",
+    cell_methods="time: sum over days",
     compute=indices.tn90p,
 )
 
@@ -815,7 +815,7 @@ tn10p = Temp(
     description="{freq} number of days with minimum daily temperature below the 10th percentile."
     "The 10th percentile is to be computed for a 5 day moving window centered on each calendar day "
     "for a reference period.",
-    cell_methods="time: minimum within days time: sum over days",
+    cell_methods="time: sum over days",
     compute=indices.tn10p,
 )
 

--- a/xclim/indicators/atmos/_wind.py
+++ b/xclim/indicators/atmos/_wind.py
@@ -16,7 +16,7 @@ calm_days = Wind(
     standard_name="number_of_days_with_sfcWind_below_threshold",
     long_name="Number of days with surface wind speed below threshold",
     description="{freq} number of days with surface wind speed < {thresh}",
-    cell_methods="time: mean within days time: sum over days",
+    cell_methods="time: sum over days",
     compute=indices.calm_days,
 )
 
@@ -26,6 +26,6 @@ windy_days = Wind(
     standard_name="number_of_days_with_sfcWind_above_threshold",
     long_name="Number of days with surface wind speed above threshold",
     description="{freq} number of days with surface wind speed >= {thresh}",
-    cell_methods="time: mean within days time: sum over days",
+    cell_methods="time: sum over days",
     compute=indices.windy_days,
 )

--- a/xclim/indicators/land/_snow.py
+++ b/xclim/indicators/land/_snow.py
@@ -119,6 +119,6 @@ snow_depth = Snow(
     standard_name="surface_snow_thickness",
     long_name="Mean of daily snow depth",
     description="{freq} mean of daily mean snow depth.",
-    cell_methods="time: mean within days time: mean over days",
+    cell_methods="time: mean over days",
     compute=xci.snow_depth,
 )


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #983
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.
- [ ] `bumpversion patch` has been called on this branch
- [ ] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

* Remove extra cell_method related to input data. 

### Does this PR introduce a breaking change?
Kind of, cell_methods are going to change on output data. 

### Other information:
