### PR TITLE
Fix BEDD for multiple latitudes

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -17,6 +17,10 @@ Internal changes
 * Marked a test (``test_release_notes_file_not_implemented``) that can only pass when source files are available so that it can easily be skipped on conda-forge build tests. (:issue:`1116`, :pull:`1117`).
 * Split a few YAML strings found in the virtual modules that regularly issued warnings on the code checking CI steps. (:pull:`1118`).
 
+Bug fixes
+^^^^^^^^^
+* Fix ``biological_effective_degree_days`` for non-scalar latitudes, when using method "gladstones". (:issue:`1136`, :pull:`1137`).
+
 0.37.0 (20 June 2022)
 ---------------------
 Contributors to this version: Abel Aoun (:user:`bzah`), Pascal Bourgault (:user:`aulemahal`), Trevor James Smith (:user:`Zeitsperre`), Gabriel Rondeau-Genesse (:user:`RondeauG`), Juliette Lavoie (:user:`juliettelavoie`), Ludwig Lierhammer (:user:`ludwiglierhammer`).

--- a/xclim/indices/_agro.py
+++ b/xclim/indices/_agro.py
@@ -384,9 +384,11 @@ def biologically_effective_degree_days(
         )
         if method.lower() == "gladstones":
             if isinstance(lat, (int, float)):
-                lat = xr.DataArray(lat)
+                lat = xarray.DataArray(lat)
             lat_mask = abs(lat) <= 50
-            k = 1 + xarray.where(lat_mask, ((abs(lat) - 40) * 0.06 / 10).clip(0, None), 0)
+            k = 1 + xarray.where(
+                lat_mask, ((abs(lat) - 40) * 0.06 / 10).clip(0, None), 0
+            )
             k_aggregated = 1
         else:
             day_length = aggregate_between_dates(

--- a/xclim/indices/_agro.py
+++ b/xclim/indices/_agro.py
@@ -383,8 +383,10 @@ def biologically_effective_degree_days(
             xarray.where(dtr < low_dtr, dtr - low_dtr, 0),
         )
         if method.lower() == "gladstones":
+            if isinstance(lat, (int, float)):
+                lat = xr.DataArray(lat)
             lat_mask = abs(lat) <= 50
-            k = 1 + xarray.where(lat_mask, max(((abs(lat) - 40) / 10) * 0.06, 0), 0)
+            k = 1 + xarray.where(lat_mask, ((abs(lat) - 40) * 0.06 / 10).clip(0, None), 0)
             k_aggregated = 1
         else:
             day_length = aggregate_between_dates(

--- a/xclim/testing/tests/test_indices.py
+++ b/xclim/testing/tests/test_indices.py
@@ -251,8 +251,8 @@ class TestAgroclimaticIndices:
             attrs=dict(units="K"),
         )
 
-        lat = xr.DataArray(45, name="lat", attrs={"units": "degrees_north"})
-        high_lat = lat.copy(data=48)
+        lat = xr.DataArray([35, 45], dims=('lat',), name="lat", attrs={"units": "degrees_north"})
+        high_lat = xr.DataArray(48, name="lat", attrs={"units": "degrees_north"})
 
         bedd = xci.biologically_effective_degree_days(
             tasmin=tn,
@@ -270,6 +270,9 @@ class TestAgroclimaticIndices:
             end_date=end_date,  # noqa
             freq="YS",
         )
+        if method != 'icclim':
+            bedd = bedd.isel(lat=1)
+            bedd_hot = bedd_hot.isel(lat=1)
         bedd_high_lat = xci.biologically_effective_degree_days(
             tasmin=tn,
             tasmax=tx,

--- a/xclim/testing/tests/test_indices.py
+++ b/xclim/testing/tests/test_indices.py
@@ -251,7 +251,9 @@ class TestAgroclimaticIndices:
             attrs=dict(units="K"),
         )
 
-        lat = xr.DataArray([35, 45], dims=('lat',), name="lat", attrs={"units": "degrees_north"})
+        lat = xr.DataArray(
+            [35, 45], dims=("lat",), name="lat", attrs={"units": "degrees_north"}
+        )
         high_lat = xr.DataArray(48, name="lat", attrs={"units": "degrees_north"})
 
         bedd = xci.biologically_effective_degree_days(
@@ -270,7 +272,7 @@ class TestAgroclimaticIndices:
             end_date=end_date,  # noqa
             freq="YS",
         )
-        if method != 'icclim':
+        if method != "icclim":
             bedd = bedd.isel(lat=1)
             bedd_hot = bedd_hot.isel(lat=1)
         bedd_high_lat = xci.biologically_effective_degree_days(


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1136
- [x] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added
- [x] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

* Use xarray's `clip` instead of builtins `max`. The latter worked with float or scalar DataArrays, but not when multiple latitudes were given. I added a conversion from float/int to DataArray to cover the case where lat is given as number. It isn't explicitly supported, but I didn't want to make a breaking change.

### Does this PR introduce a breaking change?
No.