### PR TITLE
Remove matplotlib warnings in ensemble reduce.

### DIFF
--- a/xclim/ensembles/_reduce.py
+++ b/xclim/ensembles/_reduce.py
@@ -21,13 +21,8 @@ from sklearn.cluster import KMeans
 # Avoid having to include matplotlib in xclim requirements
 try:
     from matplotlib import pyplot as plt  # noqa
-
-    if not os.getenv("READTHEDOCS"):
-        warn("Matplotlib installed. Setting make_graph to True.")
     MPL_INSTALLED = True
-
 except ImportError:
-    warn("Matplotlib not found. No graph data will be produced.")
     plt = None
     MPL_INSTALLED = False
 

--- a/xclim/ensembles/_reduce.py
+++ b/xclim/ensembles/_reduce.py
@@ -21,6 +21,7 @@ from sklearn.cluster import KMeans
 # Avoid having to include matplotlib in xclim requirements
 try:
     from matplotlib import pyplot as plt  # noqa
+
     MPL_INSTALLED = True
 except ImportError:
     plt = None


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added
- [ ] The relevant author information has been added to `AUTHORS.rst` and `.zenodo.json`

### What kind of change does this PR introduce?
Remove the warning calls that `ensemble._reduce` throws according to the availability of matplotlib.
It felt unnecessary. We don't use ` kmeans_reduce_ensemble` that much and cases where `matplotlib` is not installed must be really rare.

### Does this PR introduce a breaking change?
No.

### Other information:
No.