### PR TITLE
Mention missing checks in history

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -25,6 +25,7 @@ New features and enhancements
 * New ``xclim.core.calendar.construct_offset``, the inverse operation of ``parse_offset``. (:pull:`1090`).
 * Rechunking operations in ``xclim.indices.run_length.rle`` are now synchronized with dask's options. (:pull:`1090`).
 * A convenience recipe for installing key development branches of some dependencies has been added (`$ pip install xclim[upstream]`). (:issue:`1088`, :pull:`1092`).
+* A mention of the "missing" checks and options is added to the history attribute of indicators, where appropriate. (:issue:`1100`, :pull:`1103`).
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,15 +1,15 @@
 [bumpversion]
-current_version = 0.36.9-beta
+current_version = 0.36.10-beta
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+).(?P<patch>\d+)(\-(?P<release>[a-z]+))?
-serialize =
+serialize = 
 	{major}.{minor}.{patch}-{release}
 	{major}.{minor}.{patch}
 
 [bumpversion:part:release]
 optional_value = gamma
-values =
+values = 
 	beta
 	gamma
 
@@ -26,14 +26,14 @@ relative_files = True
 omit = */tests/*.py
 
 [flake8]
-exclude =
+exclude = 
 	.git,
 	docs,
 	build,
 	.eggs,
 max-line-length = 88
 max-complexity = 12
-ignore =
+ignore = 
 	C901
 	E203
 	E231
@@ -43,9 +43,9 @@ ignore =
 	F403
 	W503
 	W504
-per-file-ignores =
+per-file-ignores = 
 	tests/*:E402
-rst-roles =
+rst-roles = 
 	doc,
 	mod,
 	py:attr,
@@ -60,7 +60,7 @@ rst-roles =
 	py:obj,
 	py:ref,
 	ref
-extend-ignore =
+extend-ignore = 
 	RST399,
 	RST201,
 	RST203,
@@ -73,18 +73,18 @@ test = pytest
 [tool:pytest]
 addopts = --verbose
 norecursedirs = docs/notebooks/*
-filterwarnings =
+filterwarnings = 
 	ignore::UserWarning
 testpaths = xclim/testing/tests xclim/testing/tests/test_sdba
 usefixtures = xdoctest_namespace
 doctest_optionflags = NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL NUMBER ELLIPSIS
-markers =
+markers = 
 	slow: marks tests as slow (deselect with '-m "not slow"')
 	requires_docs: mark tests that can only be run with documentation present
 
 [tool:pylint]
 ignore = docs,tests
-disable =
+disable = 
 	bad-continuation,
 	invalid-name,
 	line-too-long,

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ URL = "https://github.com/Ouranosinc/xclim"
 AUTHOR = "Travis Logan"
 AUTHOR_EMAIL = "logan.travis@ouranos.ca"
 REQUIRES_PYTHON = ">=3.8.0"
-VERSION = "0.36.9-beta"
+VERSION = "0.36.10-beta"
 LICENSE = "Apache Software License 2.0"
 
 with open("README.rst") as readme_file:

--- a/xclim/__init__.py
+++ b/xclim/__init__.py
@@ -11,7 +11,7 @@ from xclim.indicators import atmos, land, seaIce  # noqa
 
 __author__ = """Travis Logan"""
 __email__ = "logan.travis@ouranos.ca"
-__version__ = "0.36.9-beta"
+__version__ = "0.36.10-beta"
 
 
 # Load official locales

--- a/xclim/testing/tests/test_indicators.py
+++ b/xclim/testing/tests/test_indicators.py
@@ -152,7 +152,10 @@ def test_attrs(tas_series):
     txm = uniIndTemp(a, thresh="5 degC", freq="YS")
     assert txm.cell_methods == "time: mean within days time: mean within years"
     assert f"{dt.datetime.now():%Y-%m-%d %H}" in txm.attrs["history"]
-    assert "TMIN(da=tas, thresh='5 degC', freq='YS')" in txm.attrs["history"]
+    assert (
+        "TMIN(da=tas, thresh='5 degC', freq='YS') with options check_missing=any"
+        in txm.attrs["history"]
+    )
     assert f"xclim version: {__version__}" in txm.attrs["history"]
     assert txm.name == "tmin5 degC"
     assert uniIndTemp.standard_name == "{freq} mean temperature"
@@ -360,6 +363,7 @@ def test_missing(tas_series):
     ):
         m = uniIndTemp(a, freq="MS")
         assert not m[0].isnull()
+        assert "check_missing=pct, missing_options={'tolerance': 0.05}" in m.history
 
     with xclim.set_options(check_missing="wmo"):
         m = uniIndTemp(a, freq="YS")

--- a/xclim/testing/tests/test_modules.py
+++ b/xclim/testing/tests/test_modules.py
@@ -47,7 +47,7 @@ def test_virtual_modules(virtual_indicator, atmosds):
         # skip when missing default values
         mod, indname, ind = virtual_indicator
         for name, param in ind.parameters.items():
-            if param.kind is not InputKind.DATASET and (
+            if param.kind not in [InputKind.DATASET, InputKind.KWARGS] and (
                 param.default in (None, _empty)
                 or (param.default == name and name not in atmosds)
             ):


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1100
- [x] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added
- [ ] `bumpversion patch` has been called on this branch
- [x] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

* The history string can be edited by subclasses of `Indicator` through the `_history_string` method.
* `ResamplingIndicator` will append `with options check_missing=XXX, missing_options=ZZZ` to the history line that gets added to the metadata. The `missing_options` part is only added when pertinent.
* Minor unrelated change : in `test_modules`, the `indexer` kwargs are not needed to automatically test virtual indicators. This bug was introduced by #1070.

### Does this PR introduce a breaking change?
Shouldn't, unless people are testing the history attribute.
