### PR TITLE
Deprecate `generic.degree_days`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -13,7 +13,8 @@ New features and enhancements
 
 New indicators
 ^^^^^^^^^^^^^^
-* New indices ``first_day_temperature_{above|below}`` and indicators ``xclim.indices.first_day_{tn|tg|tx}_{above|below}``. These indices/indicators accept operator (``op``) keyword for finer threshold comparison controls. (:issue:`1175`, :pull:`1186`).
+* New indices ``first_day_temperature_{above | below}`` and indicators ``xclim.indices.first_day_{tn | tg | tx}_{above | below}``. These indices/indicators accept operator (``op``) keyword for finer threshold comparison controls. (:issue:`1175`, :pull:`1186`).
+* New generic indice ``cumulative_difference`` for calculating difference between values and thresholds across time (e.g. temperature: degree-days, precipitation: moisture deficit), with or without resampling/accumulating by frequency. (:pull:`1202`).
 
 Breaking changes
 ^^^^^^^^^^^^^^^^
@@ -25,8 +26,9 @@ Breaking changes
     - ``xclim.indices.first_day_above`` -> ``xclim.indices.first_day_temperature_above``
     - ``xclim.indices.first_day_below`` -> ``xclim.indices.first_day_temperature_below``
 * The ``first_day_below`` and ``first_day_above`` atmos indicators are now deprecated in order to clearly communicate the variables they act upon (:issue:`1175`, :pull:`1186`). The suggested migrations are as follows:
-    - ``xclim.atmos.first_day_above`` -> ``xclim.indices.first_day_{tn|tg|tx}_above``
-    - ``xclim.atmos.first_day_below`` -> ``xclim.indices.first_day_{tn|tg|tx}_below``
+    - ``xclim.atmos.first_day_above`` -> ``xclim.indices.first_day_{tn | tg | tx}_above``
+    - ``xclim.atmos.first_day_below`` -> ``xclim.indices.first_day_{tn | tg | tx}_below``
+* The ``degree_days`` generic indice has been deprecated in favour of ``cumulative_difference`` that is not limited only to temperature variables (:issue:`1200`, :pull:`1202`). The indices for ``atmos.{heating | cooling | growing}_degree_days`` are now built from ``generic.cumulative_difference``.
 
 Bug fixes
 ^^^^^^^^^

--- a/xclim/indices/_threshold.py
+++ b/xclim/indices/_threshold.py
@@ -17,7 +17,13 @@ from xclim.core.units import (
 from xclim.core.utils import DayOfYearStr
 
 from . import run_length as rl
-from .generic import compare, domain_count, first_day_threshold_reached, threshold_count
+from .generic import (
+    compare,
+    cumulative_difference,
+    domain_count,
+    first_day_threshold_reached,
+    threshold_count,
+)
 
 # Frequencies : YS: year start, QS-DEC: seasons starting in december, MS: month start
 # See http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases
@@ -474,11 +480,7 @@ def cooling_degree_days(
 
     where :math:`[P]` is 1 if :math:`P` is true, and 0 if false.
     """
-    thresh = convert_units_to(thresh, tas)
-
-    out = (tas - thresh).clip(min=0).resample(time=freq).sum(dim="time")
-    out = to_agg_units(out, tas, "delta_prod")
-    return out
+    return cumulative_difference(tas, threshold=thresh, op=">", freq=freq)
 
 
 @declare_units(tas="[temperature]", thresh="[temperature]")
@@ -556,9 +558,7 @@ def growing_degree_days(
 
         GD4_j = \sum_{i=1}^I (TG_{ij}-{4} | TG_{ij} > {4}℃)
     """
-    thresh = convert_units_to(thresh, tas)
-    out = (tas - thresh).clip(min=0).resample(time=freq).sum(dim="time")
-    return to_agg_units(out, tas, "delta_prod")
+    return cumulative_difference(tas, threshold=thresh, op=">", freq=freq)
 
 
 @declare_units(tas="[temperature]", thresh="[temperature]")
@@ -1354,10 +1354,7 @@ def heating_degree_days(
 
         HD17_j = \sum_{i=1}^{I} (17℃ - TG_{ij}) | TG_{ij} < 17℃)
     """
-    thresh = convert_units_to(thresh, tas)
-
-    out = (thresh - tas).clip(0).resample(time=freq).sum(dim="time")
-    return to_agg_units(out, tas, "delta_prod")
+    return cumulative_difference(tas, threshold=thresh, op="<", freq=freq)
 
 
 @declare_units(tasmax="[temperature]", thresh_tasmax="[temperature]")

--- a/xclim/indices/generic.py
+++ b/xclim/indices/generic.py
@@ -21,13 +21,7 @@ from xclim.core.calendar import (
     get_calendar,
     select_time,
 )
-from xclim.core.units import (
-    convert_units_to,
-    declare_units,
-    pint2cfunits,
-    str2pint,
-    to_agg_units,
-)
+from xclim.core.units import convert_units_to, pint2cfunits, str2pint, to_agg_units
 from xclim.core.utils import DayOfYearStr
 
 from . import run_length as rl
@@ -37,6 +31,7 @@ __all__ = [
     "compare",
     "count_level_crossings",
     "count_occurrences",
+    "cumulative_difference",
     "default_freq",
     "degree_days",
     "diurnal_temperature_range",
@@ -317,7 +312,8 @@ def count_level_crossings(
     threshold : str
         Quantity.
     freq : str
-        Resampling frequency.
+        Resampling frequency defining the periods as defined in
+        https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#resampling.
     op_low : {"<", "<=", "lt", "le"}
         Comparison operator for low_data. Default: "<".
     op_high : {">", ">=", "gt", "ge"}
@@ -359,7 +355,8 @@ def count_occurrences(
     threshold : str
         Quantity.
     freq : str
-        Resampling frequency.
+        Resampling frequency defining the periods as defined in
+        https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#resampling.
     op : {">", "gt", "<", "lt", ">=", "ge", "<=", "le", "==", "eq", "!=", "ne"}
         Logical operator. e.g. arr > thresh.
     constrain : sequence of str, optional
@@ -391,7 +388,8 @@ def diurnal_temperature_range(
     reducer : {'max', 'min', 'mean', 'sum'}
         Reducer.
     freq: str
-        Resampling frequency.
+        Resampling frequency defining the periods as defined in
+        https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#resampling.
 
     Returns
     -------
@@ -427,7 +425,8 @@ def first_occurrence(
     threshold : str
         Quantity.
     freq : str
-        Resampling frequency.
+        Resampling frequency defining the periods as defined in
+        https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#resampling.
     op : {">", "gt", "<", "lt", ">=", "ge", "<=", "le", "==", "eq", "!=", "ne"}
         Logical operator. e.g. arr > thresh.
     constrain : sequence of str, optional
@@ -471,7 +470,8 @@ def last_occurrence(
     threshold : str
         Quantity.
     freq : str
-        Resampling frequency.
+        Resampling frequency defining the periods as defined in
+        https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#resampling.
     op : {">", "gt", "<", "lt", ">=", "ge", "<=", "le", "==", "eq", "!=", "ne"}
         Logical operator. e.g. arr > thresh.
     constrain : sequence of str, optional
@@ -513,7 +513,8 @@ def spell_length(
     reducer : {'max', 'min', 'mean', 'sum'}
         Reducer.
     freq : str
-        Resampling frequency.
+        Resampling frequency defining the periods as defined in
+        https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#resampling.
     op : {">", "gt", "<", "lt", ">=", "ge", "<=", "le", "==", "eq", "!=", "ne"}
         Logical operator. e.g. arr > thresh.
 
@@ -543,7 +544,8 @@ def statistics(data: xr.DataArray, reducer: str, freq: str) -> xr.DataArray:
     reducer : {'max', 'min', 'mean', 'sum'}
         Reducer.
     freq : str
-        Resampling frequency.
+        Resampling frequency defining the periods as defined in
+        https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#resampling.
 
     Returns
     -------
@@ -560,7 +562,7 @@ def thresholded_statistics(
     threshold: str,
     reducer: str,
     freq: str,
-    constrain: Sequence[str] | None,
+    constrain: Sequence[str] | None = None,
 ) -> xr.DataArray:
     """Calculate a simple statistic of the data for which some condition is met.
 
@@ -579,9 +581,10 @@ def thresholded_statistics(
     reducer : {'max', 'min', 'mean', 'sum'}
         Reducer.
     freq : str
-        Resampling frequency.
+        Resampling frequency defining the periods as defined in
+        https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#resampling.
     constrain : sequence of str, optional
-        Optionally allowed conditions.
+        Optionally allowed conditions. Default: None.
 
     Returns
     -------
@@ -615,7 +618,8 @@ def temperature_sum(
     threshold : str
         Quantity.
     freq : str
-        Resampling frequency.
+        Resampling frequency defining the periods as defined in
+        https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#resampling.
 
     Returns
     -------
@@ -643,7 +647,9 @@ def interday_diurnal_temperature_range(
     high_data : xr.DataArray
         The highest daily temperature (tasmax).
     freq : str
-        Resampling frequency.
+        Resampling frequency defining the periods as defined in
+        https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#resampling.
+
 
     Returns
     -------
@@ -671,7 +677,8 @@ def extreme_temperature_range(
     high_data : xr.DataArray
         The highest daily temperature (tasmax).
     freq : str
-        Resampling frequency.
+        Resampling frequency defining the periods as defined in
+        https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#resampling.
 
     Returns
     -------
@@ -705,8 +712,10 @@ def aggregate_between_dates(
         End (as day-of-year) dates for the aggregation periods.
     op : {'min', 'max', 'sum', 'mean', 'std'}
         Operator.
-    freq : str
-        Resampling frequency.
+    freq : str, optional
+        Resampling frequency defining the periods as defined in
+        https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#resampling.
+        Default: `None`.
 
     Returns
     -------
@@ -728,7 +737,7 @@ def aggregate_between_dates(
 
     if freq is None:
         frequencies = []
-        for _, bound in enumerate([start, end], start=1):
+        for bound in [start, end]:
             try:
                 frequencies.append(xr.infer_freq(bound.time))
             except AttributeError:
@@ -785,33 +794,54 @@ def aggregate_between_dates(
     return xr.concat(out, dim="time")
 
 
-@declare_units(tas="[temperature]")
-def degree_days(tas: xr.DataArray, threshold: str, op: str) -> xr.DataArray:
-    """Calculate the degree days below/above the temperature threshold.
+def cumulative_difference(
+    data: xr.DataArray, threshold: str, op: str, freq: str | None = None
+) -> xr.DataArray:
+    """Calculate the cumulative difference below/above a given value threshold.
 
     Parameters
     ----------
-    tas : xr.DataArray
-        Mean daily temperature.
+    data : xr.DataArray
+        Data for which to determine the cumulative difference.
     threshold : str
-        The temperature threshold.
+        The value threshold.
     op : {">", "gt", "<", "lt", ">=", "ge", "<=", "le"}
         Logical operator. e.g. arr > thresh.
+    freq : str, optional
+        Resampling frequency defining the periods as defined in
+        https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#resampling.
+        If `None`, no resampling is performed. Default: `None`.
 
     Returns
     -------
     xr.DataArray
     """
-    threshold = convert_units_to(threshold, tas)
+    threshold = convert_units_to(threshold, data)
 
     if op in ["<", "<=", "lt", "le"]:
-        out = (threshold - tas).clip(0)
+        diff = (threshold - data).clip(0)
     elif op in [">", ">=", "gt", "ge"]:
-        out = (tas - threshold).clip(0)
+        diff = (data - threshold).clip(0)
     else:
         raise NotImplementedError(f"Condition not supported: '{op}'.")
 
-    return to_agg_units(out, tas, op="delta_prod")
+    if freq is not None:
+        diff = diff.resample(time=freq).sum(dim="time")
+
+    return to_agg_units(diff, data, op="delta_prod")
+
+
+def degree_days(
+    data: xr.DataArray, threshold: str, op: str, freq=None
+) -> xr.DataArray:  # noqa: D103
+    warnings.warn(
+        "The `degree_days` generic indice is being deprecated in favour of `cumulative_difference`. "
+        "This indice will be removed in `xclim>=0.40.0`. Please update your scripts accordingly.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+
+    return cumulative_difference(data, threshold=threshold, op=op, freq=freq)
 
 
 def first_day_threshold_reached(
@@ -840,9 +870,11 @@ def first_day_threshold_reached(
     after_date : str
         Date of the year after which to look for the first event. Should have the format '%m-%d'.
     window : int
-        Minimum number of days with values above threshold needed for evaluation.
+        Minimum number of days with values above threshold needed for evaluation. Default: 1.
     freq : str
-        Resampling frequency.
+        Resampling frequency defining the periods as defined in
+        https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#resampling.
+        Default: "YS".
     constrain : sequence of str, optional
         Optionally allowed conditions.
 

--- a/xclim/testing/tests/test_generic.py
+++ b/xclim/testing/tests/test_generic.py
@@ -263,7 +263,7 @@ class TestAggregateBetweenDates:
             generic.aggregate_between_dates(data, bad_start, end, op="sum", freq="YS")
 
 
-class TestDegreeDays:
+class TestCumulativeDifference:
     @pytest.mark.parametrize(
         "op, expected",
         [("gt", [0, 5, 10, 0, 0]), (">=", [0, 5, 10, 0, 0]), ("<", [20, 0, 0, 7, 0])],
@@ -271,8 +271,8 @@ class TestDegreeDays:
     def test_simple(self, tas_series, op, expected):
         tas = tas_series(np.array([-10, 15, 20, 3, 10]) + K2C)
 
-        out = generic.degree_days(tas, threshold="10 degC", op=op)
-        out_kelvin = generic.degree_days(tas, threshold="283.15 degK", op=op)
+        out = generic.cumulative_difference(tas, threshold="10 degC", op=op)
+        out_kelvin = generic.cumulative_difference(tas, threshold="283.15 degK", op=op)
 
         np.testing.assert_allclose(out, expected)
         np.testing.assert_allclose(out, out_kelvin)
@@ -281,7 +281,13 @@ class TestDegreeDays:
         tas = tas_series(np.array([-10, 15, 20, 3, 10]) + K2C)
 
         with pytest.raises(NotImplementedError):
-            generic.degree_days(tas, threshold="10 degC", op="!=")
+            generic.cumulative_difference(tas, threshold="10 degC", op="!=")
+
+    def test_deprecated(self, tas_series):
+        tas = tas_series(np.array([-10, 15, 20, 3, 10]) + K2C)
+
+        with pytest.warns(DeprecationWarning):
+            generic.degree_days(tas, threshold="10 degC", op=">=")
 
 
 class TestFirstDayThreshold:


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1200
- [x] Tests for the changes have been added (for bug fixes / features)
  - [x] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added
- [x] The relevant author information has been added to `AUTHORS.rst` and `.zenodo.json`

### What kind of change does this PR introduce?

* Create `generic.cumulative_difference` indice.
* Deprecate `generic.degree_days`
* Link `heating/cooling/growing_degree_days` to `cumulative_difference`
* Docstring adjustments

### Does this PR introduce a breaking change?

No*. This PR introduces changes that will become breaking in xclim v0.40.0 

### Other information:
