### PR TITLE
Fix sdba_encode_cf bug

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ New features and enhancements
 Bug fixes
 ^^^^^^^^^
 * Warnings emitted from regular usage of some indices (``snowfall_approximation`` with ``method="brown"``, ``effective_growing_degree_days``) due to successive ``convert_units_to`` calls within their logic have been silenced. (:pull:`1319`).
+* Fixed a bug that prevented the use of the `sdba_encode_cf` option with xarray 2023.3.0 (:pull:`1333`).
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/environment.yml
+++ b/environment.yml
@@ -23,6 +23,7 @@ dependencies:
     - scipy>=1.2
     - xarray>=2022.06.0
     # Extras
+    - wheel
     - eofs
     - eigen
     - pybind11

--- a/xclim/sdba/base.py
+++ b/xclim/sdba/base.py
@@ -653,8 +653,8 @@ def map_blocks(reduces: Sequence[str] = None, **outvars):
                 ds = ds.copy()
                 # Optimization to circumvent the slow pickle.dumps(cftime_array)
                 for name, crd in ds.coords.items():
-                    if xr.core.common._contains_cftime_datetimes(crd.values):
-                        ds[name] = xr.conventions.encode_cf_variable(crd)
+                    if xr.core.common._contains_cftime_datetimes(crd.variable):
+                        ds[name] = xr.conventions.encode_cf_variable(crd.variable)
 
             def _call_and_transpose_on_exit(dsblock, **kwargs):
                 """Call the decorated func and transpose to ensure the same dim order as on the templace."""

--- a/xclim/testing/tests/test_sdba/test_adjustment.py
+++ b/xclim/testing/tests/test_sdba/test_adjustment.py
@@ -31,9 +31,8 @@ from xclim.sdba.utils import (
     get_correction,
     invert,
 )
-from xclim.testing import open_dataset
 
-from .utils import nancov
+from .utils import nancov  # noqa
 
 
 class TestLoci:
@@ -488,7 +487,7 @@ class TestQM:
         np.testing.assert_array_almost_equal(p, ref, 2)
 
     @pytest.mark.parametrize("use_dask", [True, False])
-    def test_add_dims(self, use_dask):
+    def test_add_dims(self, use_dask, open_dataset):
         with set_options(sdba_encode_cf=use_dask):
             if use_dask:
                 chunks = {"location": -1}
@@ -666,7 +665,7 @@ class TestExtremeValues:
         ).sum()
 
     @pytest.mark.slow
-    def test_real_data(self):
+    def test_real_data(self, open_dataset):
         dsim = open_dataset("sdba/CanESM2_1950-2100.nc").chunk()
         dref = open_dataset("sdba/ahccd_1950-2013.nc").chunk()
 

--- a/xclim/testing/tests/test_sdba/test_loess.py
+++ b/xclim/testing/tests/test_sdba/test_loess.py
@@ -3,15 +3,12 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from xclim.sdba.loess import (
-    _constant_regression,
-    _gaussian_weighting,
-    _linear_regression,
-    _loess_nb,
-    _tricube_weighting,
-    loess_smoothing,
-)
-from xclim.testing import open_dataset
+from xclim.sdba.loess import _constant_regression  # noqa
+from xclim.sdba.loess import _gaussian_weighting  # noqa
+from xclim.sdba.loess import _linear_regression  # noqa
+from xclim.sdba.loess import _loess_nb  # noqa
+from xclim.sdba.loess import _tricube_weighting  # noqa
+from xclim.sdba.loess import loess_smoothing
 
 
 @pytest.mark.slow
@@ -39,7 +36,7 @@ def test_loess_nb(d, f, w, n, dx, exp):
 
 @pytest.mark.slow
 @pytest.mark.parametrize("use_dask", [True, False])
-def test_loess_smoothing(use_dask):
+def test_loess_smoothing(use_dask, open_dataset):
     tas = open_dataset(
         "cmip3/tas.sresb1.giss_model_e_r.run1.atm.da.nc",
         chunks={"lat": 1} if use_dask else None,

--- a/xclim/testing/tests/test_sdba/test_measures.py
+++ b/xclim/testing/tests/test_sdba/test_measures.py
@@ -5,17 +5,16 @@ import pytest
 import xarray as xr
 
 from xclim import sdba
-from xclim.testing import open_dataset
 
 
-def test_bias():
+def test_bias(open_dataset):
     sim = open_dataset("sdba/CanESM2_1950-2100.nc").sel(time="1950-01-01").tasmax
     ref = open_dataset("sdba/nrcan_1950-2013.nc").sel(time="1950-01-01").tasmax
     test = sdba.measures.bias(sim, ref).values
     np.testing.assert_array_almost_equal(test, [[6.430237, 39.088974, 5.2402344]])
 
 
-def test_relative_bias():
+def test_relative_bias(open_dataset):
     sim = open_dataset("sdba/CanESM2_1950-2100.nc").sel(time="1950-01-01").tasmax
     ref = open_dataset("sdba/nrcan_1950-2013.nc").sel(time="1950-01-01").tasmax
     test = sdba.measures.relative_bias(sim, ref).values
@@ -33,14 +32,14 @@ def test_circular_bias():
     np.testing.assert_array_almost_equal(test, [1, 1, 66, -1, -1, -66])
 
 
-def test_ratio():
+def test_ratio(open_dataset):
     sim = open_dataset("sdba/CanESM2_1950-2100.nc").sel(time="1950-01-01").tasmax
     ref = open_dataset("sdba/nrcan_1950-2013.nc").sel(time="1950-01-01").tasmax
     test = sdba.measures.ratio(sim, ref).values
     np.testing.assert_array_almost_equal(test, [[1.023665, 1.1639225, 1.0192013]])
 
 
-def test_rmse():
+def test_rmse(open_dataset):
     sim = (
         open_dataset("sdba/CanESM2_1950-2100.nc").sel(time=slice("1950", "1953")).tasmax
     )
@@ -49,7 +48,7 @@ def test_rmse():
     np.testing.assert_array_almost_equal(test, [5.4499755, 18.124086, 12.387193], 4)
 
 
-def test_mae():
+def test_mae(open_dataset):
     sim = (
         open_dataset("sdba/CanESM2_1950-2100.nc").sel(time=slice("1950", "1953")).tasmax
     )
@@ -58,7 +57,7 @@ def test_mae():
     np.testing.assert_array_almost_equal(test, [4.159672, 14.2148, 9.768536], 4)
 
 
-def test_annual_cycle_correlation():
+def test_annual_cycle_correlation(open_dataset):
     sim = (
         open_dataset("sdba/CanESM2_1950-2100.nc").sel(time=slice("1950", "1953")).tasmax
     )
@@ -72,7 +71,7 @@ def test_annual_cycle_correlation():
 
 
 @pytest.mark.slow
-def test_scorr():
+def test_scorr(open_dataset):
     ref = open_dataset("NRCANdaily/nrcan_canada_daily_tasmin_1990.nc").tasmin
     sim = open_dataset("NRCANdaily/nrcan_canada_daily_tasmax_1990.nc").tasmax
     scorr = sdba.measures.scorr(sim.isel(lon=slice(0, 50)), ref.isel(lon=slice(0, 50)))

--- a/xclim/testing/tests/test_sdba/test_processing.py
+++ b/xclim/testing/tests/test_sdba/test_processing.py
@@ -23,7 +23,6 @@ from xclim.sdba.processing import (
     unstack_variables,
     unstandardize,
 )
-from xclim.testing import open_dataset
 
 
 def test_jitter_both():
@@ -258,7 +257,7 @@ def test_normalize(tas_series):
     np.testing.assert_allclose(xp, xp2)
 
 
-def test_stack_variables():
+def test_stack_variables(open_dataset):
     ds1 = open_dataset("sdba/CanESM2_1950-2100.nc")
     ds2 = open_dataset("sdba/ahccd_1950-2013.nc")
 

--- a/xclim/testing/tests/test_sdba/utils.py
+++ b/xclim/testing/tests/test_sdba/utils.py
@@ -14,7 +14,7 @@ from scipy.stats import gamma
 
 from xclim.sdba.utils import equally_spaced_nodes
 
-__all__ = ["series", "cannon_2015_rvs", "cannon_2015_dist"]
+__all__ = ["cannon_2015_dist", "cannon_2015_rvs", "nancov", "series"]
 
 
 def series(values, name, start="2000-01-01"):
@@ -40,6 +40,8 @@ def series(values, name, start="2000-01-01"):
             "units": "kg m-2 s-1",
             "kind": "*",
         }
+    else:
+        raise ValueError(f"Name `{name}` not supported.")
 
     return xr.DataArray(
         values,


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

In xarray#7494 the `_contains_cftime_datetimes` function was restricted to Variable objects. We were passing a DataArray to `xr.conventions.encode_cf_variable` , which was passing it (assuming a variable) to that function. Since the PR, this raises an error. 

In a way, this is my error because the `encode_cf_variable` clearly documents that its input should be a Variable, although there were not annotations at the time I implemented that line. 

Moreover, we were not testing this code... It depended on the `sdba_encode_cf` option being activated, but no test was activating it.

This PR passes `Variable` instances were it should and enables the option in one of the test where it makes sense.

### Does this PR introduce a breaking change?
No.

### Other information:
Fixes xscen#175.