### PR TITLE
Adjust last_spring_frost variable and introduce `op` in seasonal indices

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,9 @@ Breaking changes
 ^^^^^^^^^^^^^^^^
 * The call signatures for ``xclim.ensembles.create_ensemble`` and ``xclim.ensembles._base._ens_align_dataset`` have been deprecated. Calls to these functions made with the original signature will emit warnings. Changes will become breaking in `xclim>=0.43.0`.(:issue:`1305`, :pull:`1317`). Affected variable:
     * `mf_flag` (bool) -> `multifile` (bool)
+* The indice and indicator for ``last_spring_frost`` has been modified to use ``tasmin`` by default, reflecting its docstring and literature definition (:issue:`1324`, :pull:`1325`).
+* following indices now accept the `op` argument for modifying the threshold comparison operator (:pull:`1325`):
+    * ``snw_season_length``, ``snd_season_length``, ``growing_season_length``, ``frost_season_length``, ``frost_free_season_length``, ``rprcptot``, ``daily_pr_intensity``
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/xclim/indicators/atmos/_temperature.py
+++ b/xclim/indicators/atmos/_temperature.py
@@ -723,7 +723,7 @@ last_spring_frost = Temp(
     "for at least {window} days before a given date ({before_date})",
     description="Day of year of last spring frost, defined as the last day a minimum temperature "
     "remains below a threshold of {thresh} for at least {window} days before a given date ({before_date}).",
-    abstract="The last day when temperature is below a given threshold for a certain number of days, "
+    abstract="The last day when minimum temperature is below a given threshold for a certain number of days, "
     "limited by a final calendar date.",
     cell_methods="",
     compute=indices.last_spring_frost,

--- a/xclim/indices/_threshold.py
+++ b/xclim/indices/_threshold.py
@@ -899,6 +899,7 @@ def growing_season_length(
     window: int = 6,
     mid_date: DayOfYearStr = "07-01",
     freq: str = "YS",
+    op: str = ">=",
 ) -> xarray.DataArray:
     r"""Growing season length.
 
@@ -923,6 +924,8 @@ def growing_season_length(
         Date of the year after which to look for the end of the season. Should have the format '%m-%d'.
     freq : str
         Resampling frequency.
+    op : {">", ">=", "gt", "ge"}
+        Comparison operation. Default: ">=".
 
     Returns
     -------
@@ -963,7 +966,7 @@ def growing_season_length(
 
     """
     thresh = convert_units_to(thresh, tas)
-    cond = tas >= thresh
+    cond = compare(tas, op, thresh, constrain=(">=", ">"))
 
     out = cond.resample(time=freq).map(
         rl.season_length,
@@ -981,6 +984,7 @@ def frost_season_length(
     mid_date: DayOfYearStr | None = "01-01",
     thresh: Quantified = "0.0 degC",
     freq: str = "AS-JUL",
+    op: str = "<",
 ) -> xarray.DataArray:
     r"""Frost season length.
 
@@ -1006,6 +1010,8 @@ def frost_season_length(
         Threshold temperature on which to base evaluation.
     freq : str
         Resampling frequency.
+    op : {"<", "<=", "lt", "le"}
+        Comparison operation. Default: "<".
 
     Returns
     -------
@@ -1041,7 +1047,7 @@ def frost_season_length(
     >>> fsl_sh = frost_season_length(tasmin, freq="YS")
     """
     thresh = convert_units_to(thresh, tasmin)
-    cond = tasmin < thresh
+    cond = compare(tasmin, op, thresh, constrain=("<=", "<"))
 
     out = cond.resample(time=freq).map(
         rl.season_length,
@@ -1161,6 +1167,7 @@ def frost_free_season_length(
     mid_date: DayOfYearStr | None = "07-01",
     thresh: Quantified = "0.0 degC",
     freq: str = "YS",
+    op: str = ">=",
 ) -> xarray.DataArray:
     r"""Frost free season length.
 
@@ -1186,6 +1193,8 @@ def frost_free_season_length(
         Threshold temperature on which to base evaluation.
     freq : str
         Resampling frequency.
+    op : {">", ">=", "gt", "ge"}
+        Comparison operation. Default: ">=".
 
     Returns
     -------
@@ -1221,7 +1230,7 @@ def frost_free_season_length(
     >>> ffsl_sh = frost_free_season_length(tasmin, freq="AS-JUL")
     """
     thresh = convert_units_to(thresh, tasmin)
-    cond = tasmin >= thresh
+    cond = compare(tasmin, op, thresh, constrain=(">=", ">"))
 
     out = cond.resample(time=freq).map(
         rl.season_length,
@@ -1754,7 +1763,10 @@ def snow_cover_duration(
 
 @declare_units(snd="[length]", thresh="[length]")
 def snd_season_length(
-    snd: xarray.DataArray, thresh: Quantified = "2 cm", freq: str = "AS-JUL"
+    snd: xarray.DataArray,
+    thresh: Quantified = "2 cm",
+    freq: str = "AS-JUL",
+    op: str = ">=",
 ) -> xarray.DataArray:
     # noqa: D401
     """Number of days with snow depth above a threshold.
@@ -1773,6 +1785,8 @@ def snd_season_length(
         Threshold snow thickness.
     freq : str
         Resampling frequency.
+    op : {">", ">=", "gt", "ge"}
+        Comparison operation. Default: ">=".
 
     Returns
     -------
@@ -1781,7 +1795,7 @@ def snd_season_length(
     """
     valid = at_least_n_valid(snd.where(snd > 0), n=1, freq=freq)
     thresh = convert_units_to(thresh, snd)
-    out = threshold_count(snd, ">=", thresh, freq)
+    out = threshold_count(snd, op, thresh, freq)
     return to_agg_units(out, snd, "count").where(~valid)
 
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1324 
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Adjust both the docstring and the call signature of `last_spring_frost` indice and indicator to specify `tasmin`
* Adds the `op` functionality to `snw_season_length`, `snd_season_length`, `growing_season_length`, `frost_season_length`, `frost_free_season_length`,  `rprcptot`, `daily_pr_intensity`

### Does this PR introduce a breaking change?

Yes. `last_spring_frost` now uses tasmin by default (major), and other indices now support optional `op` with non-breaking default settings in their call signatures.

### Other information:
