### PR TITLE
Deterministic randomness

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,6 +56,11 @@ if re.match(r"^v\d+\.\d+\.\d+", helpers.TESTDATA_BRANCH):
 
 
 @pytest.fixture
+def random() -> np.random.Generator:
+    return np.random.default_rng(seed=list(map(ord, "𝕽𝔞𝖓𝔡𝖔𝔪")))
+
+
+@pytest.fixture
 def tmp_netcdf_filename(tmpdir) -> Path:
     yield Path(tmpdir).joinpath("testfile.nc")
 
@@ -112,28 +117,6 @@ def prc_series():
     """Return convective precipitation time series."""
     _prc_series = partial(test_timeseries, variable="prc")
     return _prc_series
-
-
-@pytest.fixture
-def bootstrap_series():
-    def _bootstrap_series(values, start="7/1/2000", units="kg m-2 s-1", cf_time=False):
-        if cf_time:
-            coords = xr.cftime_range(start, periods=len(values), freq="D")
-        else:
-            coords = pd.date_range(start, periods=len(values), freq="D")
-        return xr.DataArray(
-            values,
-            coords=[coords],
-            dims="time",
-            name="pr",
-            attrs={
-                "standard_name": "precipitation_flux",
-                "cell_methods": "time: mean within days",
-                "units": units,
-            },
-        )
-
-    return _bootstrap_series
 
 
 @pytest.fixture
@@ -200,7 +183,7 @@ def q_series():
 
 
 @pytest.fixture
-def ndq_series():
+def ndq_series(random):
     nx, ny, nt = 2, 3, 5000
     x = np.arange(0, nx)
     y = np.arange(0, ny)
@@ -214,7 +197,7 @@ def ndq_series():
     )
 
     return xr.DataArray(
-        np.random.lognormal(10, 1, (nt, nx, ny)),
+        random.lognormal(10, 1, (nt, nx, ny)),
         dims=("time", "x", "y"),
         coords={"time": time_range, "x": cx, "y": cy},
         attrs={

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -142,7 +142,7 @@ class TestDateHandling:
 
 
 class TestDataCheck:
-    def test_check_hourly(self, date_range):
+    def test_check_hourly(self, date_range, random):
         tas_attrs = {
             "units": "K",
             "standard_name": "air_temperature",
@@ -150,11 +150,11 @@ class TestDataCheck:
 
         n = 100
         time = date_range("2000-01-01", freq="H", periods=n)
-        da = xr.DataArray(np.random.rand(n), [("time", time)], attrs=tas_attrs)
+        da = xr.DataArray(random.random(n), [("time", time)], attrs=tas_attrs)
         datachecks.check_freq(da, "H")
 
         time = date_range("2000-01-01", freq="3H", periods=n)
-        da = xr.DataArray(np.random.rand(n), [("time", time)], attrs=tas_attrs)
+        da = xr.DataArray(random.random(n), [("time", time)], attrs=tas_attrs)
         with pytest.raises(ValidationError):
             datachecks.check_freq(da, "H")
 
@@ -169,7 +169,7 @@ class TestDataCheck:
         with pytest.raises(ValidationError, match="Unable to infer the frequency of"):
             datachecks.check_freq(da.where(da.time.dt.dayofyear != 5, drop=True), "3H")
 
-    def test_common_time(self, tas_series, date_range):
+    def test_common_time(self, tas_series, date_range, random):
         tas_attrs = {
             "units": "K",
             "standard_name": "air_temperature",
@@ -177,7 +177,7 @@ class TestDataCheck:
 
         n = 100
         time = date_range("2000-01-01", freq="H", periods=n)
-        da = xr.DataArray(np.random.rand(n), [("time", time)], attrs=tas_attrs)
+        da = xr.DataArray(random.random(n), [("time", time)], attrs=tas_attrs)
 
         # No freq
         db = da[np.array([0, 1, 4, 6, 10])]
@@ -188,7 +188,7 @@ class TestDataCheck:
 
         # Not same freq
         time = date_range("2000-01-01", freq="6H", periods=n)
-        db = xr.DataArray(np.random.rand(n), [("time", time)], attrs=tas_attrs)
+        db = xr.DataArray(random.random(n), [("time", time)], attrs=tas_attrs)
         with pytest.raises(ValidationError, match="Inputs have different frequencies"):
             datachecks.check_common_time([db, da])
 

--- a/tests/test_ensembles.py
+++ b/tests/test_ensembles.py
@@ -32,6 +32,8 @@ from xclim.testing.helpers import TESTDATA_BRANCH
 
 
 # sklearn's KMeans doesn't accept the standard numpy Generator, so we create a special fixture for these tests
+# This object is legacy and this fixture should only be used with KMeans, until they update their code to accept Generators instead.
+# https://numpy.org/doc/stable/reference/random/legacy.html#numpy.random.RandomState
 @pytest.fixture
 def random_state():
     return np.random.RandomState(seed=list(map(ord, "𝕽𝔞𝖓𝔡𝖔𝔪")))

--- a/tests/test_ensembles.py
+++ b/tests/test_ensembles.py
@@ -25,11 +25,16 @@ import xarray as xr
 from pkg_resources import parse_version
 from scipy import __version__ as __scipy_version__
 from scipy.stats.mstats import mquantiles
-from sklearn import __version__ as __sklearn_version__
 
 from xclim import ensembles
 from xclim.indices.stats import get_dist
 from xclim.testing.helpers import TESTDATA_BRANCH
+
+
+# sklearn's KMeans doesn't accept the standard numpy Generator, so we create a special fixture for these tests
+@pytest.fixture
+def random_state():
+    return np.random.RandomState(seed=list(map(ord, "𝕽𝔞𝖓𝔡𝖔𝔪")))
 
 
 class TestEnsembleStats:
@@ -291,13 +296,16 @@ class TestEnsembleStats:
 class TestEnsembleReduction:
     nc_file = os.path.join("EnsembleReduce", "TestEnsReduceCriteria.nc")
 
-    def test_kmeans_rsqcutoff(self, open_dataset):
+    def test_kmeans_rsqcutoff(self, open_dataset, random_state):
         pytest.importorskip("sklearn", minversion="0.24.1")
         ds = open_dataset(self.nc_file)
 
         # use random state variable to ensure consistent clustering in tests:
         [ids, cluster, fig_data] = ensembles.kmeans_reduce_ensemble(
-            data=ds.data, method={"rsq_cutoff": 0.5}, random_state=42, make_graph=False
+            data=ds.data,
+            method={"rsq_cutoff": 0.5},
+            random_state=random_state,
+            make_graph=False,
         )
 
         assert ids == [4, 7, 10, 23]
@@ -307,41 +315,44 @@ class TestEnsembleReduction:
         [ids, cluster, fig_data] = ensembles.kmeans_reduce_ensemble(
             data=ds.data,
             method={"rsq_cutoff": 0.5},
-            random_state=42,
+            random_state=random_state,
             make_graph=False,
             max_clusters=3,
         )
         assert ids == [4, 7, 23]
         assert len(ids) == 3
 
-    def test_kmeans_rsqopt(self, open_dataset):
+    def test_kmeans_rsqopt(self, open_dataset, random_state):
         pytest.importorskip("sklearn", minversion="0.24.1")
         ds = open_dataset(self.nc_file)
         [ids, cluster, fig_data] = ensembles.kmeans_reduce_ensemble(
             data=ds.data,
             method={"rsq_optimize": None},
-            random_state=42,
+            random_state=random_state,
             make_graph=False,
         )
-        if parse_version(__sklearn_version__) >= parse_version("1.3.0"):
-            assert ids == [4, 5, 7, 10, 11, 12, 13]
-        else:
-            assert ids == [3, 4, 5, 7, 10, 11, 12, 13]
+        assert ids == [3, 4, 5, 7, 10, 11, 12, 13]
 
-    def test_kmeans_nclust(self, open_dataset):
+    def test_kmeans_nclust(self, open_dataset, random_state):
         ds = open_dataset(self.nc_file)
 
         [ids, cluster, fig_data] = ensembles.kmeans_reduce_ensemble(
-            data=ds.data, method={"n_clusters": 4}, random_state=42, make_graph=False
+            data=ds.data,
+            method={"n_clusters": 4},
+            random_state=random_state,
+            make_graph=False,
         )
         assert ids == [4, 7, 10, 23]
 
         [ids, cluster, fig_data] = ensembles.kmeans_reduce_ensemble(
-            ds.data, method={"n_clusters": 9}, random_state=42, make_graph=False
+            ds.data,
+            method={"n_clusters": 9},
+            random_state=random_state,
+            make_graph=False,
         )
         assert ids == [0, 3, 4, 6, 7, 10, 11, 12, 13]
 
-    def test_kmeans_sampleweights(self, open_dataset):
+    def test_kmeans_sampleweights(self, open_dataset, random_state):
         ds = open_dataset(self.nc_file)
         # Test sample weights
         sample_weights = np.ones(ds.data.shape[0])
@@ -351,7 +362,7 @@ class TestEnsembleReduction:
         [ids, cluster, fig_data] = ensembles.kmeans_reduce_ensemble(
             data=ds.data,
             method={"rsq_cutoff": 0.5},
-            random_state=42,
+            random_state=random_state,
             make_graph=False,
             sample_weights=sample_weights,
         )
@@ -365,17 +376,14 @@ class TestEnsembleReduction:
         [ids, cluster, fig_data] = ensembles.kmeans_reduce_ensemble(
             data=ds.data,
             method={"rsq_optimize": None},
-            random_state=0,
+            random_state=random_state,
             make_graph=False,
             sample_weights=sample_weights,
         )
 
-        if parse_version(__sklearn_version__) >= parse_version("1.3.0"):
-            assert ids == [4, 5, 7, 10, 12, 13]
-        else:
-            assert ids == [4, 5, 7, 10, 11, 12, 13]
+        assert ids == [4, 5, 7, 10, 11, 12, 13]
 
-    def test_kmeans_variweights(self, open_dataset):
+    def test_kmeans_variweights(self, open_dataset, random_state):
         pytest.importorskip("sklearn", minversion="0.24.1")
         ds = open_dataset(self.nc_file)
         # Test sample weights
@@ -386,7 +394,7 @@ class TestEnsembleReduction:
         [ids, cluster, fig_data] = ensembles.kmeans_reduce_ensemble(
             data=ds.data,
             method={"rsq_cutoff": 0.9},
-            random_state=42,
+            random_state=random_state,
             make_graph=False,
             variable_weights=var_weights,
         )
@@ -399,7 +407,7 @@ class TestEnsembleReduction:
         [ids, cluster, fig_data] = ensembles.kmeans_reduce_ensemble(
             data=ds.data,
             method={"rsq_optimize": None},
-            random_state=42,
+            random_state=random_state,
             make_graph=False,
             variable_weights=var_weights,
         )
@@ -407,7 +415,7 @@ class TestEnsembleReduction:
         assert all(np.isin([12, 13, 16], ids))
         assert len(ids) == 6
 
-    def test_kmeans_modelweights(self, open_dataset):
+    def test_kmeans_modelweights(self, open_dataset, random_state):
         ds = open_dataset(self.nc_file)
         # Test sample weights
         model_weights = np.ones(ds.data.shape[0])
@@ -417,7 +425,7 @@ class TestEnsembleReduction:
         [ids, cluster, fig_data] = ensembles.kmeans_reduce_ensemble(
             data=ds.data,
             method={"n_clusters": 4},
-            random_state=42,
+            random_state=random_state,
             make_graph=False,
             model_weights=model_weights,
         )
@@ -430,13 +438,16 @@ class TestEnsembleReduction:
     @pytest.mark.skipif(
         "matplotlib.pyplot" not in sys.modules, reason="matplotlib.pyplot is required"
     )
-    def test_kmeans_rsqcutoff_with_graphs(self, open_dataset):
+    def test_kmeans_rsqcutoff_with_graphs(self, open_dataset, random_state):
         pytest.importorskip("sklearn", minversion="0.24.1")
         ds = open_dataset(self.nc_file)
 
         # use random state variable to ensure consistent clustering in tests:
         [ids, cluster, fig_data] = ensembles.kmeans_reduce_ensemble(
-            data=ds.data, method={"rsq_cutoff": 0.5}, random_state=42, make_graph=True
+            data=ds.data,
+            method={"rsq_cutoff": 0.5},
+            random_state=random_state,
+            make_graph=True,
         )
 
         assert ids == [4, 7, 10, 23]
@@ -445,7 +456,7 @@ class TestEnsembleReduction:
         [ids, cluster, fig_data] = ensembles.kmeans_reduce_ensemble(
             data=ds.data,
             method={"rsq_cutoff": 0.5},
-            random_state=42,
+            random_state=random_state,
             make_graph=True,
             max_clusters=3,
         )
@@ -531,13 +542,13 @@ class TestEnsembleReduction:
 
 # ## Tests for Robustness ##
 @pytest.fixture(params=[True, False])
-def robust_data(request):
+def robust_data(request, random):
     norm = get_dist("norm")
     ref = np.tile(
         np.array(
             [
-                norm.rvs(loc=274, scale=0.8, size=(40,), random_state=r)
-                for r in [101083, 19377, 473820, 483625]
+                norm.rvs(loc=274, scale=0.8, size=(40,), random_state=random)
+                for r in range(4)
             ]
         ),
         (4, 1, 1),
@@ -545,33 +556,33 @@ def robust_data(request):
     fut = np.array(
         [
             [
-                norm.rvs(loc=loc, scale=sc, size=(40,), random_state=r)
-                for loc, sc, r in shps
+                norm.rvs(loc=loc, scale=sc, size=(40,), random_state=random)
+                for loc, sc in shps
             ]
             for shps in (
                 [
-                    (274.0, 0.7, 176378),
-                    (274.0, 0.6, 839789),
-                    (274.0, 0.7, 393239),
-                    (275.6, 1.1, 747390),
+                    (274.0, 0.7),
+                    (274.0, 0.6),
+                    (274.0, 0.7),
+                    (275.6, 1.1),
                 ],  # 3 no change, 1 positive change
                 [
-                    (272.5, 1.2, 743920),
-                    (272.4, 0.8, 138489),
-                    (275.5, 0.8, 673683),
-                    (275.6, 1.1, 969383),
+                    (272.5, 1.2),
+                    (272.4, 0.8),
+                    (275.5, 0.8),
+                    (275.6, 1.1),
                 ],  # 2 neg change
                 [
-                    (275.6, 0.8, 696857),
-                    (275.8, 1.2, 379949),
-                    (276.5, 0.8, 268395),
-                    (277.6, 1.1, 456544),
+                    (275.6, 0.8),
+                    (275.8, 1.2),
+                    (276.5, 0.8),
+                    (277.6, 1.1),
                 ],  # All pos change
                 [
-                    (np.nan, 0.3, 746323),
-                    (np.nan, 1.2, 5643723),
-                    (275.5, 0.8, 118294),
-                    (275.6, 1.1, 574732),
+                    (np.nan, 0.3),
+                    (np.nan, 1.2),
+                    (275.5, 0.8),
+                    (275.6, 1.1),
                 ],  # Some NaN
             )
         ]
@@ -591,8 +602,8 @@ def robust_data(request):
     [
         (
             "ttest",
-            [0.25, 1, 1, 1],
-            [1, 0.5, 1, 1],
+            [0.75, 1, 1, 1],
+            [2 / 3, 0.5, 1, 1],
             [
                 [False, False, False, True],
                 [True, True, True, True],
@@ -604,7 +615,7 @@ def robust_data(request):
         (
             "welch-ttest",
             [0.25, 1, 1, 1],
-            [1, 0.5, 1, 1],
+            [0.5, 0.5, 1, 1],
             [
                 [False, False, False, True],
                 [True, True, True, True],
@@ -615,7 +626,7 @@ def robust_data(request):
         ),
         (
             "mannwhitney-utest",
-            [0.25, 1, 1, 1],
+            [0.5, 1, 1, 1],
             [1, 0.5, 1, 1],
             [
                 [False, False, False, True],
@@ -627,8 +638,8 @@ def robust_data(request):
         ),
         (
             "brownforsythe-test",
-            [0.5, 0.25, 0.5, 0.5],
-            [0.5, 0.0, 1, 1],
+            [0.25, 0.25, 0.25, 0],
+            [1, 0.0, 1, np.nan],
             [
                 [False, True, False, True],
                 [True, False, False, False],
@@ -716,7 +727,7 @@ def test_change_significance_weighted(robust_data):
         pos_frac = pos_frac.tas
 
     np.testing.assert_array_equal(chng_frac, [1, 1, 1, 1])
-    np.testing.assert_array_almost_equal(pos_frac, [0.88541667, 0.88541667, 1.0, 1.0])
+    np.testing.assert_array_almost_equal(pos_frac, [0.53125, 0.88541667, 1.0, 1.0])
 
 
 def test_change_significance_delta(robust_data):

--- a/tests/test_ensembles.py
+++ b/tests/test_ensembles.py
@@ -605,7 +605,7 @@ def robust_data(request, random):
             [0.75, 1, 1, 1],
             [2 / 3, 0.5, 1, 1],
             [
-                [False, False, False, True],
+                [False, True, True, True],
                 [True, True, True, True],
                 [True, True, True, True],
                 [False, False, True, True],
@@ -615,7 +615,7 @@ def robust_data(request, random):
         (
             "welch-ttest",
             [0.25, 1, 1, 1],
-            [0.5, 0.5, 1, 1],
+            [1, 0.5, 1, 1],
             [
                 [False, False, False, True],
                 [True, True, True, True],
@@ -627,9 +627,9 @@ def robust_data(request, random):
         (
             "mannwhitney-utest",
             [0.5, 1, 1, 1],
-            [1, 0.5, 1, 1],
+            [0.5, 0.5, 1, 1],
             [
-                [False, False, False, True],
+                [False, False, True, True],
                 [True, True, True, True],
                 [True, True, True, True],
                 [False, False, True, True],
@@ -641,10 +641,10 @@ def robust_data(request, random):
             [0.25, 0.25, 0.25, 0],
             [1, 0.0, 1, np.nan],
             [
-                [False, True, False, True],
+                [False, True, False, False],
                 [True, False, False, False],
-                [False, True, False, True],
                 [False, False, False, True],
+                [False, False, False, False],
             ],
             {},
         ),

--- a/tests/test_generic_indicators.py
+++ b/tests/test_generic_indicators.py
@@ -1,35 +1,33 @@
 from __future__ import annotations
 
 import numpy as np
-import pytest
 
 from xclim import generic, set_options
-from xclim.core.utils import ValidationError
 
 
 class TestFit:
-    def test_simple(self, pr_ndseries):
-        pr = pr_ndseries(np.random.rand(1000, 1, 2))
+    def test_simple(self, pr_ndseries, random):
+        pr = pr_ndseries(random.random((1000, 1, 2)))
         ts = generic.stats(pr, freq="YS", op="max")
         p = generic.fit(ts, dist="gumbel_r")
         assert p.attrs["estimator"] == "Maximum likelihood"
 
-    def test_nan(self, pr_series):
-        r = np.random.rand(22)
+    def test_nan(self, pr_series, random):
+        r = random.random(22)
         r[0] = np.nan
         pr = pr_series(r)
 
         out = generic.fit(pr, dist="norm")
         assert not np.isnan(out.values[0])
 
-    def test_ndim(self, pr_ndseries):
-        pr = pr_ndseries(np.random.rand(100, 1, 2))
+    def test_ndim(self, pr_ndseries, random):
+        pr = pr_ndseries(random.random((100, 1, 2)))
         out = generic.fit(pr, dist="norm")
         assert out.shape == (2, 1, 2)
         np.testing.assert_array_equal(out.isnull(), False)
 
-    def test_options(self, q_series):
-        q = q_series(np.random.rand(19))
+    def test_options(self, q_series, random):
+        q = q_series(random.random(19))
         with set_options(missing_options={"at_least_n": {"n": 10}}):
             out = generic.fit(q, dist="norm")
         np.testing.assert_array_equal(out.isnull(), False)
@@ -49,8 +47,8 @@ class TestReturnLevel:
         assert out.shape == (2, 2, 3)  # nrt, nx, ny
         np.testing.assert_array_equal(out.isnull(), False)
 
-    def test_any_variable(self, pr_series):
-        pr = pr_series(np.random.rand(100))
+    def test_any_variable(self, pr_series, random):
+        pr = pr_series(random.random(100))
         out = generic.return_level(pr, mode="max", t=2, dist="gamma")
         assert out.units == pr.units
 
@@ -79,8 +77,8 @@ class TestReturnLevel:
 class TestStats:
     """See other tests in test_land::TestStats"""
 
-    def test_simple(self, pr_series):
-        pr = pr_series(np.random.rand(400))
+    def test_simple(self, pr_series, random):
+        pr = pr_series(random.random(400))
         out = generic.stats(pr, freq="YS", op="min", season="MAM")
         assert out.units == pr.units
 

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -96,13 +96,13 @@ class TestMax1DayPrecipitationAmount:
 
 
 class TestColdSpellDurationIndex:
-    def test_simple(self, tasmin_series):
+    def test_simple(self, tasmin_series, random):
         i = 3650
         A = 10.0
         tn = (
             np.zeros(i)
             + A * np.sin(np.arange(i) / 365.0 * 2 * np.pi)
-            + 0.1 * np.random.rand(i)
+            + 0.1 * random.random(i)
         )
         tn[10:20] -= 2
         tn = tasmin_series(tn)
@@ -1771,11 +1771,11 @@ class TestTxMax:
 
 class TestTgMaxTgMinIndices:
     @staticmethod
-    def random_tmin_tmax_setup(length, tasmax_series, tasmin_series):
-        max_values = np.random.uniform(-20, 40, length)
+    def random_tmin_tmax_setup(length, tasmax_series, tasmin_series, random):
+        max_values = random.uniform(-20, 40, length)
         min_values = []
         for i in range(length):
-            min_values.append(np.random.uniform(-40, max_values[i]))
+            min_values.append(random.uniform(-40, max_values[i]))
         tasmax = tasmax_series(np.add(max_values, K2C))
         tasmin = tasmin_series(np.add(min_values, K2C))
         return tasmin, tasmax
@@ -2001,17 +2001,16 @@ class TestPrecipWettestDriestQuarter:
 
 class TestTempWetDryPrecipWarmColdQuarter:
     @staticmethod
-    def get_data(tas_series, pr_series):
-        np.random.seed(123)
+    def get_data(tas_series, pr_series, random):
         times = pd.date_range("2000-01-01", "2001-12-31", name="time")
         annual_cycle = np.sin(2 * np.pi * (times.dayofyear.values / 365.25 - 0.28))
         base = 10 + 15 * annual_cycle.reshape(-1, 1)
-        values = base + 3 * np.random.randn(annual_cycle.size, 1) + K2C
+        values = base + 3 * random.standard_normal((annual_cycle.size, 1)) + K2C
         tas = tas_series(values.squeeze(), start="2001-01-01").sel(
             time=slice("2001", "2002")
         )
         base = 15 * annual_cycle.reshape(-1, 1)
-        values = base + 10 + 10 * np.random.randn(annual_cycle.size, 1)
+        values = base + 10 + 10 * random.standard_normal((annual_cycle.size, 1))
         values = values / 3600 / 24
         values[values < 0] = 0
         pr = pr_series(values.squeeze(), start="2001-01-01").sel(
@@ -2022,17 +2021,19 @@ class TestTempWetDryPrecipWarmColdQuarter:
     @pytest.mark.parametrize(
         "freq,op,expected",
         [
-            ("D", "wettest", [296.22664037, 296.99585849]),
-            ("7D", "wettest", [296.22664037, 296.99585849]),
-            ("MS", "wettest", [296.25598395, 296.98613685]),
-            ("D", "driest", [272.161376, 269.31008671]),
-            ("7D", "driest", [272.161376, 269.31008671]),
-            ("MS", "driest", [272.00644843, 269.04077039]),
+            ("D", "wettest", [296.138132, 295.823782]),
+            ("7D", "wettest", [296.138132, 295.823782]),
+            ("MS", "wettest", [296.429311, 296.192342]),
+            ("D", "driest", [271.8105, 269.993252]),
+            ("7D", "driest", [271.8105, 269.993252]),
+            ("MS", "driest", [271.655305, 269.736969]),
         ],
     )
     @pytest.mark.parametrize("use_dask", [True, False])
-    def test_tg_wetdry(self, tas_series, pr_series, use_dask, freq, op, expected):
-        tas, pr = self.get_data(tas_series, pr_series)
+    def test_tg_wetdry(
+        self, tas_series, pr_series, use_dask, freq, op, expected, random
+    ):
+        tas, pr = self.get_data(tas_series, pr_series, random)
         pr = pr.resample(time=freq).mean(keep_attrs=True)
 
         tas = xci.tg_mean(tas, freq=freq)
@@ -2051,16 +2052,16 @@ class TestTempWetDryPrecipWarmColdQuarter:
     @pytest.mark.parametrize(
         "freq,op,expected",
         [
-            ("D", "warmest", [2021.82232981, 2237.15117103]),
-            ("7D", "warmest", [2021.82232981, 2237.15117103]),
-            ("MS", "warmest", [2038.54763205, 2247.47136629]),
-            ("D", "coldest", [311.91895223, 264.50013361]),
-            ("7D", "coldest", [311.91895223, 264.50013361]),
-            ("MS", "coldest", [311.91895223, 259.36682028]),
+            ("D", "warmest", [2042.826039, 2131.651904]),
+            ("7D", "warmest", [2042.826039, 2131.651904]),
+            ("MS", "warmest", [2085.393869, 2193.985419]),
+            ("D", "coldest", [246.965006, 229.86537]),
+            ("7D", "coldest", [246.965006, 229.86537]),
+            ("MS", "coldest", [245.550801, 233.847277]),
         ],
     )
-    def test_pr_warmcold(self, tas_series, pr_series, freq, op, expected):
-        tas, pr = self.get_data(tas_series, pr_series)
+    def test_pr_warmcold(self, tas_series, pr_series, freq, op, expected, random):
+        tas, pr = self.get_data(tas_series, pr_series, random)
         pr = convert_units_to(
             pr.resample(time=freq).mean(keep_attrs=True), "mm/d", context="hydro"
         )
@@ -2172,32 +2173,26 @@ class TestPrecipWettestDriestPeriod:
 
 
 class TestIsothermality:
-    @staticmethod
-    def get_data(tasmin_series, tasmax_series):
-        np.random.seed(123)
-        times = pd.date_range("2000-01-01", "2001-12-31", name="time")
-        annual_cycle = np.sin(2 * np.pi * (times.dayofyear.values / 365.25 - 0.28))
-        base = 10 + 15 * annual_cycle.reshape(-1, 1)
-        values = base + 3 * np.random.randn(annual_cycle.size, 1) + K2C
-        tasmin = tasmin_series(values.squeeze(), start="2001-01-01").sel(
-            time=slice("2001", "2002")
-        )
-        values = base + 10 + 3 * np.random.randn(annual_cycle.size, 1) + K2C
-        tasmax = tasmax_series(values.squeeze(), start="2001-01-01").sel(
-            time=slice("2001", "2002")
-        )
-        return tasmin, tasmax
-
     @pytest.mark.parametrize(
         "freq,expected",
         [
-            ("D", [18.8700109, 19.40941685]),
-            ("7D", [23.29006069, 23.36559839]),
-            ("MS", [25.05925319, 25.09443682]),
+            ("D", [19.798229, 19.559826]),
+            ("7D", [23.835284, 24.15181]),
+            ("MS", [25.260527, 26.647243]),
         ],
     )
-    def test_simple(self, tasmax_series, tasmin_series, freq, expected):
-        tasmin, tasmax = self.get_data(tasmin_series, tasmax_series)
+    def test_simple(self, tasmax_series, tasmin_series, freq, expected, random):
+        times = pd.date_range("2000-01-01", "2001-12-31", name="time")
+        annual_cycle = np.sin(2 * np.pi * (times.dayofyear.values / 365.25 - 0.28))
+        base = 10 + 15 * annual_cycle.reshape(-1, 1)
+        values = base + 3 * random.standard_normal((annual_cycle.size, 1)) + K2C
+        tasmin = tasmin_series(values.squeeze(), start="2001-01-01").sel(
+            time=slice("2001", "2002")
+        )
+        values = base + 10 + 3 * random.standard_normal((annual_cycle.size, 1)) + K2C
+        tasmax = tasmax_series(values.squeeze(), start="2001-01-01").sel(
+            time=slice("2001", "2002")
+        )
 
         # weekly
         tmin = tasmin.resample(time=freq).mean(dim="time", keep_attrs=True)
@@ -2284,13 +2279,13 @@ class TestTxTnDaysAbove:
 
 
 class TestWarmSpellDurationIndex:
-    def test_simple(self, tasmax_series):
+    def test_simple(self, tasmax_series, random):
         i = 3650
         A = 10.0
         tx = (
             np.zeros(i)
             + A * np.sin(np.arange(i) / 365.0 * 2 * np.pi)
-            + 0.1 * np.random.rand(i)
+            + 0.1 * random.random(i)
         )
         tx[10:20] += 2
         tx = tasmax_series(tx)
@@ -2944,12 +2939,12 @@ class TestClausiusClapeyronScaledPrecip:
             ],
         )
 
-    def test_workflow(self, tas_series, pr_series):
+    def test_workflow(self, tas_series, pr_series, random):
         """Test typical workflow."""
         n = int(365.25 * 10)
-        tref = tas_series(np.random.rand(n), start="1961-01-01")
-        tfut = tas_series(np.random.rand(n) + 2, start="2051-01-01")
-        pr = pr_series(np.random.rand(n) * 10, start="1961-01-01")
+        tref = tas_series(random.random(n), start="1961-01-01")
+        tfut = tas_series(random.random(n) + 2, start="2051-01-01")
+        pr = pr_series(random.random(n) * 10, start="1961-01-01")
 
         # Compute climatologies
         with xr.set_options(keep_attrs=True):

--- a/tests/test_missing.py
+++ b/tests/test_missing.py
@@ -16,18 +16,18 @@ K2C = 273.15
 class TestMissingBase:
     """The base class is well tested for daily input through the subclasses."""
 
-    def test_monthly_input(self):
+    def test_monthly_input(self, random):
         """Creating array with 11 months."""
         n = 11
         time = xr.cftime_range(start="2002-01-01", periods=n, freq="M")
-        ts = xr.DataArray(np.random.rand(n), dims="time", coords={"time": time})
+        ts = xr.DataArray(random.random(n), dims="time", coords={"time": time})
         mb = missing.MissingBase(ts, freq="YS", src_timestep="M")
         # Make sure count is 12, because we're requesting a YS freq.
         assert mb.count == 12
 
         n = 5
         time = xr.cftime_range(start="2002-06-01", periods=n, freq="MS")
-        ts = xr.DataArray(np.random.rand(n), dims="time", coords={"time": time})
+        ts = xr.DataArray(random.random(n), dims="time", coords={"time": time})
         mb = missing.MissingBase(ts, freq="AS", src_timestep="M", season="JJA")
         assert mb.count == 3
 

--- a/tests/test_partitioning.py
+++ b/tests/test_partitioning.py
@@ -21,7 +21,7 @@ def test_hawkins_sutton_smoke(open_dataset):
     hawkins_sutton(das)
 
 
-def test_hawkins_sutton_synthetic():
+def test_hawkins_sutton_synthetic(random):
     """Test logic of Hawkins-Sutton's implementation using synthetic data."""
 
     # Time, scenario, model
@@ -32,7 +32,7 @@ def test_hawkins_sutton_synthetic():
     mean = mm[np.newaxis, :] + sm[:, np.newaxis]
 
     # Natural variability
-    r = np.random.randn(4, 13, 60)
+    r = random.standard_normal((4, 13, 60))
 
     x = r + mean[:, :, np.newaxis]
     time = xr.date_range("1970-01-01", periods=60, freq="Y")
@@ -56,7 +56,7 @@ def test_hawkins_sutton_synthetic():
     hawkins_sutton(da, sm=sm)
 
     # Test with a multiplicative variable and time evolving scenarios
-    r = np.random.randn(4, 13, 60) + np.arange(60)
+    r = random.standard_normal((4, 13, 60)) + np.arange(60)
     x = r + mean[:, :, np.newaxis]
     da = xr.DataArray(x, dims=("scenario", "model", "time"), coords={"time": time})
     m, v = hawkins_sutton(da, kind="*")

--- a/tests/test_run_length.py
+++ b/tests/test_run_length.py
@@ -670,9 +670,9 @@ def test_lazy_indexing(use_dask):
 
 
 @pytest.mark.parametrize("use_dask", [True, False])
-def test_lazy_indexing_special_cases(use_dask):
-    a = xr.DataArray(np.random.rand(10, 10, 10), dims=("x", "y", "z"))
-    b = xr.DataArray(np.random.rand(10, 10, 10), dims=("x", "y", "z"))
+def test_lazy_indexing_special_cases(use_dask, random):
+    a = xr.DataArray(random.random((10, 10, 10)), dims=("x", "y", "z"))
+    b = xr.DataArray(random.random((10, 10, 10)), dims=("x", "y", "z"))
 
     if use_dask:
         a = a.chunk({"y": 5, "z": 5})

--- a/tests/test_sdba/test_adjustment.py
+++ b/tests/test_sdba/test_adjustment.py
@@ -36,9 +36,9 @@ from xclim.testing.sdba_utils import nancov  # noqa
 
 class TestLoci:
     @pytest.mark.parametrize("group,dec", (["time", 2], ["time.month", 1]))
-    def test_time_and_from_ds(self, series, group, dec, tmp_path):
+    def test_time_and_from_ds(self, series, group, dec, tmp_path, random):
         n = 10000
-        u = np.random.rand(n)
+        u = random.random(n)
 
         xd = uniform(loc=0, scale=3)
         x = xd.ppf(u)
@@ -80,9 +80,9 @@ class TestLoci:
 @pytest.mark.slow
 class TestScaling:
     @pytest.mark.parametrize("kind,name", [(ADDITIVE, "tas"), (MULTIPLICATIVE, "pr")])
-    def test_time(self, kind, name, series):
+    def test_time(self, kind, name, series, random):
         n = 10000
-        u = np.random.rand(n)
+        u = random.random(n)
 
         xd = uniform(loc=2, scale=1)
         x = xd.ppf(u)
@@ -99,9 +99,9 @@ class TestScaling:
         np.testing.assert_array_almost_equal(p, ref)
 
     @pytest.mark.parametrize("kind,name", [(ADDITIVE, "tas"), (MULTIPLICATIVE, "pr")])
-    def test_mon_U(self, mon_series, series, mon_triangular, kind, name):
+    def test_mon_U(self, mon_series, series, mon_triangular, kind, name, random):
         n = 10000
-        u = np.random.rand(n)
+        u = random.random(n)
 
         xd = uniform(loc=2, scale=1)
         x = xd.ppf(u)
@@ -118,9 +118,9 @@ class TestScaling:
         p = scaling.adjust(sim)
         np.testing.assert_array_almost_equal(p, ref)
 
-    def test_add_dim(self, series, mon_series):
+    def test_add_dim(self, series, mon_series, random):
         n = 10000
-        u = np.random.rand(n, 4)
+        u = random.random((n, 4))
 
         xd = uniform(loc=2, scale=1)
         x = xd.ppf(u)
@@ -140,7 +140,7 @@ class TestScaling:
 @pytest.mark.slow
 class TestDQM:
     @pytest.mark.parametrize("kind,name", [(ADDITIVE, "tas"), (MULTIPLICATIVE, "pr")])
-    def test_quantiles(self, series, kind, name):
+    def test_quantiles(self, series, kind, name, random):
         """Train on
         hist: U
         ref: Normal
@@ -148,7 +148,7 @@ class TestDQM:
         Predict on hist to get ref
         """
         ns = 10000
-        u = np.random.rand(ns)
+        u = random.random(ns)
 
         # Define distributions
         xd = uniform(loc=10, scale=1)
@@ -207,7 +207,7 @@ class TestDQM:
 
     @pytest.mark.parametrize("kind,name", [(ADDITIVE, "tas"), (MULTIPLICATIVE, "pr")])
     @pytest.mark.parametrize("add_dims", [True, False])
-    def test_mon_U(self, mon_series, series, kind, name, add_dims):
+    def test_mon_U(self, mon_series, series, kind, name, add_dims, random):
         """
         Train on
         hist: U
@@ -216,7 +216,7 @@ class TestDQM:
         Predict on hist to get ref
         """
         n = 5000
-        u = np.random.rand(n)
+        u = random.random(n)
 
         # Define distributions
         xd = uniform(loc=2, scale=0.1)
@@ -251,8 +251,8 @@ class TestDQM:
         np.testing.assert_array_almost_equal(mqm, int(kind == MULTIPLICATIVE), 1)
         np.testing.assert_allclose(p.transpose(..., "time"), ref_t, rtol=0.1, atol=0.5)
 
-    def test_cannon_and_from_ds(self, cannon_2015_rvs, tmp_path):
-        ref, hist, sim = cannon_2015_rvs(15000)
+    def test_cannon_and_from_ds(self, cannon_2015_rvs, tmp_path, random):
+        ref, hist, sim = cannon_2015_rvs(15000, random=random)
 
         DQM = DetrendedQuantileMapping.train(ref, hist, kind="*", group="time")
         p = DQM.adjust(sim)
@@ -275,13 +275,13 @@ class TestDQM:
 @pytest.mark.slow
 class TestQDM:
     @pytest.mark.parametrize("kind,name", [(ADDITIVE, "tas"), (MULTIPLICATIVE, "pr")])
-    def test_quantiles(self, series, kind, name):
+    def test_quantiles(self, series, kind, name, random):
         """Train on
         x : U(1,1)
         y : U(1,2)
 
         """
-        u = np.random.rand(10000)
+        u = random.random(10000)
 
         # Define distributions
         xd = uniform(loc=1, scale=1)
@@ -323,7 +323,7 @@ class TestQDM:
     @pytest.mark.parametrize("kind,name", [(ADDITIVE, "tas"), (MULTIPLICATIVE, "pr")])
     @pytest.mark.parametrize("add_dims", [True, False])
     def test_mon_U(
-        self, mon_series, series, mon_triangular, add_dims, kind, name, use_dask
+        self, mon_series, series, mon_triangular, add_dims, kind, name, use_dask, random
     ):
         """
         Train on
@@ -332,7 +332,7 @@ class TestQDM:
 
         Predict on hist to get ref
         """
-        u = np.random.rand(10000)
+        u = random.random(10000)
 
         # Define distributions
         xd = uniform(loc=1, scale=1)
@@ -407,14 +407,14 @@ class TestQDM:
 @pytest.mark.slow
 class TestQM:
     @pytest.mark.parametrize("kind,name", [(ADDITIVE, "tas"), (MULTIPLICATIVE, "pr")])
-    def test_quantiles(self, series, kind, name):
+    def test_quantiles(self, series, kind, name, random):
         """Train on
         hist: U
         ref: Normal
 
         Predict on hist to get ref
         """
-        u = np.random.rand(10000)
+        u = random.random(10000)
 
         # Define distributions
         xd = uniform(loc=10, scale=1)
@@ -448,7 +448,7 @@ class TestQM:
         np.testing.assert_array_almost_equal(p[middle], ref[middle], 1)
 
     @pytest.mark.parametrize("kind,name", [(ADDITIVE, "tas"), (MULTIPLICATIVE, "pr")])
-    def test_mon_U(self, mon_series, series, mon_triangular, kind, name):
+    def test_mon_U(self, mon_series, series, mon_triangular, kind, name, random):
         """
         Train on
         hist: U
@@ -456,7 +456,7 @@ class TestQM:
 
         Predict on hist to get ref
         """
-        u = np.random.rand(10000)
+        u = random.random(10000)
 
         # Define distributions
         xd = uniform(loc=2, scale=0.1)
@@ -525,13 +525,13 @@ class TestPrincipalComponents:
     @pytest.mark.parametrize(
         "group", (Grouper("time.month"), Grouper("time", add_dims=["lon"]))
     )
-    def test_simple(self, group):
+    def test_simple(self, group, random):
         n = 15 * 365
         m = 2  # A dummy dimension to test vectorizing.
-        ref_y = norm.rvs(loc=10, scale=1, size=(m, n))
-        ref_x = norm.rvs(loc=3, scale=2, size=(m, n))
-        sim_x = norm.rvs(loc=4, scale=2, size=(m, n))
-        sim_y = sim_x + norm.rvs(loc=1, scale=1, size=(m, n))
+        ref_y = norm.rvs(loc=10, scale=1, size=(m, n), random_state=random)
+        ref_x = norm.rvs(loc=3, scale=2, size=(m, n), random_state=random)
+        sim_x = norm.rvs(loc=4, scale=2, size=(m, n), random_state=random)
+        sim_y = sim_x + norm.rvs(loc=1, scale=1, size=(m, n), random_state=random)
 
         ref = xr.DataArray(
             [ref_x, ref_y], dims=("lat", "lon", "time"), attrs={"units": "degC"}
@@ -619,14 +619,16 @@ class TestExtremeValues:
             ["0.007 m/week", 0.95, 0.25, 2],
         ],
     )
-    def test_simple(self, c_thresh, q_thresh, frac, power):
+    def test_simple(self, c_thresh, q_thresh, frac, power, random):
         n = 45 * 365
 
         def gen_testdata(c, s):
-            base = np.clip(norm.rvs(loc=0, scale=s, size=(n,)), 0, None)
+            base = np.clip(
+                norm.rvs(loc=0, scale=s, size=(n,), random_state=random), 0, None
+            )
             qv = np.quantile(base[base > 1], q_thresh)
             base[base > qv] = genpareto.rvs(
-                c, loc=qv, scale=s, size=base[base > qv].shape
+                c, loc=qv, scale=s, size=base[base > qv].shape, random_state=random
             )
             return xr.DataArray(
                 base,
@@ -709,17 +711,17 @@ class TestSBCKutils:
         "method", [m for m in dir(adjustment) if m.startswith("SBCK_")]
     )
     @pytest.mark.parametrize("use_dask", [True])  # do we gain testing both?
-    def test_sbck(self, method, use_dask):
+    def test_sbck(self, method, use_dask, random):
         SBCK = pytest.importorskip("SBCK", minversion="0.4.0")  # noqa
 
         n = 10 * 365
         m = 2  # A dummy dimension to test vectorization.
-        ref_y = norm.rvs(loc=10, scale=1, size=(m, n))
-        ref_x = norm.rvs(loc=3, scale=2, size=(m, n))
-        hist_x = norm.rvs(loc=11, scale=1.2, size=(m, n))
-        hist_y = norm.rvs(loc=4, scale=2.2, size=(m, n))
-        sim_x = norm.rvs(loc=12, scale=2, size=(m, n))
-        sim_y = norm.rvs(loc=3, scale=1.8, size=(m, n))
+        ref_y = norm.rvs(loc=10, scale=1, size=(m, n), random_state=random)
+        ref_x = norm.rvs(loc=3, scale=2, size=(m, n), random_state=random)
+        hist_x = norm.rvs(loc=11, scale=1.2, size=(m, n), random_state=random)
+        hist_y = norm.rvs(loc=4, scale=2.2, size=(m, n), random_state=random)
+        sim_x = norm.rvs(loc=12, scale=2, size=(m, n), random_state=random)
+        sim_y = norm.rvs(loc=3, scale=1.8, size=(m, n), random_state=random)
 
         ref = xr.Dataset(
             {

--- a/tests/test_sdba/test_processing.py
+++ b/tests/test_sdba/test_processing.py
@@ -66,9 +66,9 @@ def test_jitter_over_thresh():
 
 
 @pytest.mark.parametrize("use_dask", [True, False])
-def test_adapt_freq(use_dask):
+def test_adapt_freq(use_dask, random):
     time = pd.date_range("1990-01-01", "2020-12-31", freq="D")
-    prvals = np.random.randint(0, 100, size=(time.size, 3))
+    prvals = random.integers(0, 100, size=(time.size, 3))
     pr = xr.DataArray(
         prvals,
         coords={"time": time, "lat": [0, 1, 2]},
@@ -115,9 +115,9 @@ def test_adapt_freq(use_dask):
 
 
 @pytest.mark.parametrize("use_dask", [True, False])
-def test_adapt_freq_add_dims(use_dask):
+def test_adapt_freq_add_dims(use_dask, random):
     time = pd.date_range("1990-01-01", "2020-12-31", freq="D")
-    prvals = np.random.randint(0, 100, size=(time.size, 3))
+    prvals = random.integers(0, 100, size=(time.size, 3))
     pr = xr.DataArray(
         prvals,
         coords={"time": time, "lat": [0, 1, 2]},
@@ -157,8 +157,8 @@ def test_escore():
     assert out.attrs["references"].startswith("Székely")
 
 
-def test_standardize():
-    x = np.random.standard_normal((2, 10000))
+def test_standardize(random):
+    x = random.standard_normal((2, 10000))
     x[0, 50] = np.NaN
     x = xr.DataArray(x, dims=("x", "y"), attrs={"units": "m"})
 
@@ -247,9 +247,9 @@ def test_from_additive(pr_series, hurs_series):
     np.testing.assert_allclose(hurs[1:-1], hurs2[1:-1])
 
 
-def test_normalize(tas_series):
+def test_normalize(tas_series, random):
     tas = tas_series(
-        np.random.standard_normal((int(365.25 * 36),)) + 273.15, start="2000-01-01"
+        random.standard_normal((int(365.25 * 36),)) + 273.15, start="2000-01-01"
     )
 
     xp, norm = normalize(tas, group="time.dayofyear")

--- a/tests/test_snow.py
+++ b/tests/test_snow.py
@@ -74,9 +74,9 @@ class TestSndMaxDoy:
         out = land.snd_max_doy(snd, freq="AS-JUL")
         np.testing.assert_array_equal(out, snd.time.dt.dayofyear[200])
 
-    def test_units(self, tas_series):
+    def test_units(self, tas_series, random):
         """Check that unit declaration works."""
-        tas = tas_series(np.random.rand(365), start="1999-07-01")
+        tas = tas_series(random.random(365), start="1999-07-01")
         with pytest.raises(ValidationError):
             land.snd_max_doy(tas)
 

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -10,7 +10,7 @@ from xclim.indices import stats
 
 
 @pytest.fixture(params=[True, False])
-def fitda(request):
+def fitda(request, random):
     nx, ny, nt = 2, 3, 100
     x = np.arange(nx)
     y = np.arange(ny)
@@ -18,7 +18,7 @@ def fitda(request):
     time = xr.cftime_range("2045-02-02", periods=nt, freq="D")
 
     da = xr.DataArray(
-        np.random.lognormal(2, 1, (nt, nx, ny)),
+        random.lognormal(2, 1, (nt, nx, ny)),
         dims=("time", "x", "y"),
         coords={"time": time, "x": x, "y": y},
     )
@@ -224,13 +224,13 @@ class TestPWMFit:
 
     @pytest.mark.parametrize("dist", stats._lm3_dist_map.keys())
     @pytest.mark.parametrize("use_dask", [True, False])
-    def test_pwm_fit(self, dist, use_dask):
+    def test_pwm_fit(self, dist, use_dask, random):
         """Test that the fitted parameters match parameters used to generate a random sample."""
         n = 500
         dc = stats.get_dist(dist)
         par = self.params[dist]
         da = xr.DataArray(
-            dc(**par).rvs(size=n),
+            dc(**par).rvs(size=n, random_state=random),
             dims=("time",),
             coords={"time": xr.cftime_range("1980-01-01", periods=n)},
         )
@@ -280,14 +280,14 @@ def test_frequency_analysis(ndq_series, use_dask):
 
 
 @pytest.mark.parametrize("use_dask", [True, False])
-def test_parametric_quantile(use_dask):
+def test_parametric_quantile(use_dask, random):
     mu = 23
     sigma = 2
     n = 10000
     per = 0.9
     d = norm(loc=mu, scale=sigma)
     r = xr.DataArray(
-        d.rvs(n),
+        d.rvs(n, random_state=random),
         dims=("time",),
         coords={"time": xr.cftime_range(start="1980-01-01", periods=n)},
         attrs={"history": "Mosquito bytes per minute"},
@@ -302,14 +302,14 @@ def test_parametric_quantile(use_dask):
 
 
 @pytest.mark.parametrize("use_dask", [True, False])
-def test_paramtric_cdf(use_dask):
+def test_paramtric_cdf(use_dask, random):
     mu = 23
     sigma = 2
     n = 10000
     v = 24
     d = norm(loc=mu, scale=sigma)
     r = xr.DataArray(
-        d.rvs(n),
+        d.rvs(n, random_state=random),
         dims=("time",),
         coords={"time": xr.cftime_range(start="1980-01-01", periods=n)},
         attrs={"history": "Mosquito bytes per minute"},

--- a/tests/test_temperature.py
+++ b/tests/test_temperature.py
@@ -15,13 +15,13 @@ K2C = 273.15
 
 
 class TestCSDI:
-    def test_simple(self, tasmin_series):
+    def test_simple(self, tasmin_series, random):
         i = 3650
         A = 10.0
         tn = (
             np.zeros(i)
             + A * np.sin(np.arange(i) / 365.0 * 2 * np.pi)
-            + 0.1 * np.random.rand(i)
+            + 0.1 * random.random(i)
         )
         tn += K2C
         tn[10:20] -= 2
@@ -31,13 +31,13 @@ class TestCSDI:
         out = atmos.cold_spell_duration_index(tn, tn10, freq="AS-JUL")
         assert out[0] == 10
 
-    def test_convert_units(self, tasmin_series):
+    def test_convert_units(self, tasmin_series, random):
         i = 3650
         A = 10.0
         tn = (
             np.zeros(i)
             + A * np.sin(np.arange(i) / 365.0 * 2 * np.pi)
-            + 0.1 * np.random.rand(i)
+            + 0.1 * random.random(i)
         )
         tn[10:20] -= 2
         tn = tasmin_series(tn + K2C)
@@ -47,14 +47,14 @@ class TestCSDI:
         out = atmos.cold_spell_duration_index(tn, tn10, freq="AS-JUL")
         assert out[0] == 10
 
-    def test_nan_presence(self, tasmin_series):
+    def test_nan_presence(self, tasmin_series, random):
         i = 3650
         A = 10.0
         tn = (
             np.zeros(i)
             + K2C
             + A * np.sin(np.arange(i) / 365.0 * 2 * np.pi)
-            + 0.1 * np.random.rand(i)
+            + 0.1 * random.random(i)
         )
         tn[10:20] -= 2
         tn[9] = np.nan
@@ -854,11 +854,11 @@ class TestDailyFreezeThaw:
 
 class TestGrowingSeasonLength:
     @pytest.mark.parametrize("chunks", [None, {"time": 183.0}])
-    def test_single_year(self, tas_series, chunks):
+    def test_single_year(self, tas_series, chunks, random):
         a = np.zeros(366) + K2C
         ts = tas_series(a, start="1/1/2000")
         tt = (ts.time.dt.month >= 5) & (ts.time.dt.month <= 8)
-        offset = np.random.uniform(low=5.5, high=23, size=(tt.sum().values,))
+        offset = random.uniform(low=5.5, high=23, size=(tt.sum().values,))
         ts[tt] = ts[tt] + offset
         if chunks:
             ts = ts.chunk(chunks)
@@ -867,41 +867,41 @@ class TestGrowingSeasonLength:
 
         np.testing.assert_array_equal(out, tt.sum())
 
-    def test_convert_units(self, tas_series):
+    def test_convert_units(self, tas_series, random):
         a = np.zeros(366)
 
         ts = tas_series(a, start="1/1/2000")
         ts.attrs["units"] = "C"
         tt = (ts.time.dt.month >= 5) & (ts.time.dt.month <= 8)
-        offset = np.random.uniform(low=5.5, high=23, size=(tt.sum().values,))
+        offset = random.uniform(low=5.5, high=23, size=(tt.sum().values,))
         ts[tt] = ts[tt] + offset
 
         out = atmos.growing_season_length(ts)
 
         np.testing.assert_array_equal(out, tt.sum())
 
-    def test_nan_presence(self, tas_series):
+    def test_nan_presence(self, tas_series, random):
         a = np.zeros(366)
         a[50] = np.nan
         ts = tas_series(a, start="1/1/2000")
         ts.attrs["units"] = "C"
         tt = (ts.time.dt.month >= 5) & (ts.time.dt.month <= 8)
 
-        offset = np.random.uniform(low=5.5, high=23, size=(tt.sum().values,))
+        offset = random.uniform(low=5.5, high=23, size=(tt.sum().values,))
         ts[tt] = ts[tt] + offset
 
         out = atmos.growing_season_length(ts)
 
         np.testing.assert_array_equal(out, [np.nan])
 
-    def test_multiyear(self, tas_series):
+    def test_multiyear(self, tas_series, random):
         a = np.zeros(366 * 10)
 
         ts = tas_series(a, start="1/1/2000")
         ts.attrs["units"] = "C"
         tt = (ts.time.dt.month >= 5) & (ts.time.dt.month <= 8)
 
-        offset = np.random.uniform(low=5.5, high=23, size=(tt.sum().values,))
+        offset = random.uniform(low=5.5, high=23, size=(tt.sum().values,))
         ts[tt] = ts[tt] + offset
 
         out = atmos.growing_season_length(ts)

--- a/xclim/ensembles/_reduce.py
+++ b/xclim/ensembles/_reduce.py
@@ -221,7 +221,7 @@ def kmeans_reduce_ensemble(
         See: https://scikit-learn.org/stable/modules/generated/sklearn.cluster.KMeans.html
     random_state: int or np.random.RandomState, optional
         sklearn.cluster.KMeans() random_state parameter. Determines random number generation for centroid
-        initialization. Use an int to make the randomness deterministic.
+        initialization. Use to make the randomness deterministic.
         See: https://scikit-learn.org/stable/modules/generated/sklearn.cluster.KMeans.html
     make_graph: bool
         output a dictionary of input for displays a plot of R² vs. the number of clusters.

--- a/xclim/testing/helpers.py
+++ b/xclim/testing/helpers.py
@@ -204,10 +204,20 @@ def add_example_file_paths(cache_dir: Path) -> dict[str]:
 
 
 def test_timeseries(
-    values, variable, start="7/1/2000", units=None, freq="D", as_dataset=False
+    values,
+    variable,
+    start="7/1/2000",
+    units=None,
+    freq="D",
+    as_dataset=False,
+    cftime=False,
 ):
     """Create a generic timeseries object based on pre-defined dictionaries of existing variables."""
-    coords = pd.date_range(start, periods=len(values), freq=freq)
+    if cftime:
+        coords = xr.cftime_range(start, periods=len(values), freq=freq)
+    else:
+        coords = pd.date_range(start, periods=len(values), freq=freq)
+
     data_on_var = safe_load(open_text("xclim.data", "variables.yml"))["variables"]
     if variable in data_on_var:
         attrs = {


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1428
- [x] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] CHANGES.rst has been updated (with summary of main changes)
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

Added new `random` fixture : it returns a numpy Generator with a constant seed. All tests using random number generation use that fixture. Each time the test is run, the same generator is returned, and it generate the same numbers each time.

Some tests were already using specific seeds, but I tried to use this new solution everywhere, leading to adjustment of the expected values in many places.

The KMeans object of `sci-kit learn` doesn't support the conventional numpy generator, so a specific fixture is created for these tests.

I rewrote some tests, to reduce the number of line and complexity. The normal bootstrap tests for example have all been merged into one.

### Does this PR introduce a breaking change?
No, it only affects the tests.

### Other information:
I think we have no random generation done inside dask tasks, which avoids having to implement that.
