### PR TITLE
Add actions-versions-updater.yml and add-to-project.yml workflows

### DIFF
--- a/.github/workflows/actions-versions-updater.yml
+++ b/.github/workflows/actions-versions-updater.yml
@@ -1,0 +1,23 @@
+name: GitHub Actions Version Updater
+
+on:
+  schedule:
+    - cron:  '0 0 * * 0'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.WORKFLOW_TOKEN }}
+      - name: Run GitHub Actions Version Updater
+        uses: saadmk11/github-actions-version-updater@v0.7.4
+        with:
+          token: ${{ secrets.WORKFLOW_TOKEN }}
+          committer_email: 'bumpversion[bot]@ouranos.ca'
+          committer_username: 'update-github-actions[bot]'
+          pull_request_title: '[bot] Update GitHub Action Versions'
+          pull_request_user_reviewers: "Zeitsperre"

--- a/.github/workflows/actions-versions-updater.yml
+++ b/.github/workflows/actions-versions-updater.yml
@@ -2,7 +2,8 @@ name: GitHub Actions Version Updater
 
 on:
   schedule:
-    - cron:  '0 0 * * 0'
+    # 12:00 AM on the first of every month
+    - cron:  '0 0 1 * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,16 @@
+name: Add Issues to xclim Project
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add Issue to xclim Project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.5
+        with:
+          project-url: https://github.com/orgs/Ouranosinc/projects/6
+          github-token: ${{ secrets.ADD_TO_PROJECT_TOKEN }}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,9 @@ Internal changes
 * Fixed some annotations and `dev` recipe dependencies issues to allow for the development of xclim inside a python3.11 environment. (:issue:`1376`, :pull:`1381`).
 * The deprecated `mamba-org/provision-with-micromamba` GitHub Action has been replaced with `mamba-org/setup-micromamba`. (:pull:`1388`).
 * `xclim` GitHub CI workflows now run builds against Python3.11. (:pull:`1388`).
+* Two new GitHub CI Actions have been added to the existing Workflows (:pull:`1390`):
+    * `actions/add-to-project`: Automatically adds issues to the `xclim` project.
+    * `saadmk11/github-actions-version-updater`: Updates GitHub Action versions in all Workflows (triggered monthly).
 
 v0.43.0 (2023-05-09)
 --------------------


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Adds the `actions/add-to-project` GitHub Action for moving all new issues to the `xclim` project automatically.
* Adds the `saadmk11/github-actions-version-updater` GitHub Action to automatically update all workflow actions to their newest versions on a weekly basis, if changes are found.

### Does this PR introduce a breaking change?

No. 

### Other information:

I have added an organization-level PAT with "workflow" access. This means that the `saadmk11/github-actions-version-updater`  workflow can be called from within any repo of Ouranosinc. I'll be porting this workflow to other repositories over time.