### PR TITLE
Remove deprecated indicators/indices, handle warnings 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,12 +19,15 @@ Breaking changes
 * Many previously deprecated indices and indicators have been removed from `xclim` (:pull:`1318`), with replacement indicators suggested as follows:
     - ``xclim.indicators.atmos.first_day_above`` ->  ``xclim.indicators.atmos.first_day_{tn | tg | tx}_above``
     - ``xclim.indicators.atmos.first_day_below`` -> ``xclim.indicators.atmos.first_day_{tn | tg | tx}_below``
-    - ``xclim.indicators.land.snow_cover_duration`` -> ``xclim.indicators.land.snd_season_length``
-    - ``xclim.indices.snow_cover_duration`` -> ``xclim.indices.snd_season_length``
-    - ``xclim.indicators.land.continuous_snow_cover_start`` -> ``xclim.indicators.land.snd_season_start``
-    - ``xclim.indices.continuous_snow_cover_start`` -> ``xclim.indices.snd_season_start``
     - ``xclim.indicators.land.continuous_snow_cover_end`` -> ``xclim.indicators.land.snd_season_end``
+    - ``xclim.indicators.land.continuous_snow_cover_start`` -> ``xclim.indicators.land.snd_season_start``
+    - ``xclim.indicators.land.fit`` -> ``xclim.indicators.generic.fit``
+    - ``xclim.indicators.land.frequency_analysis`` -> ``xclim.indicators.generic.return_level``
+    - ``xclim.indicators.land.snow_cover_duration`` -> ``xclim.indicators.land.snd_season_length``
+    - ``xclim.indicators.land.stats`` -> ``xclim.indicators.generic.stats``
     - ``xclim.indices.continuous_snow_cover_end`` -> ``xclim.indices.snd_season_end``
+    - ``xclim.indices.continuous_snow_cover_start`` -> ``xclim.indices.snd_season_start``
+    - ``xclim.indices.snow_cover_duration`` -> ``xclim.indices.snd_season_length``
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,17 +9,17 @@ Contributors to this version: Trevor James Smith (:user:`Zeitsperre`).
 Breaking changes
 ^^^^^^^^^^^^^^^^
 * Many previously deprecated indices and indicators have been removed from `xclim` (:pull:`1318`), with replacement indicators suggested as follows:
-    - ``xclim.indicators.atmos.first_day_above`` ->  ``xclim.indicators.atmos.first_day_{tn | tg | tx}_above``
-    - ``xclim.indicators.atmos.first_day_below`` -> ``xclim.indicators.atmos.first_day_{tn | tg | tx}_below``
-    - ``xclim.indicators.land.continuous_snow_cover_end`` -> ``xclim.indicators.land.snd_season_end``
-    - ``xclim.indicators.land.continuous_snow_cover_start`` -> ``xclim.indicators.land.snd_season_start``
-    - ``xclim.indicators.land.fit`` -> ``xclim.indicators.generic.fit``
-    - ``xclim.indicators.land.frequency_analysis`` -> ``xclim.indicators.generic.return_level``
-    - ``xclim.indicators.land.snow_cover_duration`` -> ``xclim.indicators.land.snd_season_length``
-    - ``xclim.indicators.land.stats`` -> ``xclim.indicators.generic.stats``
-    - ``xclim.indices.continuous_snow_cover_end`` -> ``xclim.indices.snd_season_end``
-    - ``xclim.indices.continuous_snow_cover_start`` -> ``xclim.indices.snd_season_start``
-    - ``xclim.indices.snow_cover_duration`` -> ``xclim.indices.snd_season_length``
+    * ``xclim.indicators.atmos.first_day_above`` ->  ``xclim.indicators.atmos.first_day_{tn | tg | tx}_above``
+    * ``xclim.indicators.atmos.first_day_below`` -> ``xclim.indicators.atmos.first_day_{tn | tg | tx}_below``
+    * ``xclim.indicators.land.continuous_snow_cover_end`` -> ``xclim.indicators.land.snd_season_end``
+    * ``xclim.indicators.land.continuous_snow_cover_start`` -> ``xclim.indicators.land.snd_season_start``
+    * ``xclim.indicators.land.fit`` -> ``xclim.indicators.generic.fit``
+    * ``xclim.indicators.land.frequency_analysis`` -> ``xclim.indicators.generic.return_level``
+    * ``xclim.indicators.land.snow_cover_duration`` -> ``xclim.indicators.land.snd_season_length``
+    * ``xclim.indicators.land.stats`` -> ``xclim.indicators.generic.stats``
+    * ``xclim.indices.continuous_snow_cover_end`` -> ``xclim.indices.snd_season_end``
+    * ``xclim.indices.continuous_snow_cover_start`` -> ``xclim.indices.snd_season_start``
+    * ``xclim.indices.snow_cover_duration`` -> ``xclim.indices.snd_season_length``
 
 Internal changes
 ^^^^^^^^^^^^^^^^
@@ -67,15 +67,15 @@ Internal changes
 ^^^^^^^^^^^^^^^^
 * Added `xclim` to the `ouranos Zenodo community <https://zenodo.org/communities/ouranos/>`_ . (:pull:`1313`).
 * Significant documentation adjustments. (:issue:`1305`, :pull:`1308`):
-    - The CONTRIBUTING page has been moved to the top level of the repository.
-    - Information concerning the licensing of xclim is clearly indicated in README.
-    - `sphinx-autodoc-typehints` is now used to simplify call signatures generated in documentation.
-    - The SDBA module API is now found with the rest of the User API documentation.
-    - `HISTORY.rst` has been renamed `CHANGES.rst`, to follow `dask`-like conventions.
-    - Hyperlink targets for individual `indices` and `indicators` now point to their entries under `API` or `Indices`.
-    - Module-level docstrings have migrated from the library scripts directly into the documentation RestructuredText files.
-    - The documentation now includes a page explaining the reasons for developing `xclim` and a section briefly detailing similar and related projects.
-    - Markdown explanations in some Jupyter Notebooks have been edited for clarity
+    * The CONTRIBUTING page has been moved to the top level of the repository.
+    * Information concerning the licensing of xclim is clearly indicated in README.
+    * `sphinx-autodoc-typehints` is now used to simplify call signatures generated in documentation.
+    * The SDBA module API is now found with the rest of the User API documentation.
+    * `HISTORY.rst` has been renamed `CHANGES.rst`, to follow `dask`-like conventions.
+    * Hyperlink targets for individual `indices` and `indicators` now point to their entries under `API` or `Indices`.
+    * Module-level docstrings have migrated from the library scripts directly into the documentation RestructuredText files.
+    * The documentation now includes a page explaining the reasons for developing `xclim` and a section briefly detailing similar and related projects.
+    * Markdown explanations in some Jupyter Notebooks have been edited for clarity
 * Removed `Mapping` abstract base class types in call signatures (`dict` variables were always expected). (:pull:`1308`).
 * Changes in testing setup now prevent ``test_mean_radiant_temperature`` from sometimes causing a segmentation fault. (:issue:`1303`, :pull:`1315`).
 * Addressed a formatting bug that caused `Indicators` with multiple variables returned to not be properly formatted in the documentation. (:issue:`1305`, :pull:`1317`).

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,24 +15,34 @@ New features and enhancements
 Breaking changes
 ^^^^^^^^^^^^^^^^
 * The call signatures for ``xclim.ensembles.create_ensemble`` and ``xclim.ensembles._base._ens_align_dataset`` have been deprecated. Calls to these functions made with the original signature will emit warnings. Changes will become breaking in `xclim>=0.43.0`.(:issue:`1305`, :pull:`1317`). Affected variable:
-    * `mf_flag` (bool) -> `multifile` (bool)
+    - `mf_flag` (bool) -> `multifile` (bool)
+* Many previously deprecated indices and indicators have been removed from `xclim` (:pull:`1318`), with replacement indicators suggested as follows:
+    - ``xclim.indicators.atmos.first_day_above`` ->  ``xclim.indicators.atmos.first_day_{tn | tg | tx}_above``
+    - ``xclim.indicators.atmos.first_day_below`` -> ``xclim.indicators.atmos.first_day_{tn | tg | tx}_below``
+    - ``xclim.indicators.land.snow_cover_duration`` -> ``xclim.indicators.land.snd_season_length``
+    - ``xclim.indices.snow_cover_duration`` -> ``xclim.indices.snd_season_length``
+    - ``xclim.indicators.land.continuous_snow_cover_start`` -> ``xclim.indicators.land.snd_season_start``
+    - ``xclim.indices.continuous_snow_cover_start`` -> ``xclim.indices.snd_season_start``
+    - ``xclim.indicators.land.continuous_snow_cover_end`` -> ``xclim.indicators.land.snd_season_end``
+    - ``xclim.indices.continuous_snow_cover_end`` -> ``xclim.indices.snd_season_end``
 
 Internal changes
 ^^^^^^^^^^^^^^^^
 * Added `xclim` to the `ouranos Zenodo community <https://zenodo.org/communities/ouranos/>`_ . (:pull:`1313`).
 * Significant documentation adjustments. (:issue:`1305`, :pull:`1308`):
-    * The CONTRIBUTING page has been moved to the top level of the repository.
-    * Information concerning the licensing of xclim is clearly indicated in README.
-    * `sphinx-autodoc-typehints` is now used to simplify call signatures generated in documentation.
-    * The SDBA module API is now found with the rest of the User API documentation.
-    * `HISTORY.rst` has been renamed `CHANGES.rst`, to follow `dask`-like conventions.
-    * Hyperlink targets for individual `indices` and `indicators` now point to their entries under `API` or `Indices`.
-    * Module-level docstrings have migrated from the library scripts directly into the documentation RestructuredText files.
-    * The documentation now includes a page explaining the reasons for developing `xclim` and a section briefly detailing similar and related projects.
-    * Markdown explanations in some Jupyter Notebooks have been edited for clarity
+    - The CONTRIBUTING page has been moved to the top level of the repository.
+    - Information concerning the licensing of xclim is clearly indicated in README.
+    - `sphinx-autodoc-typehints` is now used to simplify call signatures generated in documentation.
+    - The SDBA module API is now found with the rest of the User API documentation.
+    - `HISTORY.rst` has been renamed `CHANGES.rst`, to follow `dask`-like conventions.
+    - Hyperlink targets for individual `indices` and `indicators` now point to their entries under `API` or `Indices`.
+    - Module-level docstrings have migrated from the library scripts directly into the documentation RestructuredText files.
+    - The documentation now includes a page explaining the reasons for developing `xclim` and a section briefly detailing similar and related projects.
+    - Markdown explanations in some Jupyter Notebooks have been edited for clarity
 * Removed `Mapping` abstract base class types in call signatures (`dict` variables were always expected). (:pull:`1308`).
 * Changes in testing setup now prevent ``test_mean_radiant_temperature`` from sometimes causing a segmentation fault. (:issue:`1303`, :pull:`1315`).
 * Addressed a formatting bug that caused `Indicators` with multiple variables returned to not be properly formatted in the documentation. (:issue:`1305`, :pull:`1317`).
+* The testing suite has been adjusted to ensure calls are made to existing functions using non-deprecated syntax. The volume of warnings emitted during testing has been significantly reduced. (:pull:`1318`).
 
 0.41.0 (2023-02-28)
 -------------------

--- a/xclim/data/fr.json
+++ b/xclim/data/fr.json
@@ -792,12 +792,6 @@
     "title": "Humidité spécifique calculée à partir de la température du point de rosée et de la pression",
     "abstract": "Humidité spécifique calculée à partir de la température du point de rosée et de la pression à l'aide de la pression de vapeur saturante."
   },
-  "FIRST_DAY_BELOW": {
-    "long_name": "Premier jour de l'année avec une température quotidienne sous un seuil",
-    "description": "Premier jour de l'année après {after_date} ayant une température quotidienne sous {thresh} pour au moins {window} jours.",
-    "title": "Premier jour de l'année avec une température quotidienne sous un seuil",
-    "abstract": "Calcule le premier jour d'une période où la température moyenne quotidienne est sous un seuil donné pendant un nombre de jours, après une date de calendrier donnée."
-  },
   "FIRST_DAY_TG_BELOW": {
     "long_name": "Premier jour de l'année avec une température moyenne quotidienne sous {thresh} durant au moins {window} jours",
     "description": "Premier jour de l'année avec une température moyenne quotidienne sous {thresh} durant au moins {window} jours.",
@@ -815,12 +809,6 @@
     "description": "Premier jour de l'année avec une température maximale quotidienne sous {thresh} durant au moins {window} jours.",
     "title": "Premier jour de l'année de températures maximales quotidiennes sous un seuil",
     "abstract": "Calcule le premier jour d'une période où la température maximale quotidienne est plus basse qu'un certain seuil durant un nombre de jours donné, limité par une date minimale."
-  },
-  "FIRST_DAY_ABOVE": {
-    "long_name": "Premier jour de l'année avec une température quotidienne au-dessus d'un seuil",
-    "description": "Premier jour de l'année avec une température quotidienne au-dessus de {thresh} pour au moins {window} jours après {after_date}.",
-    "title": "Premier jour de l'année avec un température quotidienne au-dessus d'un seuil",
-    "abstract": "Calcule le premier jour d'une période où la température quotidienne est au-dessus d'un seuil donné pendant un nombre de jours, après une date de calendrier donnée."
   },
   "FIRST_DAY_TG_ABOVE": {
     "long_name": "Premier jour de l'année avec une température moyenne quotidienne au-dessus de {thresh} durant au moins {window} jours",
@@ -893,24 +881,6 @@
     "description": "Nombre {freq:m} de jours où la précipitation solide est plus grande que {low} et plus petite ou égale à {high}.",
     "title": "Jours avec neige",
     "abstract": "Nombre de jours où la neige est entre une borne inférieure et supérieure."
-  },
-  "SNOW_COVER_DURATION": {
-    "long_name": "Nombre de jour où l'épaisseur de neige est au-dessus d'un seuil",
-    "description": "Nombre {freq:m} de jours où l'épaisseur de neige est au-dessus ou égale à {thresh}.",
-    "title": "Durée du couvert de neige",
-    "abstract": "Nombre de jours pendant lesquels l'épaisseur de neige est au-dessus ou égale à un seuil donné."
-  },
-  "CONTINUOUS_SNOW_COVER_START": {
-    "long_name": "Date du début du couvert de neige continu",
-    "description": "Première date à laquelle l'épaisseur de neige est au-dessus ou égale à {thresh} pendant au moins {window} jours consécutifs.",
-    "title": "Date du début du couvert de neige",
-    "abstract": "Première date à partir de laquelle l'épaisseur de neige est au-dessus ou égale à un seuil donné pendant un nombre de jours consécutifs."
-  },
-  "CONTINUOUS_SNOW_COVER_END": {
-    "long_name": "Date de fin du couvert de neige continu",
-    "description": "Première date à laquelle l'épaisseur de neige passe sous {thresh} pendant au moins {window} jours consécutifs suite à l'établissement du couvert de neige.",
-    "title": "Date du fin du couvert de neige",
-    "abstract": "Première date à partir de laquelle l'épaisseur de neige est sous à un seuil donné pendant un nombre de jours consécutifs suite au début du couvert de neige."
   },
   "SND_SEASON_LENGTH": {
     "long_name": "Durée de couvert de neige",

--- a/xclim/data/fr.json
+++ b/xclim/data/fr.json
@@ -601,12 +601,6 @@
     "title": "Indice Richards-Baker de torrentialité",
     "abstract": "Mesure des oscillations du débit relatif au débit moyen, quantifiant la fréquence et la rapidité des changements de débits."
   },
-  "FREQ_ANALYSIS": {
-    "long_name": "Valeur de retour du débit",
-    "description": "Analyse fréquentielle de type {dist:f} des débits moyens sur {window} jours, pour le {mode} {indexer}.",
-    "title": "Valeur de retour",
-    "abstract": "Analyse fréquentielle des débits selon un mode et une distribution."
-  },
   "RETURN_LEVEL": {
     "long_name": "Valeur de retour",
     "description": "Analyse fréquentielle de type {dist:f} des moyennes sur {window} jours, pour le {mode} {indexer}.",

--- a/xclim/indicators/atmos/_temperature.py
+++ b/xclim/indicators/atmos/_temperature.py
@@ -56,11 +56,9 @@ __all__ = [
     "freshet_start",
     "frost_days",
     "last_spring_frost",
-    "first_day_above",
     "first_day_tg_above",
     "first_day_tn_above",
     "first_day_tx_above",
-    "first_day_below",
     "first_day_tg_below",
     "first_day_tn_below",
     "first_day_tx_below",
@@ -730,22 +728,6 @@ last_spring_frost = Temp(
     parameters={"before_date": {"default": "07-01"}},
 )
 
-first_day_below = Temp(
-    title="First day below",
-    identifier="first_day_below",
-    units="",
-    standard_name="day_of_year",
-    long_name="First day of year with temperature below threshold",
-    description="First day of year with temperature below {thresh} for at least {window} days after {after_date}.",
-    abstract="Calculates the first day of a period when the temperature is lower than a certain threshold during a "
-    "given number of days, after a given calendar date.",
-    cell_methods="",
-    compute=indices.first_day_temperature_below,
-    input=dict(tas="tasmin"),
-    parameters={"after_date": {"default": "07-01"}},
-    _version_deprecated="0.39.0",
-)
-
 first_day_tn_below = Temp(
     identifier="first_day_tn_below",
     units="",
@@ -788,22 +770,6 @@ first_day_tx_below = Temp(
         after_date={"default": "07-01"},
         op={"default": "<"},
     ),
-)
-
-first_day_above = Temp(
-    title="First day above",
-    identifier="first_day_above",
-    units="",
-    standard_name="day_of_year",
-    long_name="First day of year with temperature above threshold",
-    description="First day of year with temperature above {thresh} for at least {window} days after {after_date}.",
-    abstract="Calculates the first day of a period when the temperature is higher than a certain threshold during a "
-    "given number of days, after a given calendar date.",
-    cell_methods="",
-    compute=indices.first_day_temperature_above,
-    input=dict(tas="tasmin"),
-    parameters={"after_date": {"default": "07-01"}},
-    _version_deprecated="0.39.0",
 )
 
 first_day_tn_above = Temp(

--- a/xclim/indicators/land/_snow.py
+++ b/xclim/indicators/land/_snow.py
@@ -6,22 +6,19 @@ from xclim.indicators.atmos._conversion import Converter  # noqa
 
 __all__ = [
     "blowing_snow",
-    "snow_cover_duration",
-    "snd_season_length",
-    "snw_season_length",
-    "continuous_snow_cover_start",
-    "snd_season_start",
-    "snw_season_start",
-    "continuous_snow_cover_end",
-    "snd_season_end",
-    "snw_season_end",
     "snd_max_doy",
+    "snd_season_end",
+    "snd_season_length",
+    "snd_season_start",
     "snd_to_snw",
     "snow_depth",
-    "snw_to_snd",
     "snow_melt_we_max",
     "snw_max",
     "snw_max_doy",
+    "snw_season_end",
+    "snw_season_length",
+    "snw_season_start",
+    "snw_to_snd",
     "winter_storm",
 ]
 
@@ -36,17 +33,6 @@ class SnowWithIndexing(ResamplingIndicatorWithIndexing):
 
     src_freq = "D"
 
-
-snow_cover_duration = SnowWithIndexing(
-    title="Snow cover duration (depth) ",
-    identifier="snow_cover_duration",
-    units="days",
-    long_name="Snow cover duration",
-    description="The {freq} number of days with snow depth greater than or equal to {thresh}.",
-    abstract="Number of days when the snow depth is greater than or equal to a given threshold.",
-    compute=xci.snow_cover_duration,
-    _version_deprecated="0.41.0",
-)
 
 snd_season_length = SnowWithIndexing(
     title="Snow cover duration (depth)",
@@ -66,19 +52,6 @@ snw_season_length = SnowWithIndexing(
     description="The {freq} number of days with snow amount greater than or equal to {thresh}.",
     abstract="Number of days when the snow amount is greater than or equal to a given threshold.",
     compute=xci.snw_season_length,
-)
-
-continuous_snow_cover_start = Snow(
-    title="Start date of continuous snow depth cover",
-    identifier="continuous_snow_cover_start",
-    standard_name="day_of_year",
-    long_name="Start date of continuous snow depth cover",
-    description="Day of year when snow depth is above or equal to {thresh} for {window} consecutive days.",
-    abstract="The first date on which snow depth is greater than or equal to a given threshold "
-    "for a given number of consecutive days.",
-    units="",
-    compute=xci.continuous_snow_cover_start,
-    _version_deprecated="0.41.0",
 )
 
 snd_season_start = Snow(
@@ -103,18 +76,6 @@ snw_season_start = Snow(
     "for a given number of consecutive days.",
     units="",
     compute=xci.snw_season_start,
-)
-
-continuous_snow_cover_end = Snow(
-    title="End date of continuous snow depth cover",
-    identifier="continuous_snow_cover_end",
-    standard_name="day_of_year",
-    long_name="End date of continuous snow depth cover",
-    description="Day of year when snow depth is below {thresh} for {window} consecutive days.",
-    abstract="The first date on which snow depth is below a given threshold for a given number of consecutive days.",
-    units="",
-    compute=xci.continuous_snow_cover_end,
-    _version_deprecated="0.41.0",
 )
 
 snd_season_end = Snow(

--- a/xclim/indicators/land/_streamflow.py
+++ b/xclim/indicators/land/_streamflow.py
@@ -5,15 +5,10 @@ from xclim.core.cfchecks import check_valid
 from xclim.core.indicator import Indicator, ResamplingIndicator
 from xclim.core.units import declare_units
 from xclim.indices import base_flow_index, generic, rb_flashiness_index
-from xclim.indices.stats import fit as _fit
-from xclim.indices.stats import frequency_analysis
 
 __all__ = [
     "base_flow_index",
     "rb_flashiness_index",
-    "freq_analysis",
-    "stats",
-    "fit",
     "doy_qmax",
     "doy_qmin",
 ]
@@ -38,20 +33,6 @@ base_flow_index = Streamflow(
     compute=base_flow_index,
 )
 
-freq_analysis = Streamflow(
-    title="Return level",
-    identifier="freq_analysis",
-    var_name="q{window}{mode:r}{indexer}",
-    long_name="N-year return level discharge",
-    description="Streamflow frequency analysis for the {mode} {indexer} {window}-day flow estimated using the {dist} "
-    "distribution.",
-    abstract="Streamflow frequency analysis on the basis of a given mode and distribution.",
-    units="m^3 s-1",
-    compute=frequency_analysis,
-    missing="skip",
-    input={"da": "discharge"},
-    _version_deprecated="0.40",
-)
 
 rb_flashiness_index = Streamflow(
     title="Richards-Baker Flashiness Index",
@@ -63,37 +44,6 @@ rb_flashiness_index = Streamflow(
     abstract="Measurement of flow oscillations relative to average flow, "
     "quantifying the frequency and speed of flow changes.",
     compute=rb_flashiness_index,
-)
-
-
-stats = Streamflow(
-    title="Statistic of the daily flow for a given period.",
-    identifier="discharge_stats",
-    var_name="q{indexer}{op:r}",
-    long_name="Daily flow statistics",
-    description="{freq} {op} of daily flow ({indexer}).",
-    units="m^3 s-1",
-    compute=generic.select_resample_op,
-    missing="any",
-    input={"da": "discharge"},
-    _version_deprecated="0.40",
-)
-
-
-fit = Indicator(
-    title="Distribution parameters fitted over the time dimension.",
-    identifier="discharge_distribution_fit",
-    var_name="params",
-    units="",
-    standard_name="{dist} parameters",
-    long_name="{dist} distribution parameters",
-    description="Parameters of the {dist} distribution.",
-    cell_methods="time: fit",
-    src_freq=None,
-    compute=_fit,
-    input={"da": "discharge"},
-    realm="land",
-    _version_deprecated="0.40",
 )
 
 

--- a/xclim/indicators/land/_streamflow.py
+++ b/xclim/indicators/land/_streamflow.py
@@ -1,8 +1,6 @@
 """Streamflow indicator definitions."""
 from __future__ import annotations
 
-from abc import ABC
-
 from xclim.core.cfchecks import check_valid
 from xclim.core.indicator import Indicator, ResamplingIndicator
 from xclim.core.units import declare_units

--- a/xclim/indices/_threshold.py
+++ b/xclim/indices/_threshold.py
@@ -40,8 +40,6 @@ __all__ = [
     "daily_pr_intensity",
     "degree_days_exceedance_date",
     "cooling_degree_days",
-    "continuous_snow_cover_end",
-    "continuous_snow_cover_start",
     "snd_season_end",
     "snd_season_start",
     "snw_season_end",
@@ -64,7 +62,6 @@ __all__ = [
     "heating_degree_days",
     "hot_spell_frequency",
     "hot_spell_max_length",
-    "snow_cover_duration",
     "snd_season_length",
     "snw_season_length",
     "tn_days_above",
@@ -236,54 +233,6 @@ def cold_spell_frequency(
 
 
 @declare_units(snd="[length]", thresh="[length]")
-def continuous_snow_cover_end(
-    snd: xarray.DataArray,
-    thresh: Quantified = "2 cm",
-    window: int = 14,
-    freq: str = "AS-JUL",
-) -> xarray.DataArray:
-    r"""End date of continuous snow depth cover.
-
-    First day after the start of the continuous snow depth cover when snow depth is below a threshold (default: 2 cm)
-    for at least `N` (default: 14) consecutive days.
-
-    Warnings
-    --------
-    * The default `freq` is valid for the northern hemisphere.
-    * This index will be removed in a future version of xclim.
-
-    Parameters
-    ----------
-    snd : xarray.DataArray
-        Surface snow thickness.
-    thresh : str
-        Threshold snow thickness.
-    window : int
-        Minimum number of days with snow depth below threshold.
-    freq : str
-        Resampling frequency.
-
-    Returns
-    -------
-    xarray.DataArray, [dimensionless]
-        First day after the start of the continuous snow depth cover when the snow depth
-        goes below a threshold for a minimum duration.
-        If there is no such day, returns np.nan.
-
-    References
-    ----------
-    :cite:cts:`chaumont_elaboration_2017`
-    """
-    warnings.warn(
-        "The `continuous_snow_cover_end` is being deprecated in favour of `snd_season_end`"
-        "This indice will be removed in `xclim>=0.42.0`. Please update your scripts accordingly.",
-        DeprecationWarning,
-        stacklevel=3,
-    )
-    return snd_season_end(snd, thresh, window, freq)
-
-
-@declare_units(snd="[length]", thresh="[length]")
 def snd_season_end(
     snd: xarray.DataArray,
     thresh: Quantified = "2 cm",
@@ -385,53 +334,6 @@ def snw_season_end(
     )
     out.attrs.update(units="", is_dayofyear=np.int32(1), calendar=get_calendar(snw))
     return out.where(~valid)
-
-
-@declare_units(snd="[length]", thresh="[length]")
-def continuous_snow_cover_start(
-    snd: xarray.DataArray,
-    thresh: Quantified = "2 cm",
-    window: int = 14,
-    freq: str = "AS-JUL",
-) -> xarray.DataArray:
-    r"""Start date of continuous snow depth cover.
-
-    Day of year when snow depth is above or equal to a threshold (default: 2 cm)
-    for at least `N` (default: 14) consecutive days.
-
-    Warnings
-    --------
-    * The default `freq` is valid for the northern hemisphere.
-    * This index will be removed in a future version of xclim.
-
-    Parameters
-    ----------
-    snd : xarray.DataArray
-        Surface snow thickness.
-    thresh : str
-        Threshold snow thickness.
-    window : int
-        Minimum number of days with snow depth above or equal to threshold.
-    freq : str
-        Resampling frequency.
-
-    Returns
-    -------
-    xarray.DataArray, [dimensionless]
-        First day of the year when the snow depth is superior to a threshold for a minimum duration.
-        If there is no such day, returns np.nan.
-
-    References
-    ----------
-    :cite:cts:`chaumont_elaboration_2017`
-    """
-    warnings.warn(
-        "The `continuous_snow_cover_end` is being deprecated in favour of `snd_season_end`"
-        "This indice will be removed in `xclim>=0.42.0`. Please update your scripts accordingly.",
-        DeprecationWarning,
-        stacklevel=3,
-    )
-    return snd_season_start(snd, thresh, window, freq)
 
 
 @declare_units(snd="[length]", thresh="[length]")
@@ -1702,43 +1604,6 @@ def hot_spell_frequency(
     out = group.map(rl.windowed_run_events, window=window, dim="time")
     out.attrs["units"] = ""
     return out
-
-
-@declare_units(snd="[length]", thresh="[length]")
-def snow_cover_duration(
-    snd: xarray.DataArray, thresh: Quantified = "2 cm", freq: str = "AS-JUL"
-) -> xarray.DataArray:
-    # noqa: D401
-    """Number of days with snow depth above a threshold.
-
-    Number of days where surface snow depth is greater or equal to given threshold (default: 2 cm).
-
-    Warnings
-    --------
-    * The default `freq` is valid for the northern hemisphere.
-    * This index will be removed in a future version of xclim.
-
-    Parameters
-    ----------
-    snd : xarray.DataArray
-        Surface snow thickness.
-    thresh : str
-        Threshold snow thickness.
-    freq : str
-        Resampling frequency.
-
-    Returns
-    -------
-    xarray.DataArray, [time]
-        Number of days where snow depth is greater than or equal to threshold.
-    """
-    warnings.warn(
-        "The `snow_cover_duration` is being deprecated in favour of `snd_season_length` "
-        "This indice will be removed in `xclim>=0.42.0`. Please update your scripts accordingly.",
-        DeprecationWarning,
-        stacklevel=3,
-    )
-    return snd_season_length(snd, thresh, freq)
 
 
 @declare_units(snd="[length]", thresh="[length]")

--- a/xclim/indices/generic.py
+++ b/xclim/indices/generic.py
@@ -743,7 +743,7 @@ def aggregate_between_dates(
         """Get bound in number of days since base_time. Bound can be a days_since array or a DayOfYearStr."""
         if isinstance(_bound, str):
             b_i = rl.index_of_date(_group.time, _bound, max_idxs=1)  # noqa
-            if not b_i:
+            if not b_i.size > 0:
                 return None
             return (_group.time.isel(time=b_i[0]) - _group.time.isel(time=0)).dt.days
         if _base_time in _bound.time:

--- a/xclim/testing/tests/test_generic_indicators.py
+++ b/xclim/testing/tests/test_generic_indicators.py
@@ -41,11 +41,11 @@ class TestReturnLevel:
             ndq_series, mode="max", t=[2, 5], dist="gamma", season="DJF"
         )
 
-        assert out.description in [
-            "Streamflow frequency analysis for the maximal winter 1-day flow "
-            "estimated using the gamma distribution."
-        ]
-        assert out.name == "q1maxwinter"
+        assert out.description == (
+            "Frequency analysis for the maximal winter 1-day value estimated using the "
+            "gamma distribution."
+        )
+        assert out.name == "fa_1maxwinter"
         assert out.shape == (2, 2, 3)  # nrt, nx, ny
         np.testing.assert_array_equal(out.isnull(), False)
 
@@ -75,13 +75,6 @@ class TestReturnLevel:
         )
         assert np.isnan(out.values[:, 0, 0]).all()
 
-    def test_wrong_variable(self, pr_series):
-        with pytest.raises(ValidationError):
-            with pytest.warns(DeprecationWarning):
-                generic.return_level(
-                    pr_series(np.random.rand(100)), mode="max", t=2, dist="gamma"
-                )
-
 
 class TestStats:
     """See other tests in test_land::TestStats"""
@@ -93,7 +86,7 @@ class TestStats:
 
     def test_ndq(self, ndq_series):
         out = generic.stats(ndq_series, freq="YS", op="min", season="MAM")
-        assert out.attrs["units"] == "m^3 s-1"
+        assert out.attrs["units"] == "m3 s-1"
 
     def test_missing(self, ndq_series):
         a = ndq_series

--- a/xclim/testing/tests/test_indices.py
+++ b/xclim/testing/tests/test_indices.py
@@ -416,12 +416,9 @@ class TestAgroclimaticIndices:
         mx = tasmax_series(mg + K2C + 10)
         mn = tasmin_series(mg + K2C - 10)
 
-        # This indice is complaining about implicit unit specifications
-        # Indice logic / variable handling may need to be revised
-        with pytest.warns(FutureWarning):
-            out = xci.effective_growing_degree_days(
-                tasmax=mx, tasmin=mn, method=method, freq="YS"
-            )
+        out = xci.effective_growing_degree_days(
+            tasmax=mx, tasmin=mn, method=method, freq="YS"
+        )
 
         np.testing.assert_array_equal(out, np.array([np.NaN, expected]))
 
@@ -2397,17 +2394,7 @@ def test_snowfall_approximation(pr_series, tasmax_series, method, exp):
     pr = pr_series(np.ones(10))
     tasmax = tasmax_series(np.arange(10) + K2C)
 
-    # "brown" method is complaining about implicit unit definitions
-    # Method logical / variable handling may need to be revised in the indice
-    if method == "brown":
-        with pytest.warns(FutureWarning):
-            prsn = xci.snowfall_approximation(
-                pr, tas=tasmax, thresh="2 degC", method=method
-            )
-    else:
-        prsn = xci.snowfall_approximation(
-            pr, tas=tasmax, thresh="2 degC", method=method
-        )
+    prsn = xci.snowfall_approximation(pr, tas=tasmax, thresh="2 degC", method=method)
 
     np.testing.assert_allclose(prsn, exp, atol=1e-5, rtol=1e-3)
 

--- a/xclim/testing/tests/test_indices.py
+++ b/xclim/testing/tests/test_indices.py
@@ -415,9 +415,14 @@ class TestAgroclimaticIndices:
 
         mx = tasmax_series(mg + K2C + 10)
         mn = tasmin_series(mg + K2C - 10)
-        out = xci.effective_growing_degree_days(
-            tasmax=mx, tasmin=mn, method=method, freq="YS"
-        )
+
+        # This indice is complaining about implicit unit specifications
+        # Indice logic / variable handling may need to be revised
+        with pytest.warns(FutureWarning):
+            out = xci.effective_growing_degree_days(
+                tasmax=mx, tasmin=mn, method=method, freq="YS"
+            )
+
         np.testing.assert_array_equal(out, np.array([np.NaN, expected]))
 
     # gamma reference results: Obtained with `monocongo/climate_indices` library
@@ -2392,7 +2397,17 @@ def test_snowfall_approximation(pr_series, tasmax_series, method, exp):
     pr = pr_series(np.ones(10))
     tasmax = tasmax_series(np.arange(10) + K2C)
 
-    prsn = xci.snowfall_approximation(pr, tas=tasmax, thresh="2 degC", method=method)
+    # "brown" method is complaining about implicit unit definitions
+    # Method logical / variable handling may need to be revised in the indice
+    if method == "brown":
+        with pytest.warns(FutureWarning):
+            prsn = xci.snowfall_approximation(
+                pr, tas=tasmax, thresh="2 degC", method=method
+            )
+    else:
+        prsn = xci.snowfall_approximation(
+            pr, tas=tasmax, thresh="2 degC", method=method
+        )
 
     np.testing.assert_allclose(prsn, exp, atol=1e-5, rtol=1e-3)
 

--- a/xclim/testing/tests/test_indices.py
+++ b/xclim/testing/tests/test_indices.py
@@ -14,7 +14,6 @@
 from __future__ import annotations
 
 import calendar
-import os
 
 import numpy as np
 import pandas as pd
@@ -25,7 +24,6 @@ from xclim import indices as xci
 from xclim.core.calendar import date_range, percentile_doy
 from xclim.core.options import set_options
 from xclim.core.units import ValidationError, convert_units_to, units
-from xclim.indices.generic import first_day_threshold_reached
 
 K2C = 273.15
 

--- a/xclim/testing/tests/test_land.py
+++ b/xclim/testing/tests/test_land.py
@@ -2,11 +2,9 @@
 from __future__ import annotations
 
 import numpy as np
-import pytest
 import xarray as xr
 
 from xclim import land
-from xclim.core.utils import ValidationError
 
 
 def test_base_flow_index(ndq_series):
@@ -19,36 +17,6 @@ def test_rb_flashiness_index(ndq_series):
     out = land.base_flow_index(ndq_series, freq="YS")
     assert out.attrs["units"] == ""
     assert isinstance(out, xr.DataArray)
-
-
-class TestFreqAnalysisDeprecated:
-    def test_simple(self, ndq_series):
-        with pytest.warns(DeprecationWarning):
-            out = land.freq_analysis(
-                ndq_series, mode="max", t=[2, 5], dist="gamma", season="DJF"
-            )
-
-        assert out.description in [
-            "Streamflow frequency analysis for the maximal winter 1-day flow "
-            "estimated using the gamma distribution."
-        ]
-        assert out.name == "q1maxwinter"
-        assert out.shape == (2, 2, 3)  # nrt, nx, ny
-        np.testing.assert_array_equal(out.isnull(), False)
-
-    def test_wrong_variable(self, pr_series):
-        with pytest.raises(ValidationError):
-            with pytest.warns(DeprecationWarning):
-                land.freq_analysis(
-                    pr_series(np.random.rand(100)), mode="max", t=2, dist="gamma"
-                )
-
-
-class TestStatsDeprecated:
-    def test_simple(self, ndq_series):
-        with pytest.warns(DeprecationWarning):
-            out = land.stats(ndq_series, freq="YS", op="min", season="MAM")
-        assert out.attrs["units"] == "m^3 s-1"
 
 
 def test_qdoy_max(ndq_series, q_series):

--- a/xclim/testing/tests/test_land.py
+++ b/xclim/testing/tests/test_land.py
@@ -5,8 +5,8 @@ import numpy as np
 import pytest
 import xarray as xr
 
-import xclim.core.utils
 from xclim import land
+from xclim.core.utils import ValidationError
 
 
 def test_base_flow_index(ndq_series):
@@ -21,11 +21,13 @@ def test_rb_flashiness_index(ndq_series):
     assert isinstance(out, xr.DataArray)
 
 
-class Test_FA:
+class TestFreqAnalysisDeprecated:
     def test_simple(self, ndq_series):
-        out = land.freq_analysis(
-            ndq_series, mode="max", t=[2, 5], dist="gamma", season="DJF"
-        )
+        with pytest.warns(DeprecationWarning):
+            out = land.freq_analysis(
+                ndq_series, mode="max", t=[2, 5], dist="gamma", season="DJF"
+            )
+
         assert out.description in [
             "Streamflow frequency analysis for the maximal winter 1-day flow "
             "estimated using the gamma distribution."
@@ -34,48 +36,19 @@ class Test_FA:
         assert out.shape == (2, 2, 3)  # nrt, nx, ny
         np.testing.assert_array_equal(out.isnull(), False)
 
-    def test_no_indexer(self, ndq_series):
-        out = land.freq_analysis(ndq_series, mode="max", t=[2, 5], dist="gamma")
-        assert out.description in [
-            "Streamflow frequency analysis for the maximal annual 1-day flow "
-            "estimated using the gamma distribution."
-        ]
-        assert out.name == "q1maxannual"
-        assert out.shape == (2, 2, 3)  # nrt, nx, ny
-        np.testing.assert_array_equal(out.isnull(), False)
-
-    def test_q27(self, ndq_series):
-        out = land.freq_analysis(ndq_series, mode="max", t=2, dist="gamma", window=7)
-        assert out.shape == (1, 2, 3)
-
-    def test_empty(self, ndq_series):
-        q = ndq_series.copy()
-        q[:, 0, 0] = np.nan
-        out = land.freq_analysis(
-            q, mode="max", t=2, dist="genextreme", window=6, freq="YS"
-        )
-        assert np.isnan(out.values[:, 0, 0]).all()
-
     def test_wrong_variable(self, pr_series):
-        with pytest.raises(xclim.core.utils.ValidationError):
-            land.freq_analysis(
-                pr_series(np.random.rand(100)), mode="max", t=2, dist="gamma"
-            )
+        with pytest.raises(ValidationError):
+            with pytest.warns(DeprecationWarning):
+                land.freq_analysis(
+                    pr_series(np.random.rand(100)), mode="max", t=2, dist="gamma"
+                )
 
 
-class TestStats:
+class TestStatsDeprecated:
     def test_simple(self, ndq_series):
-        out = land.stats(ndq_series, freq="YS", op="min", season="MAM")
+        with pytest.warns(DeprecationWarning):
+            out = land.stats(ndq_series, freq="YS", op="min", season="MAM")
         assert out.attrs["units"] == "m^3 s-1"
-
-    def test_missing(self, ndq_series):
-        a = ndq_series
-        a = ndq_series.where(~((a.time.dt.dayofyear == 5) * (a.time.dt.year == 1902)))
-        assert a.shape == (5000, 2, 3)
-        out = land.stats(a, op="max", month=1)
-
-        np.testing.assert_array_equal(out.sel(time="1900").isnull(), False)
-        np.testing.assert_array_equal(out.sel(time="1902").isnull(), True)
 
 
 def test_qdoy_max(ndq_series, q_series):

--- a/xclim/testing/tests/test_sdba/test_processing.py
+++ b/xclim/testing/tests/test_sdba/test_processing.py
@@ -86,7 +86,7 @@ def test_adapt_freq(use_dask):
     # Where the input is considered zero
     input_zeros = sim_ad.where(prsim <= 1)
 
-    # The proportion of corrected values (time.size * 3 * 0.2 is the theoritical number of values under 1 in prsim)
+    # The proportion of corrected values (time.size * 3 * 0.2 is the theoretical number of values under 1 in prsim)
     dP0_out = (input_zeros > 1).sum() / (time.size * 3 * 0.2)
     np.testing.assert_allclose(dP0_out, 0.5, atol=0.1)
 

--- a/xclim/testing/tests/test_stats.py
+++ b/xclim/testing/tests/test_stats.py
@@ -120,18 +120,19 @@ def genextreme(request):
     return da
 
 
-def test_fit(fitda):
-    p = stats.fit(fitda, "lognorm")
+class TestFit:
+    def test_fit(self, fitda):
+        p = stats.fit(fitda, "lognorm")
 
-    assert p.dims[0] == "dparams"
-    assert p.get_axis_num("dparams") == 0
-    p0 = lognorm.fit(fitda.values[:, 0, 0])
-    np.testing.assert_array_equal(p[:, 0, 0], p0)
+        assert p.dims[0] == "dparams"
+        assert p.get_axis_num("dparams") == 0
+        p0 = lognorm.fit(fitda.values[:, 0, 0])
+        np.testing.assert_array_equal(p[:, 0, 0], p0)
 
-    # Check that we can reuse the parameters with scipy distributions
-    cdf = lognorm.cdf(0.99, *p.values)
-    assert cdf.shape == (fitda.x.size, fitda.y.size)
-    assert p.attrs["estimator"] == "Maximum likelihood"
+        # Check that we can reuse the parameters with scipy distributions
+        cdf = lognorm.cdf(0.99, *p.values)
+        assert cdf.shape == (fitda.x.size, fitda.y.size)
+        assert p.attrs["estimator"] == "Maximum likelihood"
 
 
 def test_weibull_min_fit(weibull_min):


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1281
- [x] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Deprecated Indicators have been removed:
  * first_day_below, first_day_above, snow_cover_duration, continuous_snow_cover_start, continuous_snow_cover_end
* Deprecated indices have been removed:
  * snow_cover_duration, continuous_snow_cover_start, continuous_snow_cover_end
* Most remaining deprecated calls to tests have been updated to new standards
* ~Indices that emit FutureWarnings through regular use have been identified:~
  * ~`snowfall_approximation` (`method='brown'`)~
  * ~`effective_growing_degree_days`~
  * See #1319 

### Does this PR introduce a breaking change?

Yes. This removes all currently-marked deprecated indices and indicators.

### Other information:

The volume of warnings emitted from `pytest` is significantly reduced. The only warnings now emitted are those coming from lower-level libraries, like `numpy` and `xarray`. This should make it easier to identify and handle these instances moving forward.