### PR TITLE
Make show_versions portable for other libraries

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -48,6 +48,7 @@ Internal changes
 * In order to reduce computation footprint, the GitHub CI full testing suite and doctests are now only run once a pull request has been reviewed and approved. The number of simultaneously triggered builds has also been reduced. (:issue:`1155`, :pull:`1203`).
 * ReadTheDocs now only builds full documentation (including running notebooks) when pull requests are merged to the main branch. (:issue:`1155`, :pull:`1203`).
 * `xclim` now leverages `pytest-xdist` to distribute tests among Python workers and significantly speed up the testing suite. (:pull:`1203`).
+* ``show_versions`` can now accept a list of dependencies so that other libraries can make use of this utility. (:pull:`1215`).
 
 0.38.0 (2022-09-06)
 -------------------

--- a/xclim/testing/utils.py
+++ b/xclim/testing/utils.py
@@ -443,7 +443,7 @@ def publish_release_notes(
 
 def show_versions(
     file: os.PathLike | StringIO | TextIO | None = None,
-    deps: list = "xclim",
+    deps: list | None = None,
 ) -> str | None:
     """Print the versions of xclim and its dependencies.
 
@@ -451,14 +451,14 @@ def show_versions(
     ----------
     file : {os.PathLike, StringIO, TextIO}, optional
         If provided, prints to the given file-like object. Otherwise, returns a string.
-    deps : list
-        A list of dependencies to gather and print version information from.
+    deps : list, optional
+        A list of dependencies to gather and print version information from. Otherwise, prints `xclim` dependencies.
 
     Returns
     -------
     str or None
     """
-    if deps == "xclim":
+    if deps is None:
         deps = _xclim_deps
 
     dependency_versions = [(d, lambda mod: mod.__version__) for d in deps]

--- a/xclim/testing/utils.py
+++ b/xclim/testing/utils.py
@@ -23,10 +23,8 @@ from xarray import Dataset
 from xarray import open_dataset as _open_dataset
 from yaml import safe_dump, safe_load
 
-from xclim import __version__
-
-_xclim_version = dict(xclim=__version__)
 _xclim_deps = [
+    "xclim",
     "xarray",
     "sklearn",
     "scipy",
@@ -445,7 +443,6 @@ def publish_release_notes(
 
 def show_versions(
     file: os.PathLike | StringIO | TextIO | None = None,
-    main_version: dict = "xclim",
     deps: list = "xclim",
 ) -> str | None:
     """Print the versions of xclim and its dependencies.
@@ -454,8 +451,6 @@ def show_versions(
     ----------
     file : {os.PathLike, StringIO, TextIO}, optional
         If provided, prints to the given file-like object. Otherwise, returns a string.
-    main_version : dict
-        A dictionary with the name of the primary library and its version string as value, e.g. {"xclim"="1.0"}
     deps : list
         A list of dependencies to gather and print version information from.
 
@@ -463,8 +458,6 @@ def show_versions(
     -------
     str or None
     """
-    if main_version == "xclim":
-        main_version = _xclim_version
     if deps == "xclim":
         deps = _xclim_deps
 
@@ -492,18 +485,10 @@ def show_versions(
         "INSTALLED VERSIONS",
         "------------------",
         f"python: {platform.python_version()}",
+        f"{modules_versions}",
+        f"Anaconda-based environment: {'yes' if Path(sys.base_prefix).joinpath('conda-meta').exists() else 'no'}",
     ]
 
-    if main_version:
-        main = [f"{key}: {value}" for key, value in main_version.items()]
-        installed_versions.extend(main)
-
-    installed_versions.extend(
-        [
-            f"{modules_versions}",
-            f"Anaconda-based environment: {'yes' if Path(sys.base_prefix).joinpath('conda-meta').exists() else 'no'}",
-        ]
-    )
     message = "\n".join(installed_versions)
 
     if not file:


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Makes it so that `show_versions` can be called by other libraries that depend on xclim showing _their_ dependency versions, if desired

### Does this PR introduce a breaking change?

No.

### Other information:

See: https://github.com/Ouranosinc/xscen/issues/109