### PR TITLE
Fix 1056

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,7 @@ Contributors to this version: Pascal Bourgault (:user:`aulemahal`), Juliette Lav
 Bug fixes
 ^^^^^^^^^
 * Invoking ``lazy_indexing`` twice in row (or more) using the same indexes (using dask) is now fixed. (:issue:`1048`, :pull:`1049`).
+*  Filtering out the nans before choosing the first and last values as ``fill_value`` in ``_interp_on_quantiles_1D`` (:issue:`1056`, :pull:`1053`).
 
 New features and enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/xclim/sdba/utils.py
+++ b/xclim/sdba/utils.py
@@ -395,7 +395,7 @@ def interp_on_quantiles(
     - 'nan' : Any value of `newx` outside the range of `xq` is set to NaN.
     - 'constant' : Values of `newx` smaller than the minimum of `xq` are set to the first
       value of `yq` and those larger than the maximum, set to the last one (first and
-      last values along the "quantiles" dimension). When the grouping is "time.month",
+      last non-nan values along the "quantiles" dimension). When the grouping is "time.month",
       these limits are linearly interpolated along the month dimension.
     """
     dim = group.dim

--- a/xclim/sdba/utils.py
+++ b/xclim/sdba/utils.py
@@ -314,7 +314,10 @@ def _interp_on_quantiles_1D(newx, oldx, oldy, method, extrap):
         return out
 
     if extrap == "constant":
-        fill_value = (oldy[0], oldy[-1])
+        fill_value = (
+            oldy.where(~np.isnan(oldy), drop=True)[0],
+            oldy.where(~np.isnan(oldy), drop=True)[-1],
+        )
     else:  # extrap == 'nan'
         fill_value = np.NaN
 

--- a/xclim/sdba/utils.py
+++ b/xclim/sdba/utils.py
@@ -315,8 +315,8 @@ def _interp_on_quantiles_1D(newx, oldx, oldy, method, extrap):
 
     if extrap == "constant":
         fill_value = (
-            oldy.where(~np.isnan(oldy), drop=True)[0],
-            oldy.where(~np.isnan(oldy), drop=True)[-1],
+            oldy[~np.isnan(oldy)][0],
+            oldy[~np.isnan(oldy)][-1],
         )
     else:  # extrap == 'nan'
         fill_value = np.NaN


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1056
- [ x] Tests for the changes have been added (for bug fixes / features)
  - [x ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ x] HISTORY.rst has been updated (with summary of main changes)
  - [x ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added
- [ ] `bumpversion patch` has been called on this branch
- [ x] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

* This PR fixes issue #1056. See full context there.
* `fill_value` in `_interp_on_quantiles_1D` filters out the nans before choosing the values in first and last position along the `quantiles` dimension

### Does this PR introduce a breaking change?
Yes, when using `ExtremeValues`, the extrapolation will use the real last value instead of a nan. This should allow the largest extreme of the simulation to not be set to nan. In other cases (when the `quantiles` dimension is not padded with nans), it should return the same result as before.

### Other information:
