### PR TITLE
Add streamflow as a known variable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 
 v0.45.0 (unreleased)
 --------------------
-Contributors to this version: David Huard (:user:`huard`), Trevor James Smith (:user:`Zeitsperre`), Pascal Bourgault (:user:`aulemahal`), Juliette Lavoie (:user: `juliettelavoie`).
+Contributors to this version: David Huard (:user:`huard`), Trevor James Smith (:user:`Zeitsperre`), Pascal Bourgault (:user:`aulemahal`), Juliette Lavoie (:user: `juliettelavoie`), Gabriel Rondeau-Genesse (:user:`RondeauG`).
 
 New features and enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -18,7 +18,8 @@ Bug fixes
 Internal changes
 ^^^^^^^^^^^^^^^^
 * Tolerance thresholds for error in ``test_stats::test_fit`` have been relaxed to allow for more variation in the results. Previously untested ``*_moving_yearly_window`` functions are now tested. (:issue:`1400`, :pull:`1402`).
-* Increased the guess of number of quantiles needed in ExtremeValues. ( :pull:`1413`).
+* Increased the guess of number of quantiles needed in ExtremeValues. (:pull:`1413`).
+* Added 'streamflow' to the list of known variables (:pull:`1431`).
 
 v0.44.0 (2023-06-23)
 --------------------

--- a/xclim/data/variables.yml
+++ b/xclim/data/variables.yml
@@ -198,6 +198,11 @@ variables:
     standard_name: lwe_thickness_of_snow_amount
     data_flags:
       - negative_accumulation_values:
+  streamflow:
+    canonical_units: m3 s-1
+    cell_methods: "time: mean"
+    description: The amount of water, in all phases, flowing in the river channel and flood plain.
+    standard_name: water_volume_transport_in_river_channel
   tas:
     canonical_units: K
     cell_methods: "time: mean"


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - No.
- [x] Tests for the changes have been added (for bug fixes / features)
  - [x] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Adds 'streamflow' to the list of variables known to `xclim`.

### Does this PR introduce a breaking change?

No.

### Other information:

`discharge` is already there, but no standard name exists for that variable and `streamflow` is an alternative that is likely to become the standard for https://github.com/hydrologie (xdatasets & xhydro in particular). Rather than replacing `discharge` (which is not explicitely used anywhere to my knowledge, except than to declare units), we might as well support both.
