### PR TITLE
Remove EPUB from ReadTheDocs output formats

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,6 @@ sphinx:
   configuration: docs/conf.py
 
 formats:
-  - epub
   - pdf
 
 build:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -232,21 +232,25 @@ htmlhelp_basename = "xclimdoc"
 
 # -- Options for LaTeX output ------------------------------------------
 
+latex_engine = "pdflatex"
+latex_logo = "_static/_images/xclim-logo.png"
+
 latex_elements = {
+    "fontpkg": r"""
+\setmainfont{DejaVu Serif}
+\setsansfont{DejaVu Sans}
+\setmonofont{DejaVu Sans Mono}
+""",
     # The paper size ('letterpaper' or 'a4paper').
-    #
-    # 'papersize': 'letterpaper',
+    "papersize": "letterpaper",
     # The font size ('10pt', '11pt' or '12pt').
-    #
-    # 'pointsize': '10pt',
+    "pointsize": "10pt",
     # Additional stuff for the LaTeX preamble.
-    #
-    # 'preamble': r"""
-    # \renewcommand{\v}[1]{\mathbf{#1}}
-    # """,
+    "preamble": r"""
+\renewcommand{\v}[1]{\mathbf{#1}}
+""",
     # Latex figure (float) alignment
-    #
-    # 'figure_align': 'htbp',
+    "figure_align": "htbp",
 }
 
 # Grouping the document tree into LaTeX files. List of tuples

--- a/xclim/indices/_conversion.py
+++ b/xclim/indices/_conversion.py
@@ -932,7 +932,7 @@ def clausius_clapeyron_scaled_precipitation(
     water vapor pressure :math:`e_s` changes approximately exponentially with temperature
 
     .. math::
-        \frac{\\mathrm{d}e_s(T)}{\\mathrm{d}T} \approx 1.07 e_s(T)
+        \frac{\mathrm{d}e_s(T)}{\mathrm{d}T} \approx 1.07 e_s(T)
 
     This function assumes that precipitation can be scaled by the same factor.
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added
- [ ] `bumpversion patch` has been called on this branch
- [ ] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

* Removed EPUB as an output from the ReadTheDocs version of the documentation
* Added some LaTeX elements to help build the PDF version of documentation
* Fixed a badly-written formula

### Does this PR introduce a breaking change?

No.

### Other information:
