### PR TITLE
Accelerate import - prevent numba warnings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Announcements
 Bug fixes
 ^^^^^^^^^
 * Fixed a bug in ``xclim.core.calendar.time_bnds`` when using ``DataArrayResample`` objects, caused by an upstream change in xarray 2023.5.0. (:issue:`1368`, :pull:`1377`).
+* Accelerated import of xclim by caching the compilation of `guvectorize` functions.
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,7 +13,7 @@ Announcements
 Bug fixes
 ^^^^^^^^^
 * Fixed a bug in ``xclim.core.calendar.time_bnds`` when using ``DataArrayResample`` objects, caused by an upstream change in xarray 2023.5.0. (:issue:`1368`, :pull:`1377`).
-* Accelerated import of xclim by caching the compilation of `guvectorize` functions.
+* Accelerated import of xclim by caching the compilation of `guvectorize` functions. (:pull:`1378`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/xclim/indices/fire/_cffwis.py
+++ b/xclim/indices/fire/_cffwis.py
@@ -136,7 +136,7 @@ from typing import Sequence
 
 import numpy as np
 import xarray as xr
-from numba import jit, vectorize
+from numba import njit, vectorize
 
 from xclim.core.units import convert_units_to, declare_units
 from xclim.core.utils import Quantified
@@ -203,7 +203,7 @@ DAY_LENGTH_FACTORS = np.array(
 )
 
 
-@jit
+@njit
 def _day_length(lat: int | float, mth: int):  # pragma: no cover
     """Return the average day length for a month within latitudinal bounds."""
     if -30 > lat >= -90:
@@ -223,7 +223,7 @@ def _day_length(lat: int | float, mth: int):  # pragma: no cover
     return dl[mth - 1]
 
 
-@jit
+@njit
 def _day_length_factor(lat: float, mth: int):  # pragma: no cover
     """Return the day length factor."""
     if -15 > lat >= -90:
@@ -239,7 +239,7 @@ def _day_length_factor(lat: float, mth: int):  # pragma: no cover
     return dlf[mth - 1]
 
 
-@vectorize
+@vectorize(nopython=True)
 def _fine_fuel_moisture_code(t, p, w, h, ffmc0):  # pragma: no cover
     """Compute the fine fuel moisture code over one time step.
 
@@ -318,7 +318,7 @@ def _fine_fuel_moisture_code(t, p, w, h, ffmc0):  # pragma: no cover
     return ffmc
 
 
-@vectorize
+@vectorize(nopython=True)
 def _duff_moisture_code(
     t: np.ndarray,
     p: np.ndarray,
@@ -385,7 +385,7 @@ def _duff_moisture_code(
     return dmc
 
 
-@vectorize
+@vectorize(nopython=True)
 def _drought_code(
     t: np.ndarray, p: np.ndarray, mth: np.ndarray, lat: float, dc0: float
 ) -> np.ndarray:  # pragma: no cover
@@ -517,7 +517,7 @@ def daily_severity_rating(fwi: np.ndarray) -> np.ndarry:
     return 0.0272 * fwi**1.77
 
 
-@vectorize
+@vectorize(nopython=True)
 def _overwintering_drought_code(DCf, wpr, a, b, minDC):  # pragma: no cover
     """Compute the season-starting drought code based on the previous season's last drought code and the total winter precipitation.
 

--- a/xclim/indices/fire/_ffdi.py
+++ b/xclim/indices/fire/_ffdi.py
@@ -33,16 +33,10 @@ __all__ = [
 
 
 @guvectorize(
-    [
-        (
-            float64[:],
-            float64[:],
-            float64,
-            float64,
-            float64[:],
-        )
-    ],
+    [(float64[:], float64[:], float64, float64, float64[:])],
     "(n),(n),(),()->(n)",
+    nopython=True,
+    cache=True,
 )
 def _keetch_byram_drought_index(p, t, pa, kbdi0, kbdi: float):  # pragma: no cover
     """Compute the Keetch-Byram drought (KBDI) index.
@@ -96,15 +90,10 @@ def _keetch_byram_drought_index(p, t, pa, kbdi0, kbdi: float):  # pragma: no cov
 
 
 @guvectorize(
-    [
-        (
-            float64[:],
-            float64[:],
-            int64,
-            float64[:],
-        )
-    ],
+    [(float64[:], float64[:], int64, float64[:])],
     "(n),(n),()->(n)",
+    nopython=True,
+    cache=True,
 )
 def _griffiths_drought_factor(p, smd, lim, df):  # pragma: no cover
     """Compute the Griffiths drought factor.

--- a/xclim/sdba/nbutils.py
+++ b/xclim/sdba/nbutils.py
@@ -14,6 +14,7 @@ from xarray.core import utils
     [(float32[:], float32, float32[:]), (float64[:], float64, float64[:])],
     "(n),()->()",
     nopython=True,
+    cache=True,
 )
 def _vecquantiles(arr, rnk, res):
     if np.isnan(rnk):
@@ -41,14 +42,7 @@ def vecquantiles(da, rnk, dim):
     return res
 
 
-@njit(
-    # [
-    #     float32[:, :](float32[:, :], float32[:]),
-    #     float64[:, :](float64[:, :], float64[:]),
-    #     float32[:](float32[:], float32[:]),
-    #     float64[:](float64[:], float64[:]),
-    # ],
-)
+@njit
 def _quantile(arr, q):
     if arr.ndim == 1:
         out = np.empty((q.size,), dtype=arr.dtype)
@@ -104,9 +98,7 @@ def quantile(da, q, dim):
     return res
 
 
-@njit(
-    #  [float32[:, :](float32[:, :]), float64[:, :](float64[:, :])]
-)
+@njit
 def remove_NaNs(x):  # noqa
     """Remove NaN values from series."""
     remove = np.zeros_like(x[0, :], dtype=boolean)
@@ -115,19 +107,13 @@ def remove_NaNs(x):  # noqa
     return x[:, ~remove]
 
 
-@njit(
-    #  [float32(float32[:]), float64(float64[:])]
-    fastmath=True
-)
+@njit(fastmath=True)
 def _euclidean_norm(v):
     """Compute the euclidean norm of vector v."""
     return np.sqrt(np.sum(v**2))
 
 
-@njit(
-    #  [float32(float32[:, :], float32[:, :]), float64(float64[:, :], float64[:, :])],
-    fastmath=True,
-)
+@njit(fastmath=True)
 def _correlation(X, Y):
     """Compute a correlation as the mean of pairwise distances between points in X and Y.
 
@@ -141,10 +127,7 @@ def _correlation(X, Y):
     return d / (X.shape[1] * Y.shape[1])
 
 
-@njit(
-    #  [float32(float32[:, :]), float64(float64[:, :])],
-    fastmath=True
-)
+@njit(fastmath=True)
 def _autocorrelation(X):
     """Mean of the NxN pairwise distances of points in X of shape KxN.
 
@@ -163,6 +146,8 @@ def _autocorrelation(X):
         (float64[:, :], float64[:, :], float64[:]),
     ],
     "(k, n),(k, m)->()",
+    nopython=True,
+    cache=True,
 )
 def _escore(tgt, sim, out):
     """E-score based on the Székely-Rizzo e-distances between clusters.


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes an issue raised verbally by `xscen` developers.
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

PR #1135 removed all signatures where possible, so that `@jit`-decorated function would be compiled at run time (you know "just in time"...). However, `@guvectorize` -decorated functions _must_ have signatures and thus must be compiled at compile time, which means upon import.

This PR adds `cache=True` to these function, so numba compiles them once and than saves the compilation to a `__pycache__` folder if possible. The first import will be slow as before, but subsequent imports should be much faster.
I'm sure there are edgecases where the user of xclim doesn't have write access to the source folder, which might mean this caching will be unavailable. But for most users, this should be a nice performance boost.

On my machine I went from 13s to 2.5s.

This PR also forces `nopython=True` to these `@guvectorize` functions. Numba 0.59 will change the default value of this parameter and it was raising warning complaining about our lack of precision.

### Does this PR introduce a breaking change?
It shouldn't. But I do not know all the ramifications of caching these functions...

### Other information:
@RondeauG, fyi.