### PR TITLE
Add `pyet` to list of similar projects

### DIFF
--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -20,7 +20,7 @@ Other projects similar to xclim
 `xclim` has been developed within an ecosystem of several existing projects that deal with climate and statistical correction/downscaling and has both influenced and been influenced by their approaches:
 
 * `icclim` (`icclim Source Code <https://github.com/cerfacs-globc/icclim>`_; `icclim Documentation <https://icclim.readthedocs.io/en/stable/index.html>`_)
-    - `xclim` aimed to reimplement using `xarray`-natives for the computation of climate indices. Starting from version 5.0 of `icclim`, `xclim` has become a core dependency for this project.
+    - `xclim` aimed to reimplement `icclim` using `xarray`-natives for the computation of climate indices. Starting from version 5.0 of `icclim`, `xclim` has become a core dependency for this project.
     - The `icclim` developers have prepared a documentation page comparing xclim and icclim (`xclim_and_icclim <https://icclim.readthedocs.io/en/stable/explanation/xclim_and_icclim.html>`_).
 
 * `climate_indices` (`climate_indices Source Code <https://github.com/monocongo/climate_indices>`_; `climate_indices Documentation <https://climate-indices.readthedocs.io/en/latest/index.html>`_)
@@ -30,6 +30,9 @@ Other projects similar to xclim
 * `MetPy` (`MetPy Source Code <https://github.com/Unidata/MetPy>`_; `MetPy Documentation <https://unidata.github.io/MetPy/latest/index.html>`_)
     - `MetPy` is built for reading, visualizing, and performing calculations specifically on standards-compliant, operational weather data. Like `xclim`, it makes use of `xarray`.
     - `xclim` adopted its standards and unit-handling approaches from `MetPy` and associated project `cf-xarray`.
+
+* `pyet` (`pyet Source Code <https://github.com/pyet-org/pyet>`_; `pyet Documentation <https://pyet.readthedocs.io/en/latest/>`_)
+    - `pyet` is a tool for calculating/estimating evapotranspiration using many different accepted methodologies and employs a similar design approach as `xclim`, based on `xarray`-natives.
 
 * `xcdat` (`xcdat Source Code <https://github.com/xCDAT/xcdat>`_; `xcdat Documentation <https://xcdat.readthedocs.io/en/latest/>`_)
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1306 
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] CHANGES.rst has been updated (with summary of main changes)
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Adds a mention to `pyet` as a similar project to `xclim`

### Does this PR introduce a breaking change?

No.

### Other information:

Discussion was had in #1306 about the idea of wrapping `pyet` for evapotranspiration indicators, but the idea hasn't really been explored. They appear to be using a similar approach as us, but do not use many of the speedups (`ufunc`-capabilities) that `xclim` uses (yet).

Might be interesting to see if there are low-effort ways of improving their project!