### PR TITLE
Adapt to current pint

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -35,6 +35,7 @@ Bug fixes
 ^^^^^^^^^
 * The docstring of ``cool_night_index`` suggested that `lat` was an optional parameter. This has been corrected. (:issue:`1179`, :pull:`1180`).
 * The ``mean_radiant_temperature`` indice was accessing hardcoded `lat` and `lon` coordinates from passed DataArrays. This now uses `cf-xarray` accessors. (:pull:`1180`).
+* Adopt (and adapt) unit registry declaration and preprocessors from ``cf-xarray`` to circumvent bugs caused by a refactor in ``pint`` 0.20. It also cleans the code a little bit. (:issue:`1211`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -35,7 +35,7 @@ Bug fixes
 ^^^^^^^^^
 * The docstring of ``cool_night_index`` suggested that `lat` was an optional parameter. This has been corrected. (:issue:`1179`, :pull:`1180`).
 * The ``mean_radiant_temperature`` indice was accessing hardcoded `lat` and `lon` coordinates from passed DataArrays. This now uses `cf-xarray` accessors. (:pull:`1180`).
-* Adopt (and adapt) unit registry declaration and preprocessors from ``cf-xarray`` to circumvent bugs caused by a refactor in ``pint`` 0.20. It also cleans the code a little bit. (:issue:`1211`).
+* Adopt (and adapt) unit registry declaration and preprocessors from ``cf-xarray`` to circumvent bugs caused by a refactor in ``pint`` 0.20. It also cleans the code a little bit. (:issue:`1211`, :pull:`1212`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1211 
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added
- [x] The relevant author information has been added to `AUTHORS.rst` and `.zenodo.json`

### What kind of change does this PR introduce?

* Changes how the `UnitRegistry` is declared, by copying the one from `cf-xarray`.
* I also copied the declaration of the % unit from `cf-xarray`
* This removed the need to import things that were refactored in `pint`0.20, so it fixes this.
* It also allowed to remove the string processing stuff from `units2pint`, this is now directly in the registry's `preprocessors`.
* I removed the `force_ndarray_like=True` option that `cf-xarray` uses because it made our tests fail. I haven't looked further, this is to be done in #1010.

### Does this PR introduce a breaking change?
It shouldn't!
