### PR TITLE
Fix equation in documentation of QuantileDeltaMapping

### DIFF
--- a/xclim/sdba/adjustment.py
+++ b/xclim/sdba/adjustment.py
@@ -505,7 +505,7 @@ class QuantileDeltaMapping(EmpiricalQuantileMapping):
 
     .. math::
 
-        sim\frac{F^{-1}_{ref}\left[F_{sim}(sim)\right]}{F^{-1}_{hist}\left[F_{sim}(sim)\right]}
+        sim\frac{F^{-1}_{hist}\left[F_{sim}(sim)\right]}{F^{-1}_{ref}\left[F_{sim}(sim)\right]}
 
     where :math:`F` is the cumulative distribution function (CDF). This equation is valid for multiplicative adjustment.
     The algorithm is based on the "QDM" method of [Cannon2015]_.


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added
- [ ] `bumpversion patch` has been called on this branch
- [ ] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

* Fixed equation in documentation of Fix equation in documentation of QuantileDeltaMapping

### Does this PR introduce a breaking change?
No, there are no changes to the code.

### Other information:

I think the equation in the [documentation](https://xclim.readthedocs.io/en/stable/sdba.html#xclim.sdba.adjustment.QuantileDeltaMapping) of QuantileDeltaMapping has the `hist` and `ref`  subscripts the wrong way around. This can be traced back to equations 3, 4, 5, 6 of the Cannon 2015 paper (linked in the documentation) with the following mapping from the notation in the paper to xclim:
- `_m,p` maps to `_sim`
- `_m,h` maps to `_ref`
- `_o,h` maps to `_hist` 
- `x_m,p(t)` maps to `sim`
- `tau_m,p` maps to `F_sim(sim)` (equation 3)