### PR TITLE
water_budget using evapotranspiration intead of calculating it

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,7 @@ History
 
 0.37.0 (unreleased)
 -------------------
-Contributors to this version:  Abel Aoun (:user:`bzah`), Pascal Bourgault (:user:`aulemahal`), Trevor James Smith (:user:`Zeitsperre`).
+Contributors to this version:  Abel Aoun (:user:`bzah`), Pascal Bourgault (:user:`aulemahal`), Trevor James Smith (:user:`Zeitsperre`), Gabriel Rondeau-Genesse (:user:`RondeauG`).
 
 Announcements
 ^^^^^^^^^^^^^
@@ -18,6 +18,8 @@ New features and enhancements
   * A CLI version of this function is also available from the command line: `$ xclim show_version_info`. (:pull:`1073`).
 * New "keep_attrs" option to control the handling of the attributes within the indicators. (:issue:`1026`, :pull:`1076`).
 * Added a notebook showcasing some simple examples of Spatial Analogues. (:issue:`585`, :pull:`1075`).
+* Separated water_budget into water_budget (calculated directly with evspsblpot) and water_budget_from_tas (original function). (:pull:`1086`).
+* Injected parameters in indicators are now left out of a function's signature and will not be included in the history attribute. (:pull:`1086`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/xclim/core/indicator.py
+++ b/xclim/core/indicator.py
@@ -1028,7 +1028,9 @@ class Indicator(IndicatorRegistrar):
         # different order than the real function (but order doesn't really matter with keywords).
         kwargs = OrderedDict(**das)
         for k, v in args.items():
-            if cls._all_parameters[k].kind == InputKind.KWARGS:
+            if cls._all_parameters[k].injected:
+                continue
+            elif cls._all_parameters[k].kind == InputKind.KWARGS:
                 kwargs.update(**v)
             elif cls._all_parameters[k].kind != InputKind.DATASET:
                 kwargs[k] = v

--- a/xclim/data/fr.json
+++ b/xclim/data/fr.json
@@ -939,10 +939,16 @@
     "description": "Le potentiel d'évaporation de l'eau du sol et de transpiration par les plantes si l'approvisionnement en eau est suffisant, avec la méthode de {method}.",
     "long_name": "Évapotranspiration potentielle"
   },
-  "WATER_BUDGET": {
+  "WATER_BUDGET_FROM_TAS": {
     "title": "Bilan hydrique",
     "abstract": "Précipitations moins l'évapotranspiration potentielle en tant que mesure approximative d'un bilan hydrique de surface, où l'évapotranspiration potentielle est calculée avec une méthode donnée.",
     "description": "Précipitations moins l'évapotranspiration potentielle en tant que mesure approximative d'un bilan hydrique de surface, où l'évapotranspiration potentielle est calculée avec la méthode {method}.",
+    "long_name": "Bilan hydrique"
+  },
+  "WATER_BUDGET": {
+    "title": "Bilan hydrique",
+    "abstract": "Précipitations moins l'évapotranspiration potentielle en tant que mesure approximative d'un bilan hydrique de surface.",
+    "description": "Précipitations moins l'évapotranspiration potentielle en tant que mesure approximative d'un bilan hydrique de surface.",
     "long_name": "Bilan hydrique"
   },
   "DRY_SPELL_FREQUENCY": {

--- a/xclim/indicators/atmos/_conversion.py
+++ b/xclim/indicators/atmos/_conversion.py
@@ -22,6 +22,7 @@ __all__ = [
     "rain_approximation",
     "wind_chill_index",
     "potential_evapotranspiration",
+    "water_budget_from_tas",
     "water_budget",
     "corn_heat_units",
 ]
@@ -251,8 +252,8 @@ potential_evapotranspiration = Converter(
     compute=indices.potential_evapotranspiration,
 )
 
-water_budget = Converter(
-    identifier="water_budget",
+water_budget_from_tas = Converter(
+    identifier="water_budget_from_tas",
     units="kg m-2 s-1",
     long_name="Water budget",
     description=(
@@ -260,6 +261,17 @@ water_budget = Converter(
         "where the potential evapotranspiration is calculated with the method {method}."
     ),
     compute=indices.water_budget,
+)
+
+water_budget = Converter(
+    identifier="water_budget",
+    units="kg m-2 s-1",
+    long_name="Water budget",
+    description=(
+        "Precipitation minus potential evapotranspiration as a measure of an approximated surface water budget."
+    ),
+    compute=indices.water_budget,
+    parameters={"method": "dummy"},
 )
 
 

--- a/xclim/indices/_agro.py
+++ b/xclim/indices/_agro.py
@@ -536,12 +536,14 @@ def latitude_temperature_index(
 
 @declare_units(
     pr="[precipitation]",
+    evspsblpot="[precipitation]",
     tasmin="[temperature]",
     tasmax="[temperature]",
     tas="[temperature]",
 )
 def water_budget(
     pr: xarray.DataArray,
+    evspsblpot: xarray.DataArray | None = None,
     tasmin: xarray.DataArray | None = None,
     tasmax: xarray.DataArray | None = None,
     tas: xarray.DataArray | None = None,
@@ -550,12 +552,14 @@ def water_budget(
     r"""Precipitation minus potential evapotranspiration.
 
     Precipitation minus potential evapotranspiration as a measure of an approximated surface water budget,
-    where the potential evapotranspiration is calculated with a given method.
+    where the potential evapotranspiration can be calculated with a given method.
 
     Parameters
     ----------
     pr : xarray.DataArray
       Daily precipitation.
+    evspsblpot: xarray.DataArray
+      Potential evapotranspiration
     tasmin : xarray.DataArray
       Minimum daily temperature.
     tasmax : xarray.DataArray
@@ -576,9 +580,12 @@ def water_budget(
     """
     pr = convert_units_to(pr, "kg m-2 s-1")
 
-    pet = xci.potential_evapotranspiration(
-        tasmin=tasmin, tasmax=tasmax, tas=tas, method=method
-    )
+    if evspsblpot is None:
+        pet = xci.potential_evapotranspiration(
+            tasmin=tasmin, tasmax=tasmax, tas=tas, method=method
+        )
+    else:
+        pet = evspsblpot
 
     if xarray.infer_freq(pet.time) == "MS":
         with xarray.set_options(keep_attrs=True):

--- a/xclim/indices/_agro.py
+++ b/xclim/indices/_agro.py
@@ -585,6 +585,7 @@ def water_budget(
             tasmin=tasmin, tasmax=tasmax, tas=tas, method=method
         )
     else:
+        evspsblpot = convert_units_to(pr, "kg m-2 s-1")
         pet = evspsblpot
 
     if xarray.infer_freq(pet.time) == "MS":

--- a/xclim/testing/tests/conftest.py
+++ b/xclim/testing/tests/conftest.py
@@ -240,6 +240,25 @@ def ndq_series():
 
 
 @pytest.fixture
+def evspsblpot_series():
+    def _evspsblpot_series(values, start="7/1/2000", units="kg m-2 s-1"):
+        coords = pd.date_range(start, periods=len(values), freq="D")
+        return xr.DataArray(
+            values,
+            coords=[coords],
+            dims="time",
+            name="evspsblpot",
+            attrs={
+                "standard_name": "water_evapotranspiration_flux",
+                "cell_methods": "time: mean within days",
+                "units": units,
+            },
+        )
+
+    return _evspsblpot_series
+
+
+@pytest.fixture
 def per_doy():
     def _per_doy(values, calendar="standard", units="kg m-2 s-1"):
         n = max_doy[calendar]

--- a/xclim/testing/tests/test_atmos.py
+++ b/xclim/testing/tests/test_atmos.py
@@ -290,40 +290,52 @@ class TestWaterBudget:
         pr = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc").pr
         tn = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc").tasmin
         tx = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc").tasmax
+        pet = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc").evspsblpot
 
         with xr.set_options(keep_attrs=True):
             tnC = tn - K2C
             tnC.attrs["units"] = "degC"
             prR = pr * 86400
             prR.attrs["units"] = "mm/day"
+            petR = pet * 86400
+            petR.attrs["units"] = "mm/day"
 
-        p_pet_br65 = atmos.water_budget(pr, tn, tx, method="BR65")
-        p_pet_br65C = atmos.water_budget(prR, tnC, tx, method="BR65")
-        p_pet_hg85 = atmos.water_budget(pr, tn, tx, method="HG85")
-        p_pet_hg85C = atmos.water_budget(prR, tnC, tx, method="HG85")
-        p_pet_tw48 = atmos.water_budget(pr, tn, tx, method="TW48")
-        p_pet_tw48C = atmos.water_budget(prR, tnC, tx, method="TW48")
+        p_pet_br65 = atmos.water_budget(pr, tasmin=tn, tasmax=tx, method="BR65")
+        p_pet_br65C = atmos.water_budget(prR, tasmin=tnC, tasmax=tx, method="BR65")
+        p_pet_hg85 = atmos.water_budget(pr, tasmin=tn, tasmax=tx, method="HG85")
+        p_pet_hg85C = atmos.water_budget(prR, tasmin=tnC, tasmax=tx, method="HG85")
+        p_pet_tw48 = atmos.water_budget(pr, tasmin=tn, tasmax=tx, method="TW48")
+        p_pet_tw48C = atmos.water_budget(prR, tasmin=tnC, tasmax=tx, method="TW48")
+        p_pet_evpot = atmos.water_budget(pr, evspsblpot=pet)
+        p_pet_evpotR = atmos.water_budget(prR, evspsblpot=petR)
 
         np.testing.assert_allclose(p_pet_br65, p_pet_br65C, atol=1)
         np.testing.assert_allclose(p_pet_hg85, p_pet_hg85C, atol=1)
         np.testing.assert_allclose(p_pet_tw48, p_pet_tw48C, atol=1)
+        np.testing.assert_allclose(p_pet_evpot, p_pet_evpotR, atol=1)
 
     def test_nan_values(self):
         pr = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc").pr
         tn = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc").tasmin
         tx = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc").tasmax
         tm = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc").tas
+        pet = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc").evspsblpot
 
         tn[0, 100] = np.nan
         tx[0, 101] = np.nan
 
-        p_pet_br65 = atmos.water_budget(pr, tn, tx, method="BR65")
-        p_pet_hg85 = atmos.water_budget(pr, tn, tx, method="HG85")
+        p_pet_br65 = atmos.water_budget(pr, tasmin=tn, tasmax=tx, method="BR65")
+        p_pet_hg85 = atmos.water_budget(pr, tasmin=tn, tasmax=tx, method="HG85")
 
         tm[0, 0:31] = np.nan
 
         p_pet_tw48 = atmos.water_budget(pr, tas=tm, method="TW48")
 
+        pet[0, 0:31] = np.nan
+
+        p_pet_evpot = atmos.water_budget(pr, evspsblpot=pet)
+
         np.testing.assert_allclose(p_pet_br65[0, 100:102], [np.nan, np.nan])
         np.testing.assert_allclose(p_pet_hg85[0, 100:102], [np.nan, np.nan])
         np.testing.assert_allclose(p_pet_tw48[0, 0], [np.nan])
+        np.testing.assert_allclose(p_pet_evpot[0, 0], [np.nan])

--- a/xclim/testing/tests/test_atmos.py
+++ b/xclim/testing/tests/test_atmos.py
@@ -300,12 +300,24 @@ class TestWaterBudget:
             petR = pet * 86400
             petR.attrs["units"] = "mm/day"
 
-        p_pet_br65 = atmos.water_budget_from_tas(pr, tasmin=tn, tasmax=tx, method="BR65")
-        p_pet_br65C = atmos.water_budget_from_tas(prR, tasmin=tnC, tasmax=tx, method="BR65")
-        p_pet_hg85 = atmos.water_budget_from_tas(pr, tasmin=tn, tasmax=tx, method="HG85")
-        p_pet_hg85C = atmos.water_budget_from_tas(prR, tasmin=tnC, tasmax=tx, method="HG85")
-        p_pet_tw48 = atmos.water_budget_from_tas(pr, tasmin=tn, tasmax=tx, method="TW48")
-        p_pet_tw48C = atmos.water_budget_from_tas(prR, tasmin=tnC, tasmax=tx, method="TW48")
+        p_pet_br65 = atmos.water_budget_from_tas(
+            pr, tasmin=tn, tasmax=tx, method="BR65"
+        )
+        p_pet_br65C = atmos.water_budget_from_tas(
+            prR, tasmin=tnC, tasmax=tx, method="BR65"
+        )
+        p_pet_hg85 = atmos.water_budget_from_tas(
+            pr, tasmin=tn, tasmax=tx, method="HG85"
+        )
+        p_pet_hg85C = atmos.water_budget_from_tas(
+            prR, tasmin=tnC, tasmax=tx, method="HG85"
+        )
+        p_pet_tw48 = atmos.water_budget_from_tas(
+            pr, tasmin=tn, tasmax=tx, method="TW48"
+        )
+        p_pet_tw48C = atmos.water_budget_from_tas(
+            prR, tasmin=tnC, tasmax=tx, method="TW48"
+        )
         p_pet_evpot = atmos.water_budget(pr, evspsblpot=pet)
         p_pet_evpotR = atmos.water_budget(prR, evspsblpot=petR)
 
@@ -324,8 +336,12 @@ class TestWaterBudget:
         tn[0, 100] = np.nan
         tx[0, 101] = np.nan
 
-        p_pet_br65 = atmos.water_budget_from_tas(pr, tasmin=tn, tasmax=tx, method="BR65")
-        p_pet_hg85 = atmos.water_budget_from_tas(pr, tasmin=tn, tasmax=tx, method="HG85")
+        p_pet_br65 = atmos.water_budget_from_tas(
+            pr, tasmin=tn, tasmax=tx, method="BR65"
+        )
+        p_pet_hg85 = atmos.water_budget_from_tas(
+            pr, tasmin=tn, tasmax=tx, method="HG85"
+        )
 
         tm[0, 0:31] = np.nan
 

--- a/xclim/testing/tests/test_atmos.py
+++ b/xclim/testing/tests/test_atmos.py
@@ -300,12 +300,12 @@ class TestWaterBudget:
             petR = pet * 86400
             petR.attrs["units"] = "mm/day"
 
-        p_pet_br65 = atmos.water_budget(pr, tasmin=tn, tasmax=tx, method="BR65")
-        p_pet_br65C = atmos.water_budget(prR, tasmin=tnC, tasmax=tx, method="BR65")
-        p_pet_hg85 = atmos.water_budget(pr, tasmin=tn, tasmax=tx, method="HG85")
-        p_pet_hg85C = atmos.water_budget(prR, tasmin=tnC, tasmax=tx, method="HG85")
-        p_pet_tw48 = atmos.water_budget(pr, tasmin=tn, tasmax=tx, method="TW48")
-        p_pet_tw48C = atmos.water_budget(prR, tasmin=tnC, tasmax=tx, method="TW48")
+        p_pet_br65 = atmos.water_budget_from_tas(pr, tasmin=tn, tasmax=tx, method="BR65")
+        p_pet_br65C = atmos.water_budget_from_tas(prR, tasmin=tnC, tasmax=tx, method="BR65")
+        p_pet_hg85 = atmos.water_budget_from_tas(pr, tasmin=tn, tasmax=tx, method="HG85")
+        p_pet_hg85C = atmos.water_budget_from_tas(prR, tasmin=tnC, tasmax=tx, method="HG85")
+        p_pet_tw48 = atmos.water_budget_from_tas(pr, tasmin=tn, tasmax=tx, method="TW48")
+        p_pet_tw48C = atmos.water_budget_from_tas(prR, tasmin=tnC, tasmax=tx, method="TW48")
         p_pet_evpot = atmos.water_budget(pr, evspsblpot=pet)
         p_pet_evpotR = atmos.water_budget(prR, evspsblpot=petR)
 
@@ -324,12 +324,12 @@ class TestWaterBudget:
         tn[0, 100] = np.nan
         tx[0, 101] = np.nan
 
-        p_pet_br65 = atmos.water_budget(pr, tasmin=tn, tasmax=tx, method="BR65")
-        p_pet_hg85 = atmos.water_budget(pr, tasmin=tn, tasmax=tx, method="HG85")
+        p_pet_br65 = atmos.water_budget_from_tas(pr, tasmin=tn, tasmax=tx, method="BR65")
+        p_pet_hg85 = atmos.water_budget_from_tas(pr, tasmin=tn, tasmax=tx, method="HG85")
 
         tm[0, 0:31] = np.nan
 
-        p_pet_tw48 = atmos.water_budget(pr, tas=tm, method="TW48")
+        p_pet_tw48 = atmos.water_budget_from_tas(pr, tas=tm, method="TW48")
 
         pet[0, 0:31] = np.nan
 

--- a/xclim/testing/tests/test_indicators.py
+++ b/xclim/testing/tests/test_indicators.py
@@ -30,7 +30,7 @@ from xclim.testing import open_dataset
 
 
 @declare_units(da="[temperature]", thresh="[temperature]")
-def uniindtemp_compute(da: xr.DataArray, thresh: str = "0.0 degC", freq: str = "YS"):
+def uniindtemp_compute(da: xr.DataArray, thresh: str = "0.0 degC", freq: str = "YS", method: str = "injected"):
     """Docstring"""
     out = da - convert_units_to(thresh, da)
     out = out.resample(time=freq).mean()
@@ -53,6 +53,7 @@ uniIndTemp = Daily(
         )
     ],
     compute=uniindtemp_compute,
+    parameters={"method": "injected"}
 )
 
 

--- a/xclim/testing/tests/test_indices.py
+++ b/xclim/testing/tests/test_indices.py
@@ -2491,7 +2491,7 @@ def test_water_budget(pr_series, evspsblpot_series):
     pet.attrs["units"] = "mm/day"
 
     out = xci.water_budget(pr, evspsblpot=pet)
-    np.testing.assert_allclose(out, [10, 0, -10], rtol=1e-3)
+    np.testing.assert_allclose(out, [10 / 86400, 0, -10 / 86400], rtol=1e-5)
 
 
 @pytest.mark.parametrize(

--- a/xclim/testing/tests/test_indices.py
+++ b/xclim/testing/tests/test_indices.py
@@ -2451,7 +2451,7 @@ class TestPotentialEvapotranspiration:
         np.testing.assert_allclose(out[2, 0], [2.78253138816 / 86400], rtol=1e-2)
 
 
-def test_water_budget(pr_series, tasmin_series, tasmax_series):
+def test_water_budget_from_tas(pr_series, tasmin_series, tasmax_series):
     pr = pr_series(np.array([10, 10, 10]))
     pr.attrs["units"] = "mm/day"
     pr = pr.expand_dims(lat=[45])
@@ -2460,10 +2460,10 @@ def test_water_budget(pr_series, tasmin_series, tasmax_series):
     tx = tasmax_series(np.array([10, 15, 20]) + K2C)
     tx = tx.expand_dims(lat=[45])
 
-    out = xci.water_budget(pr, tn, tx, method="BR65")
+    out = xci.water_budget(pr, tasmin=tn, tasmax=tx, method="BR65")
     np.testing.assert_allclose(out[0, 2], [6.138921 / 86400], rtol=1e-3)
 
-    out = xci.water_budget(pr, tn, tx, method="HG85")
+    out = xci.water_budget(pr, tasmin=tn, tasmax=tx, method="HG85")
     np.testing.assert_allclose(out[0, 2], [6.037411 / 86400], rtol=1e-3)
 
     time_std = date_range("1990-01-01", "1990-12-01", freq="MS", calendar="standard")
@@ -2482,6 +2482,16 @@ def test_water_budget(pr_series, tasmin_series, tasmax_series):
 
     out = xci.water_budget(prm, tas=tm, method="TW48")
     np.testing.assert_allclose(out[1, 0], [8.5746025 / 86400], rtol=1e-1)
+
+
+def test_water_budget(pr_series, evspsblpot_series):
+    pr = pr_series(np.array([10, 10, 10]))
+    pr.attrs["units"] = "mm/day"
+    pet = evspsblpot_series(np.array([0, 10, 20]))
+    pet.attrs["units"] = "mm/day"
+
+    out = xci.water_budget(pr, evspsblpot=pet)
+    np.testing.assert_allclose(out, [10, 0, -10], rtol=1e-3)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - No.
- [x] Tests for the changes have been added (for bug fixes / features)
  - [x] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added
- [ ] `bumpversion patch` has been called on this branch
- [x] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

* Added the possibility of calculating `water_budget` with `evsbspltot`, instead of being forced into calculating potential evapotranspiration from temperatures.
* The original indicator has been renamed `water_budget_from_tas`.
* Injected parameters are now left out of a function's signature and will not be included in the `history` attribute.

### Does this PR introduce a breaking change?


### Other information:
