### PR TITLE
add context='infer'

### DIFF
--- a/xclim/sdba/adjustment.py
+++ b/xclim/sdba/adjustment.py
@@ -647,7 +647,7 @@ class ExtremeValues(TrainAdjust):
         ref_params: xr.Dataset = None,
         q_thresh: float = 0.95,
     ):
-        cluster_thresh = convert_units_to(cluster_thresh, ref)
+        cluster_thresh = convert_units_to(cluster_thresh, ref, context='infer')
 
         # Approximation of how many "quantiles" values we will get:
         N = (1 - q_thresh) * ref.time.size


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

*  Adding 'infer' context in the unit conversion of the training of ExtremeValues. The goal is to be able to pass a threshold in mm d-1 even if the ref is in kg m-2 s-1. 

### Does this PR introduce a breaking change?
A threshold in mm d-1 used to work, then it didn't with the addition of the `context` arg, but now it works again!

### Other information:
ExtremeValues is often used with precipitation data.