### PR TITLE
Temporarily pin scipy < 1.9

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,10 @@ New features and enhancements
     - Wrapped SBCK tests are also properly run in the tox testing ensemble. (:pull:`1119`).
 * New indices for droughts: SPI (standardized precipitations) and SPEI (standardized water budgets) (:issue:`131`, :pull:`1096`)
 
+Breaking changes
+^^^^^^^^^^^^^^^^
+* `scipy` has been temporarily pinned below version 1.9 until lmoments3 tests can be rewritten to account for the new API. (:issue:`1142`, :pull:`1143`).
+
 Bug fixes
 ^^^^^^^^^
 * Fixed ``saturation_vapor_pressure`` for temperatures in other units than Kelvins (also fixes ``relative_humidity_from_dewpoint``). (:issue:`1125`, :pull:`1127`).
@@ -21,8 +25,8 @@ Internal changes
 * Marked a test (``test_release_notes_file_not_implemented``) that can only pass when source files are available so that it can easily be skipped on conda-forge build tests. (:issue:`1116`, :pull:`1117`).
 * Split a few YAML strings found in the virtual modules that regularly issued warnings on the code checking CI steps. (:pull:`1118`).
 
-0.37.0 (20 June 2022)
----------------------
+0.37.0 (2022-06-20)
+-------------------
 Contributors to this version: Abel Aoun (:user:`bzah`), Pascal Bourgault (:user:`aulemahal`), Trevor James Smith (:user:`Zeitsperre`), Gabriel Rondeau-Genesse (:user:`RondeauG`), Juliette Lavoie (:user:`juliettelavoie`), Ludwig Lierhammer (:user:`ludwiglierhammer`).
 
 Announcements
@@ -100,7 +104,7 @@ Internal changes
 ^^^^^^^^^^^^^^^^
 * Ipython was unpinned as version 8.2 fixed the previous issue. (:issue:`1005`, :pull:`1064`).
 
-v0.35.0 (01-04-2022)
+v0.35.0 (2022-04-01)
 --------------------
 Contributors to this version: David Huard (:user:`huard`), Trevor James Smith (:user:`Zeitsperre`) and Pascal Bourgault (:user:`aulemahal`).
 
@@ -124,7 +128,7 @@ Internal changes
 * `xclim` now uses the ``check-json`` and ``pretty-format-json`` pre-commit checks to validate and format JSON files. (:pull:`1032`).
 * The few `logging` artifacts in the ``xclim.ensembles`` module have been replaced with `warnings.warn` calls or removed. (:issue:`1039`, :pull:`1044`).
 
-v0.34.0 (25-02-2022)
+v0.34.0 (2022-02-25)
 --------------------
 Contributors to this version: Pascal Bourgault (:user:`aulemahal`), Trevor James Smith (:user:`Zeitsperre`), David Huard (:user:`huard`), Aoun Abel (:user:`bzah`).
 

--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,7 @@ dependencies:
     - poppler>=0.67
     - pyyaml
     - scikit-learn>=0.21.3
-    - scipy>=1.2
+    - scipy>=1.2,<1.9  # See https://github.com/Ouranosinc/xclim/issues/1142
     - xarray>=0.17
     # Testing and development dependencies
     - black>=22.3

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ requirements = [
     "pint>=0.10",
     "pyyaml",
     "scikit-learn>=0.21.3",
-    "scipy>=1.2",
+    "scipy>=1.2,<1.9",  # see: https://github.com/Ouranosinc/xclim/issues/1142
     "statsmodels",
     "xarray>=0.17",
 ]


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR is a workaround  for #1142
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added
- [x] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

* Pins `scipy` below v1.9 until we can implement a workaround for `lmoments3` tests

### Does this PR introduce a breaking change?

Yes. Dependencies have been affected.

### Other information:
