### PR TITLE
add calculation of standard deviation to properties, update xclim.sdb…

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -120,6 +120,11 @@
     {
       "name": "Whelan, Chistopher",
       "affiliation": "Independent Researcher, United States"
+    },
+    {
+      "name": "Braun, Marco",
+      "affiliation": "Ouranos Consortium, Montréal, Québec, Canada",
+      "orcid": "0000-0001-5061-3217"
     }
   ],
   "keywords": [

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -39,3 +39,4 @@ Contributors
 * Ag Stephens <ag.stephens@stfc.ac.uk> `@agstephens <https://github.com/agstephens>`_
 * Maliko Tanguy <malngu@ceh.ac.uk> `@malngu <https://github.com/malngu>`_
 * Christopher Whelan `@qwhelan <https://github.com/qwhelan>`_
+* Marco Braun <Braun.Marco@ouranos.ca> `@vindelico <https://github.com/vindelico>`_

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ New features and enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 * Added ``ensembles.hawkins_sutton`` method to partition the uncertainty sources in a climate projection ensemble. (:issue:`771`, :pull:`1262`).
 * New function ``xclim.core.calendar.convert_doy`` to transform day-of-year data between calendars. Also accessible from ``convert_calendar`` with ``doy=True``. (:issue:`1283`, :pull:`1406`).
+* Added new function ``xclim.sdba.properties.std``to calculate the standard deviation of a variable over all years at a given time resolution. (:pull:`???`).
+* Amended the documentation of ``xclim.sdba.properties.trend`` to document already existing functionality of calculating the return values of scipy.stats.linregress. (:pull:`???`).
 
 Bug fixes
 ^^^^^^^^^

--- a/tests/test_sdba/test_properties.py
+++ b/tests/test_sdba/test_properties.py
@@ -44,6 +44,24 @@ class TestProperties:
         assert out_season.long_name.startswith("Variance")
         assert out_season.units == "kg^2 m-4 s-2"
 
+    def test_std(self, open_dataset):
+        sim = (
+            open_dataset("sdba/CanESM2_1950-2100.nc")
+            .sel(time=slice("1950", "1980"), location="Vancouver")
+            .pr
+        ).load()
+
+        out_year = sdba.properties.std(sim)
+        np.testing.assert_array_almost_equal(out_year.values, [5.08770208398345e-05])
+
+        out_season = sdba.properties.std(sim, group="time.season")
+        np.testing.assert_array_almost_equal(
+            out_season.values,
+            [6.2666411e-05, 3.5410259e-05, 4.3654352e-05, 5.3643853e-05],
+        )
+        assert out_season.long_name.startswith("Standard deviation")
+        assert out_season.units == "kg m-2 s-1"
+
     def test_skewness(self, open_dataset):
         sim = (
             open_dataset("sdba/CanESM2_1950-2100.nc")
@@ -352,19 +370,29 @@ class TestProperties:
         ).load()
 
         slope = sdba.properties.trend(simt).values
+        intercept = sdba.properties.trend(simt, output="intercept").values
+        rvalue = sdba.properties.trend(simt, output="rvalue").values
         pvalue = sdba.properties.trend(simt, output="pvalue").values
+        stderr = sdba.properties.trend(simt, output="stderr").values
+        intercept_stderr = sdba.properties.trend(simt, output="intercept_stderr").values
+
         np.testing.assert_array_almost_equal(
-            [slope, pvalue], [-1.33720000e-01, 0.154605951862107], 4
+            [slope, intercept, rvalue, pvalue, stderr, intercept_stderr],
+            [-0.133711111111111, 288.762132222222222, -0.9706433333333333,
+             0.1546344444444444, 0.033135555555555, 0.042776666666666], 4
         )
 
         slope = sdba.properties.trend(simt, group="time.month").sel(month=1)
-        pvalue = (
-            sdba.properties.trend(simt, output="pvalue", group="time.month")
-            .sel(month=1)
-            .values
-        )
+        intercept = sdba.properties.trend(simt, output="intercept", group="time.month").sel(month=1).values
+        rvalue = sdba.properties.trend(simt, output="rvalue", group="time.month").sel(month=1).values
+        pvalue = sdba.properties.trend(simt, output="pvalue", group="time.month").sel(month=1).values
+        stderr = sdba.properties.trend(simt, output="stderr", group="time.month").sel(month=1).values
+        intercept_stderr = sdba.properties.trend(simt, output="intercept_stderr", group="time.month").sel(month=1).values
+
         np.testing.assert_array_almost_equal(
-            [slope.values, pvalue], [0.8254349999999988, 0.6085783558202086], 4
+            [slope.values, intercept, rvalue, pvalue, stderr, intercept_stderr],
+            [0.8254511111111111, 281.76353222222222, 0.576843333333333,
+             0.6085644444444444, 1.1689105555555555, 1.509056666666666], 4
         )
 
         assert slope.long_name.startswith("Slope of the interannual linear trend")

--- a/xclim/sdba/properties.py
+++ b/xclim/sdba/properties.py
@@ -176,6 +176,40 @@ var = StatisticalProperty(
 )
 
 
+def _std(da: xr.DataArray, *, group: str | Grouper = "time") -> xr.DataArray:
+    """Standard Deviation.
+
+    Standard deviation of the variable over all years at the time resolution.
+
+    Parameters
+    ----------
+    da : xr.DataArray
+      Variable on which to calculate the diagnostic.
+    group : {'time', 'time.season', 'time.month'}
+      Grouping of the output.
+      E.g. If 'time.month', the standard deviation is performed separately for each month.
+
+    Returns
+    -------
+    xr.DataArray,
+      Standard deviation of the variable.
+    """
+    units = da.units
+    if group.prop != "group":
+        da = da.groupby(group.name)
+    out = da.std(dim=group.dim)
+    out.attrs['units'] = units
+    return out
+
+
+std = StatisticalProperty(
+    identifier="std",
+    aspect="marginal",
+    cell_methods="time: std",
+    compute=_std,
+    measure="xclim.sdba.measures.RATIO",
+)
+
 def _skewness(da: xr.DataArray, *, group: str | Grouper = "time") -> xr.DataArray:
     """Skewness.
 
@@ -823,8 +857,8 @@ def _trend(
     ----------
     da : xr.DataArray
         Variable on which to calculate the diagnostic.
-    output : {'slope', 'pvalue'}
-        Attributes of the linear regression to return.
+    output : {'slope', 'intercept', 'rvalue', 'pvalue', 'stderr', 'intercept_stderr'}
+        Attributes of the linear regression to return, as defined in scipy.stats.linregress.
         'slope' is the slope of the regression line.
         'pvalue' is  for a hypothesis test whose null hypothesis is that the slope is zero,
         using Wald Test with t-distribution of the test statistic.


### PR DESCRIPTION
…a.properties.trend documentation + respective tests

<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] Tests for the changes have been added (for bug fixes / features)
  - [x] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Add new function ``xclim.sdba.properties.std``to calculate the standard deviation of a variable over all years at a given time resolution.
* Add a test for the above.
* Amended the documentation of ``xclim.sdba.properties.trend`` to document already existing functionality of calculating the return values of scipy.stats.linregress.
* Modified the test for the above to test all 6 possible return values of scipy.stats.linregress.

### Does this PR introduce a breaking change?

No.

### Other information:
