### PR TITLE
Fix/#1091 seasonal doy adjustment

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -45,6 +45,7 @@ Bug fixes
 ^^^^^^^^^
 * Clean the `bias_adjustement` and `history` attributes created by `xclim.sdba.adjust` (e.g. when an argument  is an `xr.DataArray`, only print the name instead of the whole array). (:issue:`1083`, :pull:`1087`).
 * `pydocstyle` checks were silently failing in the `pre-commit` configuration due to a badly-formed regex. This has been adjusted. (:pull:`1074`).
+* `adjust_doy_calendar` was broken when the source or the target were seasonal. (:issue:`1097`, :issue:`1091`, :pull:``)
 
 v0.36.0 (29-04-2022)
 --------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -45,7 +45,7 @@ Bug fixes
 ^^^^^^^^^
 * Clean the `bias_adjustement` and `history` attributes created by `xclim.sdba.adjust` (e.g. when an argument  is an `xr.DataArray`, only print the name instead of the whole array). (:issue:`1083`, :pull:`1087`).
 * `pydocstyle` checks were silently failing in the `pre-commit` configuration due to a badly-formed regex. This has been adjusted. (:pull:`1074`).
-* `adjust_doy_calendar` was broken when the source or the target were seasonal. (:issue:`1097`, :issue:`1091`, :pull:``)
+* `adjust_doy_calendar` was broken when the source or the target were seasonal. (:issue:`1097`, :issue:`1091`, :pull:`1099`)
 
 v0.36.0 (29-04-2022)
 --------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.36.8-beta
+current_version = 0.36.9-beta
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+).(?P<patch>\d+)(\-(?P<release>[a-z]+))?

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.36.7-beta
+current_version = 0.36.8-beta
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+).(?P<patch>\d+)(\-(?P<release>[a-z]+))?

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ URL = "https://github.com/Ouranosinc/xclim"
 AUTHOR = "Travis Logan"
 AUTHOR_EMAIL = "logan.travis@ouranos.ca"
 REQUIRES_PYTHON = ">=3.8.0"
-VERSION = "0.36.7-beta"
+VERSION = "0.36.8-beta"
 LICENSE = "Apache Software License 2.0"
 
 with open("README.rst") as readme_file:

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ URL = "https://github.com/Ouranosinc/xclim"
 AUTHOR = "Travis Logan"
 AUTHOR_EMAIL = "logan.travis@ouranos.ca"
 REQUIRES_PYTHON = ">=3.8.0"
-VERSION = "0.36.8-beta"
+VERSION = "0.36.9-beta"
 LICENSE = "Apache Software License 2.0"
 
 with open("README.rst") as readme_file:

--- a/xclim/__init__.py
+++ b/xclim/__init__.py
@@ -11,7 +11,7 @@ from xclim.indicators import atmos, land, seaIce  # noqa
 
 __author__ = """Travis Logan"""
 __email__ = "logan.travis@ouranos.ca"
-__version__ = "0.36.8-beta"
+__version__ = "0.36.9-beta"
 
 
 # Load official locales

--- a/xclim/__init__.py
+++ b/xclim/__init__.py
@@ -11,7 +11,7 @@ from xclim.indicators import atmos, land, seaIce  # noqa
 
 __author__ = """Travis Logan"""
 __email__ = "logan.travis@ouranos.ca"
-__version__ = "0.36.7-beta"
+__version__ = "0.36.8-beta"
 
 
 # Load official locales

--- a/xclim/core/missing.py
+++ b/xclim/core/missing.py
@@ -86,10 +86,7 @@ class MissingBase:
     @staticmethod
     def is_null(da, freq, **indexer):
         """Return a boolean array indicating which values are null."""
-        if indexer:
-            indexer.update({"drop": True})
-        else:
-            indexer = {"drop": True}
+        indexer.update({"drop": True})
         selected = select_time(da, **indexer)
         if selected.time.size == 0:
             raise ValueError("No data for selected period.")
@@ -156,10 +153,7 @@ class MissingBase:
             )
 
             sda = xr.DataArray(data=np.ones(len(t)), coords={"time": t}, dims=("time",))
-            if indexer:
-                indexer.update({"drop": True})
-            else:
-                indexer = {"drop": True}
+            indexer.update({"drop": True})
             st = select_time(sda, **indexer)
             if freq:
                 count = st.notnull().resample(time=freq).sum(dim="time")

--- a/xclim/core/missing.py
+++ b/xclim/core/missing.py
@@ -86,7 +86,11 @@ class MissingBase:
     @staticmethod
     def is_null(da, freq, **indexer):
         """Return a boolean array indicating which values are null."""
-        selected = select_time(da, drop=True, **indexer)
+        if indexer:
+            indexer.update({"drop": True})
+        else:
+            indexer = {"drop": True}
+        selected = select_time(da, **indexer)
         if selected.time.size == 0:
             raise ValueError("No data for selected period.")
 
@@ -152,7 +156,11 @@ class MissingBase:
             )
 
             sda = xr.DataArray(data=np.ones(len(t)), coords={"time": t}, dims=("time",))
-            st = select_time(sda, drop=True, **indexer)
+            if indexer:
+                indexer.update({"drop": True})
+            else:
+                indexer = {"drop": True}
+            st = select_time(sda, **indexer)
             if freq:
                 count = st.notnull().resample(time=freq).sum(dim="time")
             else:

--- a/xclim/sdba/utils.py
+++ b/xclim/sdba/utils.py
@@ -117,9 +117,13 @@ def ensure_longest_doy(func: Callable) -> Callable:
                 stacklevel=4,
             )
             if x.dayofyear.max() < y.dayofyear.max():
-                x = _interpolate_doy_calendar(x, int(y.dayofyear.max()))
+                x = _interpolate_doy_calendar(
+                    x, int(y.dayofyear.max()), int(y.dayofyear.min())
+                )
             else:
-                y = _interpolate_doy_calendar(y, int(x.dayofyear.max()))
+                y = _interpolate_doy_calendar(
+                    y, int(x.dayofyear.max()), int(x.dayofyear.min())
+                )
         return func(x, y, *args, **kwargs)
 
     return _ensure_longest_doy

--- a/xclim/testing/tests/test_bootstrapping.py
+++ b/xclim/testing/tests/test_bootstrapping.py
@@ -210,17 +210,17 @@ class Test_bootstrap:
     ):
         # -- GIVEN
         arr = self.ar1(alpha=0.8, n=int(4 * 365.25), positive_values=positive_values)
-        climat_variable = series(arr, start="2000-01-01")
+        climate_var = series(arr, start="2000-01-01")
         if use_dask:
-            climat_variable = climat_variable.chunk(dict(time=50))
+            climate_var = climate_var.chunk(dict(time=50))
         in_base_slice = slice("2000-01-01", "2001-12-31")
         out_base_slice = slice("2002-01-01", "2003-12-31")
-        per = percentile_doy(climat_variable.sel(time=in_base_slice), per=per)
+        per = percentile_doy(climate_var.sel(time=in_base_slice), per=per)
         # -- WHEN
-        no_bootstrap = index_fun(climat_variable, per, False)
+        no_bootstrap = index_fun(climate_var, per, False)
         no_bs_in_base = no_bootstrap.sel(time=in_base_slice)
         no_bs_out_base = no_bootstrap.sel(time=out_base_slice)
-        bootstrap = index_fun(climat_variable, per, True)
+        bootstrap = index_fun(climate_var, per, True)
         bootstrapped_in_base = bootstrap.sel(time=in_base_slice)
         bs_out_base = bootstrap.sel(time=out_base_slice)
         # -- THEN

--- a/xclim/testing/tests/test_calendar.py
+++ b/xclim/testing/tests/test_calendar.py
@@ -147,6 +147,51 @@ def test_adjust_doy_360_to_366():
     assert out.sel(dayofyear=366) == source.sel(dayofyear=360)
 
 
+def test_adjust_doy__max_93_to_max_94():
+    # GIVEN
+    source = xr.DataArray(np.arange(92), coords=[np.arange(152, 244)], dims="dayofyear")
+    time = xr.cftime_range("2000-06-01", periods=92, freq="D", calendar="all_leap")
+    target = xr.DataArray(np.arange(len(time)), coords=[time], dims="time")
+    # WHEN
+    out = adjust_doy_calendar(source, target)
+    # THEN
+    assert out[0].dayofyear == 153
+    assert out[0] == source[0]
+    assert out[-1].dayofyear == 244
+    assert out[-1] == source[-1]
+
+
+# def test_adjust_doy__leap_to_noleap_djf():
+#     # FIXME:
+#     #    this fails with `ValueError: Index 'dayofyear' must be monotonically increasing`
+#     #      on calendar.py::_interpolate_doy_calendar
+#     #      at`filled_na = da.interpolate_na(dim="dayofyear")`
+#     # GIVEN
+#     # leap source
+#     source = xr.DataArray(np.arange(92), coords=[np.concatenate([np.arange(335,367), np.arange(1, 61)])], dims="dayofyear")
+#     time = xr.cftime_range("2000-12-01", periods=91, freq="D", calendar="noleap")
+#     target = xr.DataArray(np.arange(len(time)), coords=[time], dims="time")
+#     # WHEN
+#     out = adjust_doy_calendar(source, target)
+#     # THEN
+#     assert out[0].dayofyear == 335
+#     assert out[0] == source[0]
+#     assert 366 not in out.dayofyear
+#     assert out[-1].dayofyear == 61
+#     assert out[-1] == source[-1]
+
+
+def test_adjust_doy_366_to_360():
+    source = xr.DataArray(np.arange(366), coords=[np.arange(1, 367)], dims="dayofyear")
+    time = xr.cftime_range("2000", periods=360, freq="D", calendar="360_day")
+    target = xr.DataArray(np.arange(len(time)), coords=[time], dims="time")
+
+    out = adjust_doy_calendar(source, target)
+
+    assert out.sel(dayofyear=1) == source.sel(dayofyear=1)
+    assert out.sel(dayofyear=360) == source.sel(dayofyear=366)
+
+
 @pytest.mark.parametrize(
     "file,cal,maxdoy",
     [

--- a/xclim/testing/tests/test_calendar.py
+++ b/xclim/testing/tests/test_calendar.py
@@ -161,24 +161,23 @@ def test_adjust_doy__max_93_to_max_94():
     assert out[-1] == source[-1]
 
 
-# def test_adjust_doy__leap_to_noleap_djf():
-#     # FIXME:
-#     #    this fails with `ValueError: Index 'dayofyear' must be monotonically increasing`
-#     #      on calendar.py::_interpolate_doy_calendar
-#     #      at`filled_na = da.interpolate_na(dim="dayofyear")`
-#     # GIVEN
-#     # leap source
-#     source = xr.DataArray(np.arange(92), coords=[np.concatenate([np.arange(335,367), np.arange(1, 61)])], dims="dayofyear")
-#     time = xr.cftime_range("2000-12-01", periods=91, freq="D", calendar="noleap")
-#     target = xr.DataArray(np.arange(len(time)), coords=[time], dims="time")
-#     # WHEN
-#     out = adjust_doy_calendar(source, target)
-#     # THEN
-#     assert out[0].dayofyear == 335
-#     assert out[0] == source[0]
-#     assert 366 not in out.dayofyear
-#     assert out[-1].dayofyear == 61
-#     assert out[-1] == source[-1]
+def test_adjust_doy__leap_to_noleap_djf():
+    # GIVEN
+    leap_source = xr.DataArray(
+        np.arange(92),
+        coords=[np.concatenate([np.arange(1, 61), np.arange(335, 367)])],
+        dims="dayofyear",
+    )
+    time = xr.cftime_range("2000-12-01", periods=91, freq="D", calendar="noleap")
+    no_leap_target = xr.DataArray(np.arange(len(time)), coords=[time], dims="time")
+    # WHEN
+    out = adjust_doy_calendar(leap_source, no_leap_target)
+    # THEN
+    assert out[0].dayofyear == 1
+    assert out[0] == leap_source[0]
+    assert 366 not in out.dayofyear
+    assert out[-1].dayofyear == 365
+    assert out[-1] == leap_source[-1]
 
 
 def test_adjust_doy_366_to_360():


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1091 #1097 
- [x] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added
- [x] `bumpversion patch` has been called on this branch
- [ ] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?
This PR makes adjust_doy_calendar works with partially filled time-series such as seasonal time series.
It also fix a bug on missing checks, where `drop=True` indexer kwargs was not properly overriding the current indexer.


### Does this PR introduce a breaking change?
No.
