### PR TITLE
Add `specific_humidity_from_dewpoint`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,8 +6,8 @@ History
 -----------------
 Contributors to this version: David Huard (:user:`huard`).
 
-New features and enhancements
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+New indicators
+^^^^^^^^^^^^^^
 * New indicator ``specific_humidity_from_dewpoint``, computing specific humidity from the dewpoint temperature and air pressure. (:issue:`864`)
 
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,7 +8,7 @@ Contributors to this version: David Huard (:user:`huard`).
 
 New indicators
 ^^^^^^^^^^^^^^
-* New indicator ``specific_humidity_from_dewpoint``, computing specific humidity from the dewpoint temperature and air pressure. (:issue:`864`)
+* New indicator ``specific_humidity_from_dewpoint``, computing specific humidity from the dewpoint temperature and air pressure. (:issue:`864`, :pull:`1027`)
 
 
 0.34.0 (unreleased)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,15 @@
 History
 =======
 
+0.35 (unreleased)
+-----------------
+Contributors to this version: David Huard (:user:`huard`).
+
+New features and enhancements
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+* New indicator ``specific_humidity_from_dewpoint``, computing specific humidity from the dewpoint temperature and air pressure. (:issue:`864`)
+
+
 0.34.0 (unreleased)
 -------------------
 Contributors to this version: Pascal Bourgault (:user:`aulemahal`), Trevor James Smith (:user:`Zeitsperre`), David Huard (:user:`huard`).

