### PR TITLE
Fix extremes n

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 
 v0.44.0 (unreleased)
 --------------------
-Contributors to this version: Éric Dupuis (:user:`coxipi`), Trevor James Smith (:user:`Zeitsperre`), Pascal Bourgault (:user:`aulemahal`), Ludwig Lierhammer (:user:`ludwiglierhammer`), David Huard (:user:`huard`).
+Contributors to this version: Éric Dupuis (:user:`coxipi`), Trevor James Smith (:user:`Zeitsperre`), Pascal Bourgault (:user:`aulemahal`), Ludwig Lierhammer (:user:`ludwiglierhammer`), David Huard (:user:`huard`), Juliette Lavoie (:user: `juliettelavoie`).
 
 Announcements
 ^^^^^^^^^^^^^
@@ -53,6 +53,7 @@ Internal changes
     * `actions/add-to-project`: Automatically adds issues to the `xclim` project.
     * `saadmk11/github-actions-version-updater`: Updates GitHub Action versions in all Workflows (triggered monthly).
 * Added `method` parameter to `frequency_analysis` and `fa`. (:issue:`1168`, :pull:`1398`).
+* Increase the guess of number of quantiles needed in ExtremeValues. ( :pull:`1413`).
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -53,7 +53,7 @@ Internal changes
     * `actions/add-to-project`: Automatically adds issues to the `xclim` project.
     * `saadmk11/github-actions-version-updater`: Updates GitHub Action versions in all Workflows (triggered monthly).
 * Added `method` parameter to `frequency_analysis` and `fa`. (:issue:`1168`, :pull:`1398`).
-* Increase the guess of number of quantiles needed in ExtremeValues. ( :pull:`1413`).
+* Increased the guess of number of quantiles needed in ExtremeValues. ( :pull:`1413`).
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 
 v0.45.0 (unreleased)
 --------------------
-Contributors to this version: David Huard (:user:`huard`), Trevor James Smith (:user:`Zeitsperre`), Pascal Bourgault (:user:`aulemahal`).
+Contributors to this version: David Huard (:user:`huard`), Trevor James Smith (:user:`Zeitsperre`), Pascal Bourgault (:user:`aulemahal`), Juliette Lavoie (:user: `juliettelavoie`).
 
 New features and enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -18,10 +18,11 @@ Bug fixes
 Internal changes
 ^^^^^^^^^^^^^^^^
 * Tolerance thresholds for error in ``test_stats::test_fit`` have been relaxed to allow for more variation in the results. Previously untested ``*_moving_yearly_window`` functions are now tested. (:issue:`1400`, :pull:`1402`).
+* Increased the guess of number of quantiles needed in ExtremeValues. ( :pull:`1413`).
 
 v0.44.0 (2023-06-23)
 --------------------
-Contributors to this version: Éric Dupuis (:user:`coxipi`), Trevor James Smith (:user:`Zeitsperre`), Pascal Bourgault (:user:`aulemahal`), Ludwig Lierhammer (:user:`ludwiglierhammer`), David Huard (:user:`huard`), Juliette Lavoie (:user: `juliettelavoie`).
+Contributors to this version: Éric Dupuis (:user:`coxipi`), Trevor James Smith (:user:`Zeitsperre`), Pascal Bourgault (:user:`aulemahal`), Ludwig Lierhammer (:user:`ludwiglierhammer`), David Huard (:user:`huard`).
 
 Announcements
 ^^^^^^^^^^^^^
@@ -72,7 +73,6 @@ Internal changes
     * `actions/add-to-project`: Automatically adds issues to the `xclim` project.
     * `saadmk11/github-actions-version-updater`: Updates GitHub Action versions in all Workflows (triggered monthly).
 * Added `method` parameter to `frequency_analysis` and `fa`. (:issue:`1168`, :pull:`1398`).
-* Increased the guess of number of quantiles needed in ExtremeValues. ( :pull:`1413`).
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/xclim/sdba/adjustment.py
+++ b/xclim/sdba/adjustment.py
@@ -650,8 +650,7 @@ class ExtremeValues(TrainAdjust):
 
         # Approximation of how many "quantiles" values we will get:
         N = (1 - q_thresh) * ref.time.size * 1.05  # extra padding for safety
-        # print('first N')
-        # print(N)
+
         # ref_params: cast nan to f32 not to interfere with map_blocks dtype parsing
         #   ref and hist are f32, we want to have f32 in the output.
         ds = extremes_train(

--- a/xclim/sdba/adjustment.py
+++ b/xclim/sdba/adjustment.py
@@ -649,8 +649,9 @@ class ExtremeValues(TrainAdjust):
         cluster_thresh = convert_units_to(cluster_thresh, ref, context="infer")
 
         # Approximation of how many "quantiles" values we will get:
-        N = (1 - q_thresh) * ref.time.size
-
+        N = (1 - q_thresh) * ref.time.size * 1.05  # extra padding for safety
+        # print('first N')
+        # print(N)
         # ref_params: cast nan to f32 not to interfere with map_blocks dtype parsing
         #   ref and hist are f32, we want to have f32 in the output.
         ds = extremes_train(

--- a/xclim/sdba/adjustment.py
+++ b/xclim/sdba/adjustment.py
@@ -649,7 +649,7 @@ class ExtremeValues(TrainAdjust):
         cluster_thresh = convert_units_to(cluster_thresh, ref, context="infer")
 
         # Approximation of how many "quantiles" values we will get:
-        N = (1 - q_thresh) * ref.time.size * 1.05  # extra padding for safety
+        N = (1 - q_thresh) * ref.time.size * 1.02  # extra padding for safety
         # print('first N')
         # print(N)
         # ref_params: cast nan to f32 not to interfere with map_blocks dtype parsing

--- a/xclim/sdba/adjustment.py
+++ b/xclim/sdba/adjustment.py
@@ -649,7 +649,7 @@ class ExtremeValues(TrainAdjust):
         cluster_thresh = convert_units_to(cluster_thresh, ref, context="infer")
 
         # Approximation of how many "quantiles" values we will get:
-        N = (1 - q_thresh) * ref.time.size * 1.02  # extra padding for safety
+        N = (1 - q_thresh) * ref.time.size * 1.03  # extra padding for safety
         # print('first N')
         # print(N)
         # ref_params: cast nan to f32 not to interfere with map_blocks dtype parsing

--- a/xclim/sdba/adjustment.py
+++ b/xclim/sdba/adjustment.py
@@ -649,7 +649,7 @@ class ExtremeValues(TrainAdjust):
         cluster_thresh = convert_units_to(cluster_thresh, ref, context="infer")
 
         # Approximation of how many "quantiles" values we will get:
-        N = (1 - q_thresh) * ref.time.size * 1.03  # extra padding for safety
+        N = (1 - q_thresh) * ref.time.size * 1.05  # extra padding for safety
         # print('first N')
         # print(N)
         # ref_params: cast nan to f32 not to interfere with map_blocks dtype parsing


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

*  add a bit more room in the guess of number of quantiles needed.

### Does this PR introduce a breaking change?


### Other information:
* Without the extra space, ExtremesValues fails on IPSL-CM6A-LR r3i1p1f1 when trained with EMDNA. I think this because IPSL has more extremes than EMDNA on some blocks.