### PR TITLE
Fix multiindex error on upstream xr

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,7 +26,7 @@ Internal changes
 * Tolerance thresholds for error in ``test_processing::test_adapt_freq`` have been relaxed to allow for more variation in the results. (:issue:`1417`, :pull:`1418`).
 * Added 'streamflow' to the list of known variables (:pull:`1431`).
 * Refactor base indicator classes and fix misleading inheritance of ``return_level`` (:issue:`1263`, :pull:`1446`).
-* Fix and adapt ``percentile_doy`` for an error raised by xarray > 2023.7.0 (:issue:`211`, :pull:`1450`).
+* Fix and adapt ``percentile_doy`` for an error raised by xarray > 2023.7.0 (:issue:`1417`, :pull:`1450`).
 
 v0.44.0 (2023-06-23)
 --------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,7 +27,6 @@ Internal changes
 * Increased the guess of number of quantiles needed in ExtremeValues. (:pull:`1413`).
 * Tolerance thresholds for error in ``test_processing::test_adapt_freq`` have been relaxed to allow for more variation in the results. (:issue:`1417`, :pull:`1418`).
 * Added 'streamflow' to the list of known variables (:pull:`1431`).
-* Refactor base indicator classes and fix misleading inheritance of ``return_level`` (:issue:`1263`, :pull:`1446`).
 * Fix and adapt ``percentile_doy`` for an error raised by xarray > 2023.7.0 (:issue:`1417`, :pull:`1450`).
 
 v0.44.0 (2023-06-23)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,8 @@ Internal changes
 * Increased the guess of number of quantiles needed in ExtremeValues. (:pull:`1413`).
 * Tolerance thresholds for error in ``test_processing::test_adapt_freq`` have been relaxed to allow for more variation in the results. (:issue:`1417`, :pull:`1418`).
 * Added 'streamflow' to the list of known variables (:pull:`1431`).
+* Refactor base indicator classes and fix misleading inheritance of ``return_level`` (:issue:`1263`, :pull:`1446`).
+* Fix and adapt ``percentile_doy`` for an error raised by xarray > 2023.7.0 (:issue:`211`, :pull:`1450`).
 
 v0.44.0 (2023-06-23)
 --------------------


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1417
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

Overriding a coordinate with a pandas MultiIndex was not working properly before, but this didn't result in any errors up to a recent change in xarray's master. When calling `assign_coords` with a multiindex on a coordinate that already existed, the sub-indexes would not appear in the DataArray repr. In the most recent xarray master, that now triggers an error when trying to unstack the multiindex, but only if dask is used. Before, the unstacking would proceed as normal and the sub-indexes would magically appear on the result. Dropping the previous coordinate solves this problem.

The next xarray will implement a new public `xr.Coordinates` class that should be used to assign coords, instead of a raw `pd.MultiIndex`. Nonetheless, overriding is still not possible and dropping the previous coordinate is still needed.

### Does this PR introduce a breaking change?
No.


### Other information:
See pydata/xarray#8039.
