### PR TITLE
Fix jetstream calculation bug

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ New features and enhancements
 Bug fixes
 ^^^^^^^^^
 * Fix `kldiv` docstring so the math formula renders to HTML. (:issue:`1408`, :pull:`1409`).
+* Fix `jetstream_metric_woollings` so it uses the `vertical` coordinate identified by `cf-xarray`, instead of `pressure`. (:issue:`1421`, :pull:`1422`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -1392,7 +1392,7 @@ class TestJetStreamIndices:
         },
     )
 
-    da_ua.Z.attrs = {"units": "Pa", "standard_name": "pressure"}
+    da_ua.Z.attrs = {"units": "Pa", "standard_name": "air_pressure"}
     da_ua.X.attrs = {"units": "degrees_east", "standard_name": "longitude"}
     da_ua.Y.attrs = {"units": "degrees_north", "standard_name": "latitude"}
     da_ua.T.attrs = {"standard_name": "time"}

--- a/xclim/indices/_synoptic.py
+++ b/xclim/indices/_synoptic.py
@@ -64,16 +64,16 @@ def jetstream_metric_woollings(
     lat_name = ua.cf["latitude"].name
 
     # select only relevant hPa levels, compute zonal mean wind speed
-    pmin = convert_units_to("750 hPa", ua.cf["pressure"])
-    pmax = convert_units_to("950 hPa", ua.cf["pressure"])
+    pmin = convert_units_to("750 hPa", ua.cf["vertical"])
+    pmax = convert_units_to("950 hPa", ua.cf["vertical"])
 
     ua = ua.cf.sel(
-        pressure=slice(pmin, pmax),
+        vertical=slice(pmin, pmax),
         latitude=slice(15, 75),
         longitude=slice(lon_min, lon_max),
     )
 
-    zonal_mean = ua.cf.mean(["pressure", "longitude"])
+    zonal_mean = ua.cf.mean(["vertical", "longitude"])
 
     # apply Lanczos filter - parameters are hard-coded following those used in Woollings (2010)
     filter_freq = 10


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1421
- [x] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* jetstream calculation used pressure coordinate, but it should be "vertical". 
* Modified test data to make it CF-compliant.

### Does this PR introduce a breaking change?
Yes, it won't work with datasets that used "pressure" as the vertical coordinate, but that was not CF-compliant. 


### Other information:
https://cf-xarray.readthedocs.io/en/latest/coord_axes.html#coordinate-criteria