### PR TITLE
Fix/#1084 indexer for percentile based indices

### DIFF
--- a/xclim/core/indicator.py
+++ b/xclim/core/indicator.py
@@ -1390,13 +1390,14 @@ class ResamplingIndicatorWithIndexing(ResamplingIndicator):
             )
         ]
 
-    def _preprocess_and_checks(self, das, params):
+    def _preprocess_and_checks(self, das: dict[str, DataArray], params: dict[str, Any]):
         """Perform parent's checks and also check if freq is allowed."""
         das, params = super()._preprocess_and_checks(das, params)
 
         indxr = params.get("indexer")
         if indxr:
-            das = {k: select_time(da, **indxr) for k, da in das.items()}
+            for k, da in filter(lambda kda: "time" in kda[1].coords, das.items()):
+                das.update({k: select_time(da, **indxr)})
         return das, params
 
 

--- a/xclim/indicators/atmos/_temperature.py
+++ b/xclim/indicators/atmos/_temperature.py
@@ -748,7 +748,7 @@ tropical_nights = TempWithIndexing(
     parameters={"thresh": {"default": "20.0 degC"}},
 )
 
-tg90p = Temp(
+tg90p = TempWithIndexing(
     identifier="tg90p",
     units="days",
     standard_name="days_with_air_temperature_above_threshold",
@@ -760,7 +760,7 @@ tg90p = Temp(
     compute=indices.tg90p,
 )
 
-tg10p = Temp(
+tg10p = TempWithIndexing(
     identifier="tg10p",
     units="days",
     standard_name="days_with_air_temperature_below_threshold",
@@ -772,7 +772,7 @@ tg10p = Temp(
     compute=indices.tg10p,
 )
 
-tx90p = Temp(
+tx90p = TempWithIndexing(
     identifier="tx90p",
     units="days",
     standard_name="days_with_air_temperature_above_threshold",
@@ -784,7 +784,7 @@ tx90p = Temp(
     compute=indices.tx90p,
 )
 
-tx10p = Temp(
+tx10p = TempWithIndexing(
     identifier="tx10p",
     units="days",
     standard_name="days_with_air_temperature_below_threshold",
@@ -796,7 +796,7 @@ tx10p = Temp(
     compute=indices.tx10p,
 )
 
-tn90p = Temp(
+tn90p = TempWithIndexing(
     identifier="tn90p",
     units="days",
     standard_name="days_with_air_temperature_above_threshold",
@@ -808,7 +808,7 @@ tn90p = Temp(
     compute=indices.tn90p,
 )
 
-tn10p = Temp(
+tn10p = TempWithIndexing(
     identifier="tn10p",
     units="days",
     standard_name="days_with_air_temperature_below_threshold",

--- a/xclim/testing/tests/test_precip.py
+++ b/xclim/testing/tests/test_precip.py
@@ -419,6 +419,18 @@ def test_days_over_precip_thresh():
     )
 
 
+def test_days_over_precip_thresh__seasonal_indexer():
+    # GIVEN
+    pr = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc").pr
+    per = pr.quantile(0.8, "time", keep_attrs=True)
+    # WHEN
+    out = atmos.days_over_precip_thresh(
+        pr, per, freq="AS", date_bounds=("01-10", "12-31")
+    )
+    # THEN
+    np.testing.assert_almost_equal(out[0], np.array([82.0, 66.0, 66.0, 74.0]))
+
+
 def test_fraction_over_precip_doy_thresh():
     pr = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc").pr
     per = percentile_doy(pr, window=5, per=80)

--- a/xclim/testing/tests/test_temperature.py
+++ b/xclim/testing/tests/test_temperature.py
@@ -1098,6 +1098,18 @@ class TestT90p:
         assert np.isnan(out[1])
         assert out[5] == 25
 
+    def test_tx90p__seasonal_indexer(self, tasmax_series):
+        # GIVEN
+        arr = np.asarray(np.arange(366), "float")
+        tas = tasmax_series(arr, start="1/1/2000")
+        t90 = percentile_doy(tas, window=1, per=90).sel(percentiles=90)
+        # create cold spell in june
+        tas[175:180] = 1
+        # WHEN
+        out = atmos.tx90p(tas, t90, freq="AS", season="DJF")
+        # THEN
+        assert out[0] == np.NAN  # one year without December result in a NaN by default
+
 
 class TestT10p:
     def test_tg10p_simple(self, tas_series):

--- a/xclim/testing/tests/test_temperature.py
+++ b/xclim/testing/tests/test_temperature.py
@@ -1106,9 +1106,9 @@ class TestT90p:
         # create cold spell in june
         tas[175:180] = 1
         # WHEN
-        out = atmos.tx90p(tas, t90, freq="AS", season="DJF")
+        out = atmos.tx90p(tas, t90, freq="AS", season="JJA")
         # THEN
-        assert out[0] == np.NAN  # one year without December result in a NaN by default
+        assert out[0] == 87  # non regression test
 
 
 class TestT10p:


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1084
- [x] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added
- [ ] `bumpversion patch` has been called on this branch
- [ ] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?
Fix indexer for percentile based indicator.

### Does this PR introduce a breaking change?
No.

### Other information:
This PR also enable indexer for T(G|N|X)(90|10)p indices.
This is a follow up to #1070.