### PR TITLE
Clean up ANUCLIM-based indices and add some operator handling

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -61,6 +61,7 @@ Internal changes
 * Added a `sphinx-build -b linkcheck` step to the `tox`-based `"docs"` build as well as to the ReadTheDocs configuration. (:pull:`1160`).
 * `pylint` is now setup to use a `pylintrc` file, allowing for more granular control of warnings and exceptions. Many errors are still present, so addressing them will need to occur gradually. (:pull:`1163`).
 * The generic indices `count_level_crossings`, `count_occurrences`, `first_occurrence`, and `last_occurrence` are now fully tested. (:pull:`1157`).
+* Adjusted the ANUCLIM indices by removing "ANUCLIM" from their titles, modifying their docstrings, and handling `"op"` input in a more user-friendly way. (:issue:`1055`, :pull:`1169`).
 
 0.37.0 (2022-06-20)
 -------------------

--- a/xclim/data/anuclim.yml
+++ b/xclim/data/anuclim.yml
@@ -5,9 +5,9 @@ doc: |
 
   The ANUCLIM (v6.1) software package BIOCLIM sub-module produces a set of bioclimatic parameters derived values of
   temperature and precipitation. The methods in this module are wrappers around a subset of corresponding methods of
-  `xclim.indices`.
+  :py:mod:`xclim.indices`.
 
-  Furthermore, according to the ANUCLIM user-guide :cite:t:`xu_anuclim_2010`, input values should be at a weekly or
+  Furthermore, according to the ANUCLIM user-guide :cite:p:`xu_anuclim_2010`, input values should be at a weekly or
   monthly frequency.  However, the implementation here expands these definitions and can calculate the result with daily
   input data.
 realm: atmos

--- a/xclim/indices/_anuclim.py
+++ b/xclim/indices/_anuclim.py
@@ -46,7 +46,7 @@ __all__ = [
 _xr_argops = {
     "wettest": xarray.DataArray.argmax,
     "warmest": xarray.DataArray.argmax,
-    "dryest": xarray.DataArray.argmin,
+    "dryest": xarray.DataArray.argmin,  # "dryest" is a common enough spelling mistake
     "driest": xarray.DataArray.argmin,
     "coldest": xarray.DataArray.argmin,
 }
@@ -54,7 +54,7 @@ _xr_argops = {
 _np_ops = {
     "wettest": "max",
     "warmest": "max",
-    "dryest": "min",
+    "dryest": "min",  # "dryest" is a common enough spelling mistake
     "driest": "min",
     "coldest": "min",
 }
@@ -66,16 +66,16 @@ def isothermality(
 ) -> xarray.DataArray:
     r"""Isothermality.
 
-    The mean diurnal range divided by the annual temperature range.
+    The mean diurnal temperature range divided by the annual temperature range.
 
     Parameters
     ----------
     tasmin : xarray.DataArray
-      Average daily minimum temperature at daily, weekly, or monthly frequency.
+        Average daily minimum temperature at daily, weekly, or monthly frequency.
     tasmax : xarray.DataArray
-      Average daily maximum temperature at daily, weekly, or monthly frequency.
+        Average daily maximum temperature at daily, weekly, or monthly frequency.
     freq : str
-      Resampling frequency.
+        Resampling frequency.
 
     Returns
     -------
@@ -84,10 +84,14 @@ def isothermality(
 
     Notes
     -----
-    According to the ANUCLIM user-guide https://fennerschool.anu.edu.au/files/anuclim61.pdf (ch. 6), input
-    values should be at a weekly (or monthly) frequency.  However, the xclim.indices implementation here will calculate
-    the output with input data with daily frequency as well. As such weekly or monthly input values, if desired, should
-    be calculated prior to calling the function.
+    According to the ANUCLIM user-guide (:cite:t:`xu_anuclim_2010`, ch. 6), input values should be at a weekly
+    (or monthly) frequency.  However, the xclim.indices implementation here will calculate the output with input data
+    with daily frequency as well. As such weekly or monthly input values, if desired, should be calculated prior to
+    calling the function.
+
+    References
+    ----------
+    :cite:cts:`xu_anuclim_2010`
     """
     dtr = daily_temperature_range(tasmin=tasmin, tasmax=tasmax, freq=freq)
     etr = extreme_temperature_range(tasmin=tasmin, tasmax=tasmax, freq=freq)
@@ -100,7 +104,7 @@ def isothermality(
 def temperature_seasonality(
     tas: xarray.DataArray, freq: str = "YS"
 ) -> xarray.DataArray:
-    r"""ANUCLIM temperature seasonality (coefficient of variation).
+    r"""Temperature seasonality (coefficient of variation).
 
     The annual temperature coefficient of variation expressed in percent. Calculated as the standard deviation
     of temperature values for a given year expressed as a percentage of the mean of those temperatures.
@@ -108,9 +112,9 @@ def temperature_seasonality(
     Parameters
     ----------
     tas : xarray.DataArray
-      Mean temperature at daily, weekly, or monthly frequency.
+        Mean temperature at daily, weekly, or monthly frequency.
     freq : str
-      Resampling frequency.
+        Resampling frequency.
 
     Returns
     -------
@@ -134,10 +138,14 @@ def temperature_seasonality(
     For this calculation, the mean in degrees Kelvin is used. This avoids the possibility of having to
     divide by zero, but it does mean that the values are usually quite small.
 
-    According to the ANUCLIM user-guide https://fennerschool.anu.edu.au/files/anuclim61.pdf (ch. 6), input
-    values should be at a weekly (or monthly) frequency. However, the xclim.indices implementation here will calculate
-    the result with input data with daily frequency as well. As such weekly or monthly input values, if desired,
-    should be calculated prior to calling the function.
+    According to the ANUCLIM user-guide (:cite:t:`xu_anuclim_2010`, ch. 6), input values should be at a weekly
+    (or monthly) frequency. However, the xclim.indices implementation here will calculate the result with input data
+    with daily frequency as well. As such weekly or monthly input values, if desired, should be calculated prior to
+    calling the function.
+
+    References
+    ----------
+    :cite:cts:`xu_anuclim_2010`
     """
     tas = convert_units_to(tas, "K")
 
@@ -148,23 +156,23 @@ def temperature_seasonality(
 
 @declare_units(pr="[precipitation]")
 def precip_seasonality(pr: xarray.DataArray, freq: str = "YS") -> xarray.DataArray:
-    r"""ANUCLIM Precipitation Seasonality (C of V).
+    r"""Precipitation Seasonality (C of V).
 
-    The annual precipitation Coefficient of Variation (C of V) expressed in percent. Calculated as the standard deviation
-    of precipitation values for a given year expressed as a percentage of the mean of those values.
+    The annual precipitation Coefficient of Variation (C of V) expressed in percent. Calculated as the standard
+    deviation of precipitation values for a given year expressed as a percentage of the mean of those values.
 
     Parameters
     ----------
     pr : xarray.DataArray
-      Total precipitation rate at daily, weekly, or monthly frequency.
-      Units need to be defined as a rate (e.g. mm d-1, mm week-1).
+        Total precipitation rate at daily, weekly, or monthly frequency.
+        Units need to be defined as a rate (e.g. mm d-1, mm week-1).
     freq : str
-      Resampling frequency.
+        Resampling frequency.
 
     Returns
     -------
     xarray.DataArray, [%]
-      Precipitation coefficient of variation
+        Precipitation coefficient of variation
 
     Examples
     --------
@@ -186,8 +194,12 @@ def precip_seasonality(pr: xarray.DataArray, freq: str = "YS") -> xarray.DataArr
     with daily frequency as well. As such weekly or monthly input values, if desired, should be calculated prior to
     calling the function.
 
-    If input units are in mm s-1 (or equivalent) values are converted to mm/day to avoid potentially small denominator
+    If input units are in mm s-1 (or equivalent), values are converted to mm/day to avoid potentially small denominator
     values.
+
+    References
+    ----------
+    :cite:cts:`xu_anuclim_2010`
     """
     # If units in mm/sec convert to mm/days to avoid potentially small denominator
     if units2pint(pr) == units("mm / s"):
@@ -204,20 +216,20 @@ def tg_mean_warmcold_quarter(
     op: str = None,
     freq: str = "YS",
 ) -> xarray.DataArray:
-    r"""ANUCLIM Mean temperature of warmest/coldest quarter.
+    r"""Mean temperature of warmest/coldest quarter.
 
-    The warmest (or coldest) quarter of the year is determined, and the mean temperature of this period is
-    calculated. If the input data frequency is daily ("D") or weekly ("W"), quarters are defined as 13-week periods,
-    otherwise as 3 months.
+    The warmest (or coldest) quarter of the year is determined, and the mean temperature of this period is calculated.
+    If the input data frequency is daily ("D") or weekly ("W"), quarters are defined as 13-week periods, otherwise as
+    three (3) months.
 
     Parameters
     ----------
-    tas: xarray.DataArray
-      Mean temperature at daily, weekly, or monthly frequency.
-    op: str {'warmest', 'coldest'}
-      Operation to perform: 'warmest' calculate the warmest quarter; 'coldest' calculate the coldest quarter.
-    freq: str
-      Resampling frequency.
+    tas : xarray.DataArray
+        Mean temperature at daily, weekly, or monthly frequency.
+    op : str {'warmest', 'coldest'}
+        Operation to perform: 'warmest' calculate the warmest quarter; 'coldest' calculate the coldest quarter.
+    freq : str
+        Resampling frequency.
 
     Returns
     -------
@@ -239,10 +251,17 @@ def tg_mean_warmcold_quarter(
     (or monthly) frequency. However, the xclim.indices implementation here will calculate the result with input data
     with daily frequency as well. As such weekly or monthly input values, if desired, should be calculated prior to
     calling the function.
+
+    References
+    ----------
+    :cite:cts:`xu_anuclim_2010`
     """
     out = _to_quarter(tas=tas)
 
+    if op not in ["warmest", "coldest"]:
+        raise ValueError(f'op parameter ({op}) may only be one of "warmest", "coldest"')
     oper = _np_ops[op]
+
     out = select_resample_op(out, oper, freq)
     out.attrs["units"] = tas.units
     return out
@@ -255,7 +274,7 @@ def tg_mean_wetdry_quarter(
     op: str = None,
     freq: str = "YS",
 ) -> xarray.DataArray:
-    r"""ANUCLIM Mean temperature of wettest/driest quarter.
+    r"""Mean temperature of wettest/driest quarter.
 
     The wettest (or driest) quarter of the year is determined, and the mean temperature of this period is calculated.
     If the input data frequency is daily ("D") or weekly ("W"), quarters are defined as 13-week periods,
@@ -283,11 +302,22 @@ def tg_mean_wetdry_quarter(
     (or monthly) frequency. However, the xclim.indices implementation here will calculate the result with input data
     with daily frequency as well. As such weekly or monthly input values, if desired, should be calculated prior to
     calling the function.
+
+    References
+    ----------
+    :cite:cts:`xu_anuclim_2010`
     """
+    # determine input data frequency
     tas_qrt = _to_quarter(tas=tas)
+    # returns mm values
     pr_qrt = _to_quarter(pr=pr)
 
+    if op not in ["wettest", "driest", "dryest"]:
+        raise ValueError(
+            f'op parameter ({op}) may only be one of "wettest" or "driest"'
+        )
     xr_op = _xr_argops[op]
+
     out = _from_other_arg(criteria=pr_qrt, output=tas_qrt, op=xr_op, freq=freq)
     return out.assign_attrs(units=tas.units)
 
@@ -296,11 +326,11 @@ def tg_mean_wetdry_quarter(
 def prcptot_wetdry_quarter(
     pr: xarray.DataArray, op: str = None, freq: str = "YS"
 ) -> xarray.DataArray:
-    r"""ANUCLIM Total precipitation of wettest/driest quarter.
+    r"""Total precipitation of wettest/driest quarter.
 
-    The wettest (or driest) quarter of the year is determined, and the total precipitation of this
-    period is calculated. If the input data frequency is daily ("D") or weekly ("W") quarters
-    are defined as 13-week periods, otherwise are 3 months.
+    The wettest (or driest) quarter of the year is determined, and the total precipitation of this period is calculated.
+    If the input data frequency is daily ("D") or weekly ("W") quarters are defined as 13-week periods, otherwise are
+    three (3) months.
 
     Parameters
     ----------
@@ -330,18 +360,21 @@ def prcptot_wetdry_quarter(
     (or monthly) frequency. However, the xclim.indices implementation here will calculate the result with input data
     with daily frequency as well. As such weekly or monthly input values, if desired, should be calculated prior to
     calling the function.
+
+    References
+    ----------
+    :cite:cts:`xu_anuclim_2010`
     """
     # returns mm values
     pr_qrt = _to_quarter(pr=pr)
 
-    try:
-        oper = _np_ops[op]
-    except KeyError as err:
-        raise NotImplementedError(
-            f'Unknown operation "{op}" ; not one of "wettest" or "driest"'
-        ) from err
+    if op not in ["wettest", "driest", "dryest"]:
+        raise ValueError(
+            f'op parameter ({op}) may only be one of "wettest" or "driest"'
+        )
+    op = _np_ops[op]
 
-    out = select_resample_op(pr_qrt, oper, freq)
+    out = select_resample_op(pr_qrt, op, freq)
     out.attrs["units"] = pr_qrt.units
     return out
 
@@ -353,22 +386,22 @@ def prcptot_warmcold_quarter(
     op: str = None,
     freq: str = "YS",
 ) -> xarray.DataArray:
-    r"""ANUCLIM Total precipitation of warmest/coldest quarter.
+    r"""Total precipitation of warmest/coldest quarter.
 
-    The warmest (or coldest) quarter of the year is determined, and the total
-    precipitation of this period is calculated. If the input data frequency is daily ("D) or weekly ("W"), quarters
-    are defined as 13-week periods, otherwise are 3 months.
+    The warmest (or coldest) quarter of the year is determined, and the total precipitation of this period is
+    calculated. If the input data frequency is daily ("D) or weekly ("W"), quarters are defined as 13-week periods,
+    otherwise are 3 months.
 
     Parameters
     ----------
-    pr: xarray.DataArray
-      Total precipitation rate at daily, weekly, or monthly frequency.
-    tas: xarray.DataArray
-      Mean temperature at daily, weekly, or monthly frequency.
-    op: {'warmest', 'coldest'}
-      Operation to perform: 'warmest' calculate for the warmest quarter ; 'coldest' calculate for the coldest quarter.
-    freq: str
-      Resampling frequency.
+    pr : xarray.DataArray
+        Total precipitation rate at daily, weekly, or monthly frequency.
+    tas : xarray.DataArray
+        Mean temperature at daily, weekly, or monthly frequency.
+    op : {'warmest', 'coldest'}
+        Operation to perform: 'warmest' calculate for the warmest quarter ; 'coldest' calculate for the coldest quarter.
+    freq : str
+        Resampling frequency.
 
     Returns
     -------
@@ -381,13 +414,20 @@ def prcptot_warmcold_quarter(
     (or monthly) frequency. However, the xclim.indices implementation here will calculate the result with input data
     with daily frequency as well. As such weekly or monthly input values, if desired, should be calculated prior to
     calling the function.
+
+    References
+    ----------
+    :cite:cts:`xu_anuclim_2010`
     """
     # determine input data frequency
     tas_qrt = _to_quarter(tas=tas)
     # returns mm values
     pr_qrt = _to_quarter(pr=pr)
 
+    if op not in ["warmest", "coldest"]:
+        raise ValueError(f'op parameter ({op}) may only be one of "warmest", "coldest"')
     xr_op = _xr_argops[op]
+
     out = _from_other_arg(criteria=tas_qrt, output=pr_qrt, op=xr_op, freq=freq)
     out.attrs = pr_qrt.attrs
     return out
@@ -399,14 +439,17 @@ def prcptot(
 ) -> xarray.DataArray:
     r"""Accumulated total precipitation.
 
+    The total accumulated precipitation from days where precipitation exceeds a given amount. A threshold is provided in
+    order to allow the option of reducing the impact of days with trace precipitation amounts on period totals.
+
     Parameters
     ----------
-    pr: xarray.DataArray
-      Total precipitation flux [mm d-1], [mm week-1], [mm month-1] or similar.
-    thresh: str
-      Threshold over which precipitation starts being cumulated.
-    freq: str
-      Resampling frequency.
+    pr : xarray.DataArray
+        Total precipitation flux [mm d-1], [mm week-1], [mm month-1] or similar.
+    thresh : str
+        Threshold over which precipitation starts being cumulated.
+    freq : str
+        Resampling frequency.
 
     Returns
     -------
@@ -422,21 +465,23 @@ def prcptot(
 def prcptot_wetdry_period(
     pr: xarray.DataArray, *, op: str, freq: str = "YS"
 ) -> xarray.DataArray:
-    r"""ANUCLIM precipitation of the wettest/driest day, week, or month, depending on the time step.
+    r"""Precipitation of the wettest/driest day, week, or month, depending on the time step.
+
+    The wettest (or driest) period is determined, and the total precipitation of this period is calculated.
 
     Parameters
     ----------
-    pr: xarray.DataArray
-      Total precipitation flux [mm d-1], [mm week-1], [mm month-1] or similar.
-    op: {'wettest', 'driest'}
-      Operation to perform :  'wettest' calculate the wettest period ; 'driest' calculate the driest period.
-    freq: str
-      Resampling frequency.
+    pr : xarray.DataArray
+        Total precipitation flux [mm d-1], [mm week-1], [mm month-1] or similar.
+    op : {'wettest', 'driest'}
+        Operation to perform :  'wettest' calculate the wettest period ; 'driest' calculate the driest period.
+    freq : str
+        Resampling frequency.
 
     Returns
     -------
     xarray.DataArray, [length]
-       Precipitation of {op} period
+        Precipitation of {op} period
 
     Notes
     -----
@@ -444,15 +489,21 @@ def prcptot_wetdry_period(
     (or monthly) frequency. However, the xclim.indices implementation here will calculate the result with input data
     with daily frequency as well. As such weekly or monthly input values, if desired, should be calculated prior to
     calling the function.
+
+    References
+    ----------
+    :cite:cts:`xu_anuclim_2010`
     """
     pram = rate2amount(pr)
 
-    if op == "wettest":
-        return pram.resample(time=freq).max(dim="time").assign_attrs(units=pram.units)
-    if op == "driest":
-        return pram.resample(time=freq).min(dim="time").assign_attrs(units=pram.units)
-    raise NotImplementedError(
-        f'Unknown operation "{op}" ; op parameter but be one of "wettest" or "driest"'
+    if op not in ["wettest", "driest", "dryest"]:
+        raise ValueError(
+            f'op parameter ({op}) may only be one of "wettest" or "driest"'
+        )
+    op = _np_ops[op]
+
+    return getattr(pram.resample(time=freq), op)(dim="time").assign_attrs(
+        units=pram.units
     )
 
 
@@ -470,19 +521,19 @@ def _from_other_arg(
 
     Parameters
     ----------
-    criteria: xarray.DataArray
-      Series on which operation returning index is applied.
+    criteria : xarray.DataArray
+        Series on which operation returning index is applied.
     output : xarray.DataArray
-      Series to be indexed.
-    op: Callable
-      Function returning an index, for example `np.argmin`, `np.argmax`, `np.nanargmin`, `np.nanargmax`.
-    freq: str
-      Temporal grouping.
+        Series to be indexed.
+    op : Callable
+        Function returning an index, for example: `np.argmin`, `np.argmax`, `np.nanargmin`, `np.nanargmax`.
+    freq : str
+        Temporal grouping.
 
     Returns
     -------
     xarray.DataArray
-      Output values where criteria are met at the given frequency.
+        Output values where criteria are met at the given frequency.
     """
     ds = xarray.Dataset(data_vars={"criteria": criteria, "output": output})
     dim = "time"

--- a/xclim/indices/_anuclim.py
+++ b/xclim/indices/_anuclim.py
@@ -259,7 +259,9 @@ def tg_mean_warmcold_quarter(
     out = _to_quarter(tas=tas)
 
     if op not in ["warmest", "coldest"]:
-        raise ValueError(f'op parameter ({op}) may only be one of "warmest", "coldest"')
+        raise NotImplementedError(
+            f'op parameter ({op}) may only be one of "warmest", "coldest"'
+        )
     oper = _np_ops[op]
 
     out = select_resample_op(out, oper, freq)
@@ -313,7 +315,7 @@ def tg_mean_wetdry_quarter(
     pr_qrt = _to_quarter(pr=pr)
 
     if op not in ["wettest", "driest", "dryest"]:
-        raise ValueError(
+        raise NotImplementedError(
             f'op parameter ({op}) may only be one of "wettest" or "driest"'
         )
     xr_op = _xr_argops[op]
@@ -369,7 +371,7 @@ def prcptot_wetdry_quarter(
     pr_qrt = _to_quarter(pr=pr)
 
     if op not in ["wettest", "driest", "dryest"]:
-        raise ValueError(
+        raise NotImplementedError(
             f'op parameter ({op}) may only be one of "wettest" or "driest"'
         )
     op = _np_ops[op]
@@ -425,7 +427,9 @@ def prcptot_warmcold_quarter(
     pr_qrt = _to_quarter(pr=pr)
 
     if op not in ["warmest", "coldest"]:
-        raise ValueError(f'op parameter ({op}) may only be one of "warmest", "coldest"')
+        raise NotImplementedError(
+            f'op parameter ({op}) may only be one of "warmest", "coldest"'
+        )
     xr_op = _xr_argops[op]
 
     out = _from_other_arg(criteria=tas_qrt, output=pr_qrt, op=xr_op, freq=freq)
@@ -497,7 +501,7 @@ def prcptot_wetdry_period(
     pram = rate2amount(pr)
 
     if op not in ["wettest", "driest", "dryest"]:
-        raise ValueError(
+        raise NotImplementedError(
             f'op parameter ({op}) may only be one of "wettest" or "driest"'
         )
     op = _np_ops[op]

--- a/xclim/testing/tests/conftest.py
+++ b/xclim/testing/tests/conftest.py
@@ -34,7 +34,7 @@ def lat_series():
 
 @pytest.fixture
 def tas_series():
-    def _tas_series(values, start="7/1/2000"):
+    def _tas_series(values, start="7/1/2000", units="K"):
         coords = pd.date_range(start, periods=len(values), freq="D")
         return xr.DataArray(
             values,
@@ -44,7 +44,7 @@ def tas_series():
             attrs={
                 "standard_name": "air_temperature",
                 "cell_methods": "time: mean within days",
-                "units": "K",
+                "units": units,
             },
         )
 
@@ -53,7 +53,7 @@ def tas_series():
 
 @pytest.fixture
 def tasmax_series():
-    def _tasmax_series(values, start="7/1/2000"):
+    def _tasmax_series(values, start="7/1/2000", units="K"):
         coords = pd.date_range(start, periods=len(values), freq="D")
         return xr.DataArray(
             values,
@@ -63,7 +63,7 @@ def tasmax_series():
             attrs={
                 "standard_name": "air_temperature",
                 "cell_methods": "time: maximum within days",
-                "units": "K",
+                "units": units,
             },
         )
 
@@ -72,7 +72,7 @@ def tasmax_series():
 
 @pytest.fixture
 def tasmin_series():
-    def _tasmin_series(values, start="7/1/2000"):
+    def _tasmin_series(values, start="7/1/2000", units="K"):
         coords = pd.date_range(start, periods=len(values), freq="D")
         return xr.DataArray(
             values,
@@ -82,7 +82,7 @@ def tasmin_series():
             attrs={
                 "standard_name": "air_temperature",
                 "cell_methods": "time: minimum within days",
-                "units": "K",
+                "units": units,
             },
         )
 
@@ -151,7 +151,7 @@ def bootstrap_series():
 
 @pytest.fixture
 def prsn_series():
-    def _prsn_series(values, start="7/1/2000"):
+    def _prsn_series(values, start="7/1/2000", units="kg m-2 s-1"):
         coords = pd.date_range(start, periods=len(values), freq="D")
         return xr.DataArray(
             values,
@@ -161,7 +161,7 @@ def prsn_series():
             attrs={
                 "standard_name": "solid_precipitation_flux",
                 "cell_methods": "time: mean within days",
-                "units": "kg m-2 s-1",
+                "units": units,
             },
         )
 
@@ -172,7 +172,7 @@ def prsn_series():
 def pr_hr_series():
     """Return hourly time series."""
 
-    def _pr_hr_series(values, start="1/1/2000"):
+    def _pr_hr_series(values, start="1/1/2000", units="kg m-2 s-1"):
         coords = pd.date_range(start, periods=len(values), freq="1H")
         return xr.DataArray(
             values,
@@ -182,7 +182,7 @@ def pr_hr_series():
             attrs={
                 "standard_name": "precipitation_flux",
                 "cell_methods": "time: mean within hours",
-                "units": "kg m-2 s-1",
+                "units": units,
             },
         )
 
@@ -191,7 +191,7 @@ def pr_hr_series():
 
 @pytest.fixture
 def pr_ndseries():
-    def _pr_series(values, start="1/1/2000"):
+    def _pr_series(values, start="1/1/2000", units="kg m-2 s-1"):
         nt, nx, ny = np.atleast_3d(values).shape
         time = pd.date_range(start, periods=nt, freq="D")
         x = np.arange(nx)
@@ -204,7 +204,7 @@ def pr_ndseries():
             attrs={
                 "standard_name": "precipitation_flux",
                 "cell_methods": "time: mean within days",
-                "units": "kg m-2 s-1",
+                "units": units,
             },
         )
 
@@ -213,7 +213,7 @@ def pr_ndseries():
 
 @pytest.fixture
 def q_series():
-    def _q_series(values, start="1/1/2000"):
+    def _q_series(values, start="1/1/2000", units="m3 s-1"):
         coords = pd.date_range(start, periods=len(values), freq="D")
         return xr.DataArray(
             values,
@@ -222,7 +222,7 @@ def q_series():
             name="q",
             attrs={
                 "standard_name": "water_volume_transport_in_river_channel",
-                "units": "m3 s-1",
+                "units": units,
             },
         )
 
@@ -319,7 +319,7 @@ areacello = areacella
 
 @pytest.fixture
 def hurs_series():
-    def _hurs_series(values, start="7/1/2000"):
+    def _hurs_series(values, start="7/1/2000", units="%"):
         coords = pd.date_range(start, periods=len(values), freq="D")
         return xr.DataArray(
             values,
@@ -328,7 +328,7 @@ def hurs_series():
             name="hurs",
             attrs={
                 "standard_name": "relative humidity",
-                "units": "%",
+                "units": units,
             },
         )
 
@@ -337,7 +337,7 @@ def hurs_series():
 
 @pytest.fixture
 def sfcWind_series():
-    def _sfcWind_series(values, start="7/1/2000"):
+    def _sfcWind_series(values, start="7/1/2000", units="km h-1"):
         coords = pd.date_range(start, periods=len(values), freq="D")
         return xr.DataArray(
             values,
@@ -346,7 +346,7 @@ def sfcWind_series():
             name="sfcWind",
             attrs={
                 "standard_name": "wind_speed",
-                "units": "km h-1",
+                "units": units,
             },
         )
 
@@ -355,7 +355,7 @@ def sfcWind_series():
 
 @pytest.fixture
 def huss_series():
-    def _huss_series(values, start="7/1/2000"):
+    def _huss_series(values, start="7/1/2000", units=""):
         coords = pd.date_range(start, periods=len(values), freq="D")
         return xr.DataArray(
             values,
@@ -364,7 +364,7 @@ def huss_series():
             name="huss",
             attrs={
                 "standard_name": "specific_humidity",
-                "units": "",
+                "units": units,
             },
         )
 
@@ -373,7 +373,7 @@ def huss_series():
 
 @pytest.fixture
 def snd_series():
-    def _snd_series(values, start="7/1/2000"):
+    def _snd_series(values, start="7/1/2000", units="m"):
         coords = pd.date_range(start, periods=len(values), freq="D")
         return xr.DataArray(
             values,
@@ -382,7 +382,7 @@ def snd_series():
             name="snd",
             attrs={
                 "standard_name": "surface_snow_thickness",
-                "units": "m",
+                "units": units,
             },
         )
 
@@ -391,7 +391,7 @@ def snd_series():
 
 @pytest.fixture
 def snw_series():
-    def _snw_series(values, start="7/1/2000"):
+    def _snw_series(values, start="7/1/2000", units="kg/m2"):
         coords = pd.date_range(start, periods=len(values), freq="D")
         return xr.DataArray(
             values,
@@ -400,7 +400,7 @@ def snw_series():
             name="snw",
             attrs={
                 "standard_name": "surface_snow_amount",
-                "units": "kg/m2",
+                "units": units,
             },
         )
 
@@ -424,7 +424,7 @@ def ps_series():
 
 @pytest.fixture
 def rsds_series():
-    def _rsds_series(values, start="7/1/2000"):
+    def _rsds_series(values, start="7/1/2000", units="W m-2"):
         coords = pd.date_range(start, periods=len(values), freq="D")
         return xr.DataArray(
             values,
@@ -433,7 +433,7 @@ def rsds_series():
             name="rsds",
             attrs={
                 "standard_name": "surface_downwelling_shortwave_flux_in_air",
-                "units": "W m-2",
+                "units": units,
             },
         )
 
@@ -442,7 +442,7 @@ def rsds_series():
 
 @pytest.fixture
 def rsus_series():
-    def _rsus_series(values, start="7/1/2000"):
+    def _rsus_series(values, start="7/1/2000", units="W m-2"):
         coords = pd.date_range(start, periods=len(values), freq="D")
         return xr.DataArray(
             values,
@@ -451,7 +451,7 @@ def rsus_series():
             name="rsus",
             attrs={
                 "standard_name": "surface_upwelling_shortwave_flux_in_air",
-                "units": "W m-2",
+                "units": units,
             },
         )
 
@@ -460,7 +460,7 @@ def rsus_series():
 
 @pytest.fixture
 def rlds_series():
-    def _rlds_series(values, start="7/1/2000"):
+    def _rlds_series(values, start="7/1/2000", units="W m-2"):
         coords = pd.date_range(start, periods=len(values), freq="D")
         return xr.DataArray(
             values,
@@ -469,7 +469,7 @@ def rlds_series():
             name="rlds",
             attrs={
                 "standard_name": "surface_downwelling_longwave_flux_in_air",
-                "units": "W m-2",
+                "units": units,
             },
         )
 
@@ -478,7 +478,7 @@ def rlds_series():
 
 @pytest.fixture
 def rlus_series():
-    def _rlus_series(values, start="7/1/2000"):
+    def _rlus_series(values, start="7/1/2000", units="W m-2"):
         coords = pd.date_range(start, periods=len(values), freq="D")
         return xr.DataArray(
             values,
@@ -487,7 +487,7 @@ def rlus_series():
             name="rlus",
             attrs={
                 "standard_name": "surface_upwelling_longwave_flux_in_air",
-                "units": "W m-2",
+                "units": units,
             },
         )
 

--- a/xclim/testing/tests/test_indices.py
+++ b/xclim/testing/tests/test_indices.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # Tests for `xclim` package.
 #
-# We want to tests multiple things here:
+# We want to test multiple things here:
 #  - that data results are correct
 #  - that metadata is correct and complete
 #  - that missing data are handled appropriately
@@ -1765,17 +1765,20 @@ class TestTempWetDryPrecipWarmColdQuarter:
 
 
 class TestTempWarmestColdestQuarter:
-    def test_simple(self, tas_series):
+    @staticmethod
+    def get_data(tas_series, units="K"):
         a = np.zeros(365 * 2)
-        a = tas_series(a + K2C, start="1971-01-01")
+        a = tas_series(
+            a + (K2C if units == "K" else 0), start="1971-01-01", units=units
+        )
         a[(a.time.dt.season == "JJA") & (a.time.dt.year == 1971)] += 22
         a[(a.time.dt.season == "SON") & (a.time.dt.year == 1972)] += 25
+        return a
 
+    def test_simple(self, tas_series):
+        a = self.get_data(tas_series)
         a[(a.time.dt.season == "DJF") & (a.time.dt.year == 1971)] += -15
         a[(a.time.dt.season == "MAM") & (a.time.dt.year == 1972)] += -10
-
-        with pytest.raises(KeyError):
-            xci.tg_mean_warmcold_quarter(a, op="toto")
 
         out = xci.tg_mean_warmcold_quarter(a, op="warmest")
         np.testing.assert_array_almost_equal(out, [294.66648352, 298.15])
@@ -1791,12 +1794,8 @@ class TestTempWarmestColdestQuarter:
         out = xci.tg_mean_warmcold_quarter(t_month, op="coldest")
         np.testing.assert_array_almost_equal(out, [263.15, 263.15])
 
-    def test_Celsius(self, tas_series):
-        a = np.zeros(365 * 2)
-        a = tas_series(a, start="1971-01-01")
-        a.attrs["units"] = "°C"
-        a[(a.time.dt.season == "JJA") & (a.time.dt.year == 1971)] += 22
-        a[(a.time.dt.season == "SON") & (a.time.dt.year == 1972)] += 25
+    def test_celsius(self, tas_series):
+        a = self.get_data(tas_series, units="°C")
 
         a[
             (a.time.dt.month >= 1) & (a.time.dt.month <= 3) & (a.time.dt.year == 1971)
@@ -1808,6 +1807,12 @@ class TestTempWarmestColdestQuarter:
 
         out = xci.tg_mean_warmcold_quarter(a, op="coldest")
         np.testing.assert_array_almost_equal(out, [-14.835165, -9.89011])
+
+    def test_exceptions(self, tas_series):
+        a = self.get_data(tas_series)
+
+        with pytest.raises(NotImplementedError):
+            xci.tg_mean_warmcold_quarter(a, op="toto")
 
 
 class TestPrcptot:


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1055 
- [x] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added
- [x] The relevant author information has been added to `AUTHORS.rst` and `.zenodo.json`

### What kind of change does this PR introduce?

* Removes "ANUCLIM" from the title of indices found in the `xclim.indices._anuclim` module
* Adds some user input handling for bad operator options
* Adds relevant references to the ANUCLIM indices

### Does this PR introduce a breaking change?

No.

### Other information:
