### PR TITLE
Add missing %s to extlink mappings and speed up documentation builds with mambaforge

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,6 +11,8 @@ build:
   tools:
     python: "mambaforge-4.10"
   jobs:
+    pre_install:
+      - pip install llvmlite --ignore-installed
     post_install:
       - sphinx-apidoc -o docs/ --private --module-first xclim xclim/testing/tests
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,13 +9,15 @@ formats:
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "mambaforge-4.10"
   jobs:
     post_install:
       - sphinx-apidoc -o docs/ --private --module-first xclim xclim/testing/tests
 
+conda:
+  environment: environment.yml
+
 python:
-  system_packages: true
   install:
     - method: pip
       path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,7 +12,7 @@ build:
     python: "mambaforge-4.10"
   jobs:
     pre_install:
-      - pip install llvmlite<0.39,>=0.38 --ignore-installed
+      - pip install llvmlite~=0.38 --ignore-installed
     pre_build:
       - sphinx-apidoc -o docs/ --private --module-first xclim xclim/testing/tests
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,8 +12,8 @@ build:
     python: "mambaforge-4.10"
   jobs:
     pre_install:
-      - pip install llvmlite --ignore-installed
-    post_install:
+      - pip install llvmlite<0.39,>=0.38 --ignore-installed
+    pre_build:
       - sphinx-apidoc -o docs/ --private --module-first xclim xclim/testing/tests
 
 conda:

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -20,6 +20,7 @@ Internal changes
 ^^^^^^^^^^^^^^^^
 * Marked a test (``test_release_notes_file_not_implemented``) that can only pass when source files are available so that it can easily be skipped on conda-forge build tests. (:issue:`1116`, :pull:`1117`).
 * Split a few YAML strings found in the virtual modules that regularly issued warnings on the code checking CI steps. (:pull:`1118`).
+* Fixed a few extlink warnings found in `sphinx` and configured ReadTheDocs to use `mamba` as the dependency solver. (:issue:`1139`, :pull:`1140`).
 
 0.37.0 (20 June 2022)
 ---------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -128,9 +128,9 @@ intersphinx_mapping = {
     "numpy": ("https://numpy.org/doc/stable/", None),
 }
 extlinks = {
-    "issue": ("https://github.com/Ouranosinc/xclim/issues/%s", "GH/"),
-    "pull": ("https://github.com/Ouranosinc/xclim/pull/%s", "PR/"),
-    "user": ("https://github.com/", "@"),
+    "issue": ("https://github.com/Ouranosinc/xclim/issues/%s", "GH/%s"),
+    "pull": ("https://github.com/Ouranosinc/xclim/pull/%s", "PR/%s"),
+    "user": ("https://github.com/%s", "@%s"),
 }
 
 nbsphinx_execute = "auto"


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1139 
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added
- [x] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

* Fixes the extlink replacements to conform with new API
* Use mambaforge in the ReadTheDocs build configurator

### Does this PR introduce a breaking change?

No.

### Other information:
