### PR TITLE
[WIP] Unpin scipy with newest lmoments3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ requirements = [
     "pint>=0.10",
     "pyyaml",
     "scikit-learn>=0.21.3",
-    "scipy>=1.2,<1.9",  # see: https://github.com/Ouranosinc/xclim/issues/1142
+    "scipy>=1.2",
     "statsmodels",
     "xarray>=2022.06.0",
 ]


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added
- [ ] The relevant author information has been added to `AUTHORS.rst` and `.zenodo.json`

### What kind of change does this PR introduce?

* unpins scipy which was limited by lmoments3 (scipy<1.9)

### Does this PR introduce a breaking change?

Dependencies are affected, so yes.

### Other information:

This PR is waiting on changes to be accepted upstream.

https://github.com/OpenHydrology/lmoments3/pull/13