### PR TITLE
Fix doctests

### DIFF
--- a/docs/notebooks/sdba-advanced.ipynb
+++ b/docs/notebooks/sdba-advanced.ipynb
@@ -54,6 +54,7 @@
     "from __future__ import annotations\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
+    "import nc_time_axis\n",
     "import numpy as np\n",
     "import xarray as xr\n",
     "\n",

--- a/docs/notebooks/sdba.ipynb
+++ b/docs/notebooks/sdba.ipynb
@@ -23,6 +23,7 @@
     "\n",
     "import cftime\n",
     "import matplotlib.pyplot as plt\n",
+    "import nc_time_axis\n",
     "import numpy as np\n",
     "import xarray as xr\n",
     "\n",


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1226
- [x] Tests for the changes have been added (for bug fixes / features)
  - [x] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?
Explicitly import `nc_time_axis` in the notebooks needing it, to avoid a regression bug of xarray 2022.11.0.

The bug was fixed upstream (I think), but no new xarray release was done yet. I thought this fix was small enough and made the behaviour more explicit so it was worth it even if the next xarray fixes it.

Upon import, `nc_time_axis` injects functionality in `matplotlib` so that `cftime` coordinates are supported. Previously, xarray imported it automatically on its own importation. In the next versions, `nc_time_axis` will only be imported if it is `xarray` which is doing the plotting of `cftime` coordinates, which is a bit different.

### Does this PR introduce a breaking change?
No.