### PR TITLE
[DO NOT MERGE] Automatically bumpversion on PR merge

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,6 @@
   - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
 - [ ] HISTORY.rst has been updated (with summary of main changes)
   - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added
-- [ ] `bumpversion patch` has been called on this branch
 - [ ] The relevant author information has been added to `.zenodo.json`
 
 ### What kind of change does this PR introduce?

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,35 @@
+name: "Bump Patch Version"
+
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - setup.cfg
+      - setup.py
+      - xclim/__init__.py
+
+jobs:
+  bump_patch_version:
+    runs-on: ubuntu-latest
+    container: python:3-slim
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+      - name: Config Commit Bot
+        run: |
+          git config --local user.email "bumpversion[bot]@ouranos.ca"
+          git config --local user.name "bumpversion[bot]"
+      - name: Current Version
+        run: echo "current_version=$(grep -E '__version__'  xclim/__init__.py | cut -d ' ' -f3)"
+      - name: Bump Patch Version
+        run: |
+          pip install bump2version
+          bump2version patch
+      - name: Push Changes
+        uses: ad-m/github-push-action@master
+        with:
+          force: false
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: xclim
+name: "Xclim Testing Suite"
 
 on:
   push:

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,4 +1,4 @@
-name: Publish Python 🐍 distributions 📦 to PyPI
+name: "Publish Python 🐍 distributions 📦 to PyPI"
 
 on:
   release:

--- a/.github/workflows/tag-testpypi.yml
+++ b/.github/workflows/tag-testpypi.yml
@@ -1,4 +1,4 @@
-name: Publish Python 🐍 distributions 📦 to TestPyPI
+name: "Publish Python 🐍 distributions 📦 to TestPyPI"
 
 on:
   push:


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added
- [ ] `bumpversion patch` has been called on this branch
- [ ] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

* Adds an action that will automatically run `bump2version patch` when a mergd PR changes anything other than the files where version is stored.

### Does this PR introduce a breaking change?

No.

### Other information:

Related conversation: https://github.com/Ouranosinc/xclim/pull/1099#issuecomment-1151080824

The reason for marking [DO NOT MERGE] is because I would like to employ this workflow in a test repo first. If this is misconfigured, we could have a continuously running action (bumpversion -> changes found -> bumpversion -> changes found -> etc.).
