### PR TITLE
Fix: 1425: virtual indicator realm attribute assignment logic

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Bug fixes
 ^^^^^^^^^
 * Fix `kldiv` docstring so the math formula renders to HTML. (:issue:`1408`, :pull:`1409`).
 * Fix `jetstream_metric_woollings` so it uses the `vertical` coordinate identified by `cf-xarray`, instead of `pressure`. (:issue:`1421`, :pull:`1422`).
+* Fix virtual indicator attribute assignment causing individual indicator's realm to be ignored. (:issue:`1425`, :pull:`1426`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -209,6 +209,23 @@ indices:
         assert "cdd" in converted["indicators"]
 
 
+def test_realm(tmp_path):
+    # Regression test for #1425
+    yml = """
+    realm: land
+
+    indicators:
+      ice_extent:
+        base: sea_ice_extent
+        realm: ocean
+    """
+    fh = tmp_path / "test.yml"
+
+    fh.write_text(yml)
+    mod = build_indicator_module_from_yaml(fh, name="test")
+    assert mod.ice_extent.realm == "ocean"
+
+
 class TestOfficialYaml(yamale.YamaleTestCase):
     base_dir = str(Path(__file__).parent.parent / "xclim" / "data")
     schema = "schema.yml"

--- a/xclim/core/indicator.py
+++ b/xclim/core/indicator.py
@@ -1709,11 +1709,10 @@ def build_indicator_module_from_yaml(
         """Merge or replace attribute in dbase from dextra."""
         a = dbase.get(attr)
         b = dextra.get(attr)
-        # If both are not None and sep is a string, join.
-        if a and b and sep is not None:
+        # If both are not None, join.
+        if a and b:
             dbase[attr] = sep.join([a, b])
-        # If both are not None but sep is, this overrides with b
-        # also fills when a is simply missing
+        # Otherwise, if a is None, but not b, replace.
         elif b:
             dbase[attr] = b
 
@@ -1753,8 +1752,8 @@ def build_indicator_module_from_yaml(
 
             _merge_attrs(data, defkwargs, "references", "\n")
             _merge_attrs(data, defkwargs, "keywords", " ")
-            if data.get("realm", None) is None:
-                _merge_attrs(data, defkwargs, "realm", None)
+            if data.get("realm") is None and defkwargs.get('realm') is not None:
+                data['realm'] = defkwargs["realm"]
 
             mapping[identifier] = Indicator.from_dict(
                 data, identifier=identifier, module=module_name

--- a/xclim/core/indicator.py
+++ b/xclim/core/indicator.py
@@ -1752,8 +1752,8 @@ def build_indicator_module_from_yaml(
 
             _merge_attrs(data, defkwargs, "references", "\n")
             _merge_attrs(data, defkwargs, "keywords", " ")
-            if data.get("realm") is None and defkwargs.get('realm') is not None:
-                data['realm'] = defkwargs["realm"]
+            if data.get("realm") is None and defkwargs.get("realm") is not None:
+                data["realm"] = defkwargs["realm"]
 
             mapping[identifier] = Indicator.from_dict(
                 data, identifier=identifier, module=module_name

--- a/xclim/core/indicator.py
+++ b/xclim/core/indicator.py
@@ -1753,7 +1753,8 @@ def build_indicator_module_from_yaml(
 
             _merge_attrs(data, defkwargs, "references", "\n")
             _merge_attrs(data, defkwargs, "keywords", " ")
-            _merge_attrs(data, defkwargs, "realm", None)
+            if data.get("realm", None) is None:
+                _merge_attrs(data, defkwargs, "realm", None)
 
             mapping[identifier] = Indicator.from_dict(
                 data, identifier=identifier, module=module_name


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1425
- [x] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Fix indicator realm attribute assignment logic. Only uses global realm if individual indicator realm is None. 

### Does this PR introduce a breaking change?
Yes, but fixes a bug. 

### Other information:
