### PR TITLE
Allow binary operations in generic indice call signatures

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -25,13 +25,14 @@ Breaking changes
 * `scipy` has been temporarily pinned below version 1.9 until lmoments3 tests can be rewritten to account for the new API. (:issue:`1142`, :pull:`1143`).
 * Now requires `xarray>=2022.06.0` (:pull:`1151`).
 * Documentation CI (ReadTheDocs) builds will now fail if there are any misconfigured pages, internal link/reference warnings, or broken external hyperlinks. (:issue:`1094`, :pull:`1131`, :issue:`1139`, :pull:`1140`, :pull:`1160`).
-* Call signatures for generic indices have been reordered and/or modified to accept `op`, and optionally `constrain`, in many cases, and `condition`/`conditional`/`operation` has been renamed to `op` for consistency. (:pull:`1157`). The affected indices are as follows:
+* Call signatures for generic indices have been reordered and/or modified to accept `op`, and optionally `constrain`, in many cases, and `condition`/`conditional`/`operation` has been renamed to `op` for consistency. (:issue:`389`, :pull:`1157`). The affected indices are as follows:
     - `get_op`, `compare`, `threshold_count`, `get_daily_events`, `count_level_crossings`, `count_occurrences`, `first_occurrence`, `last_occurrence`, `spell_length`, `thresholded_statistics`, `temperature_sum`, `degree_days`.
 * All indices in `xclim.indices.generic` now use `threshold` in lieu of `thresh` for consistency. (:pull:`1157`).
+* Existing function ``xclim.indices.generic.compare`` can now be used to construct operations with `op` and `constrain` variables to allow for dynamic comparisons with user input handling. (:issue:`389`, :pull:`1157`).
 * Two deprecated indices have been removed from `xclim`. (:pull:`1157`):
     - ``xclim.indices._multivariate.daily_freezethaw_cycles`` -> Replaceable with the generic ``multiday_temperature_swing`` with `thresh_tasmax='0 degC'`, `thresh_tasmin='0 degC'`, `window=1`, and `op='sum'`. The indicator version (``xclim.atmos.daily_freezethaw_cycles``) is unaffected.
     - ``xclim.indices.generic.select_time`` -> Was previously moved to ``xclim.core.calendar``.
-* Existing function ``xclim.indices.generic.compare_arrays`` can now be used to construct operations with `op` and `constrain` variables to allow for dynamic comparisons with user input handling. (:pull:`1157`).
+* The `clix-meta` indicator table parsing function (``xclim.core.utils.adapt_clix_meta_yaml``) has been adapted to support the new "op" operator handler. (:pull:`1157`).
 
 Bug fixes
 ^^^^^^^^^
@@ -40,6 +41,10 @@ Bug fixes
 * Fixed the signature and docstring of ``heat_index`` by changing ``tasmax`` to ``tas``. (:issue:`1126`, :pull:`1128`).
 * Fixed a formatting issue with virtual indicator modules (`_gen_returns_section`) that was creating malformed `Returns` sections in `sphinx`-generated documentation. (:pull:`1131`).
 * Removed some artefact reference roles introduced in :pull:`1131` that were causing LaTeX builds of the documentation to fail. (:issue:`1154`, :pull:`1156`).
+* Fix ``biological_effective_degree_days`` for non-scalar latitudes, when using method "gladstones". (:issue:`1136`, :pull:`1137`).
+* Fixed some ``extlink`` warnings found in `sphinx` and configured ReadTheDocs to use `mamba` as the dependency solver. (:issue:`1139`, :pull:`1140`).
+* Fixed some broken hyperlinks to articles, users, and external documentation throughout the code base and jupyter notebooks. (:pull:`1160`).
+* Addressed a bug that was causing `pylint` to stackoverflow by removing it from the tox configuration. `pylint` should only be called from an active environment. (:pull:`1163`)
 
 Internal changes
 ^^^^^^^^^^^^^^^^
@@ -54,13 +59,6 @@ Internal changes
 * Added a `sphinx-build -b linkcheck` step to the `tox`-based `"docs"` build as well as to the ReadTheDocs configuration. (:pull:`1160`).
 * `pylint` is now setup to use a `pylintrc` file, allowing for more granular control of warnings and exceptions. Many errors are still present, so addressing them will need to occur gradually. (:pull:`1163`).
 * The generic indices `count_level_crossings`, `count_occurrences`, `first_occurrence`, and `last_occurrence` are now fully tested. (:pull:`1157`).
-
-Bug fixes
-^^^^^^^^^
-* Fix ``biological_effective_degree_days`` for non-scalar latitudes, when using method "gladstones". (:issue:`1136`, :pull:`1137`).
-* Fixed some ``extlink`` warnings found in `sphinx` and configured ReadTheDocs to use `mamba` as the dependency solver. (:issue:`1139`, :pull:`1140`).
-* Fixed some broken hyperlinks to articles, users, and external documentation throughout the code base and jupyter notebooks. (:pull:`1160`).
-* Addressed a bug that was causing `pylint` to stackoverflow by removing it from the tox configuration. `pylint` should only be called from an active environment. (:pull:`1163`)
 
 0.37.0 (2022-06-20)
 -------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,10 +12,18 @@ New features and enhancements
     - Wrapped SBCK tests are also properly run in the tox testing ensemble. (:pull:`1119`).
 * New indices for droughts: SPI (standardized precipitations) and SPEI (standardized water budgets) (:issue:`131`, :pull:`1096`)
 * ``ensembles.create_ensembles`` now accepts a ``realizations`` argument to assign a coordinate to the "realization" axis. It also accepts a dictionary as input so that keys are used as that coordinate. (:pull:`1153`).
+* Many generic indicators that compare arrays or against thresholds or now accept an `op` keyword for specifying the logical comparison operation to use in their calculations (i.e. `{">", ">=", "<", "<=, "!=", "=="}`). (:issue:`389`, :pull:`1157`).
+    - In order to prevent user error, many of these generic indices now have a `constrain` variable that prevents calling an indice with an inappropriate comparison operator. (e.g. The following will raise an error: `op=">", constrain=("<", "<=")`). This behaviour has been added to indices accepting `op` where appropriate.
 
 Breaking changes
 ^^^^^^^^^^^^^^^^
 * `scipy` has been temporarily pinned below version 1.9 until lmoments3 tests can be rewritten to account for the new API. (:issue:`1142`, :pull:`1143`).
+* Call signatures for generic indices have been reordered and/or modified to accept `op`, and optionally `constrain`, in many cases, and `condition`/`conditional`/`operation` has been renamed to `op` for consistency. (:pull:`1157`). The affected indices are as follows:
+    - `get_op`, `compare`, `threshold_count`, `get_daily_events`, `count_level_crossings`, `count_occurrences`, `first_occurrence`, `last_occurrence`, `spell_length`, `thresholded_statistics`, `temperature_sum`, `degree_days`.
+* All indices in `xclim.indices.generic` now use `threshold` in lieu of `thresh` for consistency. (:pull:`1157`).
+* Two deprecated indices have been removed from `xclim`. (:pull:`1157`):
+    - ``xclim.indices._multivariate.daily_freezethaw_cycles`` -> Replaceable with the generic ``multiday_temperature_swing`` with `thresh_tasmax='0 degC'`, `thresh_tasmin='0 degC'`, `window=1`, and `op='sum'`. The indicator version (``xclim.atmos.daily_freezethaw_cycles``) is unaffected.
+    - ``xclim.indices.generic.select_time`` -> Was previously moved to ``xclim.core.calendar``.
 
 Bug fixes
 ^^^^^^^^^
@@ -35,6 +43,8 @@ Internal changes
 * Bibliographic references for supporting scientific articles are now found in a bibtex file (`docs/references.bib`). These are now made available within the generated documentation using ``sphinxcontrib-bibtex``. (:issue:`1094`, :pull:`1131`).
 * Added information URLs to ``setup.py`` in order to showcase issue tracker and other sites on PyPI page (:pull:`1156`).
 * Set the LaTeX to `xelatex` and configured the LaTeX build of the documentation to ignore the custom bibliographies, as they were redundant in the generated PDF. (:pull:`1158`).
+* A new function ``xclim.indices.generic.compare_arrays`` can now be used to construct operations with `op` and `constrain` variables to allow for dynamic comparisons with user input handling. (:pull:`1157`).
+* The generic indices `count_level_crossings`, `count_occurrences`, `first_occurrence`, and `last_occurrence` are now fully tested. (:pull:`1157`).
 
 Bug fixes
 ^^^^^^^^^

--- a/docs/notebooks/example.yml
+++ b/docs/notebooks/example.yml
@@ -35,7 +35,7 @@ indicators:
       units: days
       var_name: fd
     parameters:
-      condition: <
+      op: <
       threshold: 0 degC
       freq:
         default: YS

--- a/xclim/core/dataflags.py
+++ b/xclim/core/dataflags.py
@@ -333,9 +333,9 @@ def very_large_precipitation_events(
 @register_methods
 @update_xclim_history
 def values_op_thresh_repeating_for_n_or_more_days(
-    da: xarray.DataArray, *, n: int, thresh: str, op: str = "eq"
+    da: xarray.DataArray, *, n: int, thresh: str, op: str = "=="
 ) -> xarray.DataArray:
-    """Check if array values repeat at a given threshold for 'n' or more days.
+    """Check if array values repeat at a given threshold for `N` or more days.
 
     Parameters
     ----------
@@ -345,7 +345,7 @@ def values_op_thresh_repeating_for_n_or_more_days(
       Number of days needed to trigger flag.
     thresh : str
       Repeating values to search for that will trigger flag.
-    op : {"eq", "gt", "lt", "gteq", "lteq"}
+    op : {">", "gt", "<", "lt", ">=", "ge", "<=", "le", "==", "eq", "!=", "ne"}
       Operator used for comparison with thresh.
 
     Returns
@@ -366,8 +366,7 @@ def values_op_thresh_repeating_for_n_or_more_days(
     ... )
     """
     thresh = convert_units_to(thresh, da)
-    if op not in {"eq", "gt", "lt", "gteq", "lteq"}:
-        raise ValueError("Operator must not be symbolic.")
+
     repetitions = _sanitize_attrs(suspicious_run(da, window=n, op=op, thresh=thresh))
     description = (
         f"Repetitive values at {thresh} for at least {n} days found for {da.name}."

--- a/xclim/core/units.py
+++ b/xclim/core/units.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import re
 import warnings
 from inspect import signature
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable
 
 import pint.converters
 import pint.unit
@@ -26,6 +26,7 @@ from .utils import ValidationError
 
 __all__ = [
     "ValidationError",
+    "amount2rate",
     "check_units",
     "convert_units_to",
     "declare_units",

--- a/xclim/core/units.py
+++ b/xclim/core/units.py
@@ -25,6 +25,7 @@ from .options import datacheck
 from .utils import ValidationError
 
 __all__ = [
+    "ValidationError",
     "check_units",
     "convert_units_to",
     "declare_units",

--- a/xclim/data/cf.yml
+++ b/xclim/data/cf.yml
@@ -30,7 +30,7 @@ indicators:
     input:
       data: pr
     parameters:
-      condition: <
+      op: <
       freq:
         default: YS
       reducer: max
@@ -47,7 +47,7 @@ indicators:
     input:
       data: tas
     parameters:
-      condition: '>'
+      op: '>'
       freq:
         default: YS
       threshold:
@@ -66,7 +66,7 @@ indicators:
     input:
       data: tasmin
     parameters:
-      condition: <
+      op: <
       freq:
         default: YS
       threshold: 0 degree_Celsius
@@ -83,7 +83,7 @@ indicators:
     input:
       data: tasmax
     parameters:
-      condition: '>'
+      op: '>'
       freq:
         default: YS
       threshold: 25 degree_Celsius
@@ -91,7 +91,7 @@ indicators:
   ctmgeTT:
     cf_attrs:
     - cell_methods: 'time: maximum over days'
-      long_name: Maximum number of consequtive days with Tmean >= {threshold}C
+      long_name: Maximum number of consecutive days with Tmean >= {threshold}C
       proposed_standard_name: spell_length_with_air_temperature_at_or_above_threshold
       standard_name: spell_length_of_days_with_air_temperature_above_threshold
       units: day
@@ -100,7 +100,7 @@ indicators:
     input:
       data: tas
     parameters:
-      condition: '>'
+      op: '>'
       freq:
         default: YS
       reducer: max
@@ -111,7 +111,7 @@ indicators:
   ctmgtTT:
     cf_attrs:
     - cell_methods: 'time: maximum over days'
-      long_name: Maximum number of consequtive days with Tmean > {threshold}C
+      long_name: Maximum number of consecutive days with Tmean > {threshold}C
       proposed_standard_name: spell_length_with_air_temperature_above_threshold
       standard_name: spell_length_of_days_with_air_temperature_above_threshold
       units: day
@@ -120,7 +120,7 @@ indicators:
     input:
       data: tas
     parameters:
-      condition: '>'
+      op: '>'
       freq:
         default: YS
       reducer: max
@@ -131,7 +131,7 @@ indicators:
   ctmleTT:
     cf_attrs:
     - cell_methods: 'time: maximum over days'
-      long_name: Maximum number of consequtive days with Tmean <= {threshold}C
+      long_name: Maximum number of consecutive days with Tmean <= {threshold}C
       proposed_standard_name: spell_length_with_air_temperature_at_or_below_threshold
       standard_name: spell_length_of_days_with_air_temperature_below_threshold
       units: day
@@ -140,7 +140,7 @@ indicators:
     input:
       data: tas
     parameters:
-      condition: <
+      op: <
       freq:
         default: YS
       reducer: max
@@ -151,7 +151,7 @@ indicators:
   ctmltTT:
     cf_attrs:
     - cell_methods: 'time: maximum over days'
-      long_name: Maximum number of consequtive days with Tmean < {threshold}C
+      long_name: Maximum number of consecutive days with Tmean < {threshold}C
       proposed_standard_name: spell_length_with_air_temperature_below_threshold
       standard_name: spell_length_of_days_with_air_temperature_below_threshold
       units: day
@@ -160,7 +160,7 @@ indicators:
     input:
       data: tas
     parameters:
-      condition: <
+      op: <
       freq:
         default: YS
       reducer: max
@@ -171,7 +171,7 @@ indicators:
   ctngeTT:
     cf_attrs:
     - cell_methods: 'time: maximum over days'
-      long_name: Maximum number of consequtive days with Tmin >= {threshold}C
+      long_name: Maximum number of consecutive days with Tmin >= {threshold}C
       proposed_standard_name: spell_length_with_air_temperature_at_or_above_threshold
       standard_name: spell_length_of_days_with_air_temperature_above_threshold
       units: day
@@ -180,7 +180,7 @@ indicators:
     input:
       data: tasmin
     parameters:
-      condition: '>'
+      op: '>'
       freq:
         default: YS
       reducer: max
@@ -191,7 +191,7 @@ indicators:
   ctngtTT:
     cf_attrs:
     - cell_methods: 'time: maximum over days'
-      long_name: Maximum number of consequtive days with Tmin > {threshold}C
+      long_name: Maximum number of consecutive days with Tmin > {threshold}C
       proposed_standard_name: spell_length_with_air_temperature_above_threshold
       standard_name: spell_length_of_days_with_air_temperature_above_threshold
       units: day
@@ -200,7 +200,7 @@ indicators:
     input:
       data: tasmin
     parameters:
-      condition: '>'
+      op: '>'
       freq:
         default: YS
       reducer: max
@@ -211,7 +211,7 @@ indicators:
   ctnleTT:
     cf_attrs:
     - cell_methods: 'time: maximum over days'
-      long_name: Maximum number of consequtive days with Tmin <= {threshold}C
+      long_name: Maximum number of consecutive days with Tmin <= {threshold}C
       proposed_standard_name: spell_length_with_air_temperature_at_or_below_threshold
       standard_name: spell_length_of_days_with_air_temperature_below_threshold
       units: day
@@ -220,7 +220,7 @@ indicators:
     input:
       data: tasmin
     parameters:
-      condition: <
+      op: <
       freq:
         default: YS
       reducer: max
@@ -231,7 +231,7 @@ indicators:
   ctnltTT:
     cf_attrs:
     - cell_methods: 'time: maximum over days'
-      long_name: Maximum number of consequtive days with Tmin < {threshold}C
+      long_name: Maximum number of consecutive days with Tmin < {threshold}C
       proposed_standard_name: spell_length_with_air_temperature_below_threshold
       standard_name: spell_length_of_days_with_air_temperature_below_threshold
       units: day
@@ -240,7 +240,7 @@ indicators:
     input:
       data: tasmin
     parameters:
-      condition: <
+      op: <
       freq:
         default: YS
       reducer: max
@@ -251,7 +251,7 @@ indicators:
   ctxgeTT:
     cf_attrs:
     - cell_methods: 'time: maximum over days'
-      long_name: Maximum number of consequtive days with Tmax >= {threshold}C
+      long_name: Maximum number of consecutive days with Tmax >= {threshold}C
       proposed_standard_name: spell_length_with_air_temperature_at_or_above_threshold
       standard_name: spell_length_of_days_with_air_temperature_above_threshold
       units: day
@@ -260,7 +260,7 @@ indicators:
     input:
       data: tasmax
     parameters:
-      condition: '>'
+      op: '>'
       freq:
         default: YS
       reducer: max
@@ -271,7 +271,7 @@ indicators:
   ctxgtTT:
     cf_attrs:
     - cell_methods: 'time: maximum over days'
-      long_name: Maximum number of consequtive days with Tmax > {threshold}C
+      long_name: Maximum number of consecutive days with Tmax > {threshold}C
       proposed_standard_name: spell_length_with_air_temperature_above_threshold
       standard_name: spell_length_of_days_with_air_temperature_above_threshold
       units: day
@@ -280,7 +280,7 @@ indicators:
     input:
       data: tasmax
     parameters:
-      condition: '>'
+      op: '>'
       freq:
         default: YS
       reducer: max
@@ -291,7 +291,7 @@ indicators:
   ctxleTT:
     cf_attrs:
     - cell_methods: 'time: maximum over days'
-      long_name: Maximum number of consequtive days with Tmax <= {threshold}C
+      long_name: Maximum number of consecutive days with Tmax <= {threshold}C
       proposed_standard_name: spell_length_with_air_temperature_at_or_below_threshold
       standard_name: spell_length_of_days_with_air_temperature_below_threshold
       units: day
@@ -300,7 +300,7 @@ indicators:
     input:
       data: tasmax
     parameters:
-      condition: <
+      op: <
       freq:
         default: YS
       reducer: max
@@ -311,7 +311,7 @@ indicators:
   ctxltTT:
     cf_attrs:
     - cell_methods: 'time: maximum over days'
-      long_name: Maximum number of consequtive days with Tmax < {threshold}C
+      long_name: Maximum number of consecutive days with Tmax < {threshold}C
       proposed_standard_name: spell_length_with_air_temperature_below_threshold
       standard_name: spell_length_of_days_with_air_temperature_below_threshold
       units: day
@@ -320,7 +320,7 @@ indicators:
     input:
       data: tasmax
     parameters:
-      condition: <
+      op: <
       freq:
         default: YS
       reducer: max
@@ -340,7 +340,7 @@ indicators:
     input:
       data: pr
     parameters:
-      condition: '>'
+      op: '>'
       freq:
         default: YS
       reducer: max
@@ -357,7 +357,7 @@ indicators:
     input:
       data: tas
     parameters:
-      condition: '>'
+      op: '>'
       freq:
         default: YS
       threshold:
@@ -375,7 +375,7 @@ indicators:
     input:
       data: tas
     parameters:
-      condition: <
+      op: <
       freq:
         default: YS
       threshold:
@@ -454,7 +454,7 @@ indicators:
     input:
       data: tas
     parameters:
-      condition: '>'
+      op: '>'
       freq:
         default: YS
       threshold: 4 degree_Celsius
@@ -470,7 +470,7 @@ indicators:
     input:
       data: tas
     parameters:
-      condition: '>'
+      op: '>'
       freq:
         default: YS
       threshold:
@@ -488,7 +488,7 @@ indicators:
     input:
       data: tas
     parameters:
-      condition: <
+      op: <
       freq:
         default: YS
       threshold: 17 degree_Celsius
@@ -504,7 +504,7 @@ indicators:
     input:
       data: tas
     parameters:
-      condition: <
+      op: <
       freq:
         default: YS
       threshold:
@@ -583,7 +583,7 @@ indicators:
     input:
       data: pr
     parameters:
-      condition: '>'
+      op: '>'
       freq:
         default: YS
       reducer: mean

--- a/xclim/indicators/atmos/_temperature.py
+++ b/xclim/indicators/atmos/_temperature.py
@@ -449,7 +449,7 @@ daily_freezethaw_cycles = TempWithIndexing(
     units="days",
     long_name="daily freezethaw cycles",
     description="{freq} number of days with a diurnal freeze-thaw cycle "
-    ": Tmax > {thresh_tasmax} and Tmin <= {thresh_tasmin}.",
+    ": Tmax {op_tasmax} {thresh_tasmax} and Tmin {op_tasmin} {thresh_tasmin}.",
     cell_methods="",
     compute=indices.multiday_temperature_swing,
     parameters={
@@ -457,6 +457,8 @@ daily_freezethaw_cycles = TempWithIndexing(
         "window": 1,
         "thresh_tasmax": {"default": "0 degC"},
         "thresh_tasmin": {"default": "0 degC"},
+        "op_tasmax": ">",
+        "op_tasmin": "<=",
     },
 )
 
@@ -467,7 +469,7 @@ freezethaw_spell_frequency = Temp(
     units="days",
     long_name="{freq} number of freeze-thaw spells.",
     description="{freq} number of freeze-thaw spells"
-    ": Tmax > {thresh_tasmax} and Tmin <= {thresh_tasmin} "
+    ": Tmax {op_tasmax} {thresh_tasmax} and Tmin {op_tasmin} {thresh_tasmin} "
     "for at least {window} consecutive day(s).",
     cell_methods="",
     compute=indices.multiday_temperature_swing,
@@ -475,6 +477,8 @@ freezethaw_spell_frequency = Temp(
         "op": "count",
         "thresh_tasmax": {"default": "0 degC"},
         "thresh_tasmin": {"default": "0 degC"},
+        "op_tasmax": ">",
+        "op_tasmin": "<=",
     },
 )
 
@@ -485,7 +489,7 @@ freezethaw_spell_mean_length = Temp(
     units="days",
     long_name="{freq} average length of freeze-thaw spells.",
     description="{freq} average length of freeze-thaw spells"
-    ": Tmax > {thresh_tasmax} and Tmin <= {thresh_tasmin} "
+    ": Tmax {op_tasmax} {thresh_tasmax} and Tmin {op_tasmin} {thresh_tasmin} "
     "for at least {window} consecutive day(s).",
     cell_methods="",
     compute=indices.multiday_temperature_swing,
@@ -493,6 +497,8 @@ freezethaw_spell_mean_length = Temp(
         "op": "mean",
         "thresh_tasmax": {"default": "0 degC"},
         "thresh_tasmin": {"default": "0 degC"},
+        "op_tasmax": ">",
+        "op_tasmin": "<=",
     },
 )
 
@@ -503,7 +509,7 @@ freezethaw_spell_max_length = Temp(
     units="days",
     long_name="{freq} maximal length of freeze-thaw spells.",
     description="{freq} maximal length of freeze-thaw spells"
-    ": Tmax > {thresh_tasmax} and Tmin <= {thresh_tasmin} "
+    ": Tmax {op_tasmax} {thresh_tasmax} and Tmin {op_tasmin} {thresh_tasmin} "
     "for at least {window} consecutive day(s).",
     cell_methods="",
     compute=indices.multiday_temperature_swing,
@@ -511,6 +517,8 @@ freezethaw_spell_max_length = Temp(
         "op": "max",
         "thresh_tasmax": {"default": "0 degC"},
         "thresh_tasmin": {"default": "0 degC"},
+        "op_tasmax": ">",
+        "op_tasmin": "<=",
     },
 )
 

--- a/xclim/indicators/atmos/_temperature.py
+++ b/xclim/indicators/atmos/_temperature.py
@@ -99,6 +99,7 @@ tn_days_above = TempWithIndexing(
     description="{freq} number of days where daily minimum temperature exceeds {thresh}.",
     cell_methods="time: sum over days",
     compute=indices.tn_days_above,
+    parameters=dict(op=">"),
 )
 
 tn_days_below = TempWithIndexing(
@@ -109,6 +110,7 @@ tn_days_below = TempWithIndexing(
     description="{freq} number of days where daily minimum temperature is below {thresh}.",
     cell_methods="time: sum over days",
     compute=indices.tn_days_below,
+    parameters=dict(op="<"),
 )
 
 tg_days_above = TempWithIndexing(
@@ -119,6 +121,7 @@ tg_days_above = TempWithIndexing(
     description="{freq} number of days where daily mean temperature exceeds {thresh}.",
     cell_methods="time: sum over days",
     compute=indices.tg_days_above,
+    parameters=dict(op=">"),
 )
 
 tg_days_below = TempWithIndexing(
@@ -129,6 +132,7 @@ tg_days_below = TempWithIndexing(
     description="{freq} number of days where daily mean temperature is below {thresh}.",
     cell_methods="time: sum over days",
     compute=indices.tg_days_below,
+    parameters=dict(op="<"),
 )
 
 tx_days_above = TempWithIndexing(
@@ -139,6 +143,7 @@ tx_days_above = TempWithIndexing(
     description="{freq} number of days where daily maximum temperature exceeds {thresh}.",
     cell_methods="time: sum over days",
     compute=indices.tx_days_above,
+    parameters=dict(op=">"),
 )
 
 tx_days_below = TempWithIndexing(
@@ -149,6 +154,7 @@ tx_days_below = TempWithIndexing(
     description="{freq} number of days where daily max temperature is below {thresh}.",
     cell_methods="time: sum over days",
     compute=indices.tx_days_below,
+    parameters=dict(op="<"),
 )
 
 tx_tn_days_above = TempWithIndexing(

--- a/xclim/indices/_agro.py
+++ b/xclim/indices/_agro.py
@@ -743,6 +743,8 @@ def standardized_precipitation_index(
             pr,
         )
         prob = prob_zero + (1 - prob_zero) * prob_pos
+    else:
+        raise NotImplementedError(f"dist: {dist}.")
 
     # Invert to normal distribution with ppf and obtain SPI
     params_norm = xarray.DataArray(

--- a/xclim/indices/_agro.py
+++ b/xclim/indices/_agro.py
@@ -743,8 +743,6 @@ def standardized_precipitation_index(
             pr,
         )
         prob = prob_zero + (1 - prob_zero) * prob_pos
-    else:
-        raise NotImplementedError(f"dist: {dist}.")
 
     # Invert to normal distribution with ppf and obtain SPI
     params_norm = xarray.DataArray(

--- a/xclim/indices/_multivariate.py
+++ b/xclim/indices/_multivariate.py
@@ -19,7 +19,7 @@ from xclim.core.units import (
 
 from . import run_length as rl
 from ._conversion import rain_approximation, snowfall_approximation
-from .generic import compare, compare_arrays, select_resample_op, threshold_count
+from .generic import compare, select_resample_op, threshold_count
 
 # Frequencies : YS: year start, QS-DEC: seasons starting in december, MS: month start
 # See https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html
@@ -132,7 +132,7 @@ def cold_spell_duration_index(
     # Create time series out of doy values.
     thresh = resample_doy(tasmin_per, tasmin)
 
-    below = compare_arrays(tasmin, op, thresh, constrain=("<", "<="))
+    below = compare(tasmin, op, thresh, constrain=("<", "<="))
 
     out = below.resample(time=freq).map(
         rl.windowed_run_count, window=window, dim="time"
@@ -1152,11 +1152,7 @@ def fraction_over_precip_thresh(
     )
 
     # Compute the days when precip is both over the wet day threshold and the percentile threshold.
-    over = (
-        pr.where(compare_arrays(pr, op, tp, constrain))
-        .resample(time=freq)
-        .sum(dim="time")
-    )
+    over = pr.where(compare(pr, op, tp, constrain)).resample(time=freq).sum(dim="time")
 
     out = over / total
     out.attrs["units"] = ""
@@ -1641,7 +1637,7 @@ def warm_spell_duration_index(
     # Create time series out of doy values.
     thresh = resample_doy(thresh, tasmax)
 
-    above = compare_arrays(tasmax, op, thresh, constrain=(">", ">="))
+    above = compare(tasmax, op, thresh, constrain=(">", ">="))
 
     out = above.resample(time=freq).map(
         rl.windowed_run_count, window=window, dim="time"

--- a/xclim/indices/_multivariate.py
+++ b/xclim/indices/_multivariate.py
@@ -20,7 +20,7 @@ from xclim.core.units import (
 
 from . import run_length as rl
 from ._conversion import rain_approximation, snowfall_approximation
-from .generic import select_resample_op, threshold_count
+from .generic import compare, select_resample_op, threshold_count
 
 # Frequencies : YS: year start, QS-DEC: seasons starting in december, MS: month start
 # See https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html
@@ -1199,6 +1199,7 @@ def tg90p(
     tas_per: xarray.DataArray,
     freq: str = "YS",
     bootstrap: bool = False,  # noqa
+    op: str = ">",
 ) -> xarray.DataArray:  # noqa: D401
     r"""Number of days with daily mean temperature over the 90th percentile.
 
@@ -1219,6 +1220,8 @@ def tg90p(
       the rest of the time series.
       Keep bootstrap to False when there is no common period, it would give wrong results
       plus, bootstrapping is computationally expensive.
+    op: {">", ">=", "gt", "ge"}
+        Comparison operation. Default: ">".
 
     Returns
     -------
@@ -1243,7 +1246,7 @@ def tg90p(
     thresh = resample_doy(tas_per, tas)
 
     # Identify the days over the 90th percentile
-    out = threshold_count(tas, ">", thresh, freq)
+    out = threshold_count(tas, op, thresh, freq, constrain=(">", ">="))
     return to_agg_units(out, tas, "count")
 
 
@@ -1254,6 +1257,7 @@ def tg10p(
     tas_per: xarray.DataArray,
     freq: str = "YS",
     bootstrap: bool = False,  # noqa
+    op: str = "<",
 ) -> xarray.DataArray:  # noqa: D401
     r"""Number of days with daily mean temperature below the 10th percentile.
 
@@ -1274,6 +1278,8 @@ def tg10p(
       the rest of the time series.
       Keep bootstrap to False when there is no common period, it would give wrong results
       plus, bootstrapping is computationally expensive.
+    op: {"<", "<=", "lt", "le"}
+        Comparison operation. Default: "<".
 
     Returns
     -------
@@ -1298,7 +1304,7 @@ def tg10p(
     thresh = resample_doy(tas_per, tas)
 
     # Identify the days below the 10th percentile
-    out = threshold_count(tas, "<", thresh, freq)
+    out = threshold_count(tas, op, thresh, freq, constrain=("<", "<="))
     return to_agg_units(out, tas, "count")
 
 
@@ -1309,6 +1315,7 @@ def tn90p(
     tasmin_per: xarray.DataArray,
     freq: str = "YS",
     bootstrap: bool = False,  # noqa
+    op: str = ">",
 ) -> xarray.DataArray:  # noqa: D401
     r"""Number of days with daily minimum temperature over the 90th percentile.
 
@@ -1329,6 +1336,8 @@ def tn90p(
       the rest of the time series.
       Keep bootstrap to False when there is no common period, it would give wrong results
       plus, bootstrapping is computationally expensive.
+    op: {">", ">=", "gt", "ge"}
+        Comparison operation. Default: ">".
 
     Returns
     -------
@@ -1353,7 +1362,7 @@ def tn90p(
     thresh = resample_doy(tasmin_per, tasmin)
 
     # Identify the days with min temp above 90th percentile.
-    out = threshold_count(tasmin, ">", thresh, freq)
+    out = threshold_count(tasmin, op, thresh, freq, constrain=(">", ">="))
     return to_agg_units(out, tasmin, "count")
 
 
@@ -1364,6 +1373,7 @@ def tn10p(
     tasmin_per: xarray.DataArray,
     freq: str = "YS",
     bootstrap: bool = False,  # noqa
+    op: str = "<",
 ) -> xarray.DataArray:  # noqa: D401
     r"""Number of days with daily minimum temperature below the 10th percentile.
 
@@ -1384,6 +1394,8 @@ def tn10p(
       the rest of the time series.
       Keep bootstrap to False when there is no common period, it would give wrong results
       plus, bootstrapping is computationally expensive.
+    op: {"<", "<=", "lt", "le"}
+      Comparison operation. Default: "<".
 
     Returns
     -------
@@ -1408,7 +1420,7 @@ def tn10p(
     thresh = resample_doy(tasmin_per, tasmin)
 
     # Identify the days below the 10th percentile
-    out = threshold_count(tasmin, "<", thresh, freq)
+    out = threshold_count(tasmin, op, thresh, freq, constrain=("<", "<="))
     return to_agg_units(out, tasmin, "count")
 
 
@@ -1419,6 +1431,7 @@ def tx90p(
     tasmax_per: xarray.DataArray,
     freq: str = "YS",
     bootstrap: bool = False,  # noqa
+    op: str = ">",
 ) -> xarray.DataArray:  # noqa: D401
     r"""Number of days with daily maximum temperature over the 90th percentile.
 
@@ -1439,6 +1452,8 @@ def tx90p(
       the rest of the time series.
       Keep bootstrap to False when there is no common period, it would give wrong results
       plus, bootstrapping is computationally expensive.
+    op: {">", ">=", "gt", "ge"}
+      Comparison operation. Default: ">".
 
     Returns
     -------
@@ -1463,7 +1478,7 @@ def tx90p(
     thresh = resample_doy(tasmax_per, tasmax)
 
     # Identify the days with max temp above 90th percentile.
-    out = threshold_count(tasmax, ">", thresh, freq)
+    out = threshold_count(tasmax, op, thresh, freq, constrain=(">", ">="))
     return to_agg_units(out, tasmax, "count")
 
 
@@ -1474,6 +1489,7 @@ def tx10p(
     tasmax_per: xarray.DataArray,
     freq: str = "YS",
     bootstrap: bool = False,  # noqa
+    op: str = "<",
 ) -> xarray.DataArray:  # noqa: D401
     r"""Number of days with daily maximum temperature below the 10th percentile.
 
@@ -1494,6 +1510,8 @@ def tx10p(
       the rest of the time series.
       Keep bootstrap to False when there is no common period, it would give wrong results
       plus, bootstrapping is computationally expensive.
+    op: {"<", "<=", "lt", "le"}
+      Comparison operation. Default: "<".
 
     Returns
     -------
@@ -1518,7 +1536,7 @@ def tx10p(
     thresh = resample_doy(tasmax_per, tasmax)
 
     # Identify the days below the 10th percentile
-    out = threshold_count(tasmax, "<", thresh, freq)
+    out = threshold_count(tasmax, op, thresh, freq, constrain=("<", "<="))
     return to_agg_units(out, tasmax, "count")
 
 
@@ -1534,6 +1552,7 @@ def tx_tn_days_above(
     thresh_tasmin: str = "22 degC",
     thresh_tasmax: str = "30 degC",
     freq: str = "YS",
+    op: str = ">",
 ) -> xarray.DataArray:  # noqa: D401
     r"""Number of days with both hot maximum and minimum daily temperatures.
 
@@ -1551,6 +1570,8 @@ def tx_tn_days_above(
       Threshold temperature for tasmax on which to base evaluation.
     freq : str
       Resampling frequency.
+    op: {">", ">=", "gt", "ge"}
+        Comparison operation. Default: ">".
 
     Returns
     -------
@@ -1577,7 +1598,12 @@ def tx_tn_days_above(
     """
     thresh_tasmax = convert_units_to(thresh_tasmax, tasmax)
     thresh_tasmin = convert_units_to(thresh_tasmin, tasmin)
-    events = ((tasmin > thresh_tasmin) & (tasmax > thresh_tasmax)) * 1
+
+    constrain = (">", ">=")
+    events = (
+        compare(tasmin, op, thresh_tasmin, constrain)
+        & compare(tasmax, op, thresh_tasmax, constrain)
+    ) * 1
     out = events.resample(time=freq).sum(dim="time")
     return to_agg_units(out, tasmin, "count")
 

--- a/xclim/indices/_multivariate.py
+++ b/xclim/indices/_multivariate.py
@@ -1,7 +1,6 @@
 # noqa: D100
 from __future__ import annotations
 
-import warnings
 from typing import Callable
 
 import numpy as np
@@ -36,7 +35,6 @@ __all__ = [
     "warm_and_dry_days",
     "warm_and_wet_days",
     "cold_and_wet_days",
-    "daily_freezethaw_cycles",
     "multiday_temperature_swing",
     "daily_temperature_range",
     "daily_temperature_range_variability",
@@ -315,7 +313,8 @@ def warm_and_wet_days(
 
     Notes
     -----
-    Bootstrapping is not available for quartiles because it would make no significant difference to bootstrap percentiles so far from the extremes.
+    Bootstrapping is not available for quartiles because it would make no significant difference
+    to bootstrap percentiles so far from the extremes.
 
     Formula to be written (:cite:t:`beniston_trends_2009`)
 
@@ -404,78 +403,6 @@ def cold_and_wet_days(
     thresh_tasmin="[temperature]",
     thresh_tasmax="[temperature]",
 )
-def daily_freezethaw_cycles(
-    tasmin: xarray.DataArray,
-    tasmax: xarray.DataArray,
-    thresh_tasmin: str = "0 degC",
-    thresh_tasmax: str = "0 degC",
-    freq: str = "YS",
-) -> xarray.DataArray:  # noqa: D401
-    r"""Number of days with a diurnal freeze-thaw cycle.
-
-    The number of days when Tmax > thresh_tasmax and Tmin <= thresh_tasmin.
-
-    Parameters
-    ----------
-    tasmin : xarray.DataArray
-      Minimum daily temperature.
-    tasmax : xarray.DataArray
-      Maximum daily temperature.
-    thresh_tasmin : str
-      The temperature threshold needed to trigger a freeze event.
-    thresh_tasmax : str
-      The temperature threshold needed to trigger a thaw event.
-    freq : str
-      Resampling frequency.
-
-    Returns
-    -------
-    xarray.DataArray, [time]
-      Number of days with a diurnal freeze-thaw cycle
-
-    Notes
-    -----
-    Let :math:`TX_{i}` be the maximum temperature at day :math:`i` and :math:`TN_{i}` be
-    the daily minimum temperature at day :math:`i`. Then the number of freeze thaw cycles
-    during period :math:`\phi` is given by :
-
-    .. math::
-
-        \sum_{i \in \phi} [ TX_{i} > 0℃ ] [ TN_{i} <  0℃ ]
-
-    where :math:`[P]` is 1 if :math:`P` is true, and 0 if false.
-
-    Warnings
-    --------
-    The `daily_freezethaw_cycles` indice is being deprecated in favour of `multiday_temperature_swing` with
-    `thresh_tasmax='0 degC, thresh_tasmin='0 degC', window=1, op='sum'` by default. The indicator reflects this change.
-    This indice will be removed in a future version of xclim.
-    """
-    warnings.warn(
-        "The `daily_freezethaw_cycles` indice is being deprecated in favour of `multiday_temperature_swing` with "
-        "`thresh_tasmax='0 degC, thresh_tasmin='0 degC', window=1, op='sum'` by default. "
-        "This indice will be removed in `xclim>=0.28.0`. Please update your scripts accordingly.",
-        UserWarning,
-        stacklevel=3,
-    )
-
-    return multiday_temperature_swing(
-        tasmin=tasmin,
-        tasmax=tasmax,
-        thresh_tasmin=thresh_tasmin,
-        thresh_tasmax=thresh_tasmax,
-        window=1,
-        op="sum",
-        freq=freq,
-    )
-
-
-@declare_units(
-    tasmin="[temperature]",
-    tasmax="[temperature]",
-    thresh_tasmin="[temperature]",
-    thresh_tasmax="[temperature]",
-)
 def multiday_temperature_swing(
     tasmin: xarray.DataArray,
     tasmax: xarray.DataArray,
@@ -483,6 +410,8 @@ def multiday_temperature_swing(
     thresh_tasmax: str = "0 degC",
     window: int = 1,
     op: str = "mean",
+    op_tasmin: str = "<=",
+    op_tasmax: str = ">",
     freq: str = "YS",
 ) -> xarray.DataArray:  # noqa: D401
     r"""Statistics of consecutive diurnal temperature swing events.
@@ -504,6 +433,10 @@ def multiday_temperature_swing(
       The minimal length of spells to be included in the statistics.
     op : {'mean', 'sum', 'max', 'min', 'std', 'count'}
       The statistical operation to use when reducing the list of spell lengths.
+    op_tasmin : {"<", "<=", "lt", "le"}
+      Comparison operation for tasmin. Default: "<=".
+    op_tasmax : {">", ">=", "gt", "ge"}
+      Comparison operation for tasmax. Default: ">".
     freq : str
       Resampling frequency.
 
@@ -527,7 +460,10 @@ def multiday_temperature_swing(
     thaw_threshold = convert_units_to(thresh_tasmax, tasmax)
     freeze_threshold = convert_units_to(thresh_tasmin, tasmin)
 
-    ft = (tasmin <= freeze_threshold) * (tasmax > thaw_threshold)
+    freeze = compare(tasmin, op_tasmin, freeze_threshold, constrain=("<", "<="))
+    thaw = compare(tasmax, op_tasmax, thaw_threshold, constrain=(">", ">="))
+    ft = freeze * thaw
+
     if op == "count":
         out = ft.resample(time=freq).map(
             rl.windowed_run_events, window=window, dim="time"
@@ -678,6 +614,7 @@ def heat_wave_frequency(
     thresh_tasmax: str = "30 degC",
     window: int = 3,
     freq: str = "YS",
+    op: str = ">",
 ) -> xarray.DataArray:
     r"""Heat wave frequency.
 
@@ -698,6 +635,8 @@ def heat_wave_frequency(
       Minimum number of days with temperatures above thresholds to qualify as a heatwave.
     freq : str
       Resampling frequency.
+    op: {">", ">=", "gt", "ge"}
+      Comparison operation. Default: ">".
 
     Returns
     -------
@@ -720,7 +659,10 @@ def heat_wave_frequency(
     thresh_tasmax = convert_units_to(thresh_tasmax, tasmax)
     thresh_tasmin = convert_units_to(thresh_tasmin, tasmin)
 
-    cond = (tasmin > thresh_tasmin) & (tasmax > thresh_tasmax)
+    constrain = (">", ">=")
+    cond = (compare(tasmin, op, thresh_tasmin, constrain)) & (
+        compare(tasmax, op, thresh_tasmax, constrain)
+    )
     out = cond.resample(time=freq).map(rl.windowed_run_events, window=window)
     out.attrs["units"] = ""
     return out
@@ -739,6 +681,7 @@ def heat_wave_max_length(
     thresh_tasmax: str = "30 degC",
     window: int = 3,
     freq: str = "YS",
+    op: str = ">",
 ) -> xarray.DataArray:
     r"""Heat wave max length.
 
@@ -761,6 +704,8 @@ def heat_wave_max_length(
       Minimum number of days with temperatures above thresholds to qualify as a heatwave.
     freq : str
       Resampling frequency.
+    op: {">", ">=", "gt", "ge"}
+      Comparison operation. Default: ">".
 
     Returns
     -------
@@ -774,7 +719,8 @@ def heat_wave_max_length(
     characterize the occurrence of hot weather events that can result in adverse health outcomes for Canadian
     communities :cite:p:`casati_regional_2013`.
 
-    In :cite:t:`robinson_definition_2001`, the parameters would be `thresh_tasmin=27.22, thresh_tasmax=39.44, window=2` (81F, 103F).
+    In :cite:t:`robinson_definition_2001`, the parameters would be:
+    `thresh_tasmin=27.22, thresh_tasmax=39.44, window=2` (81F, 103F).
 
     References
     ----------
@@ -783,7 +729,10 @@ def heat_wave_max_length(
     thresh_tasmax = convert_units_to(thresh_tasmax, tasmax)
     thresh_tasmin = convert_units_to(thresh_tasmin, tasmin)
 
-    cond = (tasmin > thresh_tasmin) & (tasmax > thresh_tasmax)
+    constrain = (">", ">=")
+    cond = (compare(tasmin, op, thresh_tasmin, constrain)) & (
+        compare(tasmax, op, thresh_tasmax, constrain)
+    )
     max_l = cond.resample(time=freq).map(rl.longest_run, dim="time")
     out = max_l.where(max_l >= window, 0)
     return to_agg_units(out, tasmax, "count")
@@ -1154,6 +1103,7 @@ def fraction_over_precip_thresh(
     thresh: str = "1 mm/day",
     freq: str = "YS",
     bootstrap: bool = False,  # noqa
+    op: str = ">",
 ) -> xarray.DataArray:
     r"""Fraction of precipitation due to wet days with daily precipitation over a given percentile.
 
@@ -1178,6 +1128,8 @@ def fraction_over_precip_thresh(
       the rest of the time series.
       Keep bootstrap to False when there is no common period, it would give wrong results
       plus, bootstrapping is computationally expensive.
+    op: {">", ">=", "gt", "ge"}
+      Comparison operation. Default: ">".
 
     Returns
     -------
@@ -1193,11 +1145,18 @@ def fraction_over_precip_thresh(
         # Create time series out of doy values.
         tp = resample_doy(tp, pr)
 
+    constrain = (">", ">=")
     # Total precip during wet days over period
-    total = pr.where(pr > thresh).resample(time=freq).sum(dim="time")
+    total = (
+        pr.where(compare(pr, op, thresh, constrain)).resample(time=freq).sum(dim="time")
+    )
 
     # Compute the days when precip is both over the wet day threshold and the percentile threshold.
-    over = pr.where(pr > tp).resample(time=freq).sum(dim="time")
+    over = (
+        pr.where(compare_arrays(pr, op, tp, constrain))
+        .resample(time=freq)
+        .sum(dim="time")
+    )
 
     out = over / total
     out.attrs["units"] = ""
@@ -1628,6 +1587,7 @@ def warm_spell_duration_index(
     window: int = 6,
     freq: str = "YS",
     bootstrap: bool = False,  # noqa
+    op: str = ">",
 ) -> xarray.DataArray:
     r"""Warm spell duration index.
 
@@ -1652,6 +1612,8 @@ def warm_spell_duration_index(
       the rest of the time series.
       Keep bootstrap to False when there is no common period, it would give wrong results
       plus, bootstrapping is computationally expensive.
+    op: {">", ">=", "gt", "ge"}
+      Comparison operation. Default: ">".
 
     Returns
     -------
@@ -1679,7 +1641,7 @@ def warm_spell_duration_index(
     # Create time series out of doy values.
     thresh = resample_doy(thresh, tasmax)
 
-    above = tasmax > thresh
+    above = compare_arrays(tasmax, op, thresh, constrain=(">", ">="))
 
     out = above.resample(time=freq).map(
         rl.windowed_run_count, window=window, dim="time"

--- a/xclim/indices/_threshold.py
+++ b/xclim/indices/_threshold.py
@@ -1482,7 +1482,7 @@ def tn_days_above(
       Threshold temperature on which to base evaluation.
     freq : str
       Resampling frequency.
-    op : {">", ">=", "gt", "gteq"}
+    op : {">", ">=", "gt", "ge"}
       Comparison operation. Default: ">".
 
     Returns
@@ -1523,7 +1523,7 @@ def tn_days_below(
       Threshold temperature on which to base evaluation.
     freq : str
       Resampling frequency.
-    op : {"<", "<=", "lt", "lteq"}
+    op : {"<", "<=", "lt", "le"}
       Comparison operation. Default: "<".
 
     Returns
@@ -1564,7 +1564,7 @@ def tg_days_above(
       Threshold temperature on which to base evaluation.
     freq : str
       Resampling frequency.
-    op : {">", ">=", "gt", "gteq"}
+    op : {">", ">=", "gt", "ge"}
       Comparison operation. Default: ">".
 
     Returns
@@ -1605,7 +1605,7 @@ def tg_days_below(
       Threshold temperature on which to base evaluation.
     freq : str
       Resampling frequency.
-    op : {"<", "<=", "lt", "lteq"}
+    op : {"<", "<=", "lt", "le"}
       Comparison operation. Default: "<".
 
     Returns
@@ -1646,7 +1646,7 @@ def tx_days_above(
       Threshold temperature on which to base evaluation.
     freq : str
       Resampling frequency.
-    op : {">", ">=", "gt", "gteq"}
+    op : {">", ">=", "gt", "ge"}
       Comparison operation. Default: ">".
 
     Returns
@@ -1687,7 +1687,7 @@ def tx_days_below(
       Threshold temperature on which to base evaluation.
     freq : str
       Resampling frequency.
-    op : {"<", "<=", "lt", "lteq"}
+    op : {"<", "<=", "lt", "le"}
       Comparison operation. Default: "<".
 
     Returns

--- a/xclim/indices/_threshold.py
+++ b/xclim/indices/_threshold.py
@@ -1456,7 +1456,7 @@ def snow_cover_duration(
     Returns
     -------
     xarray.DataArray, [time]
-      Number of days where snow depth is greater or equal to threshold.
+      Number of days where snow depth is greater than or equal to threshold.
     """
     thresh = convert_units_to(thresh, snd)
     out = threshold_count(snd, ">=", thresh, freq)
@@ -1465,7 +1465,10 @@ def snow_cover_duration(
 
 @declare_units(tasmin="[temperature]", thresh="[temperature]")
 def tn_days_above(
-    tasmin: xarray.DataArray, thresh: str = "20.0 degC", freq: str = "YS"
+    tasmin: xarray.DataArray,
+    thresh: str = "20.0 degC",
+    freq: str = "YS",
+    op: str = ">",
 ):  # noqa: D401
     """Number of days with tasmin above a threshold (number of tropical nights).
 
@@ -1479,6 +1482,8 @@ def tn_days_above(
       Threshold temperature on which to base evaluation.
     freq : str
       Resampling frequency.
+    op : {">", ">=", "gt", "gteq"}
+      Comparison operation. Default: ">".
 
     Returns
     -------
@@ -1495,13 +1500,16 @@ def tn_days_above(
         TN_{ij} > Threshold [℃]
     """
     thresh = convert_units_to(thresh, tasmin)
-    f = threshold_count(tasmin, ">", thresh, freq)
+    f = threshold_count(tasmin, op, thresh, freq, constrain=(">", ">=", "gt", "gteq"))
     return to_agg_units(f, tasmin, "count")
 
 
 @declare_units(tasmin="[temperature]", thresh="[temperature]")
 def tn_days_below(
-    tasmin: xarray.DataArray, thresh: str = "-10.0 degC", freq: str = "YS"
+    tasmin: xarray.DataArray,
+    thresh: str = "-10.0 degC",
+    freq: str = "YS",
+    op: str = "<",
 ) -> xarray.DataArray:  # noqa: D401
     """Number of days with tasmin below a threshold.
 
@@ -1515,6 +1523,8 @@ def tn_days_below(
       Threshold temperature on which to base evaluation.
     freq : str
       Resampling frequency.
+    op : {"<", "<=", "lt", "lteq"}
+      Comparison operation. Default: "<".
 
     Returns
     -------
@@ -1531,13 +1541,16 @@ def tn_days_below(
         TN_{ij} < Threshold [℃]
     """
     thresh = convert_units_to(thresh, tasmin)
-    f1 = threshold_count(tasmin, "<", thresh, freq)
+    f1 = threshold_count(tasmin, op, thresh, freq, constrain=("<", "<=", "lt", "lteq"))
     return to_agg_units(f1, tasmin, "count")
 
 
 @declare_units(tas="[temperature]", thresh="[temperature]")
 def tg_days_above(
-    tas: xarray.DataArray, thresh: str = "10.0 degC", freq: str = "YS"
+    tas: xarray.DataArray,
+    thresh: str = "10.0 degC",
+    freq: str = "YS",
+    op: str = ">",
 ):  # noqa: D401
     """Number of days with tas above a threshold.
 
@@ -1551,6 +1564,8 @@ def tg_days_above(
       Threshold temperature on which to base evaluation.
     freq : str
       Resampling frequency.
+    op : {">", ">=", "gt", "gteq"}
+      Comparison operation. Default: ">".
 
     Returns
     -------
@@ -1567,13 +1582,16 @@ def tg_days_above(
         TG_{ij} > Threshold [℃]
     """
     thresh = convert_units_to(thresh, tas)
-    f = threshold_count(tas, ">", thresh, freq)
+    f = threshold_count(tas, op, thresh, freq, constrain=(">", ">=", "gt", "gteq"))
     return to_agg_units(f, tas, "count")
 
 
 @declare_units(tas="[temperature]", thresh="[temperature]")
 def tg_days_below(
-    tas: xarray.DataArray, thresh: str = "10.0 degC", freq: str = "YS"
+    tas: xarray.DataArray,
+    thresh: str = "10.0 degC",
+    freq: str = "YS",
+    op: str = "<",
 ):  # noqa: D401
     """Number of days with tas below a threshold.
 
@@ -1587,6 +1605,8 @@ def tg_days_below(
       Threshold temperature on which to base evaluation.
     freq : str
       Resampling frequency.
+    op : {"<", "<=", "lt", "lteq"}
+      Comparison operation. Default: "<".
 
     Returns
     -------
@@ -1603,13 +1623,16 @@ def tg_days_below(
         TG_{ij} < Threshold [℃]
     """
     thresh = convert_units_to(thresh, tas)
-    f1 = threshold_count(tas, "<", thresh, freq)
+    f1 = threshold_count(tas, op, thresh, freq, constrain=("<", "<=", "lt", "lteq"))
     return to_agg_units(f1, tas, "count")
 
 
 @declare_units(tasmax="[temperature]", thresh="[temperature]")
 def tx_days_above(
-    tasmax: xarray.DataArray, thresh: str = "25.0 degC", freq: str = "YS"
+    tasmax: xarray.DataArray,
+    thresh: str = "25.0 degC",
+    freq: str = "YS",
+    op: str = ">",
 ) -> xarray.DataArray:  # noqa: D401
     """Number of days with tasmax above a threshold (number of summer days).
 
@@ -1623,6 +1646,8 @@ def tx_days_above(
       Threshold temperature on which to base evaluation.
     freq : str
       Resampling frequency.
+    op : {">", ">=", "gt", "gteq"}
+      Comparison operation. Default: ">".
 
     Returns
     -------
@@ -1639,13 +1664,16 @@ def tx_days_above(
         TX_{ij} > Threshold [℃]
     """
     thresh = convert_units_to(thresh, tasmax)
-    f = threshold_count(tasmax, ">", thresh, freq)
+    f = threshold_count(tasmax, op, thresh, freq, constrain=(">", ">=", "gt", "gteq"))
     return to_agg_units(f, tasmax, "count")
 
 
 @declare_units(tasmax="[temperature]", thresh="[temperature]")
 def tx_days_below(
-    tasmax: xarray.DataArray, thresh: str = "25.0 degC", freq: str = "YS"
+    tasmax: xarray.DataArray,
+    thresh: str = "25.0 degC",
+    freq: str = "YS",
+    op: str = "<",
 ):  # noqa: D401
     """Number of days with tmax below a threshold.
 
@@ -1659,6 +1687,8 @@ def tx_days_below(
       Threshold temperature on which to base evaluation.
     freq : str
       Resampling frequency.
+    op : {"<", "<=", "lt", "lteq"}
+      Comparison operation. Default: "<".
 
     Returns
     -------
@@ -1675,7 +1705,7 @@ def tx_days_below(
         TN_{ij} < Threshold [℃]
     """
     thresh = convert_units_to(thresh, tasmax)
-    f1 = threshold_count(tasmax, "<", thresh, freq)
+    f1 = threshold_count(tasmax, op, thresh, freq, constrain=("<", "<=", "lt", "lteq"))
     return to_agg_units(f1, tasmax, "count")
 
 

--- a/xclim/indices/_threshold.py
+++ b/xclim/indices/_threshold.py
@@ -1500,7 +1500,7 @@ def tn_days_above(
         TN_{ij} > Threshold [℃]
     """
     thresh = convert_units_to(thresh, tasmin)
-    f = threshold_count(tasmin, op, thresh, freq, constrain=(">", ">=", "gt", "gteq"))
+    f = threshold_count(tasmin, op, thresh, freq, constrain=(">", ">="))
     return to_agg_units(f, tasmin, "count")
 
 
@@ -1541,7 +1541,7 @@ def tn_days_below(
         TN_{ij} < Threshold [℃]
     """
     thresh = convert_units_to(thresh, tasmin)
-    f1 = threshold_count(tasmin, op, thresh, freq, constrain=("<", "<=", "lt", "lteq"))
+    f1 = threshold_count(tasmin, op, thresh, freq, constrain=("<", "<="))
     return to_agg_units(f1, tasmin, "count")
 
 
@@ -1582,7 +1582,7 @@ def tg_days_above(
         TG_{ij} > Threshold [℃]
     """
     thresh = convert_units_to(thresh, tas)
-    f = threshold_count(tas, op, thresh, freq, constrain=(">", ">=", "gt", "gteq"))
+    f = threshold_count(tas, op, thresh, freq, constrain=(">", ">="))
     return to_agg_units(f, tas, "count")
 
 
@@ -1623,7 +1623,7 @@ def tg_days_below(
         TG_{ij} < Threshold [℃]
     """
     thresh = convert_units_to(thresh, tas)
-    f1 = threshold_count(tas, op, thresh, freq, constrain=("<", "<=", "lt", "lteq"))
+    f1 = threshold_count(tas, op, thresh, freq, constrain=("<", "<="))
     return to_agg_units(f1, tas, "count")
 
 
@@ -1664,7 +1664,7 @@ def tx_days_above(
         TX_{ij} > Threshold [℃]
     """
     thresh = convert_units_to(thresh, tasmax)
-    f = threshold_count(tasmax, op, thresh, freq, constrain=(">", ">=", "gt", "gteq"))
+    f = threshold_count(tasmax, op, thresh, freq, constrain=(">", ">="))
     return to_agg_units(f, tasmax, "count")
 
 
@@ -1705,7 +1705,7 @@ def tx_days_below(
         TN_{ij} < Threshold [℃]
     """
     thresh = convert_units_to(thresh, tasmax)
-    f1 = threshold_count(tasmax, op, thresh, freq, constrain=("<", "<=", "lt", "lteq"))
+    f1 = threshold_count(tasmax, op, thresh, freq, constrain=("<", "<="))
     return to_agg_units(f1, tasmax, "count")
 
 

--- a/xclim/indices/generic.py
+++ b/xclim/indices/generic.py
@@ -12,7 +12,7 @@ from typing import Sequence
 import cftime
 import numpy as np
 import xarray as xr
-from xarray.coding.cftime_offsets import _MONTH_ABBREVIATIONS
+from xarray.coding.cftime_offsets import _MONTH_ABBREVIATIONS  # noqa
 
 from xclim.core.calendar import (
     DayOfYearStr,

--- a/xclim/indices/generic.py
+++ b/xclim/indices/generic.py
@@ -295,6 +295,7 @@ def count_level_crossings(
     high_data: xr.DataArray,
     thresh: str,
     freq: str,
+    *,
     op_low: str = "<",
     op_high: str = ">=",
 ) -> xr.DataArray:

--- a/xclim/indices/generic.py
+++ b/xclim/indices/generic.py
@@ -315,7 +315,11 @@ def count_level_crossings(
 
 
 def count_occurrences(
-    data: xr.DataArray, threshold: str, condition: str, freq: str
+    data: xr.DataArray,
+    threshold: str,
+    condition: str,
+    freq: str,
+    constrain: Sequence[str] | None = None,
 ) -> xr.DataArray:
     """Calculate the number of times some condition is met.
 
@@ -334,6 +338,8 @@ def count_occurrences(
       Operator.
     freq : str
       Resampling frequency.
+    constrain : sequence of str, optional
+      Optionally allowed conditions.
 
     Returns
     -------
@@ -341,7 +347,7 @@ def count_occurrences(
     """
     threshold = convert_units_to(threshold, data)
 
-    cond = compare(data, condition, threshold)
+    cond = compare(data, condition, threshold, constrain)
 
     out = cond.resample(time=freq).sum()
     return to_agg_units(out, data, "count", dim="time")
@@ -378,7 +384,11 @@ def diurnal_temperature_range(
 
 
 def first_occurrence(
-    data: xr.DataArray, threshold: str, condition: str, freq: str
+    data: xr.DataArray,
+    threshold: str,
+    condition: str,
+    freq: str,
+    constrain: Sequence[str] | None = None,
 ) -> xr.DataArray:
     """Calculate the first time some condition is met.
 
@@ -396,6 +406,8 @@ def first_occurrence(
       Operator.
     freq : str
       Resampling frequency.
+    constrain : sequence of str, optional
+      Optionally allowed conditions.
 
     Returns
     -------
@@ -403,7 +415,7 @@ def first_occurrence(
     """
     threshold = convert_units_to(threshold, data)
 
-    cond = compare(data, condition, threshold)
+    cond = compare(data, condition, threshold, constrain)
 
     out = cond.resample(time=freq).map(
         rl.first_run,
@@ -416,7 +428,11 @@ def first_occurrence(
 
 
 def last_occurrence(
-    data: xr.DataArray, threshold: str, condition: str, freq: str
+    data: xr.DataArray,
+    threshold: str,
+    condition: str,
+    freq: str,
+    constrain: Sequence[str] | None = None,
 ) -> xr.DataArray:
     """Calculate the last time some condition is met.
 
@@ -434,6 +450,7 @@ def last_occurrence(
       Operator.
     freq : str
       Resampling frequency.
+
 
     Returns
     -------
@@ -454,7 +471,11 @@ def last_occurrence(
 
 
 def spell_length(
-    data: xr.DataArray, threshold: str, condition: str, reducer: str, freq: str
+    data: xr.DataArray,
+    threshold: str,
+    condition: str,
+    reducer: str,
+    freq: str,
 ) -> xr.DataArray:
     """Calculate statistics on lengths of spells.
 

--- a/xclim/indices/generic.py
+++ b/xclim/indices/generic.py
@@ -35,7 +35,6 @@ from . import run_length as rl
 __all__ = [
     "aggregate_between_dates",
     "compare",
-    "compare_arrays",
     "count_level_crossings",
     "count_occurrences",
     "default_freq",
@@ -164,21 +163,21 @@ def get_op(op: str, constrain: Sequence[str] | None = None) -> Callable:
 
 
 def compare(
-    da: xr.DataArray,
+    left: xr.DataArray,
     op: str,
-    threshold: float | int,
+    right: float | int | np.ndarray | xr.DataArray,
     constrain: Sequence[str] | None = None,
 ) -> xr.DataArray:
     """Compare a dataArray to a threshold using given operator.
 
     Parameters
     ----------
-    da : xr.DataArray
-      Input data.
+    left : xr.DataArray
+      A DatArray being evaluated against `right`.
     op : {">", "gt", "<", "lt", ">=", "ge", "<=", "le", "==", "eq", "!=", "ne"}
       Logical operator. e.g. arr > thresh.
-    threshold : Union[float, int]
-      Threshold value.
+    right : float, int, np.ndarray, or xr.DataArray
+      A value or array-like being evaluated against left`.
     constrain : sequence of str, optional
       Optionally allowed conditions.
 
@@ -187,7 +186,7 @@ def compare(
     xr.DataArray
         Boolean mask of the comparison.
     """
-    return get_op(op, constrain)(da, threshold)
+    return get_op(op, constrain)(left, right)
 
 
 def threshold_count(
@@ -548,29 +547,6 @@ def statistics(data: xr.DataArray, reducer: str, freq: str) -> xr.DataArray:
     out = getattr(data.resample(time=freq), reducer)()
     out.attrs["units"] = data.attrs["units"]
     return out
-
-
-def compare_arrays(
-    left: xr.DataArray, op: str, right: xr.DataArray, constrain: Sequence[str] | None
-) -> xr.DataArray:
-    """Compare two variables using a binary logical operation.
-
-    Parameters
-    ----------
-    left : xr.DataArray
-      A DatArray being evaluated against `right`.
-    op : {">", "gt", "<", "lt", ">=", "ge", "<=", "le", "==", "eq", "!=", "ne"}
-      Logical operator. e.g. array1 > array2.
-    right : xr.DataArray
-      A DatArray being evaluated against left`.
-    constrain : sequence of str, optional
-      Optionally allowed conditions.
-
-    Returns
-    -------
-    xr.DataArray
-    """
-    return getattr(left, "_binary_op")(right, get_op(op, constrain))
 
 
 def thresholded_statistics(

--- a/xclim/indices/generic.py
+++ b/xclim/indices/generic.py
@@ -166,7 +166,7 @@ def get_op(op: str, constrain: Sequence[str] | None = None) -> Callable:
 def compare(
     da: xr.DataArray,
     op: str,
-    thresh: float | int,
+    threshold: float | int,
     constrain: Sequence[str] | None = None,
 ) -> xr.DataArray:
     """Compare a dataArray to a threshold using given operator.
@@ -177,7 +177,7 @@ def compare(
       Input data.
     op : {">", "gt", "<", "lt", ">=", "ge", "<=", "le", "==", "eq", "!=", "ne"}
       Logical operator. e.g. arr > thresh.
-    thresh : Union[float, int]
+    threshold : Union[float, int]
       Threshold value.
     constrain : sequence of str, optional
       Optionally allowed conditions.
@@ -187,13 +187,13 @@ def compare(
     xr.DataArray
         Boolean mask of the comparison.
     """
-    return get_op(op, constrain)(da, thresh)
+    return get_op(op, constrain)(da, threshold)
 
 
 def threshold_count(
     da: xr.DataArray,
     op: str,
-    thresh: float | int | xr.DataArray,
+    threshold: float | int | xr.DataArray,
     freq: str,
     constrain: Sequence[str] | None = None,
 ) -> xr.DataArray:
@@ -205,7 +205,7 @@ def threshold_count(
       Input data.
     op : {">", "<", ">=", "<=", "gt", "lt", "ge", "le"}
       Logical operator. e.g. arr > thresh.
-    thresh : Union[float, int]
+    threshold : Union[float, int]
       Threshold value.
     freq : str
       Resampling frequency defining the periods as defined in
@@ -221,7 +221,7 @@ def threshold_count(
     if constrain is None:
         constrain = (">", "<", ">=", "<=")
 
-    c = compare(da, op, thresh, constrain) * 1
+    c = compare(da, op, threshold, constrain) * 1
     return c.resample(time=freq).sum(dim="time")
 
 
@@ -253,7 +253,7 @@ def domain_count(da: xr.DataArray, low: float, high: float, freq: str) -> xr.Dat
 
 def get_daily_events(
     da: xr.DataArray,
-    thresh: float,
+    threshold: float,
     op: str,
     constrain: Sequence[str] | None = None,
 ) -> xr.DataArray:
@@ -263,7 +263,7 @@ def get_daily_events(
     ----------
     da : xr.DataArray
       Input data.
-    thresh : float
+    threshold : float
       Threshold value.
     op : {">", "gt", "<", "lt", ">=", "ge", "<=", "le", "==", "eq", "!=", "ne"}
       Logical operator. e.g. arr > thresh.
@@ -281,7 +281,7 @@ def get_daily_events(
     -------
     xr.DataArray
     """
-    events = compare(da, op, thresh, constrain) * 1
+    events = compare(da, op, threshold, constrain) * 1
     events = events.where(~(np.isnan(da)))
     events = events.rename("events")
     return events
@@ -293,7 +293,7 @@ def get_daily_events(
 def count_level_crossings(
     low_data: xr.DataArray,
     high_data: xr.DataArray,
-    thresh: str,
+    threshold: str,
     freq: str,
     *,
     op_low: str = "<",
@@ -310,7 +310,7 @@ def count_level_crossings(
       Variable that must be under the threshold.
     high_data : xr.DataArray
       Variable that must be above the threshold.
-    thresh : str
+    threshold : str
       Quantity.
     freq : str
       Resampling frequency.
@@ -325,7 +325,7 @@ def count_level_crossings(
     """
     # Convert units to low_data
     high_data = convert_units_to(high_data, low_data)
-    threshold = convert_units_to(thresh, low_data)
+    threshold = convert_units_to(threshold, low_data)
 
     lower = compare(low_data, op_low, threshold, constrain=("<", "<="))
     higher = compare(high_data, op_high, threshold, constrain=(">", ">="))
@@ -805,14 +805,14 @@ def aggregate_between_dates(
 
 
 @declare_units(tas="[temperature]")
-def degree_days(tas: xr.DataArray, thresh: str, op: str) -> xr.DataArray:
+def degree_days(tas: xr.DataArray, threshold: str, op: str) -> xr.DataArray:
     """Calculate the degree days below/above the temperature threshold.
 
     Parameters
     ----------
     tas : xr.DataArray
       Mean daily temperature.
-    thresh : str
+    threshold : str
       The temperature threshold.
     op : {">", "gt", "<", "lt", ">=", "ge", "<=", "le"}
       Logical operator. e.g. arr > thresh.
@@ -821,12 +821,12 @@ def degree_days(tas: xr.DataArray, thresh: str, op: str) -> xr.DataArray:
     -------
     xarray.DataArray
     """
-    thresh = convert_units_to(thresh, tas)
+    threshold = convert_units_to(threshold, tas)
 
     if op in ["<", "<=", "lt", "le"]:
-        out = (thresh - tas).clip(0)
+        out = (threshold - tas).clip(0)
     elif op in [">", ">=", "gt", "ge"]:
-        out = (tas - thresh).clip(0)
+        out = (tas - threshold).clip(0)
     else:
         raise NotImplementedError(f"Condition not supported: '{op}'.")
 

--- a/xclim/indices/run_length.py
+++ b/xclim/indices/run_length.py
@@ -1236,7 +1236,7 @@ def suspicious_run_1d(
     op : {">", ">=", "==", "<", "<=", "eq", "gt", "lt", "gteq", "lteq", "ge", "le"}
       Operator for threshold comparison. Defaults to ">".
     thresh : float, optional
-      Threshold above which values are checked for identical values.
+      Threshold compared against which values are checked for identical values.
 
     Returns
     -------
@@ -1252,6 +1252,8 @@ def suspicious_run_1d(
             sus_runs = sus_runs & (v < thresh)
         elif op in {"==", "eq"}:
             sus_runs = sus_runs & (v == thresh)
+        elif op in {"!=", "ne"}:
+            sus_runs = sus_runs & (v != thresh)
         elif op in {">=", "gteq", "ge"}:
             sus_runs = sus_runs & (v >= thresh)
         elif op in {"<=", "lteq", "le"}:

--- a/xclim/indices/run_length.py
+++ b/xclim/indices/run_length.py
@@ -1233,7 +1233,7 @@ def suspicious_run_1d(
       Array of values to be parsed.
     window : int
       Minimum run length
-    op : {">", ">=", "==", "<", "<=", "eq", "gt", "lt", "gteq", "lteq"}
+    op : {">", ">=", "==", "<", "<=", "eq", "gt", "lt", "gteq", "lteq", "ge", "le"}
       Operator for threshold comparison. Defaults to ">".
     thresh : float, optional
       Threshold above which values are checked for identical values.
@@ -1252,9 +1252,9 @@ def suspicious_run_1d(
             sus_runs = sus_runs & (v < thresh)
         elif op in {"==", "eq"}:
             sus_runs = sus_runs & (v == thresh)
-        elif op in {">=", "gteq"}:
+        elif op in {">=", "gteq", "ge"}:
             sus_runs = sus_runs & (v >= thresh)
-        elif op in {"<=", "lteq"}:
+        elif op in {"<=", "lteq", "le"}:
             sus_runs = sus_runs & (v <= thresh)
         else:
             raise NotImplementedError(f"{op}")

--- a/xclim/indices/run_length.py
+++ b/xclim/indices/run_length.py
@@ -20,9 +20,11 @@ from xarray.core.utils import get_temp_dimname
 from xclim.core.options import OPTIONS, RUN_LENGTH_UFUNC
 from xclim.core.utils import DateStr, DayOfYearStr, uses_dask
 
-# Arrays with less than this number of data points per slice will trigger
-# the use of the ufunc version of run lengths algorithms.
 npts_opt = 9000
+"""
+Arrays with less than this number of data points per slice will trigger
+the use of the ufunc version of run lengths algorithms.
+"""
 
 
 def use_ufunc(

--- a/xclim/indices/run_length.py
+++ b/xclim/indices/run_length.py
@@ -20,11 +20,9 @@ from xarray.core.utils import get_temp_dimname
 from xclim.core.options import OPTIONS, RUN_LENGTH_UFUNC
 from xclim.core.utils import DateStr, DayOfYearStr, uses_dask
 
+# Arrays with less than this number of data points per slice will trigger
+# the use of the ufunc version of run lengths algorithms.
 npts_opt = 9000
-"""
-Arrays with less than this number of data points per slice will trigger
-the use of the ufunc version of run lengths algorithms.
-"""
 
 
 def use_ufunc(

--- a/xclim/testing/tests/test_formatting.py
+++ b/xclim/testing/tests/test_formatting.py
@@ -32,7 +32,7 @@ def test_indicator_docstring():
     )
     assert doc[6] == "Keywords : health,."
     assert doc[12] == "  Default : `ds.tasmin`. [Required units : [temperature]]"
-    assert doc[35] == (
+    assert doc[38] == (
         "  Number of heat wave events (Tmin > {thresh_tasmin} and Tmax > {thresh_tasmax} for >= {window} days) "
         "(heat_wave_events), with additional attributes: **description**: {freq} number of heat wave events "
         "over a given period. An event occurs when the minimum and maximum daily temperature both exceeds specific "

--- a/xclim/testing/tests/test_generic.py
+++ b/xclim/testing/tests/test_generic.py
@@ -270,8 +270,8 @@ class TestDegreeDays:
     def test_simple(self, tas_series, op, expected):
         tas = tas_series(np.array([-10, 15, 20, 3, 10]) + K2C)
 
-        out = generic.degree_days(tas, thresh="10 degC", op=op)
-        out_kelvin = generic.degree_days(tas, thresh="283.15 degK", op=op)
+        out = generic.degree_days(tas, threshold="10 degC", op=op)
+        out_kelvin = generic.degree_days(tas, threshold="283.15 degK", op=op)
 
         np.testing.assert_allclose(out, expected)
         np.testing.assert_allclose(out, out_kelvin)
@@ -280,14 +280,14 @@ class TestDegreeDays:
         tas = tas_series(np.array([-10, 15, 20, 3, 10]) + K2C)
 
         with pytest.raises(NotImplementedError):
-            generic.degree_days(tas, thresh="10 degC", op="!=")
+            generic.degree_days(tas, threshold="10 degC", op="!=")
 
 
 class TestGetDailyEvents:
     def test_simple(self, tas_series):
         arr = xr.DataArray(np.array([-10, 15, 20, np.NaN, 10]), name="Stuff")
 
-        out = generic.get_daily_events(arr, thresh=10, op=">=")
+        out = generic.get_daily_events(arr, threshold=10, op=">=")
 
         assert out.name == "events"
         assert out.sum() == 3
@@ -306,7 +306,12 @@ class TestGenericCountingIndices:
         tasmax = tasmax_series(np.array([5, 7, 3, 6, 13, 5, 4]) + K2C)
 
         crossings = generic.count_level_crossings(
-            tasmin, tasmax, thresh="5 degC", freq="YS", op_high=op_high, op_low=op_low
+            tasmin,
+            tasmax,
+            threshold="5 degC",
+            freq="YS",
+            op_high=op_high,
+            op_low=op_low,
         )
         np.testing.assert_array_equal(crossings, [expected])
 
@@ -321,7 +326,7 @@ class TestGenericCountingIndices:
             generic.count_level_crossings(
                 tasmin,
                 tasmax,
-                thresh="0.5 degC",
+                threshold="0.5 degC",
                 freq="YS",
                 op_high=op_high,
                 op_low=op_low,

--- a/xclim/testing/tests/test_generic.py
+++ b/xclim/testing/tests/test_generic.py
@@ -264,8 +264,8 @@ class TestDegreeDays:
     def test_simple(self, tas_series):
         tas = tas_series(np.array([-10, 15, 20, 3, 10]) + 273.15)
 
-        out = generic.degree_days(tas, thresh="10 degC", condition=">")
-        out_kelvin = generic.degree_days(tas, thresh="283.15 degK", condition=">")
+        out = generic.degree_days(tas, thresh="10 degC", op=">")
+        out_kelvin = generic.degree_days(tas, thresh="283.15 degK", op=">")
 
         np.testing.assert_allclose(out, [0, 5, 10, 0, 0])
         np.testing.assert_allclose(out, out_kelvin)
@@ -275,7 +275,7 @@ class TestGetDailyEvents:
     def test_simple(self, tas_series):
         arr = xr.DataArray(np.array([-10, 15, 20, np.NaN, 10]), name="Stuff")
 
-        out = generic.get_daily_events(arr, da_value=10, operator=">=")
+        out = generic.get_daily_events(arr, thresh=10, op=">=")
 
         assert out.name == "events"
         assert out.sum() == 3

--- a/xclim/testing/tests/test_generic.py
+++ b/xclim/testing/tests/test_generic.py
@@ -6,7 +6,6 @@ import xarray as xr
 
 from xclim.core.calendar import date_range, doy_to_days_since, select_time
 from xclim.indices import generic
-from xclim.indices.helpers import day_lengths
 
 
 class TestSelectResampleOp:
@@ -272,139 +271,149 @@ class TestDegreeDays:
         np.testing.assert_allclose(out, out_kelvin)
 
 
-def series(start, end, calendar):
-    time = date_range(start, end, calendar=calendar)
-    return xr.DataArray([1] * time.size, dims=("time",), coords={"time": time})
+class TestGetDailyEvents:
+    def test_simple(self, tas_series):
+        arr = xr.DataArray(np.array([-10, 15, 20, np.NaN, 10]), name="Stuff")
+
+        out = generic.get_daily_events(arr, da_value=10, operator=">=")
+
+        assert out.name == "events"
+        assert out.sum() == 3
+        np.testing.assert_array_equal(out, [0, 1, 1, np.NaN, 1])
 
 
-def test_select_time_month():
-    da = series("1993-01-05", "1994-12-31", "default")
+class TestTimeSelection:
+    @staticmethod
+    def series(start, end, calendar):
+        time = date_range(start, end, calendar=calendar)
+        return xr.DataArray([1] * time.size, dims=("time",), coords={"time": time})
 
-    out = select_time(da, drop=True, month=1)
-    exp = xr.concat(
-        (
-            series("1993-01-05", "1993-01-31", "default"),
-            series("1994-01-01", "1994-01-31", "default"),
-        ),
-        "time",
-    )
-    xr.testing.assert_equal(out, exp)
+    def test_select_time_month(self):
+        da = self.series("1993-01-05", "1994-12-31", "default")
 
-    out = select_time(da, month=1)
-    xr.testing.assert_equal(out.time, da.time)
-    assert out.sum() == 58
+        out = select_time(da, drop=True, month=1)
+        exp = xr.concat(
+            (
+                self.series("1993-01-05", "1993-01-31", "default"),
+                self.series("1994-01-01", "1994-01-31", "default"),
+            ),
+            "time",
+        )
+        xr.testing.assert_equal(out, exp)
 
-    da = series("1993-01-05", "1994-12-30", "360_day")
-    out = select_time(da, drop=True, month=[3, 6])
-    exp = xr.concat(
-        (
-            series("1993-03-01", "1993-03-30", "360_day"),
-            series("1993-06-01", "1993-06-30", "360_day"),
-            series("1994-03-01", "1994-03-30", "360_day"),
-            series("1994-06-01", "1994-06-30", "360_day"),
-        ),
-        "time",
-    )
-    xr.testing.assert_equal(out, exp)
+        out = select_time(da, month=1)
+        xr.testing.assert_equal(out.time, da.time)
+        assert out.sum() == 58
 
+        da = self.series("1993-01-05", "1994-12-30", "360_day")
+        out = select_time(da, drop=True, month=[3, 6])
+        exp = xr.concat(
+            (
+                self.series("1993-03-01", "1993-03-30", "360_day"),
+                self.series("1993-06-01", "1993-06-30", "360_day"),
+                self.series("1994-03-01", "1994-03-30", "360_day"),
+                self.series("1994-06-01", "1994-06-30", "360_day"),
+            ),
+            "time",
+        )
+        xr.testing.assert_equal(out, exp)
 
-def test_select_time_season():
-    da = series("1993-01-05", "1994-12-31", "default")
+    def test_select_time_season(self):
+        da = self.series("1993-01-05", "1994-12-31", "default")
 
-    out = select_time(da, drop=True, season="DJF")
-    exp = xr.concat(
-        (
-            series("1993-01-05", "1993-02-28", "default"),
-            series("1993-12-01", "1994-02-28", "default"),
-            series("1994-12-01", "1994-12-31", "default"),
-        ),
-        "time",
-    )
-    xr.testing.assert_equal(out, exp)
+        out = select_time(da, drop=True, season="DJF")
+        exp = xr.concat(
+            (
+                self.series("1993-01-05", "1993-02-28", "default"),
+                self.series("1993-12-01", "1994-02-28", "default"),
+                self.series("1994-12-01", "1994-12-31", "default"),
+            ),
+            "time",
+        )
+        xr.testing.assert_equal(out, exp)
 
-    da = series("1993-01-05", "1994-12-31", "365_day")
-    out = select_time(da, drop=True, season=["MAM", "SON"])
-    exp = xr.concat(
-        (
-            series("1993-03-01", "1993-05-31", "365_day"),
-            series("1993-09-01", "1993-11-30", "365_day"),
-            series("1994-03-01", "1994-05-31", "365_day"),
-            series("1994-09-01", "1994-11-30", "365_day"),
-        ),
-        "time",
-    )
-    xr.testing.assert_equal(out, exp)
+        da = self.series("1993-01-05", "1994-12-31", "365_day")
+        out = select_time(da, drop=True, season=["MAM", "SON"])
+        exp = xr.concat(
+            (
+                self.series("1993-03-01", "1993-05-31", "365_day"),
+                self.series("1993-09-01", "1993-11-30", "365_day"),
+                self.series("1994-03-01", "1994-05-31", "365_day"),
+                self.series("1994-09-01", "1994-11-30", "365_day"),
+            ),
+            "time",
+        )
+        xr.testing.assert_equal(out, exp)
 
+    def test_select_time_doys(self):
+        da = self.series("2003-02-13", "2004-12-31", "default")
 
-def test_select_time_doys():
-    da = series("2003-02-13", "2004-12-31", "default")
+        out = select_time(da, drop=True, doy_bounds=(360, 75))
+        exp = xr.concat(
+            (
+                self.series("2003-02-13", "2003-03-16", "default"),
+                self.series("2003-12-26", "2004-03-15", "default"),
+                self.series("2004-12-25", "2004-12-31", "default"),
+            ),
+            "time",
+        )
+        xr.testing.assert_equal(out, exp)
 
-    out = select_time(da, drop=True, doy_bounds=(360, 75))
-    exp = xr.concat(
-        (
-            series("2003-02-13", "2003-03-16", "default"),
-            series("2003-12-26", "2004-03-15", "default"),
-            series("2004-12-25", "2004-12-31", "default"),
-        ),
-        "time",
-    )
-    xr.testing.assert_equal(out, exp)
+        da = self.series("2003-02-13", "2004-12-31", "proleptic_gregorian")
 
-    da = series("2003-02-13", "2004-12-31", "proleptic_gregorian")
+        out = select_time(da, drop=True, doy_bounds=(25, 80))
+        exp = xr.concat(
+            (
+                self.series("2003-02-13", "2003-03-21", "proleptic_gregorian"),
+                self.series("2004-01-25", "2004-03-20", "proleptic_gregorian"),
+            ),
+            "time",
+        )
+        xr.testing.assert_equal(out, exp)
 
-    out = select_time(da, drop=True, doy_bounds=(25, 80))
-    exp = xr.concat(
-        (
-            series("2003-02-13", "2003-03-21", "proleptic_gregorian"),
-            series("2004-01-25", "2004-03-20", "proleptic_gregorian"),
-        ),
-        "time",
-    )
-    xr.testing.assert_equal(out, exp)
+    def test_select_time_dates(self):
+        da = self.series("2003-02-13", "2004-11-01", "all_leap")
+        da = da.where(da.time.dt.dayofyear != 92, drop=True)  # no 04-01
 
+        out = select_time(da, drop=True, date_bounds=("04-01", "12-04"))
+        exp = xr.concat(
+            (
+                self.series("2003-04-02", "2003-12-04", "all_leap"),
+                self.series("2004-04-02", "2004-11-01", "all_leap"),
+            ),
+            "time",
+        )
+        xr.testing.assert_equal(out, exp)
 
-def test_select_time_dates():
-    da = series("2003-02-13", "2004-11-01", "all_leap")
-    da = da.where(da.time.dt.dayofyear != 92, drop=True)  # no 04-01
+        da = self.series("2003-02-13", "2005-11-01", "standard")
 
-    out = select_time(da, drop=True, date_bounds=("04-01", "12-04"))
-    exp = xr.concat(
-        (
-            series("2003-04-02", "2003-12-04", "all_leap"),
-            series("2004-04-02", "2004-11-01", "all_leap"),
-        ),
-        "time",
-    )
-    xr.testing.assert_equal(out, exp)
+        out = select_time(da, drop=True, date_bounds=("10-05", "02-29"))
+        exp = xr.concat(
+            (
+                self.series("2003-02-13", "2003-02-28", "standard"),
+                self.series("2003-10-05", "2004-02-29", "standard"),
+                self.series("2004-10-05", "2005-02-28", "standard"),
+                self.series("2005-10-05", "2005-11-01", "standard"),
+            ),
+            "time",
+        )
+        xr.testing.assert_equal(out, exp)
 
-    da = series("2003-02-13", "2005-11-01", "standard")
+    def test_select_time_errors(self):
+        da = self.series("2003-01-01", "2004-01-01", "standard")
 
-    out = select_time(da, drop=True, date_bounds=("10-05", "02-29"))
-    exp = xr.concat(
-        (
-            series("2003-02-13", "2003-02-28", "standard"),
-            series("2003-10-05", "2004-02-29", "standard"),
-            series("2004-10-05", "2005-02-28", "standard"),
-            series("2005-10-05", "2005-11-01", "standard"),
-        ),
-        "time",
-    )
-    xr.testing.assert_equal(out, exp)
+        xr.testing.assert_identical(da, select_time(da))
 
+        with pytest.raises(
+            ValueError, match="Only one method of indexing may be given"
+        ):
+            select_time(da, season="DJF", month=[3, 4, 5])
 
-def test_select_time_errors():
-    da = series("2003-01-01", "2004-01-01", "standard")
+        with pytest.raises(ValueError, match="invalid day number provided in cftime."):
+            select_time(da, date_bounds=("02-30", "03-03"))
 
-    xr.testing.assert_identical(da, select_time(da))
+        with pytest.raises(ValueError):
+            select_time(da, date_bounds=("02-30",))
 
-    with pytest.raises(ValueError, match="Only one method of indexing may be given"):
-        select_time(da, season="DJF", month=[3, 4, 5])
-
-    with pytest.raises(ValueError, match="invalid day number provided in cftime."):
-        select_time(da, date_bounds=("02-30", "03-03"))
-
-    with pytest.raises(ValueError):
-        select_time(da, date_bounds=("02-30",))
-
-    with pytest.raises(TypeError):
-        select_time(da, doy_bounds=(300, 203, 202))
+        with pytest.raises(TypeError):
+            select_time(da, doy_bounds=(300, 203, 202))

--- a/xclim/testing/tests/test_indicators.py
+++ b/xclim/testing/tests/test_indicators.py
@@ -634,7 +634,7 @@ def test_indicator_from_dict():
         compute="thresholded_statistics",
         parameters=dict(
             threshold={"description": "A threshold temp"},
-            condition="<",
+            op="<",
             reducer="mean",
         ),
         input={"data": "tas"},
@@ -645,8 +645,8 @@ def test_indicator_from_dict():
     assert ind.realm == "atmos"
     # Parameters metadata modification
     assert ind.parameters["threshold"].description == "A threshold temp"
-    # Injection of paramters
-    assert ind.injected_parameters["condition"] == "<"
+    # Injection of parameters
+    assert ind.injected_parameters["op"] == "<"
     # Default value for input variable injected and meta injected
     assert ind._variable_mapping["data"] == "tas"
     assert signature(ind).parameters["tas"].default == "tas"
@@ -658,7 +658,7 @@ def test_indicator_from_dict():
 
 
 def test_indicator_errors():
-    def func(data: xr.DataArray, thresh: str = "0 degC", freq: str = "YS"):
+    def func(data: xr.DataArray, thresh: str = "0 degC", freq: str = "YS"):  # noqa
         return data
 
     doc = [
@@ -750,7 +750,7 @@ def test_indicator_errors():
         input={"data": "tas"},
     )
     with pytest.raises(ValueError, match="ResamplingIndicator require a 'freq'"):
-        ind = Daily(identifier="indi", module="test", **d)
+        Daily(identifier="indi", module="test", **d)
 
 
 def test_indicator_call_errors(tas_series):

--- a/xclim/testing/tests/test_indices.py
+++ b/xclim/testing/tests/test_indices.py
@@ -539,7 +539,7 @@ class TestDailyFreezeThawCycles:
         mn = tasmin_series(mn + K2C)
         mx = tasmax_series(mx + K2C)
         out = xci.multiday_temperature_swing(
-            mn, mx, **thresholds, op="count", window=1, freq="M"
+            mn, mx, **thresholds, op="sum", window=1, freq="M"
         )
         np.testing.assert_array_equal(out[:2], [5, 1])
         np.testing.assert_array_equal(out[2:], 0)
@@ -1629,7 +1629,7 @@ class TestTgMaxTgMinIndices:
             tasmax,
             thresh_tasmin="0 degC",
             thresh_tasmax="0 degC",
-            op="count",
+            op="sum",
             window=1,
             freq="YS",
         )
@@ -1644,7 +1644,7 @@ class TestTgMaxTgMinIndices:
             tasmax,
             thresh_tasmin="0 degC",
             thresh_tasmax="0 degC",
-            op="count",
+            op="sum",
             window=1,
             freq="YS",
         )

--- a/xclim/testing/tests/test_indices.py
+++ b/xclim/testing/tests/test_indices.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Tests for `xclim` package.
 #
 # We want to test multiple things here:
@@ -518,25 +517,14 @@ class TestAgroclimaticIndices:
 
 
 class TestDailyFreezeThawCycles:
-    def test_simple(self, tasmin_series, tasmax_series):
-        mn = np.zeros(365)
-        mx = np.zeros(365)
-
-        # 5 days in 1st month
-        mn[10:20] -= 1
-        mx[10:15] += 1
-
-        # 1 day in 2nd month
-        mn[40:44] += [1, 1, -1, -1]
-        mx[40:44] += [1, -1, 1, -1]
-
-        mn = tasmin_series(mn + K2C)
-        mx = tasmax_series(mx + K2C)
-        out = xci.multiday_temperature_swing(mn, mx, op="count", window=1, freq="M")
-        np.testing.assert_array_equal(out[:2], [5, 1])
-        np.testing.assert_array_equal(out[2:], 0)
-
-    def test_zeroed_thresholds(self, tasmin_series, tasmax_series):
+    @pytest.mark.parametrize(
+        "thresholds",
+        [
+            dict(),
+            dict(thresh_tasmax="0 degC", thresh_tasmin="0 degC"),
+        ],
+    )
+    def test_simple(self, tasmin_series, tasmax_series, thresholds):
         mn = np.zeros(365)
         mx = np.zeros(365)
 
@@ -551,7 +539,7 @@ class TestDailyFreezeThawCycles:
         mn = tasmin_series(mn + K2C)
         mx = tasmax_series(mx + K2C)
         out = xci.multiday_temperature_swing(
-            mn, mx, thresh_tasmax="0 degC", thresh_tasmin="0 degC", window=1, freq="M"
+            mn, mx, **thresholds, op="count", window=1, freq="M"
         )
         np.testing.assert_array_equal(out[:2], [5, 1])
         np.testing.assert_array_equal(out[2:], 0)
@@ -1101,7 +1089,7 @@ class TestTnDays:
         np.testing.assert_array_equal(out[:1], [2])
         np.testing.assert_array_equal(out[1:], [0])
 
-    def test_above_operator(self, tasmin_series):
+    def test_operator(self, tasmin_series):
         a = np.zeros(365)
         a[:6] += [27, 28, 29, 30, 31, 32]  # 3 at or above 30
         mn = tasmin_series(a + K2C)

--- a/xclim/testing/tests/test_units.py
+++ b/xclim/testing/tests/test_units.py
@@ -23,7 +23,7 @@ from xclim.core.utils import ValidationError
 class TestUnits:
     def test_temperature(self):
         assert 4 * units.d == 4 * units.day
-        Q_ = units.Quantity
+        Q_ = units.Quantity  # noqa
         assert Q_(1, units.C) == Q_(1, units.degC)
 
     def test_hydro(self):
@@ -68,7 +68,7 @@ class TestConvertUnitsTo:
 
         with pytest.warns(FutureWarning):
             tas = tas_series(np.arange(365), start="1/1/2001")
-            out = indices.tx_days_above(tas, 30)
+            out = indices.tx_days_above(tas, 30)  # noqa
 
         out1 = indices.tx_days_above(tas, "30 degC")
         out2 = indices.tx_days_above(tas, "303.15 K")
@@ -138,7 +138,7 @@ class TestUnitConversion:
         assert out.units == "kg m-2"
 
     def test_str2pint(self):
-        Q_ = units.Quantity
+        Q_ = units.Quantity  # noqa
         assert str2pint("-0.78 m") == Q_(-0.78, units="meter")
         assert str2pint("m kg/s") == Q_(1, units="meter kilogram/second")
         assert str2pint("11.8 degC days") == Q_(11.8, units="delta_degree_Celsius days")

--- a/xclim/testing/tests/test_utils.py
+++ b/xclim/testing/tests/test_utils.py
@@ -70,7 +70,7 @@ class Test_nan_calc_percentiles:
         assert res[()] == 29
 
     def test_calc_perc_type8(self):
-        # Exemple array from: https://en.wikipedia.org/wiki/Percentile#The_nearest-rank_method
+        # Example array from: https://en.wikipedia.org/wiki/Percentile#The_nearest-rank_method
         arr = np.asarray(
             [[15.0, 20.0, 35.0, 40.0, 50.0], [15.0, 20.0, 35.0, 40.0, 50.0]]
         )


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #389 and addresses some issues raised in #744 
- [x] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added
- [x] The relevant author information has been added to `.zenodo.json`

### What kind of change does this PR introduce?

* Adds the ability to explicitly set a binary operator for some existing indices.
* Adds the ability to constrain the allowed operators for a given indice (e.g. `xyz_days_above` → (">" | ">=") only).
* `op` is now more universally applied as the comparison operation for many generic indices.
* Adds tests for several previously untested generic indices (`count_level_crossings`, `count_occurrences`, `first_occurrence`, `last_occurrence`)
* Test `degree_days` with more operators.
* Removes `select_time` from `xclim.core.generic` (This has been deprecated for some time)
* Removed `daily_freezthaw_cycles` from `xclim.indices._multivariate.py` (This has been deprecated for some time).
* Various housekeeping fixes (Additions of `noqa` where needed, removal of useless imports).
* Revised the clix-meta parsing tools to support the new "op" operator handler, and added a smoke test to ensure is working.

### Does this PR introduce a breaking change?

Yes. 

 - Call signatures for generic indices have been modified to accept `op` in many cases, and `condition`/`conditional`/`operation` has been renamed to `op` for consistency.
 - Some generic indices call signatures have been reordered.
 - `select_time` has been removed from `generic.py` (was deprecated).
 - `daily_freezthaw_cycles` has been removed from `_multivariate.py` (was deprecated).

### Other information:
