### PR TITLE
Use platform-specific data caching directories

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,10 @@ v0.45.0 (unreleased)
 --------------------
 Contributors to this version: David Huard (:user:`huard`), Trevor James Smith (:user:`Zeitsperre`), Pascal Bourgault (:user:`aulemahal`), Juliette Lavoie (:user:`juliettelavoie`), Gabriel Rondeau-Genesse (:user:`RondeauG`), Marco Braun (:user:`vindelico`), Éric Dupuis (:user:`coxipi`).
 
+Announcements
+^^^^^^^^^^^^^
+* `xclim` now uses `platformdirs` to write `xclim-testdata` to the user's cache directory. Dynamic paths are now used to cache data dependent on the user's operating system. Developers can now safely delete the `.xclim-testdata` folder in their home directory without affecting the functionality of `xclim`.
+
 New features and enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 * Added ``ensembles.hawkins_sutton`` method to partition the uncertainty sources in a climate projection ensemble. (:issue:`771`, :pull:`1262`).

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Contributors to this version: David Huard (:user:`huard`), Trevor James Smith (:
 
 Announcements
 ^^^^^^^^^^^^^
-* `xclim` now uses `platformdirs` to write `xclim-testdata` to the user's cache directory. Dynamic paths are now used to cache data dependent on the user's operating system. Developers can now safely delete the `.xclim-testdata` folder in their home directory without affecting the functionality of `xclim`.
+* `xclim` now uses `platformdirs` to write `xclim-testdata` to the user's cache directory. Dynamic paths are now used to cache data dependent on the user's operating system. Developers can now safely delete the `.xclim-testdata` folder in their home directory without affecting the functionality of `xclim`. (:pull:`1460`).
 
 New features and enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/environment.yml
+++ b/environment.yml
@@ -47,6 +47,7 @@ dependencies:
     - nc-time-axis
     - netCDF4>=1.4
     - notebook
+    - platformdirs
     - pooch
     - pre-commit
     - pybtex

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ dev = [
   "nbqa",
   "nbval",
   "netCDF4 >=1.4",
+  "platformdirs >=3.2",
   "pre-commit >=2.9",
   "pydocstyle >=5.1.1",
   "pybtex",

--- a/xclim/testing/utils.py
+++ b/xclim/testing/utils.py
@@ -23,6 +23,7 @@ from urllib.parse import urljoin
 from urllib.request import urlopen, urlretrieve
 
 import pandas as pd
+from platformdirs import user_cache_dir
 from xarray import Dataset
 from xarray import open_dataset as _open_dataset
 
@@ -48,7 +49,7 @@ _xclim_deps = [
 ]
 
 
-_default_cache_dir = Path.home() / ".xclim_testing_data"
+_default_cache_dir = Path(user_cache_dir("xclim-testdata"))
 
 logger = logging.getLogger("xclim")
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR is a first step towards addressing #1261 
- [x] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Integrate the `platformdirs` library for more intelligent/standardized testing data caching

### Does this PR introduce a breaking change?

Not really. Users can remove the `$HOME/.xclim-testdata` folder as the testing data is now saved in a much better spot, dependent on OS.

### Other information:

https://github.com/platformdirs/platformdirs