### PR TITLE
[PyOpenSci] Add make_criteria helper

### DIFF
--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -44,6 +44,8 @@ jobs:
           micromamba-version: 'latest'
           environment-file: environment.yml
           extra-specs: |
+            eigen
+            pybind11
             python=${{ matrix.python-version }}
             pytest-reportlog
       - name: Conda and Mamba versions

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 
 v0.42.0 (unreleased)
 --------------------
-Contributors to this version: Trevor James Smith (:user:`Zeitsperre`), Juliette Lavoie (:user:`juliettelavoie`), Éric Dupuis (:user:`coxipi`).
+Contributors to this version: Trevor James Smith (:user:`Zeitsperre`), Juliette Lavoie (:user:`juliettelavoie`), Éric Dupuis (:user:`coxipi`), Pascal Bourgault (:user:`aulemahal`).
 
 Announcements
 ^^^^^^^^^^^^^
@@ -18,7 +18,7 @@ New features and enhancements
 * `scipy` is no longer pinned below v1.9 and `lmoments3>=1.0.5` is now a core dependency and installed by default with `pip`. (:issue:`1142`, :pull:`1171`).
 * Fix bug on number of bins in ``xclim.sdba.propeties.spatial_correlogram``. (:pull:`1336`)
 * Add `resample_before_rl` argument to control when resampling happens in `maximum_consecutive_{frost|frost_free|dry|tx}_days` and in heat indices (in `_threshold`)  (:issue:`1329`, :pull:`1331`)
-* Add ``xclim.ensembles.make_criteria`` to help create inputs for the ensemble-reduction methods. (:issue:`1338`).
+* Add ``xclim.ensembles.make_criteria`` to help create inputs for the ensemble-reduction methods. (:issue:`1338`, :pull:`1341`).
 
 Bug fixes
 ^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@ New features and enhancements
 * `scipy` is no longer pinned below v1.9 and `lmoments3>=1.0.5` is now a core dependency and installed by default with `pip`. (:issue:`1142`, :pull:`1171`).
 * Fix bug on number of bins in ``xclim.sdba.propeties.spatial_correlogram``. (:pull:`1336`)
 * Add `resample_before_rl` argument to control when resampling happens in `maximum_consecutive_{frost|frost_free|dry|tx}_days` and in heat indices (in `_threshold`)  (:issue:`1329`, :pull:`1331`)
+* Add ``xclim.ensembles.make_criteria`` to help create inputs for the ensemble-reduction methods. (:issue:`1338`).
 
 Bug fixes
 ^^^^^^^^^

--- a/docs/notebooks/ensembles-advanced.ipynb
+++ b/docs/notebooks/ensembles-advanced.ipynb
@@ -124,7 +124,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Ensemble reduction techniques in `xclim` require a 2D array with dimensions of `criteria` (values) and `realization` (runs/simulations)."
+    "Ensemble reduction techniques in `xclim` require a 2D array with dimensions of `criteria` (values) and `realization` (runs/simulations). Hopefully, xclim has a function for this."
    ]
   },
   {
@@ -133,16 +133,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Create 2d xr.DataArray containing criteria values\n",
-    "crit = None\n",
-    "for h in ds_crit.horizon:\n",
-    "    for v in ds_crit.data_vars:\n",
-    "        if crit is None:\n",
-    "            crit = ds_crit[v].sel(horizon=h)\n",
-    "        else:\n",
-    "            crit = xr.concat((crit, ds_crit[v].sel(horizon=h)), dim=\"criteria\")\n",
-    "crit.name = \"criteria\"\n",
-    "crit.shape"
+    "crit = ensembles.make_criteria(ds_crit)\n",
+    "crit"
    ]
   },
   {
@@ -395,13 +387,6 @@
     "plt.suptitle(\"K-means selection results\")\n",
     "plt.show()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -421,7 +406,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.10.10"
   },
   "toc": {
    "base_numbering": 1,

--- a/docs/notebooks/usage.ipynb
+++ b/docs/notebooks/usage.ipynb
@@ -274,7 +274,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When the DataArray only has a `time` dimension, xarray plots a timeseries. In this case, xarray uses the `long_name` and `units` attributes provided by xclim to label the y-axis. "
+    "When the DataArray only has a `time` dimension, xarray plots a timeseries. In this case, xarray uses the `long_name` and `units` attributes provided by xclim to label the y-axis."
    ]
   },
   {

--- a/xclim/ensembles/__init__.py
+++ b/xclim/ensembles/__init__.py
@@ -11,5 +11,10 @@ or models are concatenated along the `realization` dimension.
 from __future__ import annotations
 
 from ._base import create_ensemble, ensemble_mean_std_max_min, ensemble_percentiles
-from ._reduce import kkz_reduce_ensemble, kmeans_reduce_ensemble, plot_rsqprofile
+from ._reduce import (
+    kkz_reduce_ensemble,
+    kmeans_reduce_ensemble,
+    make_criteria,
+    plot_rsqprofile,
+)
 from ._robustness import change_significance, robustness_coefficient

--- a/xclim/ensembles/_reduce.py
+++ b/xclim/ensembles/_reduce.py
@@ -39,13 +39,13 @@ def make_criteria(ds: xarray.Dataset | xarray.DataArray):
     Parameters
     ----------
     ds : Dataset or DataArray
-      Must at least have a "realization" dimension. All values are considered independent "criterion" for the ensemble reduction.
-      If a Dataset, variables may have different sizes, but all must include the "realization" dimension.
+        Must at least have a "realization" dimension. All values are considered independent "criterion" for the ensemble reduction.
+        If a Dataset, variables may have different sizes, but all must include the "realization" dimension.
 
     Returns
     -------
     crit : DataArray
-      Same data, reshaped. Old coordinates (and variables) are available as a multiindex.
+        Same data, reshaped. Old coordinates (and variables) are available as a multiindex.
 
     Notes
     -----

--- a/xclim/ensembles/_reduce.py
+++ b/xclim/ensembles/_reduce.py
@@ -52,7 +52,7 @@ def make_criteria(ds: xarray.Dataset | xarray.DataArray):
     One can get back to the original dataset with
 
     .. code-block:: python
-    
+
         crit = make_criteria(ds)
         ds2 = crit.unstack("criteria").to_dataset("variables")
 

--- a/xclim/ensembles/_reduce.py
+++ b/xclim/ensembles/_reduce.py
@@ -27,6 +27,30 @@ except ImportError:
     MPL_INSTALLED = False
 
 
+def make_criteria(ds: xarray.Dataset | xarray.DataArray):
+    """Reshapes the input into a criteria 2D DataArray.
+
+    The reshaping preserves the "realization" dimension but stacks all other
+    dimensions and variables into a new "criteria" dimension, as expected by
+    functions :py:func:`xclim.ensembles._reduce.kkz_reduce_ensemble`
+    and :py:func:`xclim.ensembles._reduce.kmeans_reduce_ensemble`.
+
+    Parameters
+    ----------
+    ds : Dataset or DataArray
+      Must at least have a "realization" dimension. All values are considered independent "criterion" for the ensemble reduction.
+      If a Dataset, variables are concatenated before stacking the dimensions.
+
+    Returns
+    -------
+    crit : DataArray
+      Same data, reshaped.
+    """
+    if isinstance(ds, xarray.Dataset):
+        ds = ds.to_array("variables")
+    return ds.stack(criteria=set(ds.dims) - {"realization"}).rename("criteria")
+
+
 def kkz_reduce_ensemble(
     data: xarray.DataArray,
     num_select: int,

--- a/xclim/ensembles/_reduce.py
+++ b/xclim/ensembles/_reduce.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from warnings import warn
 
 import numpy as np
+import pandas as pd
 import scipy.stats
 import xarray
 from scipy.spatial.distance import cdist
@@ -39,16 +40,71 @@ def make_criteria(ds: xarray.Dataset | xarray.DataArray):
     ----------
     ds : Dataset or DataArray
       Must at least have a "realization" dimension. All values are considered independent "criterion" for the ensemble reduction.
-      If a Dataset, variables are concatenated before stacking the dimensions.
+      If a Dataset, variables may have different sizes, but all must include the "realization" dimension.
 
     Returns
     -------
     crit : DataArray
-      Same data, reshaped.
+      Same data, reshaped. Old coordinates (and variables) are available as a multiindex.
+
+    Notes
+    -----
+    One can get back to the original dataset with
+
+    >>> crit = make_criteria(ds)
+    >>> ds2 = crit.unstack("criteria").to_dataset("variables")
+
+    `ds2` will have all variables with the same dimensions, so if the original dataset had variables with different dimensions, the
+    added dimensions are filled with NaNs. The `to_dataset` part can be skipped if the original input was a DataArray.
     """
+
+    def _make_crit(da):
+        """Variable version : stack non-realization dims."""
+        return da.stack(criteria=set(da.dims) - {"realization"})
+
     if isinstance(ds, xarray.Dataset):
-        ds = ds.to_array("variables")
-    return ds.stack(criteria=set(ds.dims) - {"realization"}).rename("criteria")
+        # When variables have different set of dims, missing dims on one variable results in duplicated values when a simple stack is done.
+        # To avoid that: stack each variable independently add a new "variables" dim
+        stacked = {
+            da.name: _make_crit(da.expand_dims(variables=[da.name]))
+            for da in ds.data_vars.values()
+        }
+        # Get name of all stacked coords
+        stacked_coords = set.union(
+            *[set(da.indexes["criteria"].names) for da in stacked.values()]
+        )
+        # Concat the variables by dropping old stacked index and related coords
+        crit = xarray.concat(
+            [
+                da.reset_index("criteria").drop_vars(stacked_coords, errors="ignore")
+                for k, da in stacked.items()
+            ],
+            "criteria",
+        )
+        # Reconstruct proper stacked coordinates. When a variable is missing one of the coords, give NaNss
+        coords = [
+            (
+                crd,
+                np.concatenate(
+                    [
+                        da[crd].values
+                        if crd in da.coords
+                        else [np.NaN] * da.criteria.size
+                        for da in stacked.values()
+                    ],
+                ),
+            )
+            for crd in stacked_coords
+        ]
+        crit["criteria"] = pd.MultiIndex.from_arrays(
+            [arr for name, arr in coords], names=[name for name, arr in coords]
+        )
+        # Previous ops gave the first variable's attributes, replace by the original dataset ones.
+        crit.attrs = ds.attrs
+    else:
+        # Easy peasy, skip all the convoluted stuff
+        crit = _make_crit(ds)
+    return crit.rename("criteria")
 
 
 def kkz_reduce_ensemble(

--- a/xclim/ensembles/_reduce.py
+++ b/xclim/ensembles/_reduce.py
@@ -51,8 +51,10 @@ def make_criteria(ds: xarray.Dataset | xarray.DataArray):
     -----
     One can get back to the original dataset with
 
-    >>> crit = make_criteria(ds)
-    >>> ds2 = crit.unstack("criteria").to_dataset("variables")
+    .. code-block:: python
+    
+        crit = make_criteria(ds)
+        ds2 = crit.unstack("criteria").to_dataset("variables")
 
     `ds2` will have all variables with the same dimensions, so if the original dataset had variables with different dimensions, the
     added dimensions are filled with NaNs. The `to_dataset` part can be skipped if the original input was a DataArray.

--- a/xclim/testing/tests/test_sdba/test_properties.py
+++ b/xclim/testing/tests/test_sdba/test_properties.py
@@ -49,7 +49,7 @@ class TestProperties:
             open_dataset("sdba/CanESM2_1950-2100.nc")
             .sel(time=slice("1950", "1980"), location="Vancouver")
             .pr
-        )
+        ).load()
 
         out_year = sdba.properties.skewness(sim)
         np.testing.assert_array_almost_equal(out_year.values, [2.8497460898513745])


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR implements a suggestion made in #1335 
- [x] Tests for the changes have been added (for bug fixes / features)
  - [x] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Add a `make_criteria` helper to reshape dataset into 2D critera arrays, as expected by the ensemble reduction functions.

EDIT: Also, made this function a bit complicated so that it accepts dataset with variables of different shapes and still preserves the coordinates.

### Does this PR introduce a breaking change?
No.

### Other information:
~I need to add a test and udpate the history.~