### PR TITLE
Convert doys

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,14 @@
 Changelog
 =========
 
+v0.45.0 (unreleased)
+--------------------
+Contributors to this version: Pascal Bourgault (:user:`aulemahal`).
+
+New features and enhancements
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+* New function ``xclim.core.calendar.convert_doy`` to transform day-of-year data between calendars. Also accessible from ``convert_calendar`` with ``doy=True``. (:issue:`1283`, :pull:`1406`).
+
 v0.44.0 (2023-06-23)
 --------------------
 Contributors to this version: Éric Dupuis (:user:`coxipi`), Trevor James Smith (:user:`Zeitsperre`), Pascal Bourgault (:user:`aulemahal`), Ludwig Lierhammer (:user:`ludwiglierhammer`), David Huard (:user:`huard`).

--- a/xclim/core/calendar.py
+++ b/xclim/core/calendar.py
@@ -38,6 +38,7 @@ __all__ = [
     "common_calendar",
     "compare_offsets",
     "convert_calendar",
+    "convert_doy",
     "date_range",
     "date_range_like",
     "datetime_to_decimal_year",
@@ -230,6 +231,38 @@ def common_calendar(calendars: Sequence[str], join="outer") -> str:
     if join == "inner":
         return calendars[0]
     raise NotImplementedError(f"Unknown join criterion `{join}`.")
+
+
+def convert_doy(
+    source: xr.DataArray,
+    target: xr.DataArray | str,
+    source_cal: str | None = None,
+    align_on: str = "year",
+    missing: Any = np.nan,
+    dim: str = "time",
+) -> xr.DataArray:
+    """Convert the calendar of day of year (doy) data.
+
+    Parameters
+    ----------
+    source : xr.DataArray
+      Day of year data (range [1, 366], max depending on the calendar).
+    target : str
+      Name of the calendar to convert to.
+      Of the new `dim` axis, as converted by `convert_calendar` (must have the same size as on the source).
+    source_cal : str, optional
+      Calendar the doys are in. If not given, uses the "calendar" attribute of `source` or,
+      if absent, the calendar of its `dim` axis.
+    align_on : {'date', 'year'}
+      If 'year' (default), the doy is seen as a "percentage" of the year and is simply rescaled unto the new doy range.
+      This always result in floating point data, changing the decimal part of the value.
+      if 'date', the doy is seen as a specific date. See notes. This never changes the decimal part of the value.
+    missing : Any
+      If `align_on` is "date" and the new doy doesn't exist in the new calendar, this value is used.
+    dim : str
+      Name of the temporal dimension.
+    """
+    pass
 
 
 def convert_calendar(


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1283 
- [x] Tests for the changes have been added (for bug fixes / features)
  - [x] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* New `convert_doy` function to convert the calendar reference of doy data. Two options :
    - "year" : doy is seen as the fraction of the year. I.e. : 360 in `360_day` converts to 365 in `noleap`.
    - "date" : doy is seen as a date (MM-DD). 360 in `360_day` converts to 364 in `noleap` (December 30th).
* Convert calendar can automatically apply `convert_doy` if its new argument `doy=True` (or `doy='date'`).
* `convert_doy` will NOT convert the time coordinate.

### Does this PR introduce a breaking change?
No.

### Other information:
