### PR TITLE
Add check in `declare_units` 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,7 @@ Internal changes
 * Fixed some annotations and `dev` recipe dependencies issues to allow for the development of xclim inside a python3.11 environment. (:issue:`1376`, :pull:`1381`).
 * The deprecated `mamba-org/provision-with-micromamba` GitHub Action has been replaced with `mamba-org/setup-micromamba`. (:pull:`1388`).
 * `xclim` GitHub CI workflows now run builds against Python3.11. (:pull:`1388`).
+* In indices, verify that all parameters of type `Quantified` that have a default value have their dimension declared. (:issue:`1293`, :pull:`1393`).
 
 v0.43.0 (2023-05-09)
 --------------------

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -14,6 +14,7 @@ from xclim.core.units import (
     amount2rate,
     check_units,
     convert_units_to,
+    declare_units,
     infer_context,
     lwethickness2amount,
     pint2cfunits,
@@ -23,7 +24,7 @@ from xclim.core.units import (
     units,
     units2pint,
 )
-from xclim.core.utils import ValidationError
+from xclim.core.utils import Quantified, ValidationError
 
 
 class TestUnits:
@@ -264,3 +265,21 @@ def test_amount2lwethickness(snw_series):
 )
 def test_infer_context(std_name, dim, exp):
     assert infer_context(std_name, dim) == exp
+
+
+def test_declare_units():
+    """Test that an error is raised when parameters with type Quantified do not declare their dimensions.
+    In this example, `wo` is a Quantified parameter, but does not declare its dimension as [length].
+    """
+
+    with pytest.raises(ValueError):
+
+        @declare_units(pr="[precipitation]", evspsblpot="[precipitation]")
+        def dryness_index(
+            pr: xr.DataArray,
+            evspsblpot: xr.DataArray,
+            lat: xr.DataArray | str | None = None,
+            wo: Quantified = "200 mm",
+            freq: str = "YS",
+        ) -> xr.DataArray:
+            pass


### PR DESCRIPTION
Make sure all Quantified parameters with a default value declare their dimension.

<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1293 
- [x] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Add sanity check in declare_units. 

### Does this PR introduce a breaking change?
No

### Other information:
