### PR TITLE
Fix reordering logic in MBCn example

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -27,6 +27,7 @@ Breaking changes
 Bug fixes
 ^^^^^^^^^
 * The weighted ensemble statistics are now performed within a context in order to preserve data attributes. (:issue:`1232`, :pull:`1234`).
+* The MBCn example in documentation has been fixed to properly imitate the source. (:issue:`1249`, :pull:`1250`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/docs/notebooks/sdba.ipynb
+++ b/docs/notebooks/sdba.ipynb
@@ -510,7 +510,7 @@
     "##### Stack the variables to multivariate arrays and standardize them\n",
     "The standardization process ensure the mean and standard deviation of each column (variable) is 0 and 1 respectively.\n",
     "\n",
-    "`hist` and `sim` are standardized together so the two series are coherent. We keep the mean and standard deviation to be reused when we build the result."
+    "`scenh` and `scens` are standardized together so the two series are coherent. As we'll see further, we do not need to keep the mean and standard deviation as we only keep the rank order information from the `NpdfTransform` output."
    ]
   },
   {
@@ -527,9 +527,9 @@
     "# Standardize\n",
     "ref, _, _ = sdba.processing.standardize(ref)\n",
     "\n",
-    "allsim, savg, sstd = sdba.processing.standardize(xr.concat((scenh, scens), \"time\"))\n",
-    "hist = allsim.sel(time=scenh.time)\n",
-    "sim = allsim.sel(time=scens.time)"
+    "allsim_std, _, _ = sdba.processing.standardize(xr.concat((scenh, scens), \"time\"))\n",
+    "scenh_std = allsim.sel(time=scenh.time)\n",
+    "scens_std = allsim.sel(time=scens.time)"
    ]
   },
   {
@@ -553,21 +553,17 @@
     "with set_options(sdba_extra_output=True):\n",
     "    out = sdba.adjustment.NpdfTransform.adjust(\n",
     "        ref,\n",
-    "        hist,\n",
-    "        sim,\n",
+    "        scenh_std,\n",
+    "        scens_std,\n",
     "        base=sdba.QuantileDeltaMapping,  # Use QDM as the univariate adjustment.\n",
     "        base_kws={\"nquantiles\": 20, \"group\": \"time\"},\n",
     "        n_iter=20,  # perform 20 iteration\n",
     "        n_escore=1000,  # only send 1000 points to the escore metric (it is realy slow)\n",
     "    )\n",
     "\n",
-    "scenh = out.scenh.rename(time_hist=\"time\")  # Bias-adjusted historical period\n",
-    "scens = out.scen  # Bias-adjusted future period\n",
-    "extra = out.drop_vars([\"scenh\", \"scen\"])\n",
-    "\n",
-    "# Un-standardize (add the mean and the std back)\n",
-    "scenh = sdba.processing.unstandardize(scenh, savg, sstd)\n",
-    "scens = sdba.processing.unstandardize(scens, savg, sstd)"
+    "scenh_npdft = out.scenh.rename(time_hist=\"time\")  # Bias-adjusted historical period\n",
+    "scens_npdft = out.scen  # Bias-adjusted future period\n",
+    "extra = out.drop_vars([\"scenh\", \"scen\"])"
    ]
   },
   {
@@ -587,8 +583,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "scenh = sdba.processing.reordering(hist, scenh, group=\"time\")\n",
-    "scens = sdba.processing.reordering(sim, scens, group=\"time\")"
+    "scenh = sdba.processing.reordering(scenh_npdft, scenh, group=\"time\")\n",
+    "scens = sdba.processing.reordering(scens_npdft, scens, group=\"time\")"
    ]
   },
   {
@@ -701,7 +697,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.10.6"
   },
   "toc": {
    "base_numbering": 1,

--- a/docs/notebooks/sdba.ipynb
+++ b/docs/notebooks/sdba.ipynb
@@ -528,8 +528,8 @@
     "ref, _, _ = sdba.processing.standardize(ref)\n",
     "\n",
     "allsim_std, _, _ = sdba.processing.standardize(xr.concat((scenh, scens), \"time\"))\n",
-    "scenh_std = allsim.sel(time=scenh.time)\n",
-    "scens_std = allsim.sel(time=scens.time)"
+    "scenh_std = allsim_std.sel(time=scenh.time)\n",
+    "scens_std = allsim_std.sel(time=scens.time)"
    ]
   },
   {
@@ -603,7 +603,7 @@
    "source": [
     "##### There we are!\n",
     "\n",
-    "Let's trigger all the computations. Here we write the data to disk and use `compute=False` in order to trigger the whole computation tree only once. There seems to be no way in xarray to do the same with a `load` call."
+    "Let's trigger all the computations. The use of `dask.compute` allows the three DataArrays to be computed at the same time, avoiding repeating the common steps."
    ]
   },
   {
@@ -615,16 +615,10 @@
     "from dask import compute\n",
     "from dask.diagnostics import ProgressBar\n",
     "\n",
-    "tasks = [\n",
-    "    scenh.isel(location=2).to_netcdf(\"mbcn_scen_hist_loc2.nc\", compute=False),\n",
-    "    scens.isel(location=2).to_netcdf(\"mbcn_scen_sim_loc2.nc\", compute=False),\n",
-    "    extra.escores.isel(location=2)\n",
-    "    .to_dataset()\n",
-    "    .to_netcdf(\"mbcn_escores_loc2.nc\", compute=False),\n",
-    "]\n",
-    "\n",
     "with ProgressBar():\n",
-    "    compute(tasks)"
+    "    scenh, scens, escores = compute(\n",
+    "        scenh.isel(location=2), scens.isel(location=2), extra.escores.isel(location=2)\n",
+    "    )"
    ]
   },
   {
@@ -640,8 +634,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "scenh = xr.open_dataset(\"mbcn_scen_hist_loc2.nc\")\n",
-    "\n",
     "fig, ax = plt.subplots()\n",
     "\n",
     "dref.isel(location=2).tasmax.plot(ax=ax, label=\"Reference\")\n",
@@ -657,20 +649,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "escores = xr.open_dataarray(\"mbcn_escores_loc2.nc\")\n",
-    "diff_escore = escores.differentiate(\"iterations\")\n",
-    "diff_escore.plot()\n",
-    "plt.title(\"Difference of the subsequent e-scores.\")\n",
-    "plt.ylabel(\"E-scores difference\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "diff_escore"
+    "escores.plot()\n",
+    "plt.title(\"E-scores for each iteration.\")\n",
+    "plt.xlabel(\"iteration\")\n",
+    "plt.ylabel(\"E-score\")"
    ]
   },
   {


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1249
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* The MBCn example was doing it wrong. The NpdfT output was being reordered according to the initial adjustment, while the opposite is supposed to be done. I also renamed some variables in a way I think is clearer.

### Does this PR introduce a breaking change?
No.

### Other information:
