### PR TITLE
Add doc for CFFWIS - Reload modules

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,13 +4,18 @@ History
 
 0.41.0 (unreleased)
 -------------------
-Contributors to this version: Trevor James Smith (:user:`Zeitsperre`)
+Contributors to this version: Trevor James Smith (:user:`Zeitsperre`), Pascal Bourgault (:user:`aulemahal`).
+
+Bug fixes
+^^^^^^^^^
+* ``build_indicator_module_from_yaml`` now accepts a ``reload`` argument. When re-building a module that already exists,  ``reload=True`` removes all previous indicator before creating the new ones. (:issue:`1192`,:pull:`1284`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^
 * `xclim` has adopted `PEP 517 <https://peps.python.org/pep-0517/>`_ and `PEP 621 <https://peps.python.org/pep-0621/>`_ (``pyproject.toml`` using the `flit <https://flit.pypa.io/en/stable/>`_ backend) to replace the legacy ``setup.py`` used to manage package organisation and building. Many tooling configurations that already supported the ``pyproject.toml`` standard have been migrated to this file. CI and development tooling documentation has been updated to reflect these changes. (:pull:`1278`, suggested from `PyOpenSci Software Review <https://github.com/pyOpenSci/software-review/issues/73>`_).
 * Documentation source files have been moved around to remove some duplicated image files. (:pull:`1278`).
 * Coveralls GitHub Action removed as it did not support ``pyproject.toml``-based configurations. (:pull:`1278`).
+* Add a remark about how xclim's CFFWIS is different from the original 1982 implementation. (:issue:`1104`, :pull:`1284`).
 
 0.40.0 (2023-01-13)
 -------------------

--- a/xclim/indices/fire/_cffwis.py
+++ b/xclim/indices/fire/_cffwis.py
@@ -11,7 +11,8 @@ information available at :cite:t:`code-natural_resources_canada_data_nodate`.
 First adapted from Matlab code `CalcFWITimeSeriesWithStartup.m` from GFWED :cite:p:`fire-wang_updated_2015` made
 for using MERRA2 data, which was a translation of FWI.vba of the Canadian Fire Weather Index system. Then, updated and
 synchronized with the R code of the cffdrs package. When given the correct parameters, the current code has an error
-below 3% when compared with the :cite:t:`fire-field_development_2015` data.
+below 3% when compared with the :cite:t:`fire-field_development_2015` data. The cffdrs R package is different from the
+original 1982 implementation, and so is xclim.
 
 Parts of the code and of the documentation in this submodule are directly taken from :cite:t:`code-cantin_canadian_2014`
 which was published with the GPLv2 license.
@@ -1338,7 +1339,8 @@ def cffwis_indices(
     Notes
     -----
     See :cite:t:`code-natural_resources_canada_data_nodate`, the :py:mod:`xclim.indices.fire` module documentation,
-    and the docstring of :py:func:`fire_weather_ufunc` for more information.
+    and the docstring of :py:func:`fire_weather_ufunc` for more information. This algorithm follows the official R code
+    released by the CFS, which contains revisions from the original 1982 Fortran code.
 
     References
     ----------
@@ -1438,7 +1440,8 @@ def drought_code(
     Notes
     -----
     See :cite:cts:`code-natural_resources_canada_data_nodate`, the :py:mod:`xclim.indices.fire` module documentation,
-    and the docstring of :py:func:`fire_weather_ufunc` for more information.
+    and the docstring of :py:func:`fire_weather_ufunc` for more information. This algorithm follows the official R code
+    released by the CFS, which contains revisions from the original 1982 Fortran code.
 
     References
     ----------


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1104 and fixes #1192
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [x] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* ``build_indicator_module_from_yaml`` now accepts a ``reload`` argument. When re-building a module that already exists,  ``reload=True`` removes all previous indicator before creating the new ones. (:issue:`1192`,:pull:`1284`).
* Add a remark about how xclim's CFFWIS is different from the original 1982 implementation. (:issue:`1104`, :pull:`1284`).

### Does this PR introduce a breaking change?
No.

### Other information:
