### PR TITLE
Fix QDM's quantile computation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Bug fixes
 ^^^^^^^^^
 * Fixed a bug in the `pyproject.toml` configuration that excluded the changelog (`CHANGES.rst`) from the packaged source distribution. (:pull:`1349`).
 * When summing an all-NaN period with `resample`, xarray 2023.04.0 now returns NaN, whereas earlier versions returned 0. This broke ``fraction_over_precip_thresh``, but is now fixed. (:pull:`1354`, :issue:`1337`).
+* In sdba's Quantile Delta Mapping algorithm, the quantiles of the simulation to adjust were computed slightly differently than when creating the adjustment factor. The ``xclim.sdba.utils.rank`` function has been fixed to return "percentage-ranks" (quantiles) in the proper range. (:issue:`1334`, :pull:`1355`).
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/tests/test_sdba/test_adjustment.py
+++ b/tests/test_sdba/test_adjustment.py
@@ -388,9 +388,6 @@ class TestQDM:
 
         assert isinstance(scends, xr.Dataset)
 
-        sim_q_exp = sim.rank(dim="time", pct=True)
-        np.testing.assert_array_equal(sim_q_exp, scends.sim_q)
-
         # Theoretical results
         # ref, hist, sim = cannon_2015_dist
         # u1 = equally_spaced_nodes(1001, None)

--- a/xclim/sdba/utils.py
+++ b/xclim/sdba/utils.py
@@ -495,7 +495,7 @@ def rank(da: xr.DataArray, dim: str = "time", pct: bool = False) -> xr.DataArray
     """
     rnk = da.rank(dim, pct=pct)
     if pct:
-        mn = 1 / rnk.size
+        mn = rnk.min(dim)
         mx = rnk.max(dim)
         return mx * (rnk - mn) / (mx - mn)
     return rnk


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1334
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [x] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

We use `xclim.sdba.utils.rank` with `pct=True` as a quick way to find the quantile of each value. However, xarray returns values in the [1 / N ,1] range. Where `N` is the number of values. Furthermore, if values are repeated, they get assigned to the mean of the ranks. For example:
```
arr := [1, 1, 2, 2]
rank(pct=False) => [1.5, 1.5, 3.5, 3.5]
rank(pct=True) => [0.375, 0.375, 0.875, 0.875] ( 
quantiles => [0, 0, 1, 1]
```
We thus need to rescale the percentage rank to the [0, 1] range to use them as quantiles. This is what this PR does.

### Does this PR introduce a breaking change?
Adjustment values will slightly change. For normal data (no repeating values), the largest change will be near the 0th quantile.