### PR TITLE
Omit testing files from coverage stats

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -41,6 +41,7 @@ Internal changes
 * `isort` project configurations are now set in `setup.cfg`. (:pull:`1071`).
 * Many function docstrings, external target links, and internal section references have been adjusted to reduce warnings when building the docs. (:pull:`1074`).
 * Code snippets within documentation are now checked and reformatted to `black` conventions with `blackdoc`. A `pre-commit` hook is now in place to run these checks. (:pull:`1098`).
+* Test coverage statistic no longer includes coverage of the test files themselves. Coverage now reflects lines of usable code covered. (:pull:`1101`).
 
 Bug fixes
 ^^^^^^^^^

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ replace = __version__ = "{new_version}"
 
 [coverage:run]
 relative_files = True
-omit = */test_*.py
+omit = */tests/*.py
 
 [flake8]
 exclude =

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,13 +3,13 @@ current_version = 0.36.8-beta
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+).(?P<patch>\d+)(\-(?P<release>[a-z]+))?
-serialize = 
+serialize =
 	{major}.{minor}.{patch}-{release}
 	{major}.{minor}.{patch}
 
 [bumpversion:part:release]
 optional_value = gamma
-values = 
+values =
 	beta
 	gamma
 
@@ -23,16 +23,17 @@ replace = __version__ = "{new_version}"
 
 [coverage:run]
 relative_files = True
+omit = */test_*.py
 
 [flake8]
-exclude = 
+exclude =
 	.git,
 	docs,
 	build,
 	.eggs,
 max-line-length = 88
 max-complexity = 12
-ignore = 
+ignore =
 	C901
 	E203
 	E231
@@ -42,9 +43,9 @@ ignore =
 	F403
 	W503
 	W504
-per-file-ignores = 
+per-file-ignores =
 	tests/*:E402
-rst-roles = 
+rst-roles =
 	doc,
 	mod,
 	py:attr,
@@ -59,7 +60,7 @@ rst-roles =
 	py:obj,
 	py:ref,
 	ref
-extend-ignore = 
+extend-ignore =
 	RST399,
 	RST201,
 	RST203,
@@ -72,18 +73,18 @@ test = pytest
 [tool:pytest]
 addopts = --verbose
 norecursedirs = docs/notebooks/*
-filterwarnings = 
+filterwarnings =
 	ignore::UserWarning
 testpaths = xclim/testing/tests xclim/testing/tests/test_sdba
 usefixtures = xdoctest_namespace
 doctest_optionflags = NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL NUMBER ELLIPSIS
-markers = 
+markers =
 	slow: marks tests as slow (deselect with '-m "not slow"')
 	requires_docs: mark tests that can only be run with documentation present
 
 [tool:pylint]
 ignore = docs,tests
-disable = 
+disable =
 	bad-continuation,
 	invalid-name,
 	line-too-long,


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added
- [ ] `bumpversion patch` has been called on this branch
- [x] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

* Omits the testing files from the coverage statistics

### Does this PR introduce a breaking change?

No.

### Other information:

Coverage was artificially being boosted by the fact that the testing files were included in the statistic sent to coveralls. This PR removes them.
