### PR TITLE
Allow direct unit comparisons between two quantities

### DIFF
--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -68,13 +68,13 @@ class TestUnits:
 
 class TestConvertUnitsTo:
     def test_deprecation(self, tas_series):
-        with pytest.raises(DeprecationWarning):
+        with pytest.raises(TypeError):
             convert_units_to(0, units.K)
 
-        with pytest.raises(DeprecationWarning):
+        with pytest.raises(TypeError):
             convert_units_to(10.0, units.mm / units.day, context="hydro")
 
-        with pytest.raises(DeprecationWarning):
+        with pytest.raises(TypeError):
             tas = tas_series(np.arange(365), start="1/1/2001")
             out = indices.tx_days_above(tas, 30)  # noqa
 

--- a/xclim/core/units.py
+++ b/xclim/core/units.py
@@ -412,7 +412,7 @@ def convert_units_to(
 
     # TODO remove backwards compatibility of int/float thresholds after v1.0 release
     if isinstance(source, (float, int)):
-        raise DeprecationWarning("Please specify units explicitly.")
+        raise TypeError("Please specify units explicitly.")
 
     raise NotImplementedError(f"Source of type `{type(source)}` is not supported.")
 
@@ -1061,7 +1061,7 @@ def check_units(val: str | xr.DataArray | None, dim: str | xr.DataArray | None) 
         val = str(val).replace("UNSET ", "")
 
     if isinstance(val, (int, float)):
-        raise DeprecationWarning("Please set units explicitly using a string.")
+        raise TypeError("Please set units explicitly using a string.")
 
     try:
         dim_units = str2pint(dim) if isinstance(dim, str) else units2pint(dim)
@@ -1076,7 +1076,6 @@ def check_units(val: str | xr.DataArray | None, dim: str | xr.DataArray | None) 
     if val_dim == expected:
         return
 
-    context = infer_context(dimension=str(dim))
     # Check if there is a transformation available
     with units.context(context):
         start = pint.util.to_units_container(val_dim)


### PR DESCRIPTION
Not sure how useful this is, but this modifies check_units to accept two quantities, instead of a quantity and a dimension. 


<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] CHANGES.rst has been updated (with summary of main changes)
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* ...

### Does this PR introduce a breaking change?


### Other information:
