### PR TITLE
Refactor first_day indices into generics

### DIFF
--- a/xclim/core/calendar.py
+++ b/xclim/core/calendar.py
@@ -28,7 +28,7 @@ from xarray.coding.cftime_offsets import (
 from xarray.coding.cftimeindex import CFTimeIndex
 from xarray.core.resample import DataArrayResample
 
-from xclim.core.utils import PercentileDataArray, uses_dask
+from xclim.core.utils import DayOfYearStr, PercentileDataArray, uses_dask
 
 from .formatting import update_xclim_history
 
@@ -78,9 +78,6 @@ max_doy = {
 
 # Some xclim.core.utils functions made accessible here for backwards compatibility reasons.
 datetime_classes = {"default": pydt.datetime, **cftime._cftime.DATE_TYPES}  # noqa
-
-#: Type annotation for strings representing dates without a year (MM-DD).
-DayOfYearStr = NewType("DayOfYearStr", str)
 
 # Names of calendars that have the same number of days for all years
 uniform_calendars = ("noleap", "all_leap", "365_day", "366_day", "360_day")

--- a/xclim/indicators/atmos/_temperature.py
+++ b/xclim/indicators/atmos/_temperature.py
@@ -626,8 +626,42 @@ first_day_below = Temp(
     standard_name="day_of_year",
     long_name="First day of year with temperature below {thresh}",
     description="First day of year with temperature below {thresh} for at least {window} days.",
-    compute=indices.first_day_below,
+    compute=indices.first_day_tn_below,
+    _version_deprecated="0.39.0",
 )
+
+first_day_tn_below = Temp(
+    identifier="first_day_below",
+    units="",
+    standard_name="day_of_year",
+    long_name="First day of year with minimum temperature below {thresh}",
+    description="First day of year with minimum temperature below {thresh} for at least {window} days.",
+    compute=indices.first_day_tn_below,
+    parameters=dict(thresh={"default": "0 degC"}, after_date={"default": "07-01"}),
+)
+
+
+first_day_tg_below = Temp(
+    identifier="first_day_below",
+    units="",
+    standard_name="day_of_year",
+    long_name="First day of year with mean temperature below {thresh}",
+    description="First day of year with mean temperature below {thresh} for at least {window} days.",
+    compute=indices.first_day_tg_below,
+    parameters=dict(thresh={"default": "0 degC"}, after_date={"default": "07-01"}),
+)
+
+
+first_day_tx_below = Temp(
+    identifier="first_day_below",
+    units="",
+    standard_name="day_of_year",
+    long_name="First day of year with maximum temperature below {thresh}",
+    description="First day of year with maximum temperature below {thresh} for at least {window} days.",
+    compute=indices.first_day_tx_below,
+    parameters=dict(thresh={"default": "0 degC"}, after_date={"default": "07-01"}),
+)
+
 
 first_day_above = Temp(
     identifier="first_day_above",
@@ -635,9 +669,40 @@ first_day_above = Temp(
     standard_name="day_of_year",
     long_name="First day of year with temperature above {thresh}",
     description="First day of year with temperature above {thresh} for at least {window} days.",
-    compute=indices.first_day_above,
+    compute=indices.first_day_tn_above,
+    _version_deprecated="0.39.0",
 )
 
+first_day_tn_above = Temp(
+    identifier="first_day_above",
+    units="",
+    standard_name="day_of_year",
+    long_name="First day of year with minimum temperature above {thresh}",
+    description="First day of year with minimum temperature above {thresh} for at least {window} days.",
+    compute=indices.first_day_tn_above,
+    parameters=dict(thresh={"default": "0 degC"}, after_date={"default": "01-01"}),
+)
+
+
+first_day_tg_above = Temp(
+    identifier="first_day_above",
+    units="",
+    standard_name="day_of_year",
+    long_name="First day of year with mean temperature above {thresh}",
+    description="First day of year with mean temperature above {thresh} for at least {window} days.",
+    compute=indices.first_day_tg_above,
+    parameters=dict(thresh={"default": "0 degC"}, after_date={"default": "01-01"}),
+)
+
+first_day_tx_above = Temp(
+    identifier="first_day_above",
+    units="",
+    standard_name="day_of_year",
+    long_name="First day of year with maximum temperature above {thresh}",
+    description="First day of year with maximum temperature above {thresh} for at least {window} days.",
+    compute=indices.first_day_tx_above,
+    parameters=dict(thresh={"default": "0 degC"}, after_date={"default": "01-01"}),
+)
 
 ice_days = TempWithIndexing(
     identifier="ice_days",

--- a/xclim/indices/_threshold.py
+++ b/xclim/indices/_threshold.py
@@ -46,8 +46,14 @@ __all__ = [
     "frost_free_season_end",
     "frost_free_season_length",
     "frost_season_length",
-    "first_day_below",
     "first_day_above",
+    "first_day_below",
+    "first_day_tg_above",
+    "first_day_tn_above",
+    "first_day_tx_above",
+    "first_day_tg_below",
+    "first_day_tn_below",
+    "first_day_tx_below",
     "first_snowfall",
     "last_snowfall",
     "heat_wave_index",
@@ -1020,18 +1026,56 @@ def last_spring_frost(
     return out
 
 
-@declare_units(tasmin="[temperature]", thresh="[temperature]")
+def first_day_above(
+    tasmin: xarray.DataArray,
+    thresh: str = "0 degC",
+    after_date: DayOfYearStr = "07-01",
+    window: int = 1,
+    freq: str = "YS",
+) -> xarray.DataArray:  # noqa: D103
+    warnings.warn(
+        "The `first_day_above` indice is being deprecated in favour of `first_day_tn_above` with `thresh='0 degC'`. "
+        "This indice will be removed in `xclim>=0.40.0`. Please update your scripts accordingly.",
+        UserWarning,
+        stacklevel=3,
+    )
+
+    return first_day_tn_above(
+        tasmin, thresh=thresh, after_date=after_date, window=window, freq=freq
+    )
+
+
 def first_day_below(
     tasmin: xarray.DataArray,
     thresh: str = "0 degC",
     after_date: DayOfYearStr = "07-01",
     window: int = 1,
     freq: str = "YS",
-) -> xarray.DataArray:
-    r"""First day of temperatures inferior to a threshold temperature.
+) -> xarray.DataArray:  # noqa: D103
+    warnings.warn(
+        "The `first_day_below` indice is being deprecated in favour of `first_day_tn_below` with `thresh='0 degC'`. "
+        "This indice will be removed in `xclim>=0.40.0`. Please update your scripts accordingly.",
+        UserWarning,
+        stacklevel=3,
+    )
 
-    Returns first day of period where a temperature is inferior to a threshold over a given number of days, limited to
-    a starting calendar date.
+    return first_day_tn_below(
+        tasmin, thresh=thresh, after_date=after_date, window=window, freq=freq
+    )
+
+
+@declare_units(tasmin="[temperature]", thresh="[temperature]")
+def first_day_tn_below(
+    tasmin: xarray.DataArray,
+    thresh: str = "0 degC",
+    after_date: DayOfYearStr = "07-01",
+    window: int = 1,
+    freq: str = "YS",
+) -> xarray.DataArray:
+    r"""First day of minimum temperatures inferior to a threshold temperature.
+
+    Returns first day of period where minimum temperature is inferior to a threshold over a given number of days,
+    limited to a starting calendar date.
 
     Warnings
     --------
@@ -1044,7 +1088,7 @@ def first_day_below(
     thresh : str
         Threshold temperature on which to base evaluation.
     after_date : str
-        Date of the year after which to look for the first frost event. Should have the format '%m-%d'.
+        Date of the year after which to look for the first event. Should have the format '%m-%d'.
     window : int
         Minimum number of days with temperature below threshold needed for evaluation.
     freq : str
@@ -1056,29 +1100,108 @@ def first_day_below(
         Day of the year when minimum temperature is inferior to a threshold over a given number of days for the first time.
         If there is no such day, returns np.nan.
     """
-    thresh = convert_units_to(thresh, tasmin)
-    cond = tasmin < thresh
+    from .generic import first_day_below  # noqa
 
-    out = cond.resample(time=freq).map(
-        rl.first_run_after_date,
-        window=window,
-        date=after_date,
-        dim="time",
-        coord="dayofyear",
+    return first_day_below(
+        tasmin, threshold=thresh, after_date=after_date, window=window, freq=freq
     )
-    out.attrs.update(units="", is_dayofyear=np.int32(1), calendar=get_calendar(tasmin))
-    return out
 
 
 @declare_units(tasmin="[temperature]", thresh="[temperature]")
-def first_day_above(
+def first_day_tg_below(
+    tas: xarray.DataArray,
+    thresh: str = "0 degC",
+    after_date: DayOfYearStr = "07-01",
+    window: int = 1,
+    freq: str = "YS",
+) -> xarray.DataArray:
+    r"""First day of mean temperatures inferior to a threshold temperature.
+
+    Returns first day of period where mean temperature is inferior to a threshold over a given number of days, limited to
+    a starting calendar date.
+
+    Warnings
+    --------
+    The default `freq` is valid for the northern hemisphere.
+
+    Parameters
+    ----------
+    tas : xarray.DataArray
+        Mean daily temperature.
+    thresh : str
+        Threshold temperature on which to base evaluation.
+    after_date : str
+        Date of the year after which to look for the first event. Should have the format '%m-%d'.
+    window : int
+        Minimum number of days with temperature below threshold needed for evaluation.
+    freq : str
+        Resampling frequency.
+
+    Returns
+    -------
+    xarray.DataArray, [dimensionless]
+        Day of the year when mean temperature is inferior to a threshold over a given number of days for the first time.
+        If there is no such day, returns np.nan.
+    """
+    from .generic import first_day_below  # noqa
+
+    return first_day_below(
+        tas, threshold=thresh, after_date=after_date, window=window, freq=freq
+    )
+
+
+@declare_units(tasmin="[temperature]", thresh="[temperature]")
+def first_day_tx_below(
+    tasmax: xarray.DataArray,
+    thresh: str = "0 degC",
+    after_date: DayOfYearStr = "07-01",
+    window: int = 1,
+    freq: str = "YS",
+) -> xarray.DataArray:
+    r"""First day of maximum temperatures inferior to a threshold temperature.
+
+    Returns first day of period where a temperature is inferior to a threshold over a given number of days, limited to
+    a starting calendar date.
+
+    Warnings
+    --------
+    The default `freq` is valid for the northern hemisphere.
+
+    Parameters
+    ----------
+    tasmax : xarray.DataArray
+        Maximum daily temperature.
+    thresh : str
+        Threshold temperature on which to base evaluation.
+    after_date : str
+        Date of the year after which to look for the first event. Should have the format '%m-%d'.
+    window : int
+        Minimum number of days with temperature below threshold needed for evaluation.
+    freq : str
+        Resampling frequency.
+
+    Returns
+    -------
+    xarray.DataArray, [dimensionless]
+        Day of the year when minimum temperature is inferior to a threshold over a given number of days for the first time.
+        If there is no such day, returns np.nan.
+    """
+    from .generic import first_day_below  # noqa
+
+    return first_day_below(
+        tasmax, threshold=thresh, after_date=after_date, window=window, freq=freq
+    )
+
+
+@declare_units(tasmin="[temperature]", thresh="[temperature]")
+def first_day_tn_above(
     tasmin: xarray.DataArray,
     thresh: str = "0 degC",
     after_date: DayOfYearStr = "01-01",
     window: int = 1,
     freq: str = "YS",
 ) -> xarray.DataArray:
-    r"""First day of temperatures superior to a threshold temperature.
+    r"""First day of minimum temperatures superior to a threshold temperature.
 
     Returns first day of period where a temperature is superior to a threshold over a given number of days, limited to
     a starting calendar date.
@@ -1106,18 +1229,97 @@ def first_day_above(
         Day of the year when minimum temperature is superior to a threshold over a given number of days for the first time.
         If there is no such day, returns np.nan.
     """
-    thresh = convert_units_to(thresh, tasmin)
-    cond = tasmin > thresh
+    from .generic import first_day_above  # noqa
 
-    out = cond.resample(time=freq).map(
-        rl.first_run_after_date,
-        window=window,
-        date=after_date,
-        dim="time",
-        coord="dayofyear",
+    return first_day_above(
+        tasmin, threshold=thresh, after_date=after_date, window=window, freq=freq
     )
-    out.attrs.update(units="", is_dayofyear=np.int32(1), calendar=get_calendar(tasmin))
-    return out
+
+
+@declare_units(tasmin="[temperature]", thresh="[temperature]")
+def first_day_tg_above(
+    tas: xarray.DataArray,
+    thresh: str = "0 degC",
+    after_date: DayOfYearStr = "01-01",
+    window: int = 1,
+    freq: str = "YS",
+) -> xarray.DataArray:
+    r"""First day of mean temperatures superior to a threshold temperature.
+
+    Returns first day of period where mean temperature is superior to a threshold over a given number of days,
+    limited to a starting calendar date.
+
+    Warnings
+    --------
+    The default `freq` is valid for the northern hemisphere.
+
+    Parameters
+    ----------
+    tas : xarray.DataArray
+        Mean daily temperature.
+    thresh : str
+        Threshold temperature on which to base evaluation.
+    after_date : str
+        Date of the year after which to look for the first event. Should have the format '%m-%d'.
+    window : int
+        Minimum number of days with temperature above threshold needed for evaluation.
+    freq : str
+        Resampling frequency.
+
+    Returns
+    -------
+    xarray.DataArray, [dimensionless]
+        Day of the year when mean temperature is superior to a threshold over a given number of days for the first time.
+        If there is no such day, returns np.nan.
+    """
+    from .generic import first_day_above  # noqa
+
+    return first_day_above(
+        tas, threshold=thresh, after_date=after_date, window=window, freq=freq
+    )
+
+
+@declare_units(tasmin="[temperature]", thresh="[temperature]")
+def first_day_tx_above(
+    tasmax: xarray.DataArray,
+    thresh: str = "0 degC",
+    after_date: DayOfYearStr = "01-01",
+    window: int = 1,
+    freq: str = "YS",
+) -> xarray.DataArray:
+    r"""First day of maximum temperatures superior to a threshold temperature.
+
+    Returns first day of period where maximum temperature is superior to a threshold over a given number of days,
+    limited to a starting calendar date.
+
+    Warnings
+    --------
+    The default `freq` is valid for the northern hemisphere.
+
+    Parameters
+    ----------
+    tasmax : xarray.DataArray
+        Minimum daily temperature.
+    thresh : str
+        Threshold temperature on which to base evaluation.
+    after_date : str
+        Date of the year after which to look for the first event. Should have the format '%m-%d'.
+    window : int
+        Minimum number of days with temperature above threshold needed for evaluation.
+    freq : str
+        Resampling frequency.
+
+    Returns
+    -------
+    xarray.DataArray, [dimensionless]
+        Day of the year when maximum temperature is superior to a threshold over a given number of days for the first time.
+        If there is no such day, returns np.nan.
+    """
+    from .generic import first_day_above  # noqa
+
+    return first_day_above(
+        tasmax, threshold=thresh, after_date=after_date, window=window, freq=freq
+    )
 
 
 @declare_units(prsn="[precipitation]", thresh="[precipitation]")

--- a/xclim/indices/generic.py
+++ b/xclim/indices/generic.py
@@ -16,7 +16,6 @@ import xarray as xr
 from xarray.coding.cftime_offsets import _MONTH_ABBREVIATIONS  # noqa
 
 from xclim.core.calendar import (
-    DayOfYearStr,
     convert_calendar,
     doy_to_days_since,
     get_calendar,
@@ -29,6 +28,7 @@ from xclim.core.units import (
     str2pint,
     to_agg_units,
 )
+from xclim.core.utils import DayOfYearStr
 
 from . import run_length as rl
 
@@ -43,11 +43,16 @@ __all__ = [
     "domain_count",
     "doymax",
     "doymin",
+    "extreme_temperature_range",
+    "first_day_above",
+    "first_day_below",
+    "first_occurrence",
     "get_daily_events",
     "get_op",
     "interday_diurnal_temperature_range",
     "last_occurrence",
     "select_resample_op",
+    "spell_length",
     "statistics",
     "temperature_sum",
     "threshold_count",
@@ -808,3 +813,107 @@ def degree_days(tas: xr.DataArray, threshold: str, op: str) -> xr.DataArray:
         raise NotImplementedError(f"Condition not supported: '{op}'.")
 
     return to_agg_units(out, tas, op="delta_prod")
+
+
+def first_day_above(
+    data: xr.DataArray,
+    *,
+    threshold: str,
+    after_date: DayOfYearStr,
+    window: int = 1,
+    freq: str = "YS",
+) -> xr.DataArray:
+    r"""First day of values superior to a given threshold.
+
+    Returns first day of period where values are superior to a threshold over a given number of days,
+    limited to a starting calendar date.
+
+    Warnings
+    --------
+    :py:func:`xclim.indices.generic.first_day_above` is a base and unitless indice used for building more complex
+    indices and indicators, and should not be confused with the now-deprecated temperature indice
+    :py:func:`xclim.indices._threshold.first_day_above`.
+
+    Parameters
+    ----------
+    data : xarray.DataArray
+        Dataset being evaluated.
+    threshold : str
+        Threshold on which to base evaluation.
+    after_date : str
+        Date of the year after which to look for the first event. Should have the format '%m-%d'.
+    window : int
+        Minimum number of days with values above threshold needed for evaluation.
+    freq : str
+        Resampling frequency.
+
+    Returns
+    -------
+    xarray.DataArray, [dimensionless]
+        Day of the year when value is superior to a threshold over a given number of days for the first time.
+        If there is no such day, returns np.nan.
+    """
+    threshold = convert_units_to(threshold, data)
+    cond = data > threshold
+
+    out = cond.resample(time=freq).map(
+        rl.first_run_after_date,
+        window=window,
+        date=after_date,
+        dim="time",
+        coord="dayofyear",
+    )
+    out.attrs.update(units="", is_dayofyear=np.int32(1), calendar=get_calendar(data))
+    return out
+
+
+def first_day_below(
+    data: xr.DataArray,
+    *,
+    threshold: str,
+    after_date: DayOfYearStr,
+    window: int = 1,
+    freq: str = "YS",
+) -> xr.DataArray:
+    r"""First day of values inferior to a given threshold.
+
+    Returns first day of period where values are inferior to a threshold over a given number of days,
+    limited to a starting calendar date.
+
+    Warnings
+    --------
+    :py:func:`xclim.indices.generic.first_day_below` is a base and unitless indice used for building more complex
+    indices and indicators, and should not be confused with the now-deprecated temperature indice
+    :py:func:`xclim.indices._threshold.first_day_below`.
+
+    Parameters
+    ----------
+    data : xarray.DataArray
+        Dataset being evaluated.
+    threshold : str
+        Threshold on which to base evaluation.
+    after_date : str
+        Date of the year after which to look for the first event. Should have the format '%m-%d'.
+    window : int
+        Minimum number of days with values below threshold needed for evaluation.
+    freq : str
+        Resampling frequency.
+
+    Returns
+    -------
+    xarray.DataArray, [dimensionless]
+        Day of the year when value is inferior to a threshold over a given number of days for the first time.
+        If there is no such day, returns np.nan.
+    """
+    threshold = convert_units_to(threshold, data)
+    cond = data < threshold
+
+    out = cond.resample(time=freq).map(
+        rl.first_run_after_date,
+        window=window,
+        date=after_date,
+        dim="time",
+        coord="dayofyear",
+    )
+    out.attrs.update(units="", is_dayofyear=np.int32(1), calendar=get_calendar(data))
+    return out


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1175 
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added
- [x] The relevant author information has been added to `AUTHORS.rst` and `.zenodo.json`

### What kind of change does this PR introduce?

* Uses `DayOfYearStr` from same file source
* Refactors indices into generics that compose temperature-based indices and indicators unique to variables
* Adds deprecation notices where needed

### Does this PR introduce a breaking change?

Yes. `first_day_below` and `first_day_above` are now generics, and users must transition to using `first_day_tn_below` and `first_day_tn_above` for previous behaviour. Warnings have been added to their docstrings. For previous versions, they remain available, but will show `DeprecationWarnings` when called by user.

`xclim.indices._threshold.first_day_above|below` will be removed in xclim>=0.40.0

### Other information:

The `first_day_XX_above|below` indices all perform local imports of generic `first_day_above` and `first_day_below`. This was needed to ensure that the deprecated versionsof these indices remain available without overwriting the newer generics. This will no longer be needed in xclim>=0.40.0
