### PR TITLE
ENH: template indicators with jinja

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ requirements = [
     "scipy>=1.2",
     "statsmodels",
     "xarray>=0.17",
+    "Jinja2",
 ]
 
 dev_requirements = []

--- a/xclim/core/formatting.py
+++ b/xclim/core/formatting.py
@@ -81,9 +81,8 @@ class AttrFormatter(string.Formatter):
         for k, v in DEFAULT_FORMAT_PARAMS.items():
             if k not in kwargs:
                 kwargs.update({k: v})
-        intermediary_res = jinja_env.from_string(
-            format_string, globals={"np": np}
-        ).render()
+        kwargs.update({"np": np})  # noqa
+        intermediary_res = jinja_env.from_string(format_string, globals=kwargs).render()
         return super().format(intermediary_res, *args, **kwargs)
 
     def format_field(self, value, format_spec):

--- a/xclim/core/formatting.py
+++ b/xclim/core/formatting.py
@@ -36,7 +36,7 @@ DEFAULT_FORMAT_PARAMS = {
     "pr_per_period": "{unkown}",
 }
 
-jinja_env = Environment()
+jinja_env = Environment(autoescape=True)
 
 
 class AttrFormatter(string.Formatter):
@@ -81,8 +81,10 @@ class AttrFormatter(string.Formatter):
         for k, v in DEFAULT_FORMAT_PARAMS.items():
             if k not in kwargs:
                 kwargs.update({k: v})
-        kwargs["np"] = np  # noqa
-        return jinja_env.from_string(format_string, globals=kwargs).render()
+        intermediary_res = jinja_env.from_string(
+            format_string, globals={"np": np}
+        ).render()
+        return super().format(intermediary_res, *args, **kwargs)
 
     def format_field(self, value, format_spec):
         """Format a value given a formatting spec.

--- a/xclim/core/formatting.py
+++ b/xclim/core/formatting.py
@@ -14,8 +14,10 @@ from fnmatch import fnmatch
 from inspect import _empty, signature  # noqa
 from typing import Any, Mapping, Sequence
 
+import numpy as np
 import xarray as xr
 from boltons.funcutils import wraps
+from jinja2 import Environment
 
 from xclim.core.utils import InputKind, PercentileDataArray
 
@@ -33,6 +35,8 @@ DEFAULT_FORMAT_PARAMS = {
     "pr_per_window": "{unkown}",
     "pr_per_period": "{unkown}",
 }
+
+jinja_env = Environment()
 
 
 class AttrFormatter(string.Formatter):
@@ -77,7 +81,8 @@ class AttrFormatter(string.Formatter):
         for k, v in DEFAULT_FORMAT_PARAMS.items():
             if k not in kwargs:
                 kwargs.update({k: v})
-        return super().format(format_string, *args, **kwargs)
+        kwargs["np"] = np  # noqa
+        return jinja_env.from_string(format_string, globals=kwargs).render()
 
     def format_field(self, value, format_spec):
         """Format a value given a formatting spec.

--- a/xclim/indicators/atmos/_temperature.py
+++ b/xclim/indicators/atmos/_temperature.py
@@ -95,8 +95,8 @@ tn_days_above = TempWithIndexing(
     identifier="tn_days_above",
     units="days",
     standard_name="number_of_days_with_air_temperature_above_threshold",
-    long_name="Number of days with Tmin > {{thresh}}",
-    description="{{freq}} number of days where daily minimum temperature exceeds {{thresh}}.",
+    long_name="Number of days with Tmin > {thresh}",
+    description="{freq} number of days where daily minimum temperature exceeds {thresh}.",
     cell_methods="time: sum over days",
     compute=indices.tn_days_above,
 )
@@ -105,8 +105,8 @@ tn_days_below = TempWithIndexing(
     identifier="tn_days_below",
     units="days",
     standard_name="number_of_days_with_air_temperature_below_threshold",
-    long_name="Number of days with Tmin < {{thresh}}",
-    description="{{freq}} number of days where daily minimum temperature is below {{thresh}}.",
+    long_name="Number of days with Tmin < {thresh}",
+    description="{freq} number of days where daily minimum temperature is below {thresh}.",
     cell_methods="time: sum over days",
     compute=indices.tn_days_below,
 )
@@ -115,8 +115,8 @@ tg_days_above = TempWithIndexing(
     identifier="tg_days_above",
     units="days",
     standard_name="number_of_days_with_air_temperature_above_threshold",
-    long_name="Number of days with Tavg > {{thresh}}",
-    description="{{freq}} number of days where daily mean temperature exceeds {{thresh}}.",
+    long_name="Number of days with Tavg > {thresh}",
+    description="{freq} number of days where daily mean temperature exceeds {thresh}.",
     cell_methods="time: sum over days",
     compute=indices.tg_days_above,
 )
@@ -125,8 +125,8 @@ tg_days_below = TempWithIndexing(
     identifier="tg_days_below",
     units="days",
     standard_name="number_of_days_with_air_temperature_below_threshold",
-    long_name="Number of days with Tavg < {{thresh}}",
-    description="{{freq}} number of days where daily mean temperature is below {{thresh}}.",
+    long_name="Number of days with Tavg < {thresh}",
+    description="{freq} number of days where daily mean temperature is below {thresh}.",
     cell_methods="time: sum over days",
     compute=indices.tg_days_below,
 )
@@ -135,8 +135,8 @@ tx_days_above = TempWithIndexing(
     identifier="tx_days_above",
     units="days",
     standard_name="number_of_days_with_air_temperature_above_threshold",
-    long_name="Number of days with Tmax > {{thresh}}",
-    description="{{freq}} number of days where daily maximum temperature exceeds {{thresh}}.",
+    long_name="Number of days with Tmax > {thresh}",
+    description="{freq} number of days where daily maximum temperature exceeds {thresh}.",
     cell_methods="time: sum over days",
     compute=indices.tx_days_above,
 )
@@ -145,8 +145,8 @@ tx_days_below = TempWithIndexing(
     identifier="tx_days_below",
     units="days",
     standard_name="number_of_days_with_air_temperature_below_threshold",
-    long_name="Number of days with Tmax < {{thresh}}",
-    description="{{freq}} number of days where daily max temperature is below {{thresh}}.",
+    long_name="Number of days with Tmax < {thresh}",
+    description="{freq} number of days where daily max temperature is below {thresh}.",
     cell_methods="time: sum over days",
     compute=indices.tx_days_below,
 )
@@ -155,9 +155,9 @@ tx_tn_days_above = TempWithIndexing(
     identifier="tx_tn_days_above",
     units="days",
     standard_name="number_of_days_with_air_temperature_above_threshold",
-    long_name="Number of days with Tmax > {{thresh_tasmax}} and Tmin > {{thresh_tasmin}}",
-    description="{{freq}} number of days where daily maximum temperature exceeds "
-    "{{thresh_tasmax}} and minimum temperature exceeds {{thresh_tasmin}}.",
+    long_name="Number of days with Tmax > {thresh_tasmax} and Tmin > {thresh_tasmin}",
+    description="{freq} number of days where daily maximum temperature exceeds "
+    "{thresh_tasmax} and minimum temperature exceeds {thresh_tasmin}.",
     cell_methods="",
     compute=indices.tx_tn_days_above,
 )
@@ -167,17 +167,17 @@ heat_wave_frequency = Temp(
     identifier="heat_wave_frequency",
     units="",
     standard_name="heat_wave_events",
-    long_name="Number of heat wave events (Tmin > {{thresh_tasmin}} "
-    "and Tmax > {{thresh_tasmax}} for >= {{window}} days)",
-    description="{{freq}} number of heat wave events over a given period. "
+    long_name="Number of heat wave events (Tmin > {thresh_tasmin} "
+    "and Tmax > {thresh_tasmax} for >= {window} days)",
+    description="{freq} number of heat wave events over a given period. "
     "An event occurs when the minimum and maximum daily "
     "temperature both exceeds specific thresholds : "
-    "{% if np.isscalar(thresh_tasmin) and np.isscalar(thresh_tasmax)"
-    "  %}(Tmin > {{thresh_tasmin}} and Tmax > {{thresh_tasmax}})"
-    "{% else"
-    "  %}(Tmin > per_gridcell_tmin_thresholds and Tmax > per_gridcell_tmax_thresholds) # Not sure how to phrase it"
+    "{% if np.isscalar(thresh_tasmin) and np.isscalar(thresh_tasmax)%}"
+    "(Tmin > {thresh_tasmin} and Tmax > {thresh_tasmax}) "
+    "{% else %}"
+    "(Tmin > per_gridcell_tmin_thresholds and Tmax > per_gridcell_tmax_thresholds) "
     "{% endif %}"
-    "over a minimum number of days ({{window}}).",
+    "over a minimum number of days ({window}).",
     cell_methods="",
     keywords="health,",
     compute=indices.heat_wave_frequency,
@@ -187,13 +187,13 @@ heat_wave_max_length = Temp(
     identifier="heat_wave_max_length",
     units="days",
     standard_name="spell_length_of_days_with_air_temperature_above_threshold",
-    long_name="Maximum length of heat wave events (Tmin > {{thresh_tasmin}}"
-    "and Tmax > {{thresh_tasmax}} for >= {{window}} days)",
-    description="{{freq}} maximum length of heat wave events occurring in a given period. "
+    long_name="Maximum length of heat wave events (Tmin > {thresh_tasmin}"
+    "and Tmax > {thresh_tasmax} for >= {window} days)",
+    description="{freq} maximum length of heat wave events occurring in a given period. "
     "An event occurs when the minimum and maximum daily "
     "temperature both exceeds specific thresholds "
-    "(Tmin > {{thresh_tasmin}} and Tmax > {{thresh_tasmax}}) over "
-    "a minimum number of days ({{window}}).",
+    "(Tmin > {thresh_tasmin} and Tmax > {thresh_tasmax}) over "
+    "a minimum number of days ({window}).",
     cell_methods="",
     keywords="health,",
     compute=indices.heat_wave_max_length,
@@ -203,13 +203,13 @@ heat_wave_total_length = Temp(
     identifier="heat_wave_total_length",
     units="days",
     standard_name="spell_length_of_days_with_air_temperature_above_threshold",
-    long_name="Total length of heat wave events (Tmin > {{thresh_tasmin}} "
-    "and Tmax > {{thresh_tasmax}} for >= {{window}} days)",
-    description="{{freq}} total length of heat wave events occurring in a given period. "
+    long_name="Total length of heat wave events (Tmin > {thresh_tasmin} "
+    "and Tmax > {thresh_tasmax} for >= {window} days)",
+    description="{freq} total length of heat wave events occurring in a given period. "
     "An event occurs when the minimum and maximum daily "
     "temperature both exceeds specific thresholds "
-    "(Tmin > {{thresh_tasmin}} and Tmax > {{thresh_tasmax}}) over "
-    "a minimum number of days ({{window}}).",
+    "(Tmin > {thresh_tasmin} and Tmax > {thresh_tasmax}) over "
+    "a minimum number of days ({window}).",
     cell_methods="",
     keywords="health,",
     compute=indices.heat_wave_total_length,
@@ -221,8 +221,8 @@ heat_wave_index = Temp(
     units="days",
     standard_name="heat_wave_index",
     long_name="Number of days that are part of a heatwave",
-    description="{{freq}} number of days that are part of a heatwave, "
-    "defined as five or more consecutive days over {{thresh}}.",
+    description="{freq} number of days that are part of a heatwave, "
+    "defined as five or more consecutive days over {thresh}.",
     cell_methods="",
     compute=indices.heat_wave_index,
 )
@@ -232,10 +232,10 @@ hot_spell_frequency = Temp(
     identifier="hot_spell_frequency",
     units="",
     standard_name="hot_spell_events",
-    long_name="Number of hot spell events (Tmax > {{thresh_tasmax}} for >= {{window}} days)",
-    description="{{freq}} number of hot spell events over a given period. "
-    "An event occurs when the maximum daily temperature exceeds a specific threshold: (Tmax > {{thresh_tasmax}}) "
-    "over a minimum number of days ({{window}}).",
+    long_name="Number of hot spell events (Tmax > {thresh_tasmax} for >= {window} days)",
+    description="{freq} number of hot spell events over a given period. "
+    "An event occurs when the maximum daily temperature exceeds a specific threshold: (Tmax > {thresh_tasmax}) "
+    "over a minimum number of days ({window}).",
     cell_methods="",
     keywords="health,",
     compute=indices.hot_spell_frequency,
@@ -245,10 +245,10 @@ hot_spell_max_length = Temp(
     identifier="hot_spell_max_length",
     units="days",
     standard_name="spell_length_of_days_with_air_temperature_above_threshold",
-    long_name="Maximum length of hot spell events (Tmax > {{thresh_tasmax}} for >= {{window}} days)",
-    description="{{freq}} maximum length of hot spell events occurring in a given period. "
-    "An event occurs when the maximum daily temperature exceeds a specific threshold: (Tmax > {{thresh_tasmax}}) "
-    "over a minimum number of days ({{window}}).",
+    long_name="Maximum length of hot spell events (Tmax > {thresh_tasmax} for >= {window} days)",
+    description="{freq} maximum length of hot spell events occurring in a given period. "
+    "An event occurs when the maximum daily temperature exceeds a specific threshold: (Tmax > {thresh_tasmax}) "
+    "over a minimum number of days ({window}).",
     cell_methods="",
     keywords="health,",
     compute=indices.hot_spell_max_length,
@@ -259,7 +259,7 @@ tg_mean = TempWithIndexing(
     units="K",
     standard_name="air_temperature",
     long_name="Mean daily mean temperature",
-    description="{{freq}} mean of daily mean temperature.",
+    description="{freq} mean of daily mean temperature.",
     cell_methods="time: mean over days",
     compute=indices.tg_mean,
 )
@@ -269,7 +269,7 @@ tg_max = TempWithIndexing(
     units="K",
     standard_name="air_temperature",
     long_name="Maximum daily mean temperature",
-    description="{{freq}} maximum of daily mean temperature.",
+    description="{freq} maximum of daily mean temperature.",
     cell_methods="time: maximum over days",
     compute=indices.tg_max,
 )
@@ -279,7 +279,7 @@ tg_min = TempWithIndexing(
     units="K",
     standard_name="air_temperature",
     long_name="Minimum daily mean temperature",
-    description="{{freq}} minimum of daily mean temperature.",
+    description="{freq} minimum of daily mean temperature.",
     cell_methods="time: minimum over days",
     compute=indices.tg_min,
 )
@@ -289,7 +289,7 @@ tx_mean = TempWithIndexing(
     units="K",
     standard_name="air_temperature",
     long_name="Mean daily maximum temperature",
-    description="{{freq}} mean of daily maximum temperature.",
+    description="{freq} mean of daily maximum temperature.",
     cell_methods="time: mean over days",
     compute=indices.tx_mean,
 )
@@ -299,7 +299,7 @@ tx_max = TempWithIndexing(
     units="K",
     standard_name="air_temperature",
     long_name="Maximum daily maximum temperature",
-    description="{{freq}} maximum of daily maximum temperature.",
+    description="{freq} maximum of daily maximum temperature.",
     cell_methods="time: maximum over days",
     compute=indices.tx_max,
 )
@@ -309,7 +309,7 @@ tx_min = TempWithIndexing(
     units="K",
     standard_name="air_temperature",
     long_name="Minimum daily maximum temperature",
-    description="{{freq}} minimum of daily maximum temperature.",
+    description="{freq} minimum of daily maximum temperature.",
     cell_methods="time: minimum over days",
     compute=indices.tx_min,
 )
@@ -319,7 +319,7 @@ tn_mean = TempWithIndexing(
     units="K",
     standard_name="air_temperature",
     long_name="Mean daily minimum temperature",
-    description="{{freq}} mean of daily minimum temperature.",
+    description="{freq} mean of daily minimum temperature.",
     cell_methods="time: mean over days",
     compute=indices.tn_mean,
 )
@@ -329,7 +329,7 @@ tn_max = TempWithIndexing(
     units="K",
     standard_name="air_temperature",
     long_name="Maximum daily minimum temperature",
-    description="{{freq}} maximum of daily minimum temperature.",
+    description="{freq} maximum of daily minimum temperature.",
     cell_methods="time: maximum over days",
     compute=indices.tn_max,
 )
@@ -339,7 +339,7 @@ tn_min = TempWithIndexing(
     units="K",
     standard_name="air_temperature",
     long_name="Minimum daily minimum temperature",
-    description="{{freq}} minimum of daily minimum temperature.",
+    description="{freq} minimum of daily minimum temperature.",
     cell_methods="time: minimum over days",
     compute=indices.tn_min,
 )
@@ -350,7 +350,7 @@ daily_temperature_range = TempWithIndexing(
     units="K",
     standard_name="air_temperature",
     long_name="Mean Diurnal Temperature Range",
-    description="{{freq}} mean diurnal temperature range.",
+    description="{freq} mean diurnal temperature range.",
     cell_methods="time range within days time: mean over days",
     compute=indices.daily_temperature_range,
     parameters=dict(op="mean"),
@@ -362,7 +362,7 @@ max_daily_temperature_range = TempWithIndexing(
     units="K",
     standard_name="air_temperature",
     long_name="Maximum Diurnal Temperature Range",
-    description="{{freq}} maximum diurnal temperature range.",
+    description="{freq} maximum diurnal temperature range.",
     cell_methods="time range within days time: max over days",
     compute=indices.daily_temperature_range,
     parameters=dict(op="max"),
@@ -373,7 +373,7 @@ daily_temperature_range_variability = TempWithIndexing(
     units="K",
     standard_name="air_temperature",
     long_name="Mean Diurnal Temperature Range Variability",
-    description="{{freq}} mean diurnal temparature range variability "
+    description="{freq} mean diurnal temparature range variability "
     "(defined as the average day-to-day variation "
     "in daily temperature range "
     "for the given time period)",
@@ -387,21 +387,21 @@ extreme_temperature_range = TempWithIndexing(
     units="K",
     standard_name="air_temperature",
     long_name="Intra-period Extreme Temperature Range",
-    description="{{freq}} range between the maximum of daily max temperature "
+    description="{freq} range between the maximum of daily max temperature "
     "(tx_max) and the minimum of daily min temperature (tn_min)",
     compute=indices.extreme_temperature_range,
 )
 
 cold_spell_duration_index = Temp(
     identifier="cold_spell_duration_index",
-    var_name="csdi_{{window}}",
+    var_name="csdi_{window}",
     units="days",
     standard_name="cold_spell_duration_index",
     long_name="Number of days part of a percentile-defined cold spell",
-    description="{{freq}} number of days with at least {{window}} consecutive days "
-    "where the daily minimum temperature is below the {{tasmin_per_thresh}}th "
-    "percentile(s). A {{tasmin_per_window}} day(s) window, centred on each calendar day in the "
-    "{{tasmin_per_period}} period, is used to compute the {{tasmin_per_thresh}}th percentile(s).",
+    description="{freq} number of days with at least {window} consecutive days "
+    "where the daily minimum temperature is below the {tasmin_per_thresh}th "
+    "percentile(s). A {tasmin_per_window} day(s) window, centred on each calendar day in the "
+    "{tasmin_per_period} period, is used to compute the {tasmin_per_thresh}th percentile(s).",
     cell_methods="",
     compute=indices.cold_spell_duration_index,
 )
@@ -411,9 +411,9 @@ cold_spell_days = Temp(
     units="days",
     standard_name="cold_spell_days",
     long_name="Number of days part of a cold spell",
-    description="{{freq}} number of days that are part of a cold spell, defined as {{window}} "
+    description="{freq} number of days that are part of a cold spell, defined as {window} "
     "or more consecutive days with mean daily "
-    "temperature below {{thresh}}.",
+    "temperature below {thresh}.",
     cell_methods="",
     compute=indices.cold_spell_days,
 )
@@ -423,9 +423,9 @@ cold_spell_frequency = Temp(
     units="",
     standard_name="cold_spell_frequency",
     long_name="Number of cold spell events",
-    description="{{freq}} number cold spell events, defined as {{window}} "
+    description="{freq} number cold spell events, defined as {window} "
     "or more consecutive days with mean daily "
-    "temperature below {{thresh}}.",
+    "temperature below {thresh}.",
     cell_methods="",
     compute=indices.cold_spell_frequency,
 )
@@ -446,8 +446,8 @@ daily_freezethaw_cycles = TempWithIndexing(
     identifier="dlyfrzthw",
     units="days",
     long_name="daily freezethaw cycles",
-    description="{{freq}} number of days with a diurnal freeze-thaw cycle "
-    ": Tmax > {{thresh_tasmax}} and Tmin <= {{thresh_tasmin}}.",
+    description="{freq} number of days with a diurnal freeze-thaw cycle "
+    ": Tmax > {thresh_tasmax} and Tmin <= {thresh_tasmin}.",
     cell_methods="",
     compute=indices.multiday_temperature_swing,
     parameters={
@@ -463,10 +463,10 @@ freezethaw_spell_frequency = Temp(
     identifier="freezethaw_spell_frequency",
     title="Frequency of freeze-thaw spells",
     units="days",
-    long_name="{{freq}} number of freeze-thaw spells.",
-    description="{{freq}} number of freeze-thaw spells"
-    ": Tmax > {{thresh_tasmax}} and Tmin <= {{thresh_tasmin}} "
-    "for at least {{window}} consecutive day(s).",
+    long_name="{freq} number of freeze-thaw spells.",
+    description="{freq} number of freeze-thaw spells"
+    ": Tmax > {thresh_tasmax} and Tmin <= {thresh_tasmin} "
+    "for at least {window} consecutive day(s).",
     cell_methods="",
     compute=indices.multiday_temperature_swing,
     parameters={
@@ -481,10 +481,10 @@ freezethaw_spell_mean_length = Temp(
     identifier="freezethaw_spell_mean_length",
     title="Averge length of freeze-thaw spells.",
     units="days",
-    long_name="{{freq}} average length of freeze-thaw spells.",
-    description="{{freq}} average length of freeze-thaw spells"
-    ": Tmax > {{thresh_tasmax}} and Tmin <= {{thresh_tasmin}} "
-    "for at least {{window}} consecutive day(s).",
+    long_name="{freq} average length of freeze-thaw spells.",
+    description="{freq} average length of freeze-thaw spells"
+    ": Tmax > {thresh_tasmax} and Tmin <= {thresh_tasmin} "
+    "for at least {window} consecutive day(s).",
     cell_methods="",
     compute=indices.multiday_temperature_swing,
     parameters={
@@ -499,10 +499,10 @@ freezethaw_spell_max_length = Temp(
     identifier="freezethaw_spell_max_length",
     title="Maximal length of freeze-thaw spells.",
     units="days",
-    long_name="{{freq}} maximal length of freeze-thaw spells.",
-    description="{{freq}} maximal length of freeze-thaw spells"
-    ": Tmax > {{thresh_tasmax}} and Tmin <= {{thresh_tasmin}} "
-    "for at least {{window}} consecutive day(s).",
+    long_name="{freq} maximal length of freeze-thaw spells.",
+    description="{freq} maximal length of freeze-thaw spells"
+    ": Tmax > {thresh_tasmax} and Tmin <= {thresh_tasmin} "
+    "for at least {window} consecutive day(s).",
     cell_methods="",
     compute=indices.multiday_temperature_swing,
     parameters={
@@ -517,8 +517,8 @@ cooling_degree_days = TempWithIndexing(
     identifier="cooling_degree_days",
     units="K days",
     standard_name="integral_of_air_temperature_excess_wrt_time",
-    long_name="Cooling degree days (Tmean > {{thresh}})",
-    description="{{freq}} cooling degree days above {{thresh}}.",
+    long_name="Cooling degree days (Tmean > {thresh})",
+    description="{freq} cooling degree days above {thresh}.",
     cell_methods="time: sum over days",
     compute=indices.cooling_degree_days,
     parameters={"thresh": {"default": "18.0 degC"}},
@@ -528,8 +528,8 @@ heating_degree_days = TempWithIndexing(
     identifier="heating_degree_days",
     units="K days",
     standard_name="integral_of_air_temperature_deficit_wrt_time",
-    long_name="Heating degree days (Tmean < {{thresh}})",
-    description="{{freq}} heating degree days below {{thresh}}.",
+    long_name="Heating degree days (Tmean < {thresh})",
+    description="{freq} heating degree days below {thresh}.",
     cell_methods="time: sum over days",
     compute=indices.heating_degree_days,
     parameters={"thresh": {"default": "17.0 degC"}},
@@ -539,8 +539,8 @@ growing_degree_days = TempWithIndexing(
     identifier="growing_degree_days",
     units="K days",
     standard_name="integral_of_air_temperature_excess_wrt_time",
-    long_name="Growing degree days above {{thresh}}",
-    description="{{freq}} growing degree days above {{thresh}}.",
+    long_name="Growing degree days above {thresh}",
+    description="{freq} growing degree days above {thresh}.",
     cell_methods="time: sum over days",
     compute=indices.growing_degree_days,
     parameters={"thresh": {"default": "4.0 degC"}},
@@ -550,8 +550,8 @@ freezing_degree_days = TempWithIndexing(
     identifier="freezing_degree_days",
     units="K days",
     standard_name="integral_of_air_temperature_deficit_wrt_time",
-    long_name="Freezing degree days (Tmean < {{thresh}})",
-    description="{{freq}} freezing degree days below {{thresh}}.",
+    long_name="Freezing degree days (Tmean < {thresh})",
+    description="{freq} freezing degree days below {thresh}.",
     cell_methods="time: sum over days",
     compute=indices.heating_degree_days,
     parameters={"thresh": {"default": "0 degC"}},
@@ -562,7 +562,7 @@ thawing_degree_days = TempWithIndexing(
     units="K days",
     standard_name="integral_of_air_temperature_excess_wrt_time",
     long_name="Thawing degree days (degree days above 0°C)",
-    description="{{freq}} thawing degree days above 0°C.",
+    description="{freq} thawing degree days above 0°C.",
     cell_methods="time: sum over days",
     compute=indices.growing_degree_days,
     parameters={"thresh": {"default": "0 degC"}},
@@ -574,7 +574,7 @@ freshet_start = Temp(
     standard_name="day_of_year",
     long_name="Day of year of spring freshet start",
     description="Day of year of spring freshet start, defined as the first day a temperature "
-    "threshold of {{thresh}} is exceeded for at least {{window}} days.",
+    "threshold of {thresh} is exceeded for at least {window} days.",
     compute=indices.freshet_start,
 )
 
@@ -582,8 +582,8 @@ frost_days = TempWithIndexing(
     identifier="frost_days",
     units="days",
     standard_name="days_with_air_temperature_below_threshold",
-    long_name="Number of frost days (Tmin < {{thresh}})",
-    description="{{freq}} number of days with minimum daily temperature below {{thresh}}.",
+    long_name="Number of frost days (Tmin < {thresh})",
+    description="{freq} number of days with minimum daily temperature below {thresh}.",
     cell_methods="time: sum over days",
     compute=indices.frost_days,
 )
@@ -593,10 +593,10 @@ frost_season_length = Temp(
     units="days",
     standard_name="days_with_air_temperature_below_threshold",
     long_name="Length of the frost season",
-    description="{{freq}} number of days between the first occurrence of at least "
-    "{{window}} consecutive days with minimum daily temperature below freezing and "
-    "the first occurrence of at least {{window}} consecutive days with "
-    "minimuim daily temperature above freezing after {{mid_date}}.",
+    description="{freq} number of days between the first occurrence of at least "
+    "{window} consecutive days with minimum daily temperature below freezing and "
+    "the first occurrence of at least {window} consecutive days with "
+    "minimuim daily temperature above freezing after {mid_date}.",
     cell_methods="time: sum over days",
     compute=indices.frost_season_length,
     parameters=dict(thresh="0 degC"),
@@ -608,7 +608,7 @@ last_spring_frost = Temp(
     standard_name="day_of_year",
     long_name="Day of year of last spring frost",
     description="Day of year of last spring frost, defined as the last day a minimum temperature "
-    "threshold of {{thresh}} is not exceeded before a given date.",
+    "threshold of {thresh} is not exceeded before a given date.",
     compute=indices.last_spring_frost,
 )
 
@@ -616,8 +616,8 @@ first_day_below = Temp(
     identifier="first_day_below",
     units="",
     standard_name="day_of_year",
-    long_name="First day of year with temperature below {{thresh}}",
-    description="First day of year with temperature below {{thresh}} for at least {{window}} days.",
+    long_name="First day of year with temperature below {thresh}",
+    description="First day of year with temperature below {thresh} for at least {window} days.",
     compute=indices.first_day_below,
 )
 
@@ -625,8 +625,8 @@ first_day_above = Temp(
     identifier="first_day_above",
     units="",
     standard_name="day_of_year",
-    long_name="First day of year with temperature above {{thresh}}",
-    description="First day of year with temperature above {{thresh}} for at least {{window}} days.",
+    long_name="First day of year with temperature above {thresh}",
+    description="First day of year with temperature above {thresh} for at least {window} days.",
     compute=indices.first_day_above,
 )
 
@@ -635,8 +635,8 @@ ice_days = TempWithIndexing(
     identifier="ice_days",
     standard_name="days_with_air_temperature_below_threshold",
     units="days",
-    long_name="Number of ice days (Tmax < {{thresh}})",
-    description="{{freq}} number of days with maximum daily temperature below {{thresh}}.",
+    long_name="Number of ice days (Tmax < {thresh})",
+    description="{freq} number of days with maximum daily temperature below {thresh}.",
     cell_methods="time: sum over days",
     compute=indices.ice_days,
 )
@@ -645,9 +645,9 @@ consecutive_frost_days = Temp(
     identifier="consecutive_frost_days",
     units="days",
     standard_name="spell_length_of_days_with_air_temperature_below_threshold",
-    long_name="Maximum number of consecutive days with Tmin < {{thresh}}",
-    description="{{freq}} maximum number of consecutive days with "
-    "minimum daily temperature below {{thresh}}.",
+    long_name="Maximum number of consecutive days with Tmin < {thresh}",
+    description="{freq} maximum number of consecutive days with "
+    "minimum daily temperature below {thresh}.",
     cell_methods="time: maximum over days",
     compute=indices.maximum_consecutive_frost_days,
 )
@@ -657,10 +657,10 @@ frost_free_season_length = Temp(
     units="days",
     standard_name="days_with_air_temperature_above_threshold",
     long_name="Length of the frost free season",
-    description="{{freq}} number of days between the first occurrence of at least "
-    "{{window}} consecutive days with minimum daily temperature above or at the freezing point and "
-    "the first occurrence of at least {{window}} consecutive days with "
-    "minimum daily temperature below freezing after {{mid_date}}.",
+    description="{freq} number of days between the first occurrence of at least "
+    "{window} consecutive days with minimum daily temperature above or at the freezing point and "
+    "the first occurrence of at least {window} consecutive days with "
+    "minimum daily temperature below freezing after {mid_date}.",
     cell_methods="time: sum over days",
     compute=indices.frost_free_season_length,
     parameters={"thresh": {"default": "0 degC"}},
@@ -672,7 +672,7 @@ frost_free_season_start = Temp(
     standard_name="day_of_year",
     long_name="Day of year of frost free season start",
     description="Day of year of beginning of frost free season, defined as the first day a minimum temperature "
-    "threshold of {{thresh}} is equal or exceeded for at least {{window}} days.",
+    "threshold of {thresh} is equal or exceeded for at least {window} days.",
     compute=indices.frost_free_season_start,
     parameters={"thresh": {"default": "0 degC"}},
 )
@@ -683,7 +683,7 @@ frost_free_season_end = Temp(
     standard_name="day_of_year",
     long_name="Day of year of frost free season end",
     description="Day of year of end of frost free season, defined as the first day minimum temperatures below a  "
-    "threshold of {{thresh}}, after a run of days above this threshold, for at least {{window}} days.",
+    "threshold of {thresh}, after a run of days above this threshold, for at least {window} days.",
     cell_methods="",
     compute=indices.frost_free_season_end,
     parameters={"thresh": {"default": "0 degC"}},
@@ -693,9 +693,9 @@ maximum_consecutive_frost_free_days = Temp(
     identifier="consecutive_frost_free_days",
     units="days",
     standard_name="spell_length_of_days_with_air_temperature_above_threshold",
-    long_name="Maximum number of consecutive days with Tmin >= {{thresh}}",
-    description="{{freq}} maximum number of consecutive days with "
-    "minimum daily temperature above or equal to {{thresh}}.",
+    long_name="Maximum number of consecutive days with Tmin >= {thresh}",
+    description="{freq} maximum number of consecutive days with "
+    "minimum daily temperature above or equal to {thresh}.",
     cell_methods="time: maximum over days",
     compute=indices.maximum_consecutive_frost_free_days,
 )
@@ -706,8 +706,8 @@ growing_season_start = Temp(
     standard_name="day_of_year",
     long_name="Day of year of growing season start",
     description="Day of year of start of growing season, defined as the first day of "
-    "consistent superior or equal to threshold temperature of {{thresh}} after a run of "
-    "{{window}} days inferior to threshold temperature.",
+    "consistent superior or equal to threshold temperature of {thresh} after a run of "
+    "{window} days inferior to threshold temperature.",
     cell_methods="",
     compute=indices.growing_season_start,
     parameters={"thresh": {"default": "5.0 degC"}},
@@ -717,11 +717,11 @@ growing_season_length = Temp(
     identifier="growing_season_length",
     units="days",
     standard_name="growing_season_length",
-    long_name="ETCCDI Growing Season Length (Tmean > {{thresh}})",
-    description="{{freq}} number of days between the first occurrence of at least "
-    "{{window}} consecutive days with mean daily temperature over {{thresh}} and "
-    "the first occurrence of at least {{window}} consecutive days with "
-    "mean daily temperature below {{thresh}} after {{mid_date}}.",
+    long_name="ETCCDI Growing Season Length (Tmean > {thresh})",
+    description="{freq} number of days between the first occurrence of at least "
+    "{window} consecutive days with mean daily temperature over {thresh} and "
+    "the first occurrence of at least {window} consecutive days with "
+    "mean daily temperature below {thresh} after {mid_date}.",
     cell_methods="",
     compute=indices.growing_season_length,
     parameters={"thresh": {"default": "5.0 degC"}},
@@ -733,8 +733,8 @@ growing_season_end = Temp(
     standard_name="day_of_year",
     long_name="Day of year of growing season end",
     description="Day of year of end of growing season, defined as the first day of "
-    "consistent inferior threshold temperature of {{thresh}} after a run of "
-    "{{window}} days superior to threshold temperature.",
+    "consistent inferior threshold temperature of {thresh} after a run of "
+    "{window} days superior to threshold temperature.",
     cell_methods="",
     compute=indices.growing_season_end,
     parameters={"thresh": {"default": "5.0 degC"}},
@@ -744,9 +744,9 @@ tropical_nights = TempWithIndexing(
     identifier="tropical_nights",
     units="days",
     standard_name="number_of_days_with_air_temperature_above_threshold",
-    long_name="Number of Tropical Nights (Tmin > {{thresh}})",
-    description="{{freq}} number of Tropical Nights : defined as days with minimum daily temperature"
-    " above {{thresh}}.",
+    long_name="Number of Tropical Nights (Tmin > {thresh})",
+    description="{freq} number of Tropical Nights : defined as days with minimum daily temperature"
+    " above {thresh}.",
     cell_methods="time: sum over days",
     compute=indices.tn_days_above,
     parameters={"thresh": {"default": "20.0 degC"}},
@@ -756,10 +756,10 @@ tg90p = TempWithIndexing(
     identifier="tg90p",
     units="days",
     standard_name="days_with_air_temperature_above_threshold",
-    long_name="Number of days when Tmean > {{tas_per_thresh}}th percentile",
-    description="{{freq}} number of days with mean daily temperature above the the {{tas_per_thresh}}th "
-    "percentile(s). A {{tas_per_window}} day(s) window, centred on each calendar day in the "
-    "{{tas_per_period}} period, is used to compute the {{tas_per_thresh}}th percentile(s).",
+    long_name="Number of days when Tmean > {tas_per_thresh}th percentile",
+    description="{freq} number of days with mean daily temperature above the the {tas_per_thresh}th "
+    "percentile(s). A {tas_per_window} day(s) window, centred on each calendar day in the "
+    "{tas_per_period} period, is used to compute the {tas_per_thresh}th percentile(s).",
     cell_methods="time: sum over days",
     compute=indices.tg90p,
 )
@@ -768,10 +768,10 @@ tg10p = TempWithIndexing(
     identifier="tg10p",
     units="days",
     standard_name="days_with_air_temperature_below_threshold",
-    long_name="Number of days when Tmean < {{tas_per_thresh}}th percentile",
-    description="{{freq}} number of days with mean daily temperature below the {{tas_per_thresh}}th "
-    "percentile(s). A {{tas_per_window}} day(s) window, centred on each calendar day in the "
-    "{{tas_per_period}} period, is used to compute the {{tas_per_thresh}}th percentile(s).",
+    long_name="Number of days when Tmean < {tas_per_thresh}th percentile",
+    description="{freq} number of days with mean daily temperature below the {tas_per_thresh}th "
+    "percentile(s). A {tas_per_window} day(s) window, centred on each calendar day in the "
+    "{tas_per_period} period, is used to compute the {tas_per_thresh}th percentile(s).",
     cell_methods="time: sum over days",
     compute=indices.tg10p,
 )
@@ -780,10 +780,10 @@ tx90p = TempWithIndexing(
     identifier="tx90p",
     units="days",
     standard_name="days_with_air_temperature_above_threshold",
-    long_name="Number of days when Tmax > {{tasmax_per_thresh}}th percentile",
-    description="{{freq}} number of days with maximum daily temperature above the {{tasmax_per_thresh}}th "
-    "percentile(s). A {{tasmax_per_window}} day(s) window, centred on each calendar day in the "
-    "{{tasmax_per_period}} period, is used to compute the {{tasmax_per_thresh}}th percentile(s).",
+    long_name="Number of days when Tmax > {tasmax_per_thresh}th percentile",
+    description="{freq} number of days with maximum daily temperature above the {tasmax_per_thresh}th "
+    "percentile(s). A {tasmax_per_window} day(s) window, centred on each calendar day in the "
+    "{tasmax_per_period} period, is used to compute the {tasmax_per_thresh}th percentile(s).",
     cell_methods="time: sum over days",
     compute=indices.tx90p,
 )
@@ -792,10 +792,10 @@ tx10p = TempWithIndexing(
     identifier="tx10p",
     units="days",
     standard_name="days_with_air_temperature_below_threshold",
-    long_name="Number of days when Tmax < {{tasmax_per_thresh}}th percentile",
-    description="{{freq}} number of days with maximum daily temperature below the {{tasmax_per_thresh}}th "
-    "percentile(s). A {{tasmax_per_window}} day(s) window, centred on each calendar day in the "
-    "{{tasmax_per_period}} period, is used to compute the {{tasmax_per_thresh}}th percentile(s).",
+    long_name="Number of days when Tmax < {tasmax_per_thresh}th percentile",
+    description="{freq} number of days with maximum daily temperature below the {tasmax_per_thresh}th "
+    "percentile(s). A {tasmax_per_window} day(s) window, centred on each calendar day in the "
+    "{tasmax_per_period} period, is used to compute the {tasmax_per_thresh}th percentile(s).",
     cell_methods="time: sum over days",
     compute=indices.tx10p,
 )
@@ -804,10 +804,10 @@ tn90p = TempWithIndexing(
     identifier="tn90p",
     units="days",
     standard_name="days_with_air_temperature_above_threshold",
-    long_name="Number of days when Tmin > {{tasmin_per_thresh}}th percentile",
-    description="{{freq}} number of days with minimum daily temperature above the the {{tasmin_per_thresh}}th "
-    "percentile(s). A {{tasmin_per_window}} day(s) window, centred on each calendar day in the "
-    "{{tasmin_per_period}} period, is used to compute the {{tasmin_per_thresh}}th percentile(s).",
+    long_name="Number of days when Tmin > {tasmin_per_thresh}th percentile",
+    description="{freq} number of days with minimum daily temperature above the the {tasmin_per_thresh}th "
+    "percentile(s). A {tasmin_per_window} day(s) window, centred on each calendar day in the "
+    "{tasmin_per_period} period, is used to compute the {tasmin_per_thresh}th percentile(s).",
     cell_methods="time: sum over days",
     compute=indices.tn90p,
 )
@@ -816,10 +816,10 @@ tn10p = TempWithIndexing(
     identifier="tn10p",
     units="days",
     standard_name="days_with_air_temperature_below_threshold",
-    long_name="Number of days when Tmin < {{tasmin_per_thresh}}th percentile",
-    description="{{freq}} number of days with minimum daily temperature below the the {{tasmin_per_thresh}}th "
-    "percentile(s). A {{tasmin_per_window}} day(s) window, centred on each calendar day in the "
-    "{{tasmin_per_period}} period, is used to compute the {{tasmin_per_thresh}}th percentile(s).",
+    long_name="Number of days when Tmin < {tasmin_per_thresh}th percentile",
+    description="{freq} number of days with minimum daily temperature below the the {tasmin_per_thresh}th "
+    "percentile(s). A {tasmin_per_window} day(s) window, centred on each calendar day in the "
+    "{tasmin_per_period} period, is used to compute the {tasmin_per_thresh}th percentile(s).",
     cell_methods="time: sum over days",
     compute=indices.tn10p,
 )
@@ -829,9 +829,9 @@ degree_days_exceedance_date = Temp(
     identifier="degree_days_exceedance_date",
     units="",
     standard_name="day_of_year",
-    long_name="Day of year when cumulative degree days exceed {{sum_thresh}}.",
-    description="Day of year when the integral of degree days (tmean {{op}} {{thresh}})"
-    " exceeds {{sum_thresh}}, the cumulative sum starts on {{after_date}}.",
+    long_name="Day of year when cumulative degree days exceed {sum_thresh}.",
+    description="Day of year when the integral of degree days (tmean {op} {thresh})"
+    " exceeds {sum_thresh}, the cumulative sum starts on {after_date}.",
     cell_methods="",
     compute=indices.degree_days_exceedance_date,
 )
@@ -840,10 +840,10 @@ degree_days_exceedance_date = Temp(
 warm_spell_duration_index = Temp(
     identifier="warm_spell_duration_index",
     long_name="Number of days part of a percentile-defined warm spell",
-    description="{{freq}} number of days with at least {{window}} consecutive days "
-    "where the daily maximum temperature is above the {{tasmax_per_thresh}}th "
-    "percentile(s). A {{tasmax_per_window}} day(s) window, centred on each calendar day in the "
-    "{{tasmax_per_period}} period, is used to compute the {{tasmax_per_thresh}}th percentile(s).",
+    description="{freq} number of days with at least {window} consecutive days "
+    "where the daily maximum temperature is above the {tasmax_per_thresh}th "
+    "percentile(s). A {tasmax_per_window} day(s) window, centred on each calendar day in the "
+    "{tasmax_per_period} period, is used to compute the {tasmax_per_thresh}th percentile(s).",
     units="days",
     standard_name="number_of_days_with_air_temperature_above_threshold",
     cell_methods="time: sum over days",
@@ -853,7 +853,7 @@ warm_spell_duration_index = Temp(
 
 maximum_consecutive_warm_days = Temp(
     identifier="maximum_consecutive_warm_days",
-    description="{{freq}} longest spell of consecutive days with Tmax above {{thresh}}.",
+    description="{freq} longest spell of consecutive days with Tmax above {thresh}.",
     units="days",
     standard_name="spell_length_of_days_with_air_temperature_above_threshold",
     cell_methods="time: maximum over days",
@@ -871,7 +871,7 @@ class FireSeasonBase(Indicator):
 
 fire_season = FireSeasonBase(
     identifier="fire_season",
-    description="Fire season mask, computed with method {{method}}.",
+    description="Fire season mask, computed with method {method}.",
     units="",
     compute=indices.fire_season,
 )
@@ -880,10 +880,10 @@ fire_season = FireSeasonBase(
 huglin_index = Temp(
     identifier="huglin_index",
     units="",
-    long_name="Huglin heliothermal index (Summation of ((Tmin + Tmax)/2 - {{thresh}}) * Latitude-based day-length"
-    "coefficient (`k`), for days between {{start_date}} and {{end_date}}).",
+    long_name="Huglin heliothermal index (Summation of ((Tmin + Tmax)/2 - {thresh}) * Latitude-based day-length"
+    "coefficient (`k`), for days between {start_date} and {end_date}).",
     description="Heat-summation index for agroclimatic suitability estimation, developed specifically for viticulture. "
-    "Considers daily Tmin and Tmax with a base of {{thresh}}, typically between 1 April and 30 September. "
+    "Considers daily Tmin and Tmax with a base of {thresh}, typically between 1 April and 30 September. "
     "Integrates a day-length coefficient calculation for higher latitudes.",
     cell_methods="",
     comment="Metric originally published in Huglin (1978). Day-length coefficient based on Hall & Jones (2010)",
@@ -896,10 +896,10 @@ huglin_index = Temp(
 biologically_effective_degree_days = Temp(
     identifier="biologically_effective_degree_days",
     units="K days",
-    long_name="Biologically effective degree days computed with {{method}} formula (Summation of min((max((Tmin + Tmax)/2"
-    " - {{thresh_tasmin}}, 0) * k) + TR_adg, 9°C), for days between {{start_date}} and {{end_date}}).",
+    long_name="Biologically effective degree days computed with {method} formula (Summation of min((max((Tmin + Tmax)/2"
+    " - {thresh_tasmin}, 0) * k) + TR_adg, 9°C), for days between {start_date} and {end_date}).",
     description="Heat-summation index for agroclimatic suitability estimation, developed specifically for viticulture. "
-    "Considers daily Tmin and Tmax with a base of {{thresh_tasmin}} between 1 April and 31 October, with a maximum daily "
+    "Considers daily Tmin and Tmax with a base of {thresh_tasmin} between 1 April and 31 October, with a maximum daily "
     "value for degree days (typically 9°C). It also integrates a modification coefficient for latitudes "
     "between 40°N and 50°N as well as swings in daily temperature range.",
     cell_methods="",
@@ -913,12 +913,12 @@ biologically_effective_degree_days = Temp(
 effective_growing_degree_days = Temp(
     identifier="effective_growing_degree_days",
     units="K days",
-    long_name="Effective growing degree days computed with {{method}} formula (Summation of max((Tmin + Tmax)/2 "
-    "- {{thresh}}, 0), for days between between dynamically-determined start and end dates).",
+    long_name="Effective growing degree days computed with {method} formula (Summation of max((Tmin + Tmax)/2 "
+    "- {thresh}, 0), for days between between dynamically-determined start and end dates).",
     description="Heat-summation index for agroclimatic suitability estimation."
-    "Considers daily Tmin and Tmax with a base of {{thresh}} between dynamically-determined growing season start"
-    "and end dates. The 'bootsma' method uses a 10-day average temperature above {{thresh}} to identify a start date, "
-    "while the 'qian' method uses a weighted mean average above {{thresh}} over 5 days to determine start date. "
+    "Considers daily Tmin and Tmax with a base of {thresh} between dynamically-determined growing season start"
+    "and end dates. The 'bootsma' method uses a 10-day average temperature above {thresh} to identify a start date, "
+    "while the 'qian' method uses a weighted mean average above {thresh} over 5 days to determine start date. "
     "The end date of the growing season is the date of first fall frost (Tmin < 0°C).",
     cell_methods="",
     comment="Original formula published in Bootsma et al. 2005.",
@@ -933,7 +933,7 @@ latitude_temperature_index = Temp(
     long_name="Latitude-temperature index",
     description="A climate indice based on mean temperature of the warmest month and a latitude-based coefficient to "
     "account for longer day-length favouring growing conditions. Developed specifically for viticulture. "
-    "Mean temperature of warmest month * ({{lat_factor}} - latitude).",
+    "Mean temperature of warmest month * ({lat_factor} - latitude).",
     cell_methods="",
     allowed_periods=["A"],
     comment="Indice originally published in Jackson, D. I., & Cherry, N. J. (1988)",

--- a/xclim/indicators/atmos/_temperature.py
+++ b/xclim/indicators/atmos/_temperature.py
@@ -95,8 +95,8 @@ tn_days_above = TempWithIndexing(
     identifier="tn_days_above",
     units="days",
     standard_name="number_of_days_with_air_temperature_above_threshold",
-    long_name="Number of days with Tmin > {thresh}",
-    description="{freq} number of days where daily minimum temperature exceeds {thresh}.",
+    long_name="Number of days with Tmin > {{thresh}}",
+    description="{{freq}} number of days where daily minimum temperature exceeds {{thresh}}.",
     cell_methods="time: sum over days",
     compute=indices.tn_days_above,
 )
@@ -105,8 +105,8 @@ tn_days_below = TempWithIndexing(
     identifier="tn_days_below",
     units="days",
     standard_name="number_of_days_with_air_temperature_below_threshold",
-    long_name="Number of days with Tmin < {thresh}",
-    description="{freq} number of days where daily minimum temperature is below {thresh}.",
+    long_name="Number of days with Tmin < {{thresh}}",
+    description="{{freq}} number of days where daily minimum temperature is below {{thresh}}.",
     cell_methods="time: sum over days",
     compute=indices.tn_days_below,
 )
@@ -115,8 +115,8 @@ tg_days_above = TempWithIndexing(
     identifier="tg_days_above",
     units="days",
     standard_name="number_of_days_with_air_temperature_above_threshold",
-    long_name="Number of days with Tavg > {thresh}",
-    description="{freq} number of days where daily mean temperature exceeds {thresh}.",
+    long_name="Number of days with Tavg > {{thresh}}",
+    description="{{freq}} number of days where daily mean temperature exceeds {{thresh}}.",
     cell_methods="time: sum over days",
     compute=indices.tg_days_above,
 )
@@ -125,8 +125,8 @@ tg_days_below = TempWithIndexing(
     identifier="tg_days_below",
     units="days",
     standard_name="number_of_days_with_air_temperature_below_threshold",
-    long_name="Number of days with Tavg < {thresh}",
-    description="{freq} number of days where daily mean temperature is below {thresh}.",
+    long_name="Number of days with Tavg < {{thresh}}",
+    description="{{freq}} number of days where daily mean temperature is below {{thresh}}.",
     cell_methods="time: sum over days",
     compute=indices.tg_days_below,
 )
@@ -135,8 +135,8 @@ tx_days_above = TempWithIndexing(
     identifier="tx_days_above",
     units="days",
     standard_name="number_of_days_with_air_temperature_above_threshold",
-    long_name="Number of days with Tmax > {thresh}",
-    description="{freq} number of days where daily maximum temperature exceeds {thresh}.",
+    long_name="Number of days with Tmax > {{thresh}}",
+    description="{{freq}} number of days where daily maximum temperature exceeds {{thresh}}.",
     cell_methods="time: sum over days",
     compute=indices.tx_days_above,
 )
@@ -145,8 +145,8 @@ tx_days_below = TempWithIndexing(
     identifier="tx_days_below",
     units="days",
     standard_name="number_of_days_with_air_temperature_below_threshold",
-    long_name="Number of days with Tmax < {thresh}",
-    description="{freq} number of days where daily max temperature is below {thresh}.",
+    long_name="Number of days with Tmax < {{thresh}}",
+    description="{{freq}} number of days where daily max temperature is below {{thresh}}.",
     cell_methods="time: sum over days",
     compute=indices.tx_days_below,
 )
@@ -155,9 +155,9 @@ tx_tn_days_above = TempWithIndexing(
     identifier="tx_tn_days_above",
     units="days",
     standard_name="number_of_days_with_air_temperature_above_threshold",
-    long_name="Number of days with Tmax > {thresh_tasmax} and Tmin > {thresh_tasmin}",
-    description="{freq} number of days where daily maximum temperature exceeds "
-    "{thresh_tasmax} and minimum temperature exceeds {thresh_tasmin}.",
+    long_name="Number of days with Tmax > {{thresh_tasmax}} and Tmin > {{thresh_tasmin}}",
+    description="{{freq}} number of days where daily maximum temperature exceeds "
+    "{{thresh_tasmax}} and minimum temperature exceeds {{thresh_tasmin}}.",
     cell_methods="",
     compute=indices.tx_tn_days_above,
 )
@@ -167,13 +167,17 @@ heat_wave_frequency = Temp(
     identifier="heat_wave_frequency",
     units="",
     standard_name="heat_wave_events",
-    long_name="Number of heat wave events (Tmin > {thresh_tasmin} "
-    "and Tmax > {thresh_tasmax} for >= {window} days)",
-    description="{freq} number of heat wave events over a given period. "
+    long_name="Number of heat wave events (Tmin > {{thresh_tasmin}} "
+    "and Tmax > {{thresh_tasmax}} for >= {{window}} days)",
+    description="{{freq}} number of heat wave events over a given period. "
     "An event occurs when the minimum and maximum daily "
     "temperature both exceeds specific thresholds : "
-    "(Tmin > {thresh_tasmin} and Tmax > {thresh_tasmax}) "
-    "over a minimum number of days ({window}).",
+    "{% if np.isscalar(thresh_tasmin) and np.isscalar(thresh_tasmax)"
+    "  %}(Tmin > {{thresh_tasmin}} and Tmax > {{thresh_tasmax}})"
+    "{% else"
+    "  %}(Tmin > per_gridcell_tmin_thresholds and Tmax > per_gridcell_tmax_thresholds) # Not sure how to phrase it"
+    "{% endif %}"
+    "over a minimum number of days ({{window}}).",
     cell_methods="",
     keywords="health,",
     compute=indices.heat_wave_frequency,
@@ -183,13 +187,13 @@ heat_wave_max_length = Temp(
     identifier="heat_wave_max_length",
     units="days",
     standard_name="spell_length_of_days_with_air_temperature_above_threshold",
-    long_name="Maximum length of heat wave events (Tmin > {thresh_tasmin}"
-    "and Tmax > {thresh_tasmax} for >= {window} days)",
-    description="{freq} maximum length of heat wave events occurring in a given period. "
+    long_name="Maximum length of heat wave events (Tmin > {{thresh_tasmin}}"
+    "and Tmax > {{thresh_tasmax}} for >= {{window}} days)",
+    description="{{freq}} maximum length of heat wave events occurring in a given period. "
     "An event occurs when the minimum and maximum daily "
     "temperature both exceeds specific thresholds "
-    "(Tmin > {thresh_tasmin} and Tmax > {thresh_tasmax}) over "
-    "a minimum number of days ({window}).",
+    "(Tmin > {{thresh_tasmin}} and Tmax > {{thresh_tasmax}}) over "
+    "a minimum number of days ({{window}}).",
     cell_methods="",
     keywords="health,",
     compute=indices.heat_wave_max_length,
@@ -199,13 +203,13 @@ heat_wave_total_length = Temp(
     identifier="heat_wave_total_length",
     units="days",
     standard_name="spell_length_of_days_with_air_temperature_above_threshold",
-    long_name="Total length of heat wave events (Tmin > {thresh_tasmin} "
-    "and Tmax > {thresh_tasmax} for >= {window} days)",
-    description="{freq} total length of heat wave events occurring in a given period. "
+    long_name="Total length of heat wave events (Tmin > {{thresh_tasmin}} "
+    "and Tmax > {{thresh_tasmax}} for >= {{window}} days)",
+    description="{{freq}} total length of heat wave events occurring in a given period. "
     "An event occurs when the minimum and maximum daily "
     "temperature both exceeds specific thresholds "
-    "(Tmin > {thresh_tasmin} and Tmax > {thresh_tasmax}) over "
-    "a minimum number of days ({window}).",
+    "(Tmin > {{thresh_tasmin}} and Tmax > {{thresh_tasmax}}) over "
+    "a minimum number of days ({{window}}).",
     cell_methods="",
     keywords="health,",
     compute=indices.heat_wave_total_length,
@@ -217,8 +221,8 @@ heat_wave_index = Temp(
     units="days",
     standard_name="heat_wave_index",
     long_name="Number of days that are part of a heatwave",
-    description="{freq} number of days that are part of a heatwave, "
-    "defined as five or more consecutive days over {thresh}.",
+    description="{{freq}} number of days that are part of a heatwave, "
+    "defined as five or more consecutive days over {{thresh}}.",
     cell_methods="",
     compute=indices.heat_wave_index,
 )
@@ -228,10 +232,10 @@ hot_spell_frequency = Temp(
     identifier="hot_spell_frequency",
     units="",
     standard_name="hot_spell_events",
-    long_name="Number of hot spell events (Tmax > {thresh_tasmax} for >= {window} days)",
-    description="{freq} number of hot spell events over a given period. "
-    "An event occurs when the maximum daily temperature exceeds a specific threshold: (Tmax > {thresh_tasmax}) "
-    "over a minimum number of days ({window}).",
+    long_name="Number of hot spell events (Tmax > {{thresh_tasmax}} for >= {{window}} days)",
+    description="{{freq}} number of hot spell events over a given period. "
+    "An event occurs when the maximum daily temperature exceeds a specific threshold: (Tmax > {{thresh_tasmax}}) "
+    "over a minimum number of days ({{window}}).",
     cell_methods="",
     keywords="health,",
     compute=indices.hot_spell_frequency,
@@ -241,10 +245,10 @@ hot_spell_max_length = Temp(
     identifier="hot_spell_max_length",
     units="days",
     standard_name="spell_length_of_days_with_air_temperature_above_threshold",
-    long_name="Maximum length of hot spell events (Tmax > {thresh_tasmax} for >= {window} days)",
-    description="{freq} maximum length of hot spell events occurring in a given period. "
-    "An event occurs when the maximum daily temperature exceeds a specific threshold: (Tmax > {thresh_tasmax}) "
-    "over a minimum number of days ({window}).",
+    long_name="Maximum length of hot spell events (Tmax > {{thresh_tasmax}} for >= {{window}} days)",
+    description="{{freq}} maximum length of hot spell events occurring in a given period. "
+    "An event occurs when the maximum daily temperature exceeds a specific threshold: (Tmax > {{thresh_tasmax}}) "
+    "over a minimum number of days ({{window}}).",
     cell_methods="",
     keywords="health,",
     compute=indices.hot_spell_max_length,
@@ -255,7 +259,7 @@ tg_mean = TempWithIndexing(
     units="K",
     standard_name="air_temperature",
     long_name="Mean daily mean temperature",
-    description="{freq} mean of daily mean temperature.",
+    description="{{freq}} mean of daily mean temperature.",
     cell_methods="time: mean over days",
     compute=indices.tg_mean,
 )
@@ -265,7 +269,7 @@ tg_max = TempWithIndexing(
     units="K",
     standard_name="air_temperature",
     long_name="Maximum daily mean temperature",
-    description="{freq} maximum of daily mean temperature.",
+    description="{{freq}} maximum of daily mean temperature.",
     cell_methods="time: maximum over days",
     compute=indices.tg_max,
 )
@@ -275,7 +279,7 @@ tg_min = TempWithIndexing(
     units="K",
     standard_name="air_temperature",
     long_name="Minimum daily mean temperature",
-    description="{freq} minimum of daily mean temperature.",
+    description="{{freq}} minimum of daily mean temperature.",
     cell_methods="time: minimum over days",
     compute=indices.tg_min,
 )
@@ -285,7 +289,7 @@ tx_mean = TempWithIndexing(
     units="K",
     standard_name="air_temperature",
     long_name="Mean daily maximum temperature",
-    description="{freq} mean of daily maximum temperature.",
+    description="{{freq}} mean of daily maximum temperature.",
     cell_methods="time: mean over days",
     compute=indices.tx_mean,
 )
@@ -295,7 +299,7 @@ tx_max = TempWithIndexing(
     units="K",
     standard_name="air_temperature",
     long_name="Maximum daily maximum temperature",
-    description="{freq} maximum of daily maximum temperature.",
+    description="{{freq}} maximum of daily maximum temperature.",
     cell_methods="time: maximum over days",
     compute=indices.tx_max,
 )
@@ -305,7 +309,7 @@ tx_min = TempWithIndexing(
     units="K",
     standard_name="air_temperature",
     long_name="Minimum daily maximum temperature",
-    description="{freq} minimum of daily maximum temperature.",
+    description="{{freq}} minimum of daily maximum temperature.",
     cell_methods="time: minimum over days",
     compute=indices.tx_min,
 )
@@ -315,7 +319,7 @@ tn_mean = TempWithIndexing(
     units="K",
     standard_name="air_temperature",
     long_name="Mean daily minimum temperature",
-    description="{freq} mean of daily minimum temperature.",
+    description="{{freq}} mean of daily minimum temperature.",
     cell_methods="time: mean over days",
     compute=indices.tn_mean,
 )
@@ -325,7 +329,7 @@ tn_max = TempWithIndexing(
     units="K",
     standard_name="air_temperature",
     long_name="Maximum daily minimum temperature",
-    description="{freq} maximum of daily minimum temperature.",
+    description="{{freq}} maximum of daily minimum temperature.",
     cell_methods="time: maximum over days",
     compute=indices.tn_max,
 )
@@ -335,7 +339,7 @@ tn_min = TempWithIndexing(
     units="K",
     standard_name="air_temperature",
     long_name="Minimum daily minimum temperature",
-    description="{freq} minimum of daily minimum temperature.",
+    description="{{freq}} minimum of daily minimum temperature.",
     cell_methods="time: minimum over days",
     compute=indices.tn_min,
 )
@@ -346,7 +350,7 @@ daily_temperature_range = TempWithIndexing(
     units="K",
     standard_name="air_temperature",
     long_name="Mean Diurnal Temperature Range",
-    description="{freq} mean diurnal temperature range.",
+    description="{{freq}} mean diurnal temperature range.",
     cell_methods="time range within days time: mean over days",
     compute=indices.daily_temperature_range,
     parameters=dict(op="mean"),
@@ -358,7 +362,7 @@ max_daily_temperature_range = TempWithIndexing(
     units="K",
     standard_name="air_temperature",
     long_name="Maximum Diurnal Temperature Range",
-    description="{freq} maximum diurnal temperature range.",
+    description="{{freq}} maximum diurnal temperature range.",
     cell_methods="time range within days time: max over days",
     compute=indices.daily_temperature_range,
     parameters=dict(op="max"),
@@ -369,7 +373,7 @@ daily_temperature_range_variability = TempWithIndexing(
     units="K",
     standard_name="air_temperature",
     long_name="Mean Diurnal Temperature Range Variability",
-    description="{freq} mean diurnal temparature range variability "
+    description="{{freq}} mean diurnal temparature range variability "
     "(defined as the average day-to-day variation "
     "in daily temperature range "
     "for the given time period)",
@@ -383,21 +387,21 @@ extreme_temperature_range = TempWithIndexing(
     units="K",
     standard_name="air_temperature",
     long_name="Intra-period Extreme Temperature Range",
-    description="{freq} range between the maximum of daily max temperature "
+    description="{{freq}} range between the maximum of daily max temperature "
     "(tx_max) and the minimum of daily min temperature (tn_min)",
     compute=indices.extreme_temperature_range,
 )
 
 cold_spell_duration_index = Temp(
     identifier="cold_spell_duration_index",
-    var_name="csdi_{window}",
+    var_name="csdi_{{window}}",
     units="days",
     standard_name="cold_spell_duration_index",
     long_name="Number of days part of a percentile-defined cold spell",
-    description="{freq} number of days with at least {window} consecutive days "
-    "where the daily minimum temperature is below the {tasmin_per_thresh}th "
-    "percentile(s). A {tasmin_per_window} day(s) window, centred on each calendar day in the "
-    "{tasmin_per_period} period, is used to compute the {tasmin_per_thresh}th percentile(s).",
+    description="{{freq}} number of days with at least {{window}} consecutive days "
+    "where the daily minimum temperature is below the {{tasmin_per_thresh}}th "
+    "percentile(s). A {{tasmin_per_window}} day(s) window, centred on each calendar day in the "
+    "{{tasmin_per_period}} period, is used to compute the {{tasmin_per_thresh}}th percentile(s).",
     cell_methods="",
     compute=indices.cold_spell_duration_index,
 )
@@ -407,9 +411,9 @@ cold_spell_days = Temp(
     units="days",
     standard_name="cold_spell_days",
     long_name="Number of days part of a cold spell",
-    description="{freq} number of days that are part of a cold spell, defined as {window} "
+    description="{{freq}} number of days that are part of a cold spell, defined as {{window}} "
     "or more consecutive days with mean daily "
-    "temperature below {thresh}.",
+    "temperature below {{thresh}}.",
     cell_methods="",
     compute=indices.cold_spell_days,
 )
@@ -419,9 +423,9 @@ cold_spell_frequency = Temp(
     units="",
     standard_name="cold_spell_frequency",
     long_name="Number of cold spell events",
-    description="{freq} number cold spell events, defined as {window} "
+    description="{{freq}} number cold spell events, defined as {{window}} "
     "or more consecutive days with mean daily "
-    "temperature below {thresh}.",
+    "temperature below {{thresh}}.",
     cell_methods="",
     compute=indices.cold_spell_frequency,
 )
@@ -442,8 +446,8 @@ daily_freezethaw_cycles = TempWithIndexing(
     identifier="dlyfrzthw",
     units="days",
     long_name="daily freezethaw cycles",
-    description="{freq} number of days with a diurnal freeze-thaw cycle "
-    ": Tmax > {thresh_tasmax} and Tmin <= {thresh_tasmin}.",
+    description="{{freq}} number of days with a diurnal freeze-thaw cycle "
+    ": Tmax > {{thresh_tasmax}} and Tmin <= {{thresh_tasmin}}.",
     cell_methods="",
     compute=indices.multiday_temperature_swing,
     parameters={
@@ -459,10 +463,10 @@ freezethaw_spell_frequency = Temp(
     identifier="freezethaw_spell_frequency",
     title="Frequency of freeze-thaw spells",
     units="days",
-    long_name="{freq} number of freeze-thaw spells.",
-    description="{freq} number of freeze-thaw spells"
-    ": Tmax > {thresh_tasmax} and Tmin <= {thresh_tasmin} "
-    "for at least {window} consecutive day(s).",
+    long_name="{{freq}} number of freeze-thaw spells.",
+    description="{{freq}} number of freeze-thaw spells"
+    ": Tmax > {{thresh_tasmax}} and Tmin <= {{thresh_tasmin}} "
+    "for at least {{window}} consecutive day(s).",
     cell_methods="",
     compute=indices.multiday_temperature_swing,
     parameters={
@@ -477,10 +481,10 @@ freezethaw_spell_mean_length = Temp(
     identifier="freezethaw_spell_mean_length",
     title="Averge length of freeze-thaw spells.",
     units="days",
-    long_name="{freq} average length of freeze-thaw spells.",
-    description="{freq} average length of freeze-thaw spells"
-    ": Tmax > {thresh_tasmax} and Tmin <= {thresh_tasmin} "
-    "for at least {window} consecutive day(s).",
+    long_name="{{freq}} average length of freeze-thaw spells.",
+    description="{{freq}} average length of freeze-thaw spells"
+    ": Tmax > {{thresh_tasmax}} and Tmin <= {{thresh_tasmin}} "
+    "for at least {{window}} consecutive day(s).",
     cell_methods="",
     compute=indices.multiday_temperature_swing,
     parameters={
@@ -495,10 +499,10 @@ freezethaw_spell_max_length = Temp(
     identifier="freezethaw_spell_max_length",
     title="Maximal length of freeze-thaw spells.",
     units="days",
-    long_name="{freq} maximal length of freeze-thaw spells.",
-    description="{freq} maximal length of freeze-thaw spells"
-    ": Tmax > {thresh_tasmax} and Tmin <= {thresh_tasmin} "
-    "for at least {window} consecutive day(s).",
+    long_name="{{freq}} maximal length of freeze-thaw spells.",
+    description="{{freq}} maximal length of freeze-thaw spells"
+    ": Tmax > {{thresh_tasmax}} and Tmin <= {{thresh_tasmin}} "
+    "for at least {{window}} consecutive day(s).",
     cell_methods="",
     compute=indices.multiday_temperature_swing,
     parameters={
@@ -513,8 +517,8 @@ cooling_degree_days = TempWithIndexing(
     identifier="cooling_degree_days",
     units="K days",
     standard_name="integral_of_air_temperature_excess_wrt_time",
-    long_name="Cooling degree days (Tmean > {thresh})",
-    description="{freq} cooling degree days above {thresh}.",
+    long_name="Cooling degree days (Tmean > {{thresh}})",
+    description="{{freq}} cooling degree days above {{thresh}}.",
     cell_methods="time: sum over days",
     compute=indices.cooling_degree_days,
     parameters={"thresh": {"default": "18.0 degC"}},
@@ -524,8 +528,8 @@ heating_degree_days = TempWithIndexing(
     identifier="heating_degree_days",
     units="K days",
     standard_name="integral_of_air_temperature_deficit_wrt_time",
-    long_name="Heating degree days (Tmean < {thresh})",
-    description="{freq} heating degree days below {thresh}.",
+    long_name="Heating degree days (Tmean < {{thresh}})",
+    description="{{freq}} heating degree days below {{thresh}}.",
     cell_methods="time: sum over days",
     compute=indices.heating_degree_days,
     parameters={"thresh": {"default": "17.0 degC"}},
@@ -535,8 +539,8 @@ growing_degree_days = TempWithIndexing(
     identifier="growing_degree_days",
     units="K days",
     standard_name="integral_of_air_temperature_excess_wrt_time",
-    long_name="Growing degree days above {thresh}",
-    description="{freq} growing degree days above {thresh}.",
+    long_name="Growing degree days above {{thresh}}",
+    description="{{freq}} growing degree days above {{thresh}}.",
     cell_methods="time: sum over days",
     compute=indices.growing_degree_days,
     parameters={"thresh": {"default": "4.0 degC"}},
@@ -546,8 +550,8 @@ freezing_degree_days = TempWithIndexing(
     identifier="freezing_degree_days",
     units="K days",
     standard_name="integral_of_air_temperature_deficit_wrt_time",
-    long_name="Freezing degree days (Tmean < {thresh})",
-    description="{freq} freezing degree days below {thresh}.",
+    long_name="Freezing degree days (Tmean < {{thresh}})",
+    description="{{freq}} freezing degree days below {{thresh}}.",
     cell_methods="time: sum over days",
     compute=indices.heating_degree_days,
     parameters={"thresh": {"default": "0 degC"}},
@@ -558,7 +562,7 @@ thawing_degree_days = TempWithIndexing(
     units="K days",
     standard_name="integral_of_air_temperature_excess_wrt_time",
     long_name="Thawing degree days (degree days above 0°C)",
-    description="{freq} thawing degree days above 0°C.",
+    description="{{freq}} thawing degree days above 0°C.",
     cell_methods="time: sum over days",
     compute=indices.growing_degree_days,
     parameters={"thresh": {"default": "0 degC"}},
@@ -570,7 +574,7 @@ freshet_start = Temp(
     standard_name="day_of_year",
     long_name="Day of year of spring freshet start",
     description="Day of year of spring freshet start, defined as the first day a temperature "
-    "threshold of {thresh} is exceeded for at least {window} days.",
+    "threshold of {{thresh}} is exceeded for at least {{window}} days.",
     compute=indices.freshet_start,
 )
 
@@ -578,8 +582,8 @@ frost_days = TempWithIndexing(
     identifier="frost_days",
     units="days",
     standard_name="days_with_air_temperature_below_threshold",
-    long_name="Number of frost days (Tmin < {thresh})",
-    description="{freq} number of days with minimum daily temperature below {thresh}.",
+    long_name="Number of frost days (Tmin < {{thresh}})",
+    description="{{freq}} number of days with minimum daily temperature below {{thresh}}.",
     cell_methods="time: sum over days",
     compute=indices.frost_days,
 )
@@ -589,10 +593,10 @@ frost_season_length = Temp(
     units="days",
     standard_name="days_with_air_temperature_below_threshold",
     long_name="Length of the frost season",
-    description="{freq} number of days between the first occurrence of at least "
-    "{window} consecutive days with minimum daily temperature below freezing and "
-    "the first occurrence of at least {window} consecutive days with "
-    "minimuim daily temperature above freezing after {mid_date}.",
+    description="{{freq}} number of days between the first occurrence of at least "
+    "{{window}} consecutive days with minimum daily temperature below freezing and "
+    "the first occurrence of at least {{window}} consecutive days with "
+    "minimuim daily temperature above freezing after {{mid_date}}.",
     cell_methods="time: sum over days",
     compute=indices.frost_season_length,
     parameters=dict(thresh="0 degC"),
@@ -604,7 +608,7 @@ last_spring_frost = Temp(
     standard_name="day_of_year",
     long_name="Day of year of last spring frost",
     description="Day of year of last spring frost, defined as the last day a minimum temperature "
-    "threshold of {thresh} is not exceeded before a given date.",
+    "threshold of {{thresh}} is not exceeded before a given date.",
     compute=indices.last_spring_frost,
 )
 
@@ -612,8 +616,8 @@ first_day_below = Temp(
     identifier="first_day_below",
     units="",
     standard_name="day_of_year",
-    long_name="First day of year with temperature below {thresh}",
-    description="First day of year with temperature below {thresh} for at least {window} days.",
+    long_name="First day of year with temperature below {{thresh}}",
+    description="First day of year with temperature below {{thresh}} for at least {{window}} days.",
     compute=indices.first_day_below,
 )
 
@@ -621,8 +625,8 @@ first_day_above = Temp(
     identifier="first_day_above",
     units="",
     standard_name="day_of_year",
-    long_name="First day of year with temperature above {thresh}",
-    description="First day of year with temperature above {thresh} for at least {window} days.",
+    long_name="First day of year with temperature above {{thresh}}",
+    description="First day of year with temperature above {{thresh}} for at least {{window}} days.",
     compute=indices.first_day_above,
 )
 
@@ -631,8 +635,8 @@ ice_days = TempWithIndexing(
     identifier="ice_days",
     standard_name="days_with_air_temperature_below_threshold",
     units="days",
-    long_name="Number of ice days (Tmax < {thresh})",
-    description="{freq} number of days with maximum daily temperature below {thresh}.",
+    long_name="Number of ice days (Tmax < {{thresh}})",
+    description="{{freq}} number of days with maximum daily temperature below {{thresh}}.",
     cell_methods="time: sum over days",
     compute=indices.ice_days,
 )
@@ -641,9 +645,9 @@ consecutive_frost_days = Temp(
     identifier="consecutive_frost_days",
     units="days",
     standard_name="spell_length_of_days_with_air_temperature_below_threshold",
-    long_name="Maximum number of consecutive days with Tmin < {thresh}",
-    description="{freq} maximum number of consecutive days with "
-    "minimum daily temperature below {thresh}.",
+    long_name="Maximum number of consecutive days with Tmin < {{thresh}}",
+    description="{{freq}} maximum number of consecutive days with "
+    "minimum daily temperature below {{thresh}}.",
     cell_methods="time: maximum over days",
     compute=indices.maximum_consecutive_frost_days,
 )
@@ -653,10 +657,10 @@ frost_free_season_length = Temp(
     units="days",
     standard_name="days_with_air_temperature_above_threshold",
     long_name="Length of the frost free season",
-    description="{freq} number of days between the first occurrence of at least "
-    "{window} consecutive days with minimum daily temperature above or at the freezing point and "
-    "the first occurrence of at least {window} consecutive days with "
-    "minimum daily temperature below freezing after {mid_date}.",
+    description="{{freq}} number of days between the first occurrence of at least "
+    "{{window}} consecutive days with minimum daily temperature above or at the freezing point and "
+    "the first occurrence of at least {{window}} consecutive days with "
+    "minimum daily temperature below freezing after {{mid_date}}.",
     cell_methods="time: sum over days",
     compute=indices.frost_free_season_length,
     parameters={"thresh": {"default": "0 degC"}},
@@ -668,7 +672,7 @@ frost_free_season_start = Temp(
     standard_name="day_of_year",
     long_name="Day of year of frost free season start",
     description="Day of year of beginning of frost free season, defined as the first day a minimum temperature "
-    "threshold of {thresh} is equal or exceeded for at least {window} days.",
+    "threshold of {{thresh}} is equal or exceeded for at least {{window}} days.",
     compute=indices.frost_free_season_start,
     parameters={"thresh": {"default": "0 degC"}},
 )
@@ -679,7 +683,7 @@ frost_free_season_end = Temp(
     standard_name="day_of_year",
     long_name="Day of year of frost free season end",
     description="Day of year of end of frost free season, defined as the first day minimum temperatures below a  "
-    "threshold of {thresh}, after a run of days above this threshold, for at least {window} days.",
+    "threshold of {{thresh}}, after a run of days above this threshold, for at least {{window}} days.",
     cell_methods="",
     compute=indices.frost_free_season_end,
     parameters={"thresh": {"default": "0 degC"}},
@@ -689,9 +693,9 @@ maximum_consecutive_frost_free_days = Temp(
     identifier="consecutive_frost_free_days",
     units="days",
     standard_name="spell_length_of_days_with_air_temperature_above_threshold",
-    long_name="Maximum number of consecutive days with Tmin >= {thresh}",
-    description="{freq} maximum number of consecutive days with "
-    "minimum daily temperature above or equal to {thresh}.",
+    long_name="Maximum number of consecutive days with Tmin >= {{thresh}}",
+    description="{{freq}} maximum number of consecutive days with "
+    "minimum daily temperature above or equal to {{thresh}}.",
     cell_methods="time: maximum over days",
     compute=indices.maximum_consecutive_frost_free_days,
 )
@@ -702,8 +706,8 @@ growing_season_start = Temp(
     standard_name="day_of_year",
     long_name="Day of year of growing season start",
     description="Day of year of start of growing season, defined as the first day of "
-    "consistent superior or equal to threshold temperature of {thresh} after a run of "
-    "{window} days inferior to threshold temperature.",
+    "consistent superior or equal to threshold temperature of {{thresh}} after a run of "
+    "{{window}} days inferior to threshold temperature.",
     cell_methods="",
     compute=indices.growing_season_start,
     parameters={"thresh": {"default": "5.0 degC"}},
@@ -713,11 +717,11 @@ growing_season_length = Temp(
     identifier="growing_season_length",
     units="days",
     standard_name="growing_season_length",
-    long_name="ETCCDI Growing Season Length (Tmean > {thresh})",
-    description="{freq} number of days between the first occurrence of at least "
-    "{window} consecutive days with mean daily temperature over {thresh} and "
-    "the first occurrence of at least {window} consecutive days with "
-    "mean daily temperature below {thresh} after {mid_date}.",
+    long_name="ETCCDI Growing Season Length (Tmean > {{thresh}})",
+    description="{{freq}} number of days between the first occurrence of at least "
+    "{{window}} consecutive days with mean daily temperature over {{thresh}} and "
+    "the first occurrence of at least {{window}} consecutive days with "
+    "mean daily temperature below {{thresh}} after {{mid_date}}.",
     cell_methods="",
     compute=indices.growing_season_length,
     parameters={"thresh": {"default": "5.0 degC"}},
@@ -729,8 +733,8 @@ growing_season_end = Temp(
     standard_name="day_of_year",
     long_name="Day of year of growing season end",
     description="Day of year of end of growing season, defined as the first day of "
-    "consistent inferior threshold temperature of {thresh} after a run of "
-    "{window} days superior to threshold temperature.",
+    "consistent inferior threshold temperature of {{thresh}} after a run of "
+    "{{window}} days superior to threshold temperature.",
     cell_methods="",
     compute=indices.growing_season_end,
     parameters={"thresh": {"default": "5.0 degC"}},
@@ -740,9 +744,9 @@ tropical_nights = TempWithIndexing(
     identifier="tropical_nights",
     units="days",
     standard_name="number_of_days_with_air_temperature_above_threshold",
-    long_name="Number of Tropical Nights (Tmin > {thresh})",
-    description="{freq} number of Tropical Nights : defined as days with minimum daily temperature"
-    " above {thresh}.",
+    long_name="Number of Tropical Nights (Tmin > {{thresh}})",
+    description="{{freq}} number of Tropical Nights : defined as days with minimum daily temperature"
+    " above {{thresh}}.",
     cell_methods="time: sum over days",
     compute=indices.tn_days_above,
     parameters={"thresh": {"default": "20.0 degC"}},
@@ -752,10 +756,10 @@ tg90p = TempWithIndexing(
     identifier="tg90p",
     units="days",
     standard_name="days_with_air_temperature_above_threshold",
-    long_name="Number of days when Tmean > {tas_per_thresh}th percentile",
-    description="{freq} number of days with mean daily temperature above the the {tas_per_thresh}th "
-    "percentile(s). A {tas_per_window} day(s) window, centred on each calendar day in the "
-    "{tas_per_period} period, is used to compute the {tas_per_thresh}th percentile(s).",
+    long_name="Number of days when Tmean > {{tas_per_thresh}}th percentile",
+    description="{{freq}} number of days with mean daily temperature above the the {{tas_per_thresh}}th "
+    "percentile(s). A {{tas_per_window}} day(s) window, centred on each calendar day in the "
+    "{{tas_per_period}} period, is used to compute the {{tas_per_thresh}}th percentile(s).",
     cell_methods="time: sum over days",
     compute=indices.tg90p,
 )
@@ -764,10 +768,10 @@ tg10p = TempWithIndexing(
     identifier="tg10p",
     units="days",
     standard_name="days_with_air_temperature_below_threshold",
-    long_name="Number of days when Tmean < {tas_per_thresh}th percentile",
-    description="{freq} number of days with mean daily temperature below the {tas_per_thresh}th "
-    "percentile(s). A {tas_per_window} day(s) window, centred on each calendar day in the "
-    "{tas_per_period} period, is used to compute the {tas_per_thresh}th percentile(s).",
+    long_name="Number of days when Tmean < {{tas_per_thresh}}th percentile",
+    description="{{freq}} number of days with mean daily temperature below the {{tas_per_thresh}}th "
+    "percentile(s). A {{tas_per_window}} day(s) window, centred on each calendar day in the "
+    "{{tas_per_period}} period, is used to compute the {{tas_per_thresh}}th percentile(s).",
     cell_methods="time: sum over days",
     compute=indices.tg10p,
 )
@@ -776,10 +780,10 @@ tx90p = TempWithIndexing(
     identifier="tx90p",
     units="days",
     standard_name="days_with_air_temperature_above_threshold",
-    long_name="Number of days when Tmax > {tasmax_per_thresh}th percentile",
-    description="{freq} number of days with maximum daily temperature above the {tasmax_per_thresh}th "
-    "percentile(s). A {tasmax_per_window} day(s) window, centred on each calendar day in the "
-    "{tasmax_per_period} period, is used to compute the {tasmax_per_thresh}th percentile(s).",
+    long_name="Number of days when Tmax > {{tasmax_per_thresh}}th percentile",
+    description="{{freq}} number of days with maximum daily temperature above the {{tasmax_per_thresh}}th "
+    "percentile(s). A {{tasmax_per_window}} day(s) window, centred on each calendar day in the "
+    "{{tasmax_per_period}} period, is used to compute the {{tasmax_per_thresh}}th percentile(s).",
     cell_methods="time: sum over days",
     compute=indices.tx90p,
 )
@@ -788,10 +792,10 @@ tx10p = TempWithIndexing(
     identifier="tx10p",
     units="days",
     standard_name="days_with_air_temperature_below_threshold",
-    long_name="Number of days when Tmax < {tasmax_per_thresh}th percentile",
-    description="{freq} number of days with maximum daily temperature below the {tasmax_per_thresh}th "
-    "percentile(s). A {tasmax_per_window} day(s) window, centred on each calendar day in the "
-    "{tasmax_per_period} period, is used to compute the {tasmax_per_thresh}th percentile(s).",
+    long_name="Number of days when Tmax < {{tasmax_per_thresh}}th percentile",
+    description="{{freq}} number of days with maximum daily temperature below the {{tasmax_per_thresh}}th "
+    "percentile(s). A {{tasmax_per_window}} day(s) window, centred on each calendar day in the "
+    "{{tasmax_per_period}} period, is used to compute the {{tasmax_per_thresh}}th percentile(s).",
     cell_methods="time: sum over days",
     compute=indices.tx10p,
 )
@@ -800,10 +804,10 @@ tn90p = TempWithIndexing(
     identifier="tn90p",
     units="days",
     standard_name="days_with_air_temperature_above_threshold",
-    long_name="Number of days when Tmin > {tasmin_per_thresh}th percentile",
-    description="{freq} number of days with minimum daily temperature above the the {tasmin_per_thresh}th "
-    "percentile(s). A {tasmin_per_window} day(s) window, centred on each calendar day in the "
-    "{tasmin_per_period} period, is used to compute the {tasmin_per_thresh}th percentile(s).",
+    long_name="Number of days when Tmin > {{tasmin_per_thresh}}th percentile",
+    description="{{freq}} number of days with minimum daily temperature above the the {{tasmin_per_thresh}}th "
+    "percentile(s). A {{tasmin_per_window}} day(s) window, centred on each calendar day in the "
+    "{{tasmin_per_period}} period, is used to compute the {{tasmin_per_thresh}}th percentile(s).",
     cell_methods="time: sum over days",
     compute=indices.tn90p,
 )
@@ -812,10 +816,10 @@ tn10p = TempWithIndexing(
     identifier="tn10p",
     units="days",
     standard_name="days_with_air_temperature_below_threshold",
-    long_name="Number of days when Tmin < {tasmin_per_thresh}th percentile",
-    description="{freq} number of days with minimum daily temperature below the the {tasmin_per_thresh}th "
-    "percentile(s). A {tasmin_per_window} day(s) window, centred on each calendar day in the "
-    "{tasmin_per_period} period, is used to compute the {tasmin_per_thresh}th percentile(s).",
+    long_name="Number of days when Tmin < {{tasmin_per_thresh}}th percentile",
+    description="{{freq}} number of days with minimum daily temperature below the the {{tasmin_per_thresh}}th "
+    "percentile(s). A {{tasmin_per_window}} day(s) window, centred on each calendar day in the "
+    "{{tasmin_per_period}} period, is used to compute the {{tasmin_per_thresh}}th percentile(s).",
     cell_methods="time: sum over days",
     compute=indices.tn10p,
 )
@@ -825,9 +829,9 @@ degree_days_exceedance_date = Temp(
     identifier="degree_days_exceedance_date",
     units="",
     standard_name="day_of_year",
-    long_name="Day of year when cumulative degree days exceed {sum_thresh}.",
-    description="Day of year when the integral of degree days (tmean {op} {thresh})"
-    " exceeds {sum_thresh}, the cumulative sum starts on {after_date}.",
+    long_name="Day of year when cumulative degree days exceed {{sum_thresh}}.",
+    description="Day of year when the integral of degree days (tmean {{op}} {{thresh}})"
+    " exceeds {{sum_thresh}}, the cumulative sum starts on {{after_date}}.",
     cell_methods="",
     compute=indices.degree_days_exceedance_date,
 )
@@ -836,10 +840,10 @@ degree_days_exceedance_date = Temp(
 warm_spell_duration_index = Temp(
     identifier="warm_spell_duration_index",
     long_name="Number of days part of a percentile-defined warm spell",
-    description="{freq} number of days with at least {window} consecutive days "
-    "where the daily maximum temperature is above the {tasmax_per_thresh}th "
-    "percentile(s). A {tasmax_per_window} day(s) window, centred on each calendar day in the "
-    "{tasmax_per_period} period, is used to compute the {tasmax_per_thresh}th percentile(s).",
+    description="{{freq}} number of days with at least {{window}} consecutive days "
+    "where the daily maximum temperature is above the {{tasmax_per_thresh}}th "
+    "percentile(s). A {{tasmax_per_window}} day(s) window, centred on each calendar day in the "
+    "{{tasmax_per_period}} period, is used to compute the {{tasmax_per_thresh}}th percentile(s).",
     units="days",
     standard_name="number_of_days_with_air_temperature_above_threshold",
     cell_methods="time: sum over days",
@@ -849,7 +853,7 @@ warm_spell_duration_index = Temp(
 
 maximum_consecutive_warm_days = Temp(
     identifier="maximum_consecutive_warm_days",
-    description="{freq} longest spell of consecutive days with Tmax above {thresh}.",
+    description="{{freq}} longest spell of consecutive days with Tmax above {{thresh}}.",
     units="days",
     standard_name="spell_length_of_days_with_air_temperature_above_threshold",
     cell_methods="time: maximum over days",
@@ -867,7 +871,7 @@ class FireSeasonBase(Indicator):
 
 fire_season = FireSeasonBase(
     identifier="fire_season",
-    description="Fire season mask, computed with method {method}.",
+    description="Fire season mask, computed with method {{method}}.",
     units="",
     compute=indices.fire_season,
 )
@@ -876,10 +880,10 @@ fire_season = FireSeasonBase(
 huglin_index = Temp(
     identifier="huglin_index",
     units="",
-    long_name="Huglin heliothermal index (Summation of ((Tmin + Tmax)/2 - {thresh}) * Latitude-based day-length"
-    "coefficient (`k`), for days between {start_date} and {end_date}).",
+    long_name="Huglin heliothermal index (Summation of ((Tmin + Tmax)/2 - {{thresh}}) * Latitude-based day-length"
+    "coefficient (`k`), for days between {{start_date}} and {{end_date}}).",
     description="Heat-summation index for agroclimatic suitability estimation, developed specifically for viticulture. "
-    "Considers daily Tmin and Tmax with a base of {thresh}, typically between 1 April and 30 September. "
+    "Considers daily Tmin and Tmax with a base of {{thresh}}, typically between 1 April and 30 September. "
     "Integrates a day-length coefficient calculation for higher latitudes.",
     cell_methods="",
     comment="Metric originally published in Huglin (1978). Day-length coefficient based on Hall & Jones (2010)",
@@ -892,10 +896,10 @@ huglin_index = Temp(
 biologically_effective_degree_days = Temp(
     identifier="biologically_effective_degree_days",
     units="K days",
-    long_name="Biologically effective degree days computed with {method} formula (Summation of min((max((Tmin + Tmax)/2"
-    " - {thresh_tasmin}, 0) * k) + TR_adg, 9°C), for days between {start_date} and {end_date}).",
+    long_name="Biologically effective degree days computed with {{method}} formula (Summation of min((max((Tmin + Tmax)/2"
+    " - {{thresh_tasmin}}, 0) * k) + TR_adg, 9°C), for days between {{start_date}} and {{end_date}}).",
     description="Heat-summation index for agroclimatic suitability estimation, developed specifically for viticulture. "
-    "Considers daily Tmin and Tmax with a base of {thresh_tasmin} between 1 April and 31 October, with a maximum daily "
+    "Considers daily Tmin and Tmax with a base of {{thresh_tasmin}} between 1 April and 31 October, with a maximum daily "
     "value for degree days (typically 9°C). It also integrates a modification coefficient for latitudes "
     "between 40°N and 50°N as well as swings in daily temperature range.",
     cell_methods="",
@@ -909,12 +913,12 @@ biologically_effective_degree_days = Temp(
 effective_growing_degree_days = Temp(
     identifier="effective_growing_degree_days",
     units="K days",
-    long_name="Effective growing degree days computed with {method} formula (Summation of max((Tmin + Tmax)/2 "
-    "- {thresh}, 0), for days between between dynamically-determined start and end dates).",
+    long_name="Effective growing degree days computed with {{method}} formula (Summation of max((Tmin + Tmax)/2 "
+    "- {{thresh}}, 0), for days between between dynamically-determined start and end dates).",
     description="Heat-summation index for agroclimatic suitability estimation."
-    "Considers daily Tmin and Tmax with a base of {thresh} between dynamically-determined growing season start"
-    "and end dates. The 'bootsma' method uses a 10-day average temperature above {thresh} to identify a start date, "
-    "while the 'qian' method uses a weighted mean average above {thresh} over 5 days to determine start date. "
+    "Considers daily Tmin and Tmax with a base of {{thresh}} between dynamically-determined growing season start"
+    "and end dates. The 'bootsma' method uses a 10-day average temperature above {{thresh}} to identify a start date, "
+    "while the 'qian' method uses a weighted mean average above {{thresh}} over 5 days to determine start date. "
     "The end date of the growing season is the date of first fall frost (Tmin < 0°C).",
     cell_methods="",
     comment="Original formula published in Bootsma et al. 2005.",
@@ -929,7 +933,7 @@ latitude_temperature_index = Temp(
     long_name="Latitude-temperature index",
     description="A climate indice based on mean temperature of the warmest month and a latitude-based coefficient to "
     "account for longer day-length favouring growing conditions. Developed specifically for viticulture. "
-    "Mean temperature of warmest month * ({lat_factor} - latitude).",
+    "Mean temperature of warmest month * ({{lat_factor}} - latitude).",
     cell_methods="",
     allowed_periods=["A"],
     comment="Indice originally published in Jackson, D. I., & Cherry, N. J. (1988)",


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1174
    - This PR fixes #1093
    - This PR fixes #890 
    - This PR fixes #XYZ
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added
- [ ] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?
Follow up to discussions in here: https://github.com/Ouranosinc/xclim/issues/1093
This pr is a proof of concept to get an idea of how jinja can be used to format indicator descriptions.

### Does this PR introduce a breaking change?
No, it should not.

### Other information:

To illustrate the results with heat_wave_frequency:
```
ds = xr.open_dataset("/Users/aoun/workspace/xclim/climpact.sampledata.gridded.1991-2010.nc")
res = xclim.atmos.heat_wave_frequency(tasmin = ds.tmin,tasmax=ds.tmax)
print(res.attrs["description"])
```
prints
`"Ys number of heat wave events over a given period. an event occurs when the minimum and maximum daily temperature both exceeds specific thresholds : (tmin > 22.0 degc and tmax > 30 degc)over a minimum number of days (3)."`
