### PR TITLE
Fix saturation vapor pressure

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,10 @@ New features and enhancements
     - Wrapped SBCK tests are also properly run in the tox testing ensemble. (:pull:`1119`).
 * New indices for droughts: SPI (standardized precipitations) and SPEI (standardized water budgets) (:issue:`131`, :pull:`1096`)
 
+Bug fixes
+^^^^^^^^^
+* Fixed ``saturation_vapor_pressure`` for temperatures in other units than Kelvins (also fixes ``relative_humidity_from_dewpoint``). (:issue:`1125`, :pull:`1127`).
+
 Internal changes
 ^^^^^^^^^^^^^^^^
 * Marked a test (``test_release_notes_file_not_implemented``) that can only pass when source files are available so that it can easily be skipped on conda-forge build tests. (:issue:`1116`, :pull:`1117`).

--- a/xclim/indices/_conversion.py
+++ b/xclim/indices/_conversion.py
@@ -368,8 +368,8 @@ def saturation_vapor_pressure(
         thresh = convert_units_to(ice_thresh, "degK")
     else:
         thresh = convert_units_to("0 K", "degK")
-    ref_is_water = tas > thresh
     tas = convert_units_to(tas, "K")
+    ref_is_water = tas > thresh
     if method in ["sonntag90", "SO90"]:
         e_sat = xr.where(
             ref_is_water,

--- a/xclim/testing/tests/test_indices.py
+++ b/xclim/testing/tests/test_indices.py
@@ -2105,9 +2105,7 @@ def test_specific_humidity_from_dewpoint(tas_series, ps_series):
 @pytest.mark.parametrize(
     "ice_thresh,exp0", [(None, [125, 286, 568]), ("0 degC", [103, 260, 563])]
 )
-@pytest.mark.parametrize(
-    "units", ["degC", "degK"]
-)
+@pytest.mark.parametrize("units", ["degC", "degK"])
 def test_saturation_vapor_pressure(tas_series, method, ice_thresh, exp0, units):
     tas = tas_series(np.array([-20, -10, -1, 10, 20, 25, 30, 40, 60]) + K2C)
     tas = convert_units_to(tas, units)

--- a/xclim/testing/tests/test_indices.py
+++ b/xclim/testing/tests/test_indices.py
@@ -2105,8 +2105,12 @@ def test_specific_humidity_from_dewpoint(tas_series, ps_series):
 @pytest.mark.parametrize(
     "ice_thresh,exp0", [(None, [125, 286, 568]), ("0 degC", [103, 260, 563])]
 )
-def test_saturation_vapor_pressure(tas_series, method, ice_thresh, exp0):
+@pytest.mark.parametrize(
+    "units", ["degC", "degK"]
+)
+def test_saturation_vapor_pressure(tas_series, method, ice_thresh, exp0, units):
     tas = tas_series(np.array([-20, -10, -1, 10, 20, 25, 30, 40, 60]) + K2C)
+    tas = convert_units_to(tas, units)
     # Expected values obtained with the Sonntag90 method
     e_sat_exp = exp0 + [1228, 2339, 3169, 4247, 7385, 19947]
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1125
- [x] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added
- [x] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

* Fixes a bug in saturation vapor pressure :  the "ref is water" mask was computed before `tas` was converted to the units of the ice thresholds, so it only worked for Kelvins.

### Does this PR introduce a breaking change?
Nope.

### Other information:
Nothing to disclose.