### PR TITLE
Note about conventions and time coordinate, fix Zenodo link

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 
 v0.43.0 (unreleased)
 --------------------
-Contributors to this version: Trevor James Smith (:user:`Zeitsperre`).
+Contributors to this version: Trevor James Smith (:user:`Zeitsperre`), Pascal Bourgault (:user:`aulemahal`).
 
 Bug fixes
 ^^^^^^^^^
@@ -31,6 +31,7 @@ Internal changes
 * In order to follow best practices and reduce the installed size of the `xclim` wheel, the `tests` folder containing the testing suite has been split from the package and placed in the top-level of the code repository. (:issue:`1348`, :pull:`1349`, suggested from `PyOpenSci Software Review <https://github.com/pyOpenSci/software-review/issues/73>`_). Submodules that were previously called within ``xclim.testing.tests`` have been refactored as follows:
     * ``xclim.testing.tests.data`` → ``xclim.testing.helpers``
     * ``xclim.testing.tests.test_sdba.utils`` → ``xclim.testing.sdba_utils``
+* Added a "Conventions" section to the README. (:issue:`1342`, :pull:`1351`).
 
 v0.42.0 (2023-04-03)
 --------------------

--- a/README.rst
+++ b/README.rst
@@ -64,6 +64,19 @@ How to make the most of xclim: `Basic Usage Examples`_ and `In-Depth Examples`_.
 .. _Basic Usage Examples: https://xclim.readthedocs.io/en/stable/notebooks/usage.html
 .. _In-Depth Examples: https://xclim.readthedocs.io/en/stable/notebooks/index.html
 
+Conventions
+-----------
+In order to provide a coherent interface, xclim tries to follow different sets of conventions. In particular, input data should follow the `CF conventions`_ whenever possible for variable attributes. Variable names are usually the ones used in `CMIP6`_, when they exist.
+
+However, xclim will *always* assume the temporal coordinate is named "time". If your data uses another name (for example: "T"), you can rename the variable with:
+
+.. code-block:: python
+
+    ds = ds.rename(T="time")
+
+.. _CF Conventions: http://cfconventions.org/
+.. _CMIP6: https://clipc-services.ceda.ac.uk/dreq/mipVars.html
+
 Contributing to xclim
 ---------------------
 xclim is in active development and is being used in production by climate services specialists around the world.

--- a/README.rst
+++ b/README.rst
@@ -92,7 +92,7 @@ How to cite this library
 ------------------------
 If you wish to cite xclim in a research publication, we kindly ask that you use the bibliographical reference information available through `Zenodo`_
 
-.. _Zenodo: https://doi.org/10.5281/zenodo.2795043S
+.. _Zenodo: https://doi.org/10.5281/zenodo.2795043
 
 License
 -------

--- a/docs/notebooks/usage.ipynb
+++ b/docs/notebooks/usage.ipynb
@@ -95,7 +95,17 @@
     "\n",
     "Very few indices will convert their output to specific units; Rather, it is the dimensionality that will be consistent on output. The [Units Handling](units.ipynb) page goes more into detail on how unit conversion can easily be done.\n",
     "\n",
-    "This doesn't apply to **`Indicators`**. Those will always output data in a specific unit, the one listed in the `Indicators.cf_attrs` metadata dictionary.\n"
+    "This doesn't apply to **`Indicators`**. Those will always output data in a specific unit, the one listed in the `Indicators.cf_attrs` metadata dictionary.\n",
+    "\n",
+    "### Conventions\n",
+    "\n",
+    "As you may have noticed, the `growing_degree_days` function above was not told along which dimension to operate. In xclim, the temporal dimension is _always_ assumed to be named `\"time\"`. All functions which reduce or compute over that dimension will expect that name. If you ever have another name in your data, you can simply rename it like:\n",
+    "\n",
+    "```\n",
+    "ds = ds.rename(T=\"time\")\n",
+    "```\n",
+    "\n",
+    "For other names and attributes, xclim tries to follow different sets of conventions. In particular, input data should follow the [CF conventions](http://cfconventions.org/) whenever possible for variable attributes. Variable names are usually the ones used in [CMIP6](https://clipc-services.ceda.ac.uk/dreq/mipVars.html), when they exist."
    ]
   },
   {
@@ -353,7 +363,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.10.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1342
    - This PR fixes #1353 
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Adds a "Conventions" section in the README to give some details about which conventions we are trying to follow, and a special note on how "time" is always the assumed name of the temporal coordinate.
* Fixes a broken link to our Zenodo DOI entry on the README.

### Does this PR introduce a breaking change?
No.


### Other information:
