### PR TITLE
Add contributing note on numba caching

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -62,6 +62,7 @@ General notes for implementing new bias-adjustment methods:
 * If the algorithm gets complicated and would generate many dask tasks, it should be implemented as functions wrapped
   by :py:func:`~xclim.sdba.map_blocks` or :py:func:`~xclim.sdba.map_groups` in ``xclim/sdba/_adjustment.py``.
 * xclim doesn't implement monolithic multi-parameter methods, but rather smaller modular functions to construct post-processing workflows.
+* If you are working on numba-accelerated function that use ``@guvectorize``, consider disabling caching during the development phase and reactivating it once all changes are ready for review.
 
 Report Bugs
 ~~~~~~~~~~~

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -62,7 +62,7 @@ General notes for implementing new bias-adjustment methods:
 * If the algorithm gets complicated and would generate many dask tasks, it should be implemented as functions wrapped
   by :py:func:`~xclim.sdba.map_blocks` or :py:func:`~xclim.sdba.map_groups` in ``xclim/sdba/_adjustment.py``.
 * xclim doesn't implement monolithic multi-parameter methods, but rather smaller modular functions to construct post-processing workflows.
-* If you are working on numba-accelerated function that use ``@guvectorize``, consider disabling caching during the development phase and reactivating it once all changes are ready for review.
+* If you are working on numba-accelerated function that use ``@guvectorize``, consider disabling caching during the development phase and reactivating it once all changes are ready for review. This is done by commenting ``cache=True`` in the decorator.
 
 Report Bugs
 ~~~~~~~~~~~


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] CHANGES.rst has been updated (with summary of main changes)
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

PR #1378 introduced caching for the `guvectorize` functions. Turns out that this caching interferes with the development of these function as the cached version doesn't get updated when the code is modified. (As tested by @coxipi )

However, when installing a new version of xclim, cached copies are removed and thus updated. The bug mentionned above only affects locally installed versions (`pip install -e`). A note was added to the contributing notes.

### Does this PR introduce a breaking change?
No

### Other information:
No