### PR TITLE
Small clean up of dependencies and environment

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,7 @@ Internal changes
 * In order to ensure documentation can be rebuilt at a later time, errors raised by `sphinx` linkcheck are now set to be ignored when building the documentation. (:pull:`1375`).
 * With the publication of `xclim`, the code repository now offers a `CITATION.cff` configuration for users to properly cite the software (APA formatted and raw BibTeX) for academic purposes. (:issue:`95`, :pull:`250`).
 * Logging messages emitted when redefining units via `pint` (caused by `logging` interactions with dependencies) have been silenced. (:issue:`1373`, :pull:`1384`).
+* Fixed some annotations and dev dependencies issues to allow the development of xclim inside a python 3.11 environment. (:issue:`1376`, :pull:`1381`).
 
 v0.43.0 (2023-05-09)
 --------------------

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
     - conda-forge
     - defaults
 dependencies:
-    - python>=3.8
+    - python>=3.8,<3.11  # pin due to sphinx-autodoc-typehints errors in Python3.11
     - astroid
     - boltons>=20.1
     - bottleneck>=1.3.1
@@ -15,7 +15,7 @@ dependencies:
     - lmoments3
     - numba
     - numpy>=1.16
-    - pandas>=0.23,<2.0 # Pinned due to incompatibility with xarray <=2023.03
+    - pandas>=0.23
     - pint>=0.9
     - poppler>=0.67
     - pyyaml

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
     - conda-forge
     - defaults
 dependencies:
-    - python>=3.8,<3.11  # pin due to sphinx-autodoc-typehints errors in Python3.11
+    - python>=3.8
     - astroid
     - boltons>=20.1
     - bottleneck>=1.3.1

--- a/environment.yml
+++ b/environment.yml
@@ -58,7 +58,7 @@ dependencies:
     - sphinx-autodoc-typehints
     - sphinx-codeautolink
     - sphinx-copybutton
-    - sphinx-rtd-theme>=1.0
+    - sphinx_rtd_theme>=1.0
     - sphinxcontrib-bibtex
     - tokenize-rt
     - tox

--- a/environment.yml
+++ b/environment.yml
@@ -23,7 +23,6 @@ dependencies:
     - scipy>=1.2
     - xarray>=2022.06.0
     # Extras
-    - clisops
     - eofs
     - flox
     - pytest-json-report  # Added due to a packaging bug with ESMPy. See: https://github.com/esmf-org/esmf/issues/115

--- a/environment.yml
+++ b/environment.yml
@@ -21,11 +21,11 @@ dependencies:
     - pyyaml
     - scikit-learn>=0.21.3
     - scipy>=1.2
+    - statsmodels
     - xarray>=2022.06.0
     # Extras
     - eofs
     - flox
-    - pytest-json-report  # Added due to a packaging bug with ESMPy. See: https://github.com/esmf-org/esmf/issues/115
   # Testing and development dependencies
     - black>=22.12
     - blackdoc
@@ -33,6 +33,7 @@ dependencies:
     - cairosvg
     - coverage
     - distributed>=2.0
+    - filelock
     - flake8
     - flake8-rst-docstrings
     - flit
@@ -49,7 +50,7 @@ dependencies:
     - pre-commit
     - pybtex
     - pydocstyle
-    - pylint<2.15
+    - pylint
     - pytest
     - pytest-cov
     - pytest-xdist>=3.2
@@ -59,7 +60,6 @@ dependencies:
     - sphinx-copybutton
     - sphinx-rtd-theme>=1.0
     - sphinxcontrib-bibtex
-    - statsmodels
     - tokenize-rt
     - tox
 #    - tox-conda  # Will be added when a tox@v4.0+ compatible plugin is released.

--- a/pylintrc
+++ b/pylintrc
@@ -195,8 +195,8 @@ timeout-methods=requests.api.delete,requests.api.get,requests.api.head,requests.
 [EXCEPTIONS]
 
 # Exceptions that will emit a warning when caught.
-overgeneral-exceptions=BaseException,
-                       Exception
+overgeneral-exceptions=builtins.BaseException,
+                       builtins.Exception
 
 
 [REFACTORING]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ dev = [
   "pre-commit >=2.9",
   "pydocstyle >=5.1.1",
   "pybtex",
-  "pylint <2.15",
+  "pylint",
   "pytest",
   "pytest-cov",
   "pytest-xdist[psutil] >=3.2",

--- a/xclim/core/indicator.py
+++ b/xclim/core/indicator.py
@@ -190,11 +190,11 @@ class Parameter:
     _empty = _empty
 
     kind: InputKind
-    default: "Any" = _empty_default
+    default: Any = _empty_default
     description: str = ""
     units: str = _empty
     choices: set = _empty
-    value: "Any" = _empty
+    value: Any = _empty
 
     def update(self, other: dict) -> None:
         """Update a parameter's values from a dict."""
@@ -368,7 +368,7 @@ class Indicator(IndicatorRegistrar):
 
     # Note: typing and class types in this call signature will cause errors with sphinx-autodoc-typehints
     # See: https://github.com/tox-dev/sphinx-autodoc-typehints/issues/186#issuecomment-1450739378
-    _all_parameters: dict[str, "Parameter"] = {}
+    _all_parameters: dict = {}
     """A dictionary mapping metadata about the input parameters to the indicator.
 
     Keys are the arguments of the "compute" function. All parameters are listed, even
@@ -378,7 +378,7 @@ class Indicator(IndicatorRegistrar):
 
     # Note: typing and class types in this call signature will cause errors with sphinx-autodoc-typehints
     # See: https://github.com/tox-dev/sphinx-autodoc-typehints/issues/186#issuecomment-1450739378
-    cf_attrs: list[dict[str, "Any"]] = None
+    cf_attrs: list[dict[str, str]] = None
     """A list of metadata information for each output of the indicator.
 
     It minimally contains a "var_name" entry, and may contain : "standard_name", "long_name",

--- a/xclim/core/indicator.py
+++ b/xclim/core/indicator.py
@@ -302,30 +302,30 @@ class Indicator(IndicatorRegistrar):
     Parameters
     ----------
     identifier : str
-      Unique ID for class registry, should be a valid slug.
+        Unique ID for class registry, should be a valid slug.
     realm : {'atmos', 'seaIce', 'land', 'ocean'}
-      General domain of validity of the indicator. Indicators created outside xclim.indicators must set this attribute.
+        General domain of validity of the indicator. Indicators created outside xclim.indicators must set this attribute.
     compute : func
-      The function computing the indicators. It should return one or more DataArray.
+        The function computing the indicators. It should return one or more DataArray.
     cf_attrs : list of dicts
-      Attributes to be formatted and added to the computation's output.
-      See :py:attr:`xclim.core.indicator.Indicator.cf_attrs`.
+        Attributes to be formatted and added to the computation's output.
+        See :py:attr:`xclim.core.indicator.Indicator.cf_attrs`.
     title : str
-      A succinct description of what is in the computed outputs. Parsed from `compute` docstring if None (first paragraph).
+        A succinct description of what is in the computed outputs. Parsed from `compute` docstring if None (first paragraph).
     abstract : str
-      A long description of what is in the computed outputs. Parsed from `compute` docstring if None (second paragraph).
+        A long description of what is in the computed outputs. Parsed from `compute` docstring if None (second paragraph).
     keywords : str
-      Comma separated list of keywords. Parsed from `compute` docstring if None (from a "Keywords" section).
+        Comma separated list of keywords. Parsed from `compute` docstring if None (from a "Keywords" section).
     references : str
-      Published or web-based references that describe the data or methods used to produce it. Parsed from
-      `compute` docstring if None (from the "References" section).
+        Published or web-based references that describe the data or methods used to produce it. Parsed from
+        `compute` docstring if None (from the "References" section).
     notes : str
-      Notes regarding computing function, for example the mathematical formulation. Parsed from `compute`
-      docstring if None (form the "Notes" section).
+        Notes regarding computing function, for example the mathematical formulation. Parsed from `compute`
+        docstring if None (form the "Notes" section).
     src_freq : str, sequence of strings, optional
-      The expected frequency of the input data. Can be a list for multiple frequencies, or None if irrelevant.
+        The expected frequency of the input data. Can be a list for multiple frequencies, or None if irrelevant.
     context : str
-      The `pint` unit context, for example use 'hydro' to allow conversion from kg m-2 s-1 to mm/day.
+        The `pint` unit context, for example use 'hydro' to allow conversion from kg m-2 s-1 to mm/day.
 
     Notes
     -----

--- a/xclim/core/utils.py
+++ b/xclim/core/utils.py
@@ -582,9 +582,16 @@ class InputKind(IntEnum):
     """
 
 
-def infer_kind_from_parameter(param: Parameter, has_units: bool = False) -> InputKind:
+def infer_kind_from_parameter(param, has_units: bool = False) -> InputKind:
     """Return the appropriate InputKind constant from an ``inspect.Parameter`` object.
 
+    Parameters
+    ----------
+    param : Parameter
+    has_units : bool
+
+    Notes
+    -----
     The correspondence between parameters and kinds is documented in :py:class:`xclim.core.utils.InputKind`.
     The only information not inferable through the `inspect` object is whether the parameter
     has been assigned units through the :py:func:`xclim.core.units.declare_units` decorator.


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1376 
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Removes `clisops` from the `environment.yml`, which removes the indirect dev dependency to `xESMF`. 
* While missing around I realized we make an explicit import of `filelock`, without listing it in the env (it's a dep of `tox`).
* `statsmodels` was in the "dev" deps section, but is a hard dep.
* On my machine at least, the pin of `pylint` was blocking the creation of an env with python 3.11. I removed it and it seems to work. I modified the rc file slightly to suppress one warning in the output. And, comble de l'ironie, running `pylint` in my older env (python 3.10, pylint 2.14) failed... So I leave the study of why it was pinned and if it is safe to unpin it to @Zeitsperre .

### Does this PR introduce a breaking change?
No

### Other information:
This might be a step towards #1268 !