### PR TITLE
Fix Heat Index and remove cell methods check on "Converter"

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,11 @@ New features and enhancements
     - Wrapped SBCK tests are also properly run in the tox testing ensemble. (:pull:`1119`).
 * New indices for droughts: SPI (standardized precipitations) and SPEI (standardized water budgets) (:issue:`131`, :pull:`1096`)
 
+Bug fixes
+^^^^^^^^^
+* Indicators that do not care about the input frequency of the data will not check the cell methods of their inputs. (:pull:`1128`).
+* Fixed the signature and docstring of ``heat_index`` by changing ``tasmax`` to ``tas``. (:issue:`1126`, :pull:`1128`).
+
 Internal changes
 ^^^^^^^^^^^^^^^^
 * Marked a test (``test_release_notes_file_not_implemented``) that can only pass when source files are available so that it can easily be skipped on conda-forge build tests. (:issue:`1116`, :pull:`1117`).

--- a/xclim/core/cfchecks.py
+++ b/xclim/core/cfchecks.py
@@ -34,14 +34,14 @@ def check_valid(var, key: str, expected: str | Sequence[str]):
         )
 
 
-def cfcheck_from_name(varname, vardata):
+def cfcheck_from_name(varname, vardata, attrs=["cell_methods", "standard_name"]):
     """Perform cfchecks on a DataArray using specifications from xclim's default variables."""
     data = VARIABLES[varname]
-    if "cell_methods" in data:
+    if "cell_methods" in data and "cell_methods" in attrs:
         _check_cell_methods(
             getattr(vardata, "cell_methods", None), data["cell_methods"]
         )
-    if "standard_name" in data:
+    if "standard_name" in data and "standard_name" in attrs:
         check_valid(vardata, "standard_name", data["standard_name"])
 
 

--- a/xclim/indicators/atmos/_conversion.py
+++ b/xclim/indicators/atmos/_conversion.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from inspect import _empty  # noqa
 
 from xclim import indices
+from xclim.core.cfchecks import cfcheck_from_name
 from xclim.core.indicator import Indicator
 from xclim.core.utils import InputKind
 
@@ -33,6 +34,21 @@ __all__ = [
 class Converter(Indicator):
     """Class for indicators doing variable conversion (dimension-independent 1-to-1 computation)."""
 
+    def cfcheck(self, **das):
+        for varname, vardata in das.items():
+            try:
+                # Only check standard_name, and not cell_methods which depends on the variable's frequency.
+                cfcheck_from_name(varname, vardata, attrs=["standard_name"])
+            except KeyError:
+                # Silently ignore unknown variables.
+                pass
+
+
+class DailyConverter(Indicator):
+    """Class for indicators doing variable conversion (dimension-independent 1-to-1 computation), for only on daily variables."""
+
+    src_freq = "D"
+
 
 humidex = Converter(
     identifier="humidex",
@@ -44,6 +60,7 @@ humidex = Converter(
     compute=indices.humidex,
 )
 
+
 heat_index = Converter(
     identifier="heat_index",
     units="C",
@@ -54,7 +71,8 @@ heat_index = Converter(
     compute=indices.heat_index,
 )
 
-tg = Converter(
+
+tg = DailyConverter(
     identifier="tg",
     units="K",
     standard_name="air_temperature",
@@ -277,7 +295,7 @@ water_budget = Converter(
 )
 
 
-corn_heat_units = Converter(
+corn_heat_units = DailyConverter(
     identifier="corn_heat_units",
     units="",
     long_name="Corn heat units (Tmin > {thresh_tasmin} and Tmax > {thresh_tasmax}).",

--- a/xclim/indicators/atmos/_conversion.py
+++ b/xclim/indicators/atmos/_conversion.py
@@ -44,12 +44,6 @@ class Converter(Indicator):
                 pass
 
 
-class DailyConverter(Indicator):
-    """Class for indicators doing variable conversion (dimension-independent 1-to-1 computation), for only on daily variables."""
-
-    src_freq = "D"
-
-
 humidex = Converter(
     identifier="humidex",
     units="C",
@@ -72,7 +66,7 @@ heat_index = Converter(
 )
 
 
-tg = DailyConverter(
+tg = Converter(
     identifier="tg",
     units="K",
     standard_name="air_temperature",
@@ -295,7 +289,7 @@ water_budget = Converter(
 )
 
 
-corn_heat_units = DailyConverter(
+corn_heat_units = Converter(
     identifier="corn_heat_units",
     units="",
     long_name="Corn heat units (Tmin > {thresh_tasmin} and Tmax > {thresh_tasmax}).",

--- a/xclim/indices/_conversion.py
+++ b/xclim/indices/_conversion.py
@@ -136,24 +136,24 @@ def humidex(
     return out
 
 
-@declare_units(tasmax="[temperature]", hurs="[]")
-def heat_index(tasmax: xr.DataArray, hurs: xr.DataArray) -> xr.DataArray:
-    r"""Daily heat index.
+@declare_units(tas="[temperature]", hurs="[]")
+def heat_index(tas: xr.DataArray, hurs: xr.DataArray) -> xr.DataArray:
+    r"""Heat index.
 
     Perceived temperature after relative humidity is taken into account ([Blazejczyk2012]_).
     The index is only valid for temperatures above 20°C.
 
     Parameters
     ----------
-    tasmax : xr.DataArray
-      Maximum daily temperature.
+    tas : xr.DataArray
+      Temperature. The equation assumes an instantaneous value.
     hurs : xr.DataArray
-      Relative humidity.
+      Relative humidity. The equation assumes an instantaneous value.
 
     Returns
     -------
-    xr.DataArray, [time][temperature]
-      Heat index for days with temperature above 20°C.
+    xr.DataArray, [temperature]
+      Heat index for moments with temperature above 20°C.
 
     References
     ----------
@@ -167,33 +167,24 @@ def heat_index(tasmax: xr.DataArray, hurs: xr.DataArray) -> xr.DataArray:
     heat balance equations which account for many variables other than vapor
     pressure, which is used exclusively in the humidex calculation.
     """
-    thresh = "20.0 degC"
-    thresh = convert_units_to(thresh, "degC")
-    t = convert_units_to(tasmax, "degC")
+    thresh = 20  # degC
+    t = convert_units_to(tas, "degC")
     t = t.where(t > thresh)
     r = convert_units_to(hurs, "%")
-
-    tr = t * r
-    tt = t * t
-    rr = r * r
-    ttr = tt * r
-    trr = t * rr
-    ttrr = tt * rr
 
     out = (
         -8.78469475556
         + 1.61139411 * t
         + 2.33854883889 * r
-        - 0.14611605 * tr
-        - 0.012308094 * tt
-        - 0.0164248277778 * rr
-        + 0.002211732 * ttr
-        + 0.00072546 * trr
-        - 0.000003582 * ttrr
+        - 0.14611605 * t * r
+        - 0.012308094 * t * t
+        - 0.0164248277778 * r * r
+        + 0.002211732 * t * t * r
+        + 0.00072546 * t * r * r
+        - 0.000003582 * t * t * r * r
     )
     out = out.assign_attrs(units="degC")
-
-    return convert_units_to(out, tasmax.units)
+    return convert_units_to(out, tas.units)
 
 
 @declare_units(tasmin="[temperature]", tasmax="[temperature]")

--- a/xclim/testing/tests/test_atmos.py
+++ b/xclim/testing/tests/test_atmos.py
@@ -88,28 +88,31 @@ def test_humidex(tas_series):
 
 def test_heat_index(atmosds):
     # Keep just Montreal values for summer time as we need tas > 20 degC
-    tas = atmosds.tas[1][193:210]
-    hurs = atmosds.hurs[1][193:210]
+    tas = atmosds.tasmax[1][150:170]
+    hurs = atmosds.hurs[1][150:170]
 
     expected = np.array(
         [
+            25.0,
+            27.0,
+            29.0,
+            27.0,
+            24.0,
+            np.nan,
+            np.nan,
+            23.0,
+            24.0,
             np.nan,
             np.nan,
             24.0,
+            28.0,
             25.0,
-            24.0,
+            30.0,
             26.0,
-            26.0,
-            20.0,
-            22.0,
-            22.0,
-            20.0,
-            22.0,
-            21.0,
-            24.0,
-            25.0,
-            25.0,
-            26.0,
+            31.0,
+            33.0,
+            34.0,
+            28.0,
         ]
     )
 

--- a/xclim/testing/tests/test_atmos.py
+++ b/xclim/testing/tests/test_atmos.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import numpy as np
 import xarray as xr
 
-from xclim import atmos
+from xclim import atmos, set_options
 from xclim.testing import open_dataset
 
 K2C = 273.16
@@ -113,7 +113,8 @@ def test_heat_index(atmosds):
         ]
     )
 
-    hi = atmos.heat_index(tas, hurs)
+    with set_options(cf_compliance="raise"):
+        hi = atmos.heat_index(tas, hurs)
     np.testing.assert_array_almost_equal(hi, expected, 0)
     assert hi.name == "heat_index"
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1126
- [x] Tests for the changes have been added (for bug fixes / features)
  - [x] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added
- [x] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

* Fix the signature and docstring of `heat_index` : instead of `tasmax`, `tas` is asked for. Also, the docstring specifies that the equation expects instantaneous values.
* Added argument `attrs` to `cfcheck_from_name` to control which attributes are checked.
* Indicator build with `Converter` will not check the cell_methods of the inputs as those depend on the frequency, which is not important for those indicators.
* Code simplification for `heat_index`.

### Does this PR introduce a breaking change?
Using `heat_index(ds=ds)` is now broken.

### Other information:
.