### PR TITLE
Lazy compilation for njit functions of sdba.nbutils and utci

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,7 +11,7 @@ New features and enhancements
 * Adjustment methods of `SBCK <https://github.com/yrobink/SBCK>`_ are wrapped into xclim when that package is installed. (:issue:`1109`, :pull:`1115`).
     - Wrapped SBCK tests are also properly run in the tox testing ensemble. (:pull:`1119`).
 * Method ``FAO_PM98`` (based on Penman-Monteith formula) to compute potential evapotranspiration. (:pull:`1122`).
-* Most numba functions of ``sdba.nbutils`` now use the lazy compilation mode. This significantly accelerates the import time of xclim. (:issue:`1135`, :pull:`1164`).
+* Most numba functions of ``sdba.nbutils`` now use the lazy compilation mode. This significantly accelerates the import time of xclim. (:issue:`1135`, :pull:`1167`).
 
 New indicators
 ^^^^^^^^^^^^^^

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,7 @@ New features and enhancements
 * Adjustment methods of `SBCK <https://github.com/yrobink/SBCK>`_ are wrapped into xclim when that package is installed. (:issue:`1109`, :pull:`1115`).
     - Wrapped SBCK tests are also properly run in the tox testing ensemble. (:pull:`1119`).
 * Method ``FAO_PM98`` (based on Penman-Monteith formula) to compute potential evapotranspiration. (:pull:`1122`).
+* Most numba functions of ``sdba.nbutils`` now use the lazy compilation mode. This significantly accelerates the import time of xclim. (:issue:`1135`, :pull:`1164`).
 
 New indicators
 ^^^^^^^^^^^^^^

--- a/xclim/indices/_conversion.py
+++ b/xclim/indices/_conversion.py
@@ -1224,10 +1224,10 @@ def potential_evapotranspiration(
 
 
 @vectorize(
-    [
-        float64(float64, float64, float64, float64),
-        float32(float32, float32, float32, float32),
-    ],
+    # [
+    #     float64(float64, float64, float64, float64),
+    #     float32(float32, float32, float32, float32),
+    # ],
 )
 def _utci(tas, sfcWind, dt, wvp):
     """Return the empirical polynomial function for UTCI. See :py:func:`universal_thermal_climate_index`."""
@@ -1544,7 +1544,16 @@ def universal_thermal_climate_index(
     delta = mrt - tas
     pa = convert_units_to(e_sat, "kPa") * convert_units_to(hurs, "1")
 
-    utci = _utci(tas, sfcWind, delta, pa)
+    utci = xr.apply_ufunc(
+        _utci,
+        tas,
+        sfcWind,
+        delta,
+        pa,
+        input_core_dims=[[], [], [], []],
+        dask="parallelized",
+        output_dtypes=[tas.dtype],
+    )
 
     utci = utci.assign_attrs({"units": "degC"})
     if mask_invalid:

--- a/xclim/sdba/nbutils.py
+++ b/xclim/sdba/nbutils.py
@@ -43,12 +43,12 @@ def vecquantiles(da, rnk, dim):
 
 
 @njit(
-    [
-        float32[:, :](float32[:, :], float32[:]),
-        float64[:, :](float64[:, :], float64[:]),
-        float32[:](float32[:], float32[:]),
-        float64[:](float64[:], float64[:]),
-    ],
+    # [
+    #     float32[:, :](float32[:, :], float32[:]),
+    #     float64[:, :](float64[:, :], float64[:]),
+    #     float32[:](float32[:], float32[:]),
+    #     float64[:](float64[:], float64[:]),
+    # ],
 )
 def _quantile(arr, q):
     if arr.ndim == 1:
@@ -105,7 +105,9 @@ def quantile(da, q, dim):
     return res
 
 
-@njit([float32[:, :](float32[:, :]), float64[:, :](float64[:, :])])
+@njit(
+    #  [float32[:, :](float32[:, :]), float64[:, :](float64[:, :])]
+)
 def remove_NaNs(x):  # noqa
     """Remove NaN values from series."""
     remove = np.zeros_like(x[0, :], dtype=boolean)
@@ -114,14 +116,17 @@ def remove_NaNs(x):  # noqa
     return x[:, ~remove]
 
 
-@njit([float32(float32[:]), float64(float64[:])], fastmath=True)
+@njit(
+    #  [float32(float32[:]), float64(float64[:])]
+    fastmath=True
+)
 def _euclidean_norm(v):
     """Compute the euclidean norm of vector v."""
     return np.sqrt(np.sum(v**2))
 
 
 @njit(
-    [float32(float32[:, :], float32[:, :]), float64(float64[:, :], float64[:, :])],
+    #  [float32(float32[:, :], float32[:, :]), float64(float64[:, :], float64[:, :])],
     fastmath=True,
 )
 def _correlation(X, Y):
@@ -137,7 +142,10 @@ def _correlation(X, Y):
     return d / (X.shape[1] * Y.shape[1])
 
 
-@njit([float32(float32[:, :]), float64(float64[:, :])], fastmath=True)
+@njit(
+    #  [float32(float32[:, :]), float64(float64[:, :])],
+    fastmath=True
+)
 def _autocorrelation(X):
     """Mean of the NxN pairwise distances of points in X of shape KxN.
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1135
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added
- [x] The relevant author information has been added to `AUTHORS.rst` and `.zenodo.json`

### What kind of change does this PR introduce?
Remove type signatures to `njit` function in `sdba.nbutils` as well as for `_utci`. They are thus compiled at execution time instead of at import time.

I wasn't able to switch the two  `guvectorize` functions to the lazy mode. Removing the type signatures made `numba` raise a strange error about having the wrong number of inputs... 

### Does this PR introduce a breaking change?
I don't think so. However, I'm not sure how this changes the performance when using dask? I'm guessing it doesn't change anything.

### Other information:
I was able to cut down by two the import time (at least on my machine):
From the 22s shown in the issue, it went to 11s here.
![Capture d’écran du 2022-08-29 20-17-09](https://user-images.githubusercontent.com/20629530/187321805-84ac9171-209f-4ea8-b565-5da6d2b68742.png)

