### PR TITLE
Faster escore

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,11 +4,15 @@ Changelog
 
 v0.44.0 (unreleased)
 --------------------
-Contributors to this version: Trevor James Smith (:user:`Zeitsperre`), Pascal Bourgault (:user:`aulemahal`).
+Contributors to this version: Trevor James Smith (:user:`Zeitsperre`), Pascal Bourgault (:user:`aulemahal`), Éric Dupuis (:user:`coxipi`).
 
 Announcements
 ^^^^^^^^^^^^^
 * `xclim: xarray-based climate data analytics` has been published in the Journal of Open Source Software (`DOI:10.21105/joss.05415 <https://doi.org/10.21105/joss.05415>`_). Users can now make use of the `Cite this repository` button in the sidebar for academic purposes. Many thanks to our core developers and user base for their fine contributions over the years! (:issue:`95`, :pull:`250`).
+
+New features and enhancements
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+* ``xclim.sdba.processing.escore`` performance was improved with a faster runtime (:pull:`1360`).
 
 Bug fixes
 ^^^^^^^^^

--- a/xclim/sdba/_adjustment.py
+++ b/xclim/sdba/_adjustment.py
@@ -247,14 +247,12 @@ def npdf_transform(ds: xr.Dataset, **kwargs) -> xr.Dataset:
     dim = kwargs["pts_dim"]
 
     escores = []
-    imax = len(ds.rot_matrices.iterations) - 1
     for i, R in enumerate(ds.rot_matrices.transpose("iterations", ...)):
         # @ operator stands for matrix multiplication (along named dimensions): x@R = R@x
         # @R rotates an array defined over dimension x unto new dimension x'. x@R = x'
-        if i == 0:
-            refp = ref @ R
-            histp = hist @ R
-            simp = sim @ R
+        refp = ref @ R
+        histp = hist @ R
+        simp = sim @ R
 
         # Perform univariate adjustment in rotated space (x')
         ADJ = kwargs["base"].train(
@@ -267,14 +265,8 @@ def npdf_transform(ds: xr.Dataset, **kwargs) -> xr.Dataset:
         # Note that x'@R is a back rotation because the matrix multiplication is now done along x' due to xarray
         # operating along named dimensions.
         # In normal linear algebra, this is equivalent to taking @R.T, the back rotation.
-        # from IPython import embed;embed()
-        if i < imax:
-            R_next = ds.rot_matrices.isel(iterations=i + 1)
-            hist = (scenhp @ R) @ R_next
-            sim = (scensp @ R) @ R_next
-        else:
-            hist = scenhp @ R
-            sim = scensp @ R
+        hist = scenhp @ R
+        sim = scensp @ R
 
         # Compute score
         if kwargs["n_escore"] >= 0:

--- a/xclim/sdba/nbutils.py
+++ b/xclim/sdba/nbutils.py
@@ -14,7 +14,7 @@ from xarray.core import utils
     [(float32[:], float32, float32[:]), (float64[:], float64, float64[:])],
     "(n),()->()",
     nopython=True,
-    cache=True,
+    # cache=True,
 )
 def _vecquantiles(arr, rnk, res):
     if np.isnan(rnk):
@@ -149,7 +149,6 @@ def _autocorrelation(X):
     #         d += np.sqrt(np.sum((X[:, i] - X[:, j])**2))
     #         # d += _euclidean_norm(X[:, i] - X[:, j])
     # return (2 * d) / X.shape[1] ** 2
-    # diff = np.expand_dims(X, -1)  - np.expand_dims(X, 1)
     diff = X[:, :, np.newaxis] - X[:, np.newaxis, :]
     d = np.sqrt(np.sum(diff**2, axis=0))
     return np.sum(d) / X.shape[1] ** 2
@@ -161,8 +160,8 @@ def _autocorrelation(X):
         (float64[:, :], float64[:, :], float64[:]),
     ],
     "(k, n),(k, m)->()",
-    nopython=True,
-    cache=True,
+    # nopython=True,
+    # cache=True,
 )
 def _escore(tgt, sim, out):
     """E-score based on the Székely-Rizzo e-distances between clusters.

--- a/xclim/sdba/nbutils.py
+++ b/xclim/sdba/nbutils.py
@@ -107,13 +107,6 @@ def remove_NaNs(x):  # noqa
     return x[:, ~remove]
 
 
-# This is now unused
-@njit(fastmath=True)
-def _euclidean_norm(v):
-    """Compute the euclidean norm of vector v."""
-    return np.sqrt(np.sum(v**2))
-
-
 @njit(fastmath=True)
 def _correlation(X, Y):
     """Compute a correlation as the mean of pairwise distances between points in X and Y.


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* correlation functions in `_escore` now have an additional loop that basically replaces the numpy operation: `v1[:] - v2[:]`. This makes the function run much faster (~ 30 times faster)

### Does this PR introduce a breaking change?

No

### Other information:

There are some instances where nopython has a harder time for some numpy functions: https://stackoverflow.com/questions/42846313/numba-nopython-mode-slower-than-object-mode, this could be related. 
