### PR TITLE
Add ends to yearly window

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -14,7 +14,7 @@ Bug fixes
 New features and enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 * ``xclim.sdba.measures.rmse`` and ``xclim.sdba.measures.mae`` now use `numpy` instead of `sklearn`. This improves their performances when using `dask`. (:pull:`1051`).
-* Argument ``append_ends`` added to `sdba.unpack_moving_yearly_window` (:pull:`1059`).
+* Argument ``append_ends`` added to ``sdba.unpack_moving_yearly_window`` (:pull:`1059`).
 
 0.35.0 (01-04-2022)
 -------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -14,6 +14,7 @@ Bug fixes
 New features and enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 * ``xclim.sdba.measures.rmse`` and ``xclim.sdba.measures.mae`` now use `numpy` instead of `sklearn`. This improves their performances when using `dask`. (:pull:`1051`).
+* Argument ``append_ends`` added to `sdba.unpack_moving_yearly_window` (:pull:`1059`).
 
 0.35.0 (01-04-2022)
 -------------------

--- a/docs/notebooks/sdba-advanced.ipynb
+++ b/docs/notebooks/sdba-advanced.ipynb
@@ -352,7 +352,10 @@
     "1. The constructed array has the same \"time\" axis for all windows. This is a problem if the actual _year_ is of importance for the adjustment, but this is not the case for any of xclim's current adjustment methods.\n",
     "2. The input timeseries must be in a calendar with uniform year lengths. For daily data, this means only the \"360_day\", \"noleap\" and \"all_leap\" calendars are supported.\n",
     "\n",
-    "The \"unpack\" function does the opposite : it concatenates the windows together to recreate the original timeseries. Only the central `step` years are kept from each window. Which means the final timeseries has  `(window - step) / 2` years missing on either side, with the extra year missing on the right in case of an odd `(window - step)`.\n",
+    "The \"unpack\" function does the opposite : it concatenates the windows together to recreate the original timeseries.\n",
+    "The time points that are not part of a window will not appear un the reconstructed timeseries.\n",
+    "If `append_ends` is True, the reconstructed timeseries will go from the first time point of the first window to the last time point of the last window. In the middle, the central `step` years are kept from each window.\n",
+    "If `append_ends` is False, only the central `step` years are kept from each window. Which means the final timeseries has  `(window - step) / 2` years missing on either side, with the extra year missing on the right in case of an odd `(window - step)`. We are missing data, but the contribution from each window is equal.\n",
     "\n",
     "Here, as`ref` and `hist` cover 15 years, we will use a window of 15 on sim. With a step of 2, this means the first window goes from 2000 to 2014 (inclusive). The last window goes from 2016 to 2030. `window - step = 13`, so 6 years will be missing at the beginning of the final `scen` and 7 years at the end."
    ]
@@ -392,12 +395,19 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here, we retrieve the full timeseries."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "scen_win = unpack_moving_yearly_window(QDM.adjust(sim_win))\n",
+    "scen_win = unpack_moving_yearly_window(QDM.adjust(sim_win), append_ends=True)\n",
     "scen_win"
    ]
   },
@@ -405,7 +415,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here is another short example, with an uneven number of years. Here `sim` goes from 2000 to 2029 (30 years instead of 31). With a step of 2 and a window of 15, the first window goes again from 2000 to 2014, but the last one is now from 2014 to 2028. The next window would be 2016-2030, but that last year doesn't exist. The final timeseries is thus from 2006 to 2021, 6 years missing at the beginning, like last time and **8** years missing at the end."
+    "Whereas here, we have gaps at the edges."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scen_win = unpack_moving_yearly_window(QDM.adjust(sim_win), append_ends=False)\n",
+    "scen_win"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here is another short example, with an uneven number of years. Here `sim` goes from 2000 to 2029 (30 years instead of 31). With a step of 2 and a window of 15, the first window goes again from 2000 to 2014, but the last one is now from 2014 to 2028. The next window would be 2016-2030, but that last year doesn't exist. "
    ]
   },
   {
@@ -421,12 +448,36 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here, we don't recover the full timeseries, even when we append the ends, because 2029 is not part of a window."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "sim2 = unpack_moving_yearly_window(sim_win)\n",
+    "sim2 = unpack_moving_yearly_window(sim_win, append_ends=True)\n",
+    "sim2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Without appending the ends, the final timeseries is from 2006 to 2021, 6 years missing at the beginning, like last time and **8** years missing at the end."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sim2 = unpack_moving_yearly_window(sim_win, append_ends=False)\n",
     "sim2"
    ]
   },
@@ -797,9 +848,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "xclimDev",
    "language": "python",
-   "name": "python3"
+   "name": "xclimdev"
   },
   "language_info": {
    "codemirror_mode": {
@@ -811,7 +862,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.9.7"
   },
   "toc": {
    "base_numbering": 1,

--- a/docs/notebooks/sdba-advanced.ipynb
+++ b/docs/notebooks/sdba-advanced.ipynb
@@ -353,7 +353,7 @@
     "2. The input timeseries must be in a calendar with uniform year lengths. For daily data, this means only the \"360_day\", \"noleap\" and \"all_leap\" calendars are supported.\n",
     "\n",
     "The \"unpack\" function does the opposite : it concatenates the windows together to recreate the original timeseries.\n",
-    "The time points that are not part of a window will not appear un the reconstructed timeseries.\n",
+    "The time points that are not part of a window will not appear in the reconstructed timeseries.\n",
     "If `append_ends` is True, the reconstructed timeseries will go from the first time point of the first window to the last time point of the last window. In the middle, the central `step` years are kept from each window.\n",
     "If `append_ends` is False, only the central `step` years are kept from each window. Which means the final timeseries has  `(window - step) / 2` years missing on either side, with the extra year missing on the right in case of an odd `(window - step)`. We are missing data, but the contribution from each window is equal.\n",
     "\n",

--- a/docs/notebooks/sdba-advanced.ipynb
+++ b/docs/notebooks/sdba-advanced.ipynb
@@ -848,9 +848,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "xclimDev",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "xclimdev"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -862,7 +862,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.6"
   },
   "toc": {
    "base_numbering": 1,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.35.3-beta
+current_version = 0.35.4-beta
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+).(?P<patch>\d+)(\-(?P<release>[a-z]+))?

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ URL = "https://github.com/Ouranosinc/xclim"
 AUTHOR = "Travis Logan"
 AUTHOR_EMAIL = "logan.travis@ouranos.ca"
 REQUIRES_PYTHON = ">=3.8.0"
-VERSION = "0.35.3-beta"
+VERSION = "0.35.4-beta"
 LICENSE = "Apache Software License 2.0"
 
 with open("README.rst") as readme_file:

--- a/xclim/__init__.py
+++ b/xclim/__init__.py
@@ -9,7 +9,7 @@ from xclim.indicators import atmos, land, seaIce  # noqa
 
 __author__ = """Travis Logan"""
 __email__ = "logan.travis@ouranos.ca"
-__version__ = "0.35.3-beta"
+__version__ = "0.35.4-beta"
 
 
 # Load official locales

--- a/xclim/sdba/processing.py
+++ b/xclim/sdba/processing.py
@@ -575,7 +575,7 @@ def unpack_moving_yearly_window(da: xr.DataArray, dim: str = "movingwin", append
 
     if append_ends:
         out.insert(0, da.isel({dim: 0, 'time': slice(None, left * N_in_year)}).drop_vars(dim))  # add end at the front
-        back_end = da.isel({dim: -1, 'time': slice(-(left+1) * N_in_year, None)}).drop_vars(dim)
+        back_end = da.isel({dim: -1, 'time': slice((left + step) * N_in_year, None)}).drop_vars(dim)
         dt = da.isel({dim: -1})[dim].values - da.isel({dim: 0})[dim].values
         back_end["time"] = back_end.time + dt
         out.append(back_end)  # add end at the back

--- a/xclim/sdba/processing.py
+++ b/xclim/sdba/processing.py
@@ -516,8 +516,11 @@ def unpack_moving_yearly_window(da: xr.DataArray, dim: str = "movingwin", append
     """Unpack a constructed moving window dataset to a normal timeseries, only keeping the central data.
 
     Unpack DataArrays created with :py:func:`construct_moving_yearly_window` and recreate a timeseries data.
-    Only keeps the central non-overlapping years. If `append_ends` is False, the final timeseries will be (window - step) years shorter than
-    the initial one.
+    If `append_ends` is False, only keeps the central non-overlapping years. The final timeseries will be
+    (window - step) years shorter than the initial one. If `append_ends` is True, the times from first and last windows
+     will be be included in the final timeseries.
+
+    The time points that are not in a window will never be included in the final timeseries.
 
     The window length and window step are inferred from the coordinates.
 

--- a/xclim/sdba/processing.py
+++ b/xclim/sdba/processing.py
@@ -513,7 +513,7 @@ def construct_moving_yearly_window(
 
 
 def unpack_moving_yearly_window(
-    da: xr.DataArray, dim: str = "movingwin", append_ends=True
+    da: xr.DataArray, dim: str = "movingwin", append_ends: bool = True
 ):
     """Unpack a constructed moving window dataset to a normal timeseries, only keeping the central data.
 

--- a/xclim/sdba/processing.py
+++ b/xclim/sdba/processing.py
@@ -512,11 +512,11 @@ def construct_moving_yearly_window(
     return daw
 
 
-def unpack_moving_yearly_window(da: xr.DataArray, dim: str = "movingwin"):
+def unpack_moving_yearly_window(da: xr.DataArray, dim: str = "movingwin", append_ends=True):
     """Unpack a constructed moving window dataset to a normal timeseries, only keeping the central data.
 
     Unpack DataArrays created with :py:func:`construct_moving_yearly_window` and recreate a timeseries data.
-    Only keeps the central non-overlapping years. The final timeseries will be (window - step) years shorter than
+    Only keeps the central non-overlapping years. If `append_ends` is False, the final timeseries will be (window - step) years shorter than
     the initial one.
 
     The window length and window step are inferred from the coordinates.
@@ -527,6 +527,13 @@ def unpack_moving_yearly_window(da: xr.DataArray, dim: str = "movingwin"):
       As constructed by :py:func:`construct_moving_yearly_window`.
     dim : str
       The window dimension name as given to the construction function.
+    append_ends: bool
+      Whether to append the ends of the timeseries
+      If False, the final timeseries will be (window - step) years shorter than the initial one,
+      but all windows will contribute equally.
+      If True, the windows at both ends of the timeseries will keep the central non-overlapping years as well as the
+      end non-overlapping years. The final timeseries will be the same lenght as the initial timeseries if the windows
+      span the whole timeseries. The time steps that are not in a window will be left out of the final timeseries.
     """
     # Get number of samples by year (and perform checks)
     N_in_year = _get_number_of_elements_by_year(da.time)
@@ -550,14 +557,25 @@ def unpack_moving_yearly_window(da: xr.DataArray, dim: str = "movingwin"):
     left = int((window - step) // 2)  # first year to keep
 
     # Keep only the middle years
-    da = da.isel(time=slice(left * N_in_year, (left + step) * N_in_year))
+    da_mid = da.isel(time=slice(left * N_in_year, (left + step) * N_in_year))
 
     out = []
-    for win_start in da[dim]:
-        slc = da.sel({dim: win_start}).drop_vars(dim)
-        dt = win_start.values - da[dim][0].values
+    for win_start in da_mid[dim]:
+        slc = da_mid.sel({dim: win_start}).drop_vars(dim)
+        dt = win_start.values - da_mid[dim][0].values
         slc["time"] = slc.time + dt
         out.append(slc)
+
+    #ds_final =
+
+    #display(da)
+
+    if append_ends:
+        out.insert(0, da.isel({dim: 0, 'time': slice(None, left * N_in_year)}).drop_vars(dim))  # add end at the front
+        back_end = da.isel({dim: -1, 'time': slice(-(left+1) * N_in_year, None)}).drop_vars(dim)
+        dt = da.isel({dim: -1})[dim].values - da.isel({dim: 0})[dim].values
+        back_end["time"] = back_end.time + dt
+        out.append(back_end)  # add end at the back
 
     return xr.concat(out, "time")
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [x] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added
- [x] `bumpversion patch` has been called on this branch
- [x] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

* The `append_end` argument has been added to `sdba.unpack_moving_yearly_window`. 
* When set to False, we keep the original behavior of returning the middle years of each window. Hence, the reconstructed timeseries is missing (window-time)/2 time points from the original timeseries.
* When set to True, we append the year before the middle years of the first window and the years after the middle years of the last window. Hence, we can recover the full inital timeseries.
* In both case, years that are not convered by a window at the end of the timeseries are not including. The user must make sure to set the window and step sizes probably, if they want to recover the initial time series.

### Does this PR introduce a breaking change?
Yes, the default behavior is `append_ends`=`True`, but we can recover the previous behavior by setting it to `False`


### Other information:
