### PR TITLE
Deprecate `freshet_start` indice

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -17,10 +17,10 @@ New indicators
 
 Breaking changes
 ^^^^^^^^^^^^^^^^
-* Indices that accept `lat` or `lon` coordinates in their call signatures will now use `cf-xarray` accessors to gather these variables in the event that they are not explicitly supplied. (:pull:`1180`). This affects the following
+* Indices that accept `lat` or `lon` coordinates in their call signatures will now use `cf-xarray` accessors to gather these variables in the event that they are not explicitly supplied. (:pull:`1180`). This affects the following:
     - ``huglin_index``, ``biologically_effective_degree_days``, ``cool_night_index``, ``latitude_temperature_index``, ``water_budget``, ``potential_evapotranspiration``
 * ``cool_night_index`` now optionally accepts ``lat: str = "north" | "south"`` for calculating CNI over DataArrays lacking a latitude coordinate. (:pull:`1180`).
-* The offset value in ``standardized_precipitation_evapotranspiration_index`` is changed to better reproduce results in the reference library ``monocongo/climate_indices``.
+* The offset value in ``standardized_precipitation_evapotranspiration_index`` is changed to better reproduce results in the reference library ``monocongo/climate_indices``. (:issue:`1141`, :pull:`1183`).
 * The ``first_day_below`` and ``first_day_above`` indices are now deprecated in order to clearly communicate the variables they act upon (:issue:`1175`, :pull:`1186`). The suggested migrations are as follows:
     - ``xclim.indices.first_day_above`` -> ``xclim.indices.first_day_temperature_above``
     - ``xclim.indices.first_day_below`` -> ``xclim.indices.first_day_temperature_below``
@@ -29,6 +29,7 @@ Breaking changes
     - ``xclim.atmos.first_day_below`` -> ``xclim.indices.first_day_{tn|tg|tx}_below``
 * English indicator metadata has been adjusted to remove frequencies and other variable-sourced fields in the `long_name` of indicators. English indicators now have an explicit `title` and `abstract`. (:issue:`936`, :pull:`1123`).
 * French indicator metadata translations are now more uniform and follow agreed-upon grammar conventions, removing variable-sourced fields in `long_name_fr`. (:issue:`936`, :pull:`1123`).
+* The ``freshet_start`` indice is now deprecated in favour of ``first_day_temperature_above`` with `thresh='0 degC', window=5`. The `freshet_start` indicator is now based on ``first_day_temperature_above``, but is otherwise unaffected. (:issue:`1195`, :pull:`1196`).
 
 Bug fixes
 ^^^^^^^^^

--- a/xclim/data/fr.json
+++ b/xclim/data/fr.json
@@ -521,10 +521,10 @@
     "abstract": "Indice de sommation de chaleur pour l'estimation de l'adéquation agroclimatique, développé spécifiquement pour la viticulture. Il prend en compte les Tmin et Tmax quotidiennes avec un seuil de base donné, généralement entre le 1er avril et le 30 septembre, et intègre un calcul de coefficient de longueur de jour pour les latitudes plus élevées. Métrique initialement publiée dans Huglin (1978). Le coefficient de longueur du jour est basé sur Hall & Jones (2010)."
   },
   "FRESHET_START": {
-    "long_name": "Premier jour ayant un dépassement constant du seuil de température",
+    "long_name": "Jour de l'année du début de la crue printanière",
     "description": "Jour de l'année du début de la crue printanière, défini comme le premier jour la température moyenne quotidienne est au-dessus de {thresh} pendant au moins {window} jours.",
-    "title": "Jour de l'année du début de la crue nivale",
-    "abstract": "Premier jour où la température moyenne quotidienne est au-dessus d'un seuil donné depuis un certain nombre de jours consécutifs."
+    "title": "Jour de l'année du début de la crue printanière",
+    "abstract": "Jour de l'année du début de la crue printanière, défini comme le premier jour où la température moyenne quotidienne est au-dessus d'un seuil donné depuis un certain nombre de jours consécutifs."
   },
   "FROST_SEASON_LENGTH": {
     "long_name": "Durée de la saison de gel",

--- a/xclim/indicators/atmos/_temperature.py
+++ b/xclim/indicators/atmos/_temperature.py
@@ -662,11 +662,13 @@ freshet_start = Temp(
     identifier="freshet_start",
     units="",
     standard_name="day_of_year",
-    long_name="First day consistently exceeding threshold temperature",
-    description="Day of year of spring freshet start, defined as the first day a temperature threshold of {thresh} "
+    long_name="Day of year of the spring freshet start",
+    description="Day of year of the spring freshet start, defined as the first day a temperature threshold of {thresh} "
     "is exceeded for at least {window} days.",
-    abstract="First day when the temperature exceeds a certain threshold for a given number of consecutive days",
-    compute=indices.freshet_start,
+    abstract="Day of year of the spring freshet start, defined as the first day when the temperature exceeds a certain "
+    "threshold for a given number of consecutive days.",
+    compute=indices.first_day_temperature_above,
+    parameters={"thresh": {"default": "0 degC"}, "window": {"default": 5}},
 )
 
 frost_days = TempWithIndexing(

--- a/xclim/testing/tests/test_indices.py
+++ b/xclim/testing/tests/test_indices.py
@@ -807,7 +807,11 @@ class TestFreshetStart:
         tg[i : i + w + 1] += 6  # Second valid condition, should be ignored.
 
         tg = tas_series(tg + K2C, start="1/1/2000")
-        out = xci.freshet_start(tg, window=w)
+
+        # Check for DeprecationWarning
+        with pytest.warns(DeprecationWarning):
+            out = xci.freshet_start(tg, window=w)
+
         assert out[0] == tg.indexes["time"][30].dayofyear
         for attr in ["units", "is_dayofyear", "calendar"]:
             assert attr in out.attrs.keys()


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1195 
- [x] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added
- [x] The relevant author information has been added to `AUTHORS.rst` and `.zenodo.json`

### What kind of change does this PR introduce?

* Deprecate `freshet_start` indice in favour of `first_day_temperature_above` with `thresh='0 degC', window=5`.
* Indicator version now wraps `first_day_temperature_above` with default values.
* Metadata for `freshet_start` indicator is now more hydrology-focused.

### Does this PR introduce a breaking change?

Yes. `freshet_start` indice is slated for removal in v0.40.0.

### Other information:
