### PR TITLE
changed zscore in kmeans_reduce_ensemble to work with dask arrays

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -31,6 +31,7 @@ Bug fixes
 * Fixed the signature and docstring of ``heat_index`` by changing ``tasmax`` to ``tas``. (:issue:`1126`, :pull:`1128`).
 * Fixed a formatting issue with virtual indicator modules (`_gen_returns_section`) that was creating malformed `Returns` sections in `sphinx`-generated documentation. (:pull:`1131`).
 * Removed some artefact reference roles introduced in :pull:`1131` that were causing LaTeX builds of the documentation to fail. (:issue:`1154`, :pull:`1156`).
+* Fixed kmeans_reduce_ensemble breaking when using dask arrays (:pull:`1170`)
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/xclim/ensembles/_reduce.py
+++ b/xclim/ensembles/_reduce.py
@@ -243,9 +243,8 @@ def kmeans_reduce_ensemble(
     n_idx = np.shape(data)[1]  # number of indicators
 
     # normalize the data matrix
-    z = xarray.DataArray(
-        scipy.stats.zscore(data.data, axis=0, ddof=1), coords=data.coords
-    )  # ddof=1 to be the same as Matlab's zscore
+    std = data.std(dim="realization", ddof=1)
+    z = (data - data.mean(dim="realization")) / std.where(std > 0)
 
     if sample_weights is None:
         sample_weights = np.ones(n_sim)


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - No
- [x] Tests for the changes have been added (for bug fixes / features)
  - [x] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added
- [x] The relevant author information has been added to `AUTHORS.rst` and `.zenodo.json`

### What kind of change does this PR introduce?

* `scipy.stats.zscore` breaks when `data` is a dask array. The changes compute the results in a more robust way.

### Does this PR introduce a breaking change?
No.

### Other information:

Results are equal between the two methods:
```
z = xarray.DataArray(
        scipy.stats.zscore(data.data, axis=0, ddof=1), coords=data.coords
    )

std = data.std(dim="realization", ddof=1)
z2 = (data - data.mean(dim="realization")) / std.where(std > 0)

z.equals(z2)
True
```