### PR TITLE
Support use of calendar version xclim-testdata tags

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ on:
       - submitted
 
 env:
-  XCLIM_TESTDATA_BRANCH: 2023.2.6
+  XCLIM_TESTDATA_BRANCH: 2023.5.4
 
 jobs:
   black:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ on:
       - submitted
 
 env:
-  XCLIM_TESTDATA_BRANCH: v0.41.0
+  XCLIM_TESTDATA_BRANCH: 2023.2.6
 
 jobs:
   black:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ on:
       - submitted
 
 env:
-  XCLIM_TESTDATA_BRANCH: 2023.5.4
+  XCLIM_TESTDATA_BRANCH: v2023.5.4
 
 jobs:
   black:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,7 @@ Internal changes
 * New helper function ``xclim.testing.helpers.test_timeseries``. (:pull:`1356`).
 * `tox` recipes and documentation now refer to the official build of `SBCK`, available on PyPI. (:issue:`1362`, :pull:`1364`).
 * Excluded some URLs from `sphinx linkcheck` that were causing issues on ReadTheDocs. (:pull:`1364`).
+* Tagged versions of `xclim-testdata` now follow a `calendar-based versioning <https://calver.org/>`_ scheme for easier determination of compatibility between `xclim` and testing data. (:pull:`1367`, `xclim-testdata discussion <https://github.com/Ouranosinc/xclim-testdata/pull/24>`_)
 
 v0.42.0 (2023-04-03)
 --------------------


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Checks for outdated xclim now use the date of last modification to determine installation date of xclim to generate a CalVer string to compare against xclim-testdata

### Does this PR introduce a breaking change?
No.

### Other information:
See: https://github.com/Ouranosinc/xclim-testdata/pull/24