### PR TITLE
Fix mean radiant temperature segfaults

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,7 @@ Internal changes
     * The documentation now includes a page explaining the reasons for developing `xclim` and a section briefly detailing similar and related projects.
     * Markdown explanations in some Jupyter Notebooks have been edited for clarity
 * Removed `Mapping` abstract base class types in call signatures (`dict` variables were always expected). (:pull:`1308`).
+* Changes in testing setup now prevent ``test_mean_radiant_temperature`` from sometimes causing a segmentation fault. (:issue:`1303`, :pull:`1315`).
 
 0.41.0 (2023-02-28)
 -------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,6 +179,5 @@ usefixtures = "xdoctest_namespace"
 doctest_optionflags = ["NORMALIZE_WHITESPACE", "IGNORE_EXCEPTION_DETAIL", "NUMBER", "ELLIPSIS"]
 markers = [
   "slow: marks tests as slow (deselect with '-m \"not slow\"')",
-  "requires_docs: mark tests that can only be run with documentation present",
-  "thread_unsafe: Causes segfaults with pytest-xdist distributed testing"
+  "requires_docs: mark tests that can only be run with documentation present"
 ]

--- a/xclim/testing/tests/conftest.py
+++ b/xclim/testing/tests/conftest.py
@@ -13,6 +13,7 @@ import xarray as xr
 from filelock import FileLock
 
 import xclim
+from xclim.core import indicator
 from xclim.core.calendar import max_doy
 from xclim.testing.tests.data import (
     add_example_file_paths,
@@ -571,8 +572,8 @@ def is_matplotlib_installed(xdoctest_namespace) -> None:
 @pytest.fixture
 def official_indicators():
     # Remove unofficial indicators (as those created during the tests, and those from YAML-built modules)
-    registry_cp = xclim.core.indicator.registry.copy()
-    for cls in xclim.core.indicator.registry.values():
+    registry_cp = indicator.registry.copy()
+    for cls in indicator.registry.values():
         if cls.identifier.upper() != cls._registry_id:
             registry_cp.pop(cls._registry_id)
     return registry_cp

--- a/xclim/testing/tests/conftest.py
+++ b/xclim/testing/tests/conftest.py
@@ -585,7 +585,7 @@ def atmosds(threadsafe_data_dir) -> xr.Dataset:
         threadsafe_data_dir.joinpath("atmosds.nc"),
         cache_dir=threadsafe_data_dir,
         branch=TESTDATA_BRANCH,
-    )
+    ).load()
 
 
 @pytest.fixture(scope="function")

--- a/xclim/testing/tests/test_atmos.py
+++ b/xclim/testing/tests/test_atmos.py
@@ -556,10 +556,10 @@ class TestMeanRadiantTemperature:
     def test_mean_radiant_temperature(self, atmosds):
         dataset = atmosds
 
-        rsds = dataset.rsds.copy(deep=True)
-        rsus = dataset.rsus.copy(deep=True)
-        rlds = dataset.rlds.copy(deep=True)
-        rlus = dataset.rlus.copy(deep=True)
+        rsds = dataset.rsds
+        rsus = dataset.rsus
+        rlds = dataset.rlds
+        rlus = dataset.rlus
 
         # Expected values
         exp_sun = [np.nan, np.nan, np.nan, np.nan, np.nan]

--- a/xclim/testing/tests/test_atmos.py
+++ b/xclim/testing/tests/test_atmos.py
@@ -552,16 +552,14 @@ class TestUTCI:
         np.testing.assert_allclose(utci.isel(time=0), utci_exp, rtol=1e-03)
 
 
-@pytest.mark.skipif(sys.version_info == (3, 10), reason="Crashes often on Python3.10")
-@pytest.mark.thread_unsafe
 class TestMeanRadiantTemperature:
     def test_mean_radiant_temperature(self, atmosds):
         dataset = atmosds
 
-        rsds = dataset.rsds
-        rsus = dataset.rsus
-        rlds = dataset.rlds
-        rlus = dataset.rlus
+        rsds = dataset.rsds.copy(deep=True)
+        rsus = dataset.rsus.copy(deep=True)
+        rlds = dataset.rlds.copy(deep=True)
+        rlus = dataset.rlus.copy(deep=True)
 
         # Expected values
         exp_sun = [np.nan, np.nan, np.nan, np.nan, np.nan]


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1303 
- [x] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* adjustments to tests to prevent `test_mean_radiant_temperature()` from causing segfaults

### Does this PR introduce a breaking change?

No.

### Other information:

There is something thread-unsafe when making multiple calls to `atmos.mean_radiant_temperature`. My theory is that `dask` is trying to read the exact same blocks of data in rapid succession, as the values between all calls are being compared at the same time. If we `.load()` this data, we don't trigger and this is fine, somehow.