### PR TITLE
Fix lazy_indexing when using twice the same indexes (with dask)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,14 @@
 History
 =======
 
+0.36.0 (unreleased)
+-------------------
+Contributors to this version: Pascal Bourgault (:user:`aulemahal`).
+
+Bug fixes
+^^^^^^^^^
+* Invoking ``lazy_indexing`` twice in row (or more) using the same indexes (using dask) is now fixed. (:issue:`1048`, :pull:`1049`).
+
 0.35.0 (01-04-2022)
 -------------------
 Contributors to this version: David Huard (:user:`huard`), Trevor James Smith (:user:`Zeitsperre`) and Pascal Bourgault (:user:`aulemahal`).

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.35.0
+current_version = 0.35.1-beta
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+).(?P<patch>\d+)(\-(?P<release>[a-z]+))?

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ URL = "https://github.com/Ouranosinc/xclim"
 AUTHOR = "Travis Logan"
 AUTHOR_EMAIL = "logan.travis@ouranos.ca"
 REQUIRES_PYTHON = ">=3.8.0"
-VERSION = "0.35.0"
+VERSION = "0.35.1-beta"
 LICENSE = "Apache Software License 2.0"
 
 with open("README.rst") as readme_file:

--- a/xclim/__init__.py
+++ b/xclim/__init__.py
@@ -9,7 +9,7 @@ from xclim.indicators import atmos, land, seaIce  # noqa
 
 __author__ = """Travis Logan"""
 __email__ = "logan.travis@ouranos.ca"
-__version__ = "0.35.0"
+__version__ = "0.35.1-beta"
 
 
 # Load official locales


### PR DESCRIPTION
…h dask - upd hist

<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1048
- [x] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added
- [x] `bumpversion patch` has been called on this branch
- [x] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

* Uses `map_blocks` in a different (better) manner so that xarray/dask is able to differentiate when the indexing function is called with the same indexes but a different array.

### Does this PR introduce a breaking change?
Nope.

### Other information:
`map_blocks` converts DataArray arguments to datasets, and this bugs when the dataarrays don't have names. I added a simple workaround.