### PR TITLE
Fix: pre-commit conda-forge package

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -43,7 +43,7 @@ dependencies:
     - nc-time-axis
     - netCDF4>=1.4
     - pooch
-    - pre_commit
+    - pre-commit
     - pybtex
     - pydocstyle
     - pylint<2.15


### PR DESCRIPTION
Boring fix of pre-commit conda-forge package used in environment.yml.

There are two conda-forge packages for `pre-commit` I was afraid `pre_commit` (underscored) might be a fraud (that's a very common way of distributing malware, at least on npm), but it seems to just be the former version of pre-commit.

See: https://github.com/search?q=org%3Aconda-forge+pre_commit 