### PR TITLE
Translated attrs from virtual modules do not override the ones of the base indicators.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,7 +9,8 @@ Contributors to this version: Pascal Bourgault (:user:`aulemahal`), Juliette Lav
 Bug fixes
 ^^^^^^^^^
 * Invoking ``lazy_indexing`` twice in row (or more) using the same indexes (using dask) is now fixed. (:issue:`1048`, :pull:`1049`).
-*  Filtering out the nans before choosing the first and last values as ``fill_value`` in ``_interp_on_quantiles_1D`` (:issue:`1056`, :pull:`1057`).
+* Filtering out the nans before choosing the first and last values as ``fill_value`` in ``_interp_on_quantiles_1D`` (:issue:`1056`, :pull:`1057`).
+* Translations from virtual indicator modules do not override those of the base indicators anymore. (:issue:`1053`, :pull:`1058`).
 
 New features and enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/notebooks/example.fr.json
+++ b/docs/notebooks/example.fr.json
@@ -22,5 +22,8 @@
   "R99P.R99p_days": {
     "long_name": "Nombre de jours de fortes pluies (> {perc}e percentile)",
     "description": "Nombre de jours où la pluie est plus forte que le {perc}e percentile de la série."
+  },
+  "RX5DAY": {
+    "long_name": "Cumul maximal de la précipitation quotidienne sur 5 jours."
   }
 }

--- a/xclim/core/locales.py
+++ b/xclim/core/locales.py
@@ -48,6 +48,7 @@ Those default translations are found in the `xclim/locales` folder.
 """
 import json
 import warnings
+from copy import deepcopy
 from pathlib import Path
 from typing import Mapping, Optional, Sequence, Tuple, Union
 
@@ -122,7 +123,7 @@ def get_local_dict(
         if locale not in _LOCALES:
             raise UnavailableLocaleError(locale)
 
-        return locale, _LOCALES[locale]
+        return locale, deepcopy(_LOCALES[locale])
 
     if isinstance(locale[1], dict):
         trans = locale[1]
@@ -131,7 +132,7 @@ def get_local_dict(
         trans = read_locale_file(locale[1])
 
     if locale[0] in _LOCALES:
-        loaded_trans = _LOCALES[locale[0]]
+        loaded_trans = deepcopy(_LOCALES[locale[0]])
         # Passed translations have priority
         loaded_trans.update(trans)
         trans = loaded_trans

--- a/xclim/testing/tests/test_modules.py
+++ b/xclim/testing/tests/test_modules.py
@@ -100,6 +100,20 @@ def test_custom_indices():
 
 
 @pytest.mark.requires_docs
+def test_indicator_module_translations():
+    # Use the example in the Extending Xclim notebook for testing.
+    nbpath = Path(__file__).parent.parent.parent.parent / "docs" / "notebooks"
+
+    ex = build_indicator_module_from_yaml(nbpath / "example", name="ex_trans")
+    assert ex.RX5day.translate_attrs("fr")["cf_attrs"][0]["long_name"].startswith(
+        "Cumul maximal"
+    )
+    assert indicators.atmos.max_n_day_precipitation_amount.translate_attrs("fr")[
+        "cf_attrs"
+    ][0]["long_name"].startswith("Maximum du cumul")
+
+
+@pytest.mark.requires_docs
 def test_build_indicator_module_from_yaml_edge_cases():
     # Use the example in the Extending Xclim notebook for testing.
     nbpath = Path(__file__).parent.parent.parent.parent / "docs" / "notebooks"


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1053
- [x] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added
- [ ] `bumpversion patch` has been called on this branch
- [ ] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?
This was an issue of dictionaries being passed around and updated directly, instead updating copies.
The fix makes `xc.core.locales.get_local_dict` return a copy of stored data.

### Does this PR introduce a breaking change?
It shouldn't.