--- a/xclim/data/fr.json
+++ b/xclim/data/fr.json
@@ -719,15 +719,21 @@
   },
   "HURS": {
     "long_name": "Humidité relative",
-    "description": "Calculée à partir de la température, de l'humidité spécifique et de la pression à l'aide de la pression de vapeur saturante, laquelle fut calculée en suivant la méthode {method}",
+    "description": "Calculée à partir de la température, de l'humidité spécifique et de la pression à l'aide de la pression de vapeur saturante, laquelle fut calculée en suivant la méthode {method}.",
     "title": "Humidité relative à partir de l'humidité spécifique et de la pression",
     "abstract": "Calcul de l'humidité relative à partir de la température, de l'humidité spécifique et de la pression à l'aide de la pression de vapeur saturante."
   },
   "HUSS": {
     "long_name": "Humidité spécifique",
-    "description": "Calculée à partir de la température, de l'humidité relative et de la pression à l'aide de la pression de vapeur saturante, laquelle fut calculée en suivant la méthode {method}",
+    "description": "Calculée à partir de la température, de l'humidité relative et de la pression à l'aide de la pression de vapeur saturante, laquelle fut calculée en suivant la méthode {method}.",
     "title": "Humidité spécifique à partir de l'humidité relative et de la pression",
     "abstract": "Calcul de l'humidité spécifique à partir de la température, de l'humidité relative et de la pression à l'aide de la pression de vapeur saturante."
+  },
+  "HUSS_FROMDEWPOINT": {
+    "long_name": "Humidité spécifique",
+    "description": "Calculée à partir de la température du point de rosée et de la pression à l'aide de la pression de vapeur saturante, laquelle fut calculée en suivant la méthode {method}.",
+    "title": "Humidité spécifique à partir de la température du point de rosée et de la pression",
+    "abstract": "Calcul de l'humidité spécifique à partir de la température du point de rosée et de la pression à l'aide de la pression de vapeur saturante."
   },
   "FIRST_DAY_BELOW": {
     "long_name": "Premier jour de l'année avec une température sous {thresh}",

--- a/xclim/indicators/atmos/_conversion.py
+++ b/xclim/indicators/atmos/_conversion.py
@@ -15,6 +15,7 @@ __all__ = [
     "relative_humidity_from_dewpoint",
     "relative_humidity",
     "specific_humidity",
+    "specific_humidity_from_dewpoint",
     "snowfall_approximation",
     "rain_approximation",
     "wind_chill_index",
@@ -179,6 +180,17 @@ specific_humidity = Converter(
     parameters={"invalid_values": "mask"},
 )
 
+specific_humidity_from_dewpoint = Converter(
+    identifier="huss_fromdewpoint",
+    units="",
+    long_name="Specific Humidity",
+    standard_name="specific_humidity",
+    description=lambda **kws: (
+        "Computed from dewpoint temperature and pressure through the saturation "
+        "vapor pressure, which was calculated according to the {method} method."
+    ),
+    compute=indices.specific_humidity_from_dewpoint,
+)
 
 snowfall_approximation = Converter(
     identifier="prsn",

--- a/xclim/indicators/atmos/_conversion.py
+++ b/xclim/indicators/atmos/_conversion.py
@@ -185,7 +185,7 @@ specific_humidity_from_dewpoint = Converter(
     units="",
     long_name="Specific Humidity",
     standard_name="specific_humidity",
-    description=lambda **kws: (
+    description=(
         "Computed from dewpoint temperature and pressure through the saturation "
         "vapor pressure, which was calculated according to the {method} method."
     ),

--- a/xclim/testing/tests/test_atmos.py
+++ b/xclim/testing/tests/test_atmos.py
@@ -165,6 +165,25 @@ def test_specific_humidity(tas_series, hurs_series, huss_series, ps_series):
     assert huss.name == "huss"
 
 
+def test_specific_humidity_from_dewpoint(tas_series, ps_series, huss_series):
+    tdps = tas_series([272, 283, 293])
+    ps = ps_series([100000, 105000, 110000])
+    # Computed from MetPy
+    # >>> from metpy.units import units as u
+    # >>> from metpy.calc import specific_humidity_from_dewpoint as sh
+    # >>> sh([100000, 105000, 110000] * u.Pa, [272, 283, 293] * u.degK)
+    # array([0.0035031, 0.00722795, 0.01319614]) < Unit('dimensionless') >
+    huss_exp = huss_series([0.0035031, 0.00722795, 0.01319614])
+
+    huss = atmos.specific_humidity_from_dewpoint(
+        tdps=tdps,
+        ps=ps,
+        method="sonntag90",
+    )
+    np.testing.assert_allclose(huss, huss_exp, atol=1e-4, rtol=0.05)
+    assert huss.name == "huss_fromdewpoint"
+
+
 def test_snowfall_approximation(pr_series, tasmax_series):
     pr = pr_series(np.ones(10))
     tasmax = tasmax_series(np.arange(10) + K2C)

--- a/xclim/testing/tests/test_indices.py
+++ b/xclim/testing/tests/test_indices.py
@@ -1986,6 +1986,19 @@ def test_relative_humidity_dewpoint(
     )
 
 
+def test_specific_humidity_from_dewpoint(tas_series, ps_series):
+    """Specific humidity from dewpoint."""
+    # Test taken from MetPy
+    ps = ps_series([1013.25])
+    ps.attrs["units"] = "mbar"
+
+    tdps = tas_series([16.973])
+    tdps.attrs["units"] = "degC"
+
+    q = xci.specific_humidity_from_dewpoint(tdps, ps)
+    np.testing.assert_allclose(q, 0.012, 3)
+
+
 @pytest.mark.parametrize("method", ["tetens30", "sonntag90", "goffgratch46", "wmo08"])
 @pytest.mark.parametrize(
     "ice_thresh,exp0", [(None, [125, 286, 568]), ("0 degC", [103, 260, 563])]


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #864 
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.
- [ ] `bumpversion patch` has been called on this branch
- [ ] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

* Adds new indice and indicator for specific_humidity_from_dewpoint. 

### Does this PR introduce a breaking change?
No

### Other information:
- `long_name` is capitalized for humidity indicators (long_name="Specific Humidity"). Is that a typo ?
- Didn't implement the `invalid_values` stuff cause I wasn't sure if it applied here. 
