### PR TITLE
Fix time_bnds on resample objects with xarray 2023.5.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@ Internal changes
 ^^^^^^^^^^^^^^^^
 * In order to ensure documentation can be rebuilt at a later time, errors raised by `sphinx` linkcheck are now set to be ignored when building the documentation. (:pull:`1375`).
 
+Bug fixes
+^^^^^^^^^
+* Fixed a bug in ``xclim.core.calendar.time_bnds`` when using ``DataArrayResample`` objects, caused by an upstream change in xarray 2023.5.0. (:issue:`1368`, :pull:`1377`).
+
 v0.43.0 (2023-05-09)
 --------------------
 Contributors to this version: Trevor James Smith (:user:`Zeitsperre`), Ludwig Lierhammer (:user:`ludwiglierhammer`), Pascal Bourgault (:user:`aulemahal`), Juliette Lavoie (:user:`juliettelavoie`), Alexis Beaupré (:user:`Beauprel`), Éric Dupuis (:user:`coxipi`).

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -69,9 +69,14 @@ def test_time_bnds(freq, datetime_index, cftime_index):
     # cftime resolution goes down to microsecond only, code below corrects
     # that to allow for comparison with pandas datetime
     cftime_ends += np.timedelta64(999, "ns")
-    datetime_starts = da_datetime._full_index.to_period(freq).start_time
-    datetime_ends = da_datetime._full_index.to_period(freq).end_time
-
+    if hasattr(da_datetime, "_full_index"):
+        datetime_starts = da_datetime._full_index.to_period(freq).start_time
+        datetime_ends = da_datetime._full_index.to_period(freq).end_time
+    else:
+        datetime_starts = (
+            da_datetime.groupers[0].group_as_index.to_period(freq).start_time
+        )
+        datetime_ends = da_datetime.groupers[0].group_as_index.to_period(freq).end_time
     assert_array_equal(cftime_starts, datetime_starts)
     assert_array_equal(cftime_ends, datetime_ends)
 

--- a/xclim/core/calendar.py
+++ b/xclim/core/calendar.py
@@ -888,7 +888,18 @@ def time_bnds(time, freq=None, precision=None):
     if isinstance(time, (xr.DataArray, xr.Dataset)):
         time = time.indexes[time.name]
     elif isinstance(time, (DataArrayResample, DatasetResample)):
-        time = time._full_index
+        # TODO: Remove conditional when pinning xarray above 2023.5.0
+        if hasattr(time, "_full_index"):  # xr < 2023.5.0
+            time = time._full_index
+        else:  # xr >= 2023.5.0
+            for grouper in time.groupers:
+                if "time" in grouper.dims:
+                    time = grouper.group_as_index
+                    break
+            else:
+                raise ValueError(
+                    'Got object resampled along another dimension than "time".'
+                )
 
     if freq is None and hasattr(time, "freq"):
         freq = time.freq


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1368
- [x] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* We were using a private property on `DataArrayResample` objects, recent xarray refactored the class. This PR catches the case where the property is absent (xarray 2023.5.0 and above) and uses the new structure instead. The if/else could be removed when we pin xarray for other reasons, this not being serious enough IMO.

### Does this PR introduce a breaking change?
No.
