### PR TITLE
CF-xarray latitude handling

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,20 @@
 History
 =======
 
+0.39.0 (unreleased)
+-------------------
+
+Breaking changes
+^^^^^^^^^^^^^^^^
+* Indices that accept `lat` or `lon` coordinates in their call signatures will now use `cf-xarray` accessors to gather these variables in the event that they are not explicitly supplied. (:pull:`1180`). This affects the following
+    - ``huglin_index``, ``biologically_effective_degree_days``, ``cool_night_index``, ``latitude_temperature_index``, ``water_budget``, ``potential_evapotranspiration``
+* ``cool_night_index`` now accepts ``lat: str = "north" | "south"`` for calculating CNI over DataArrays lacking a latitude coordinate. (:pull:`1180`).
+
+Bug fixes
+^^^^^^^^^
+* The docstring of ``cool_night_index`` suggested that `lat` was an optional parameter. This has been corrected. (:issue:`1179`, :pull:`1180`).
+* The ``mean_radiant_temperature`` indice was accessing hardcoded `lat` and `lon` coordinates from passed DataArrays. This now uses `cf-xarray` accessors. (:pull:`1180`).
+
 0.38.0 (2022-09-06)
 -------------------
 Contributors to this version: Pascal Bourgault (:user:`aulemahal`), Éric Dupuis (:user:`coxipi`), Trevor James Smith (:user:`Zeitsperre`), Abel Aoun (:user:`bzah`), Gabriel Rondeau-Genesse (:user:`RondeauG`), Dougie Squire (:user:`dougiesquire`).

--- a/xclim/indices/_agro.py
+++ b/xclim/indices/_agro.py
@@ -435,7 +435,7 @@ def biologically_effective_degree_days(
     return bedd
 
 
-@declare_units(tasmin="[temperature]", lat="[]")
+@declare_units(tasmin="[temperature]")
 def cool_night_index(
     tasmin: xarray.DataArray,
     lat: xarray.DataArray | str | None = None,

--- a/xclim/indices/_agro.py
+++ b/xclim/indices/_agro.py
@@ -13,7 +13,7 @@ from xclim.core.units import convert_units_to, declare_units, rate2amount, to_ag
 from xclim.core.utils import DayOfYearStr, uses_dask
 from xclim.indices._threshold import first_day_above, first_day_below, freshet_start
 from xclim.indices.generic import aggregate_between_dates
-from xclim.indices.helpers import day_lengths, gather_lat
+from xclim.indices.helpers import _gather_lat, day_lengths
 from xclim.indices.stats import dist_method, fit
 
 # Frequencies : YS: year start, QS-DEC: seasons starting in december, MS: month start
@@ -215,7 +215,7 @@ def huglin_index(
     thresh = convert_units_to(thresh, "degC")
 
     if lat is None:
-        lat = gather_lat(tas)
+        lat = _gather_lat(tas)
 
     if method.lower() == "smoothed":
         lat_mask = abs(lat) <= 50
@@ -384,7 +384,7 @@ def biologically_effective_degree_days(
     thresh_tasmin = convert_units_to(thresh_tasmin, "degC")
     max_daily_degree_days = convert_units_to(max_daily_degree_days, "degC")
 
-    if method.lower() in ["gladstones", "jones"] and lat is not None:
+    if method.lower() in ["gladstones", "jones"]:
         low_dtr = convert_units_to(low_dtr, "degC")
         high_dtr = convert_units_to(high_dtr, "degC")
         dtr = tasmax - tasmin
@@ -395,7 +395,7 @@ def biologically_effective_degree_days(
         )
 
         if lat is None:
-            lat = gather_lat(tasmin)
+            lat = _gather_lat(tasmin)
 
         if method.lower() == "gladstones":
             if isinstance(lat, (int, float)):
@@ -486,7 +486,7 @@ def cool_night_index(
     months = tasmin.time.dt.month
 
     if lat is None:
-        lat = gather_lat(tasmin)
+        lat = _gather_lat(tasmin)
     if isinstance(lat, xarray.DataArray):
         month = xarray.where(lat > 0, 9, 3)
     elif isinstance(lat, str):
@@ -559,7 +559,7 @@ def latitude_temperature_index(
     mtwm = tas.resample(time=freq).max(dim="time")
 
     if lat is None:
-        lat = gather_lat(tas)
+        lat = _gather_lat(tas)
 
     lat_mask = (abs(lat) >= 0) & (abs(lat) <= lat_factor)
     lat_coeff = xarray.where(lat_mask, lat_factor - abs(lat), 0)
@@ -645,7 +645,7 @@ def water_budget(
     pr = convert_units_to(pr, "kg m-2 s-1")
 
     if lat is None and evspsblpot is None:
-        lat = gather_lat(pr)
+        lat = _gather_lat(pr)
 
     if evspsblpot is None:
         pet = xci.potential_evapotranspiration(

--- a/xclim/indices/_agro.py
+++ b/xclim/indices/_agro.py
@@ -13,7 +13,7 @@ from xclim.core.units import convert_units_to, declare_units, rate2amount, to_ag
 from xclim.core.utils import DayOfYearStr, uses_dask
 from xclim.indices._threshold import first_day_above, first_day_below, freshet_start
 from xclim.indices.generic import aggregate_between_dates
-from xclim.indices.helpers import day_lengths
+from xclim.indices.helpers import day_lengths, gather_lat
 from xclim.indices.stats import dist_method, fit
 
 # Frequencies : YS: year start, QS-DEC: seasons starting in december, MS: month start
@@ -130,7 +130,7 @@ def corn_heat_units(
 def huglin_index(
     tas: xarray.DataArray,
     tasmax: xarray.DataArray,
-    lat: xarray.DataArray,
+    lat: xarray.DataArray | None = None,
     thresh: str = "10 degC",
     method: str = "smoothed",
     start_date: DayOfYearStr = "04-01",
@@ -151,6 +151,7 @@ def huglin_index(
       Maximum daily temperature.
     lat: xarray.DataArray
       Latitude coordinate.
+      If None, a CF-conformant "latitude" field must be available within the passed DataArray.
     thresh: str
       The temperature threshold.
     method: {"smoothed", "icclim", "jones"}
@@ -212,6 +213,9 @@ def huglin_index(
     tas = convert_units_to(tas, "degC")
     tasmax = convert_units_to(tasmax, "degC")
     thresh = convert_units_to(thresh, "degC")
+
+    if lat is None:
+        lat = gather_lat(tas)
 
     if method.lower() == "smoothed":
         lat_mask = abs(lat) <= 50
@@ -305,6 +309,8 @@ def biologically_effective_degree_days(
       Maximum daily temperature.
     lat : xarray.DataArray, optional
       Latitude coordinate.
+      If None and method in ["gladstones", "icclim"],
+      a CF-conformant "latitude" field must be available within the passed DataArray.
     thresh_tasmin : str
       The minimum temperature threshold.
     method : {"gladstones", "icclim", "jones"}
@@ -387,6 +393,10 @@ def biologically_effective_degree_days(
             dtr - high_dtr,
             xarray.where(dtr < low_dtr, dtr - low_dtr, 0),
         )
+
+        if lat is None:
+            lat = gather_lat(tasmin)
+
         if method.lower() == "gladstones":
             if isinstance(lat, (int, float)):
                 lat = xarray.DataArray(lat)
@@ -427,7 +437,9 @@ def biologically_effective_degree_days(
 
 @declare_units(tasmin="[temperature]", lat="[]")
 def cool_night_index(
-    tasmin: xarray.DataArray, lat: xarray.DataArray, freq: str = "YS"
+    tasmin: xarray.DataArray,
+    lat: xarray.DataArray | str | None = None,
+    freq: str = "YS",
 ) -> xarray.DataArray:
     """Cool Night Index.
 
@@ -437,11 +449,12 @@ def cool_night_index(
     Parameters
     ----------
     tasmin : xarray.DataArray
-      Minimum daily temperature.
-    lat: xarray.DataArray, optional
-      Latitude coordinate.
+        Minimum daily temperature.
+    lat : xarray.DataArray or {"north", "south"}, optional
+        Latitude coordinate.
+        If None, a CF-conformant "latitude" field must be available within the passed DataArray.
     freq : str
-      Resampling frequency.
+        Resampling frequency.
 
     Returns
     -------
@@ -471,7 +484,21 @@ def cool_night_index(
 
     # Use September in northern hemisphere, March in southern hemisphere.
     months = tasmin.time.dt.month
-    month = xarray.where(lat > 0, 9, 3)
+
+    if lat is None:
+        lat = gather_lat(tasmin)
+    if isinstance(lat, xarray.DataArray):
+        month = xarray.where(lat > 0, 9, 3)
+    elif isinstance(lat, str):
+        if lat.lower() == "north":
+            month = 9
+        elif lat.lower() == "south":
+            month = 3
+        else:
+            raise ValueError(f"Latitude value unsupported: {lat}.")
+    else:
+        raise ValueError(f"Latitude: {lat}.")
+
     tasmin = tasmin.where(months == month, drop=True)
 
     cni = tasmin.resample(time=freq).mean()
@@ -482,7 +509,7 @@ def cool_night_index(
 @declare_units(tas="[temperature]", lat="[]")
 def latitude_temperature_index(
     tas: xarray.DataArray,
-    lat: xarray.DataArray,
+    lat: xarray.DataArray | None = None,
     lat_factor: float = 75,
     freq: str = "YS",
 ) -> xarray.DataArray:
@@ -495,8 +522,9 @@ def latitude_temperature_index(
     ----------
     tas: xarray.DataArray
       Mean daily temperature.
-    lat: xarray.DataArray
+    lat: xarray.DataArray, optional
       Latitude coordinate.
+      If None, a CF-conformant "latitude" field must be available within the passed DataArray.
     lat_factor: float
       Latitude factor. Maximum poleward latitude. Default: 75.
     freq : str
@@ -529,6 +557,9 @@ def latitude_temperature_index(
 
     tas = tas.resample(time="MS").mean(dim="time")
     mtwm = tas.resample(time=freq).max(dim="time")
+
+    if lat is None:
+        lat = gather_lat(tas)
 
     lat_mask = (abs(lat) >= 0) & (abs(lat) <= lat_factor)
     lat_coeff = xarray.where(lat_mask, lat_factor - abs(lat), 0)
@@ -576,27 +607,28 @@ def water_budget(
     ----------
     pr : xarray.DataArray
       Daily precipitation.
-    evspsblpot: xarray.DataArray
+    evspsblpot: xarray.DataArray, optional
       Potential evapotranspiration
-    tasmin : xarray.DataArray
+    tasmin : xarray.DataArray, optional
       Minimum daily temperature.
-    tasmax : xarray.DataArray
+    tasmax : xarray.DataArray, optional
       Maximum daily temperature.
-    tas : xarray.DataArray
+    tas : xarray.DataArray, optional
       Mean daily temperature.
-    lat : xarray.DataArray
-      Latitude, needed if evspsblpot is not given.
-    hurs : xarray.DataArray
+    lat : xarray.DataArray, optional
+      Latitude coordinate, needed if evspsblpot is not given.
+      If None, a CF-conformant "latitude" field must be available within the `pr` DataArray.
+    hurs : xarray.DataArray, optional
       Relative humidity.
-    rsds : xarray.DataArray
+    rsds : xarray.DataArray, optional
       Surface Downwelling Shortwave Radiation
-    rsus : xarray.DataArray
+    rsus : xarray.DataArray, optional
       Surface Upwelling Shortwave Radiation
-    rlds : xarray.DataArray
+    rlds : xarray.DataArray, optional
       Surface Downwelling Longwave Radiation
-    rlus : xarray.DataArray
+    rlus : xarray.DataArray, optional
       Surface Upwelling Longwave Radiation
-    sfcwind : xarray.DataArray
+    sfcwind : xarray.DataArray, optional
       Surface wind velocity (at 10 m)
     method : str
       Method to use to calculate the potential evapotranspiration.
@@ -611,6 +643,9 @@ def water_budget(
       Precipitation minus potential evapotranspiration.
     """
     pr = convert_units_to(pr, "kg m-2 s-1")
+
+    if lat is None and evspsblpot is None:
+        lat = gather_lat(pr)
 
     if evspsblpot is None:
         pet = xci.potential_evapotranspiration(

--- a/xclim/indices/_agro.py
+++ b/xclim/indices/_agro.py
@@ -501,7 +501,7 @@ def cool_night_index(
 
     tasmin = tasmin.where(months == month, drop=True)
 
-    cni = tasmin.resample(time=freq).mean()
+    cni = tasmin.resample(time=freq).mean(keep_attrs=True)
     cni.attrs["units"] = "degC"
     return cni
 
@@ -555,8 +555,8 @@ def latitude_temperature_index(
     """
     tas = convert_units_to(tas, "degC")
 
-    tas = tas.resample(time="MS").mean(dim="time")
-    mtwm = tas.resample(time=freq).max(dim="time")
+    tas = tas.resample(time="MS").mean(dim="time", keep_attrs=True)
+    mtwm = tas.resample(time=freq).max(dim="time", keep_attrs=True)
 
     if lat is None:
         lat = _gather_lat(tas)
@@ -666,7 +666,7 @@ def water_budget(
 
     if xarray.infer_freq(pet.time) == "MS":
         with xarray.set_options(keep_attrs=True):
-            pr = pr.resample(time="MS").mean(dim="time")
+            pr = pr.resample(time="MS").mean(dim="time", keep_attrs=True)
 
     out = pr - pet
 

--- a/xclim/indices/_agro.py
+++ b/xclim/indices/_agro.py
@@ -451,7 +451,7 @@ def cool_night_index(
     tasmin : xarray.DataArray
         Minimum daily temperature.
     lat : xarray.DataArray or {"north", "south"}, optional
-        Latitude coordinate.
+        Latitude coordinate as an array, float or string.
         If None, a CF-conformant "latitude" field must be available within the passed DataArray.
     freq : str
         Resampling frequency.

--- a/xclim/indices/_agro.py
+++ b/xclim/indices/_agro.py
@@ -665,8 +665,7 @@ def water_budget(
         pet = convert_units_to(evspsblpot, "kg m-2 s-1")
 
     if xarray.infer_freq(pet.time) == "MS":
-        with xarray.set_options(keep_attrs=True):
-            pr = pr.resample(time="MS").mean(dim="time", keep_attrs=True)
+        pr = pr.resample(time="MS").mean(dim="time", keep_attrs=True)
 
     out = pr - pet
 

--- a/xclim/indices/_conversion.py
+++ b/xclim/indices/_conversion.py
@@ -8,12 +8,12 @@ from numba import float32, float64, vectorize  # noqa
 from xclim.core.calendar import date_range, datetime_to_decimal_year
 from xclim.core.units import amount2rate, convert_units_to, declare_units, units2pint
 from xclim.indices.helpers import (
+    _gather_lat,
+    _gather_lon,
     cosine_of_solar_zenith_angle,
     day_lengths,
     distance_from_sun,
     extraterrestrial_solar_radiation,
-    gather_lat,
-    gather_lon,
     solar_declination,
     time_correction_for_solar_angle,
     wind_speed_height_conversion,
@@ -1070,7 +1070,7 @@ def potential_evapotranspiration(
     :cite:cts:`baier_estimation_1965,george_h_hargreaves_reference_1985,tanguy_historical_2018,thornthwaite_approach_1948,mcguinness_comparison_1972,allen_crop_1998`
     """
     if lat is None:
-        lat = gather_lat(tasmin if tas is None else tas)
+        lat = _gather_lat(tasmin if tas is None else tas)
 
     if method in ["baierrobertson65", "BR65"]:
         tasmin = convert_units_to(tasmin, "degF")
@@ -1676,8 +1676,8 @@ def mean_radiant_temperature(
     dates = rsds.time
     hours = ((dates - dates.dt.floor("D")).dt.seconds / 3600).assign_attrs(units="h")
 
-    lat = gather_lat(rsds)
-    lon = gather_lon(rsds)
+    lat = _gather_lat(rsds)
+    lon = _gather_lon(rsds)
 
     decimal_year = datetime_to_decimal_year(times=dates, calendar=dates.dt.calendar)
     day_angle = ((decimal_year % 1) * 2 * np.pi).assign_attrs(units="rad")

--- a/xclim/indices/helpers.py
+++ b/xclim/indices/helpers.py
@@ -406,7 +406,7 @@ def wind_speed_height_conversion(
         raise NotImplementedError(f"'{method}' method is not implemented.")
 
 
-def gather_lat(da: xr.DataArray) -> xr.DataArray:
+def _gather_lat(da: xr.DataArray) -> xr.DataArray:
     """Gather latitude coordinate using cf-xarray.
 
     Parameters
@@ -431,7 +431,7 @@ def gather_lat(da: xr.DataArray) -> xr.DataArray:
         raise ValueError(msg) from err
 
 
-def gather_lon(da: xr.DataArray) -> xr.DataArray:
+def _gather_lon(da: xr.DataArray) -> xr.DataArray:
     """Gather longitude coordinate using cf-xarray.
 
     Parameters

--- a/xclim/indices/helpers.py
+++ b/xclim/indices/helpers.py
@@ -7,6 +7,8 @@ Functions that encapsulate some geophysical logic but could be shared by many in
 """
 from __future__ import annotations
 
+from inspect import stack
+
 import cftime
 import numpy as np
 import xarray as xr
@@ -401,3 +403,53 @@ def wind_speed_height_conversion(
             return ua * np.log(67.8 * h_target - 5.42) / np.log(67.8 * h_source - 5.42)
     else:
         raise NotImplementedError(f"'{method}' method is not implemented.")
+
+
+def gather_lat(da: xr.DataArray) -> xr.DataArray:
+    """Gather latitude coordinate using cf-xarray.
+
+    Parameters
+    ----------
+    da : xarray.DataArray
+        CF-conformant DataArray with a "latitude" coordinate.
+
+    Returns
+    -------
+    xarray.DataArray
+        Latitude coordinate.
+    """
+    try:
+        lat = da.cf["latitude"]
+        return lat
+    except KeyError as err:
+        n_func = stack()[1].function
+        msg = (
+            f"{n_func} could not find latitude coordinate in DataArray. "
+            "Try passing it explicitly (`lat=ds.lat`)."
+        )
+        raise ValueError(msg) from err
+
+
+def gather_lon(da: xr.DataArray) -> xr.DataArray:
+    """Gather longitude coordinate using cf-xarray.
+
+    Parameters
+    ----------
+    da : xarray.DataArray
+        CF-conformant DataArray with a "longitude" coordinate.
+
+    Returns
+    -------
+    xarray.DataArray
+        Longitude coordinate.
+    """
+    try:
+        lat = da.cf["longitude"]
+        return lat
+    except KeyError as err:
+        n_func = stack()[1].function
+        msg = (
+            f"{n_func} could not find longitude coordinate in DataArray. "
+            "Try passing it explicitly (`lon=ds.lon`)."
+        )
+        raise ValueError(msg) from err

--- a/xclim/indices/helpers.py
+++ b/xclim/indices/helpers.py
@@ -8,7 +8,7 @@ Functions that encapsulate some geophysical logic but could be shared by many in
 from __future__ import annotations
 
 from inspect import stack
-
+import cf_xarray  # noqa
 import cftime
 import numpy as np
 import xarray as xr

--- a/xclim/indices/helpers.py
+++ b/xclim/indices/helpers.py
@@ -8,6 +8,7 @@ Functions that encapsulate some geophysical logic but could be shared by many in
 from __future__ import annotations
 
 from inspect import stack
+
 import cf_xarray  # noqa
 import cftime
 import numpy as np


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1179 
- [x] Tests for the changes have been added (for bug fixes / features)
  - [x] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added
- [x] The relevant author information has been added to `AUTHORS.rst` and `.zenodo.json`

### What kind of change does this PR introduce?

* Adds `cf-xarray`-based accessor functions for latitude and longitude
* Implements these accessors for many agroclimatic indices that use `lat` and/or `lon`
* Adds the option to send `"north"` or `"south"` for `lat` to `cool_night_index`
* Cleans up a few bad docstrings

### Does this PR introduce a breaking change?

Yes. The call signature for `cool_night_index` has been affected.

### Other information:
