### PR TITLE
CI Updates, Cache cleaning, and Mastodon Workflow

### DIFF
--- a/.github/workflows/actions-versions-updater.yml
+++ b/.github/workflows/actions-versions-updater.yml
@@ -21,4 +21,4 @@ jobs:
           committer_email: 'bumpversion[bot]@ouranos.ca'
           committer_username: 'update-github-actions[bot]'
           pull_request_title: '[bot] Update GitHub Action Versions'
-          pull_request_user_reviewers: "Zeitsperre"
+          pull_request_team_reviewers: "xclim-core"

--- a/.github/workflows/cache-cleaner.yml
+++ b/.github/workflows/cache-cleaner.yml
@@ -1,0 +1,34 @@
+# Example taken from https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#managing-caches
+name: Cleanup Caches on PR Merge
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Cleanup
+        run: |
+          gh extension install actions/gh-actions-cache
+
+          REPO=${{ github.repository }}
+          BRANCH="refs/pull/${{ github.event.pull_request.number }}/merge"
+
+          echo "Fetching list of cache key"
+          cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH -L 100 | cut -f 1 )
+
+          ## Setting this to not fail the workflow while deleting cache keys.
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $cacheKeysForPR
+          do
+              gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
+          done
+          echo "Done"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-mastodon.yml
+++ b/.github/workflows/publish-mastodon.yml
@@ -1,0 +1,34 @@
+name: Publish Release Announcement to Mastodon
+
+on:
+  status:
+    types:
+      - published
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Current Version
+      run: |
+        CURRENT_VERSION="$(grep -E '__version__'  xclim/__init__.py | cut -d ' ' -f3)"
+        echo "current_version=${CURRENT_VERSION}" >> $GITHUB_ENV
+
+    - name: Send toot to Mastodon
+      id: mastodon
+      uses: cbrgm/mastodon-github-action@v1
+      with:
+        message: |
+          New #xclim release: v${{ env.current_version }} 🎉
+
+          Source code available at: https://github.com/Ouranosinc/xclim
+          Check out the docs for more information: https://xclim.readthedocs.io/en/v${{ env.current_version }}/
+        visibility: "public" # default: public
+      env:
+        MASTODON_URL: ${{ secrets.MASTODON_URL }} # https://example.social
+        MASTODON_ACCESS_TOKEN: ${{ secrets.MASTODON_ACCESS_TOKEN }} # access token

--- a/.github/workflows/testdata_version.yml
+++ b/.github/workflows/testdata_version.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
-          body-includes: It appears that this PR modifies the `XCLIM_TESTDATA_BRANCH` environment variable
+          body-includes: It appears that this Pull Request modifies the `main.yml` workflow.
       - name: Compare Versions
         if: ${{( env.XCLIM_TESTDATA_TAG != env.XCLIM_TESTDATA_BRANCH )}}
         uses: actions/github-script@v6.4.1
@@ -50,11 +50,13 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             > **Warning**
-            > It appears that this PR modifies the `XCLIM_TESTDATA_BRANCH` environment variable to a tag that is not the latest in the `Ouranosinc/xclim-testdata` repository.
+            > It appears that this Pull Request modifies the `main.yml` workflow.
 
-            Please be sure to modify this value to match the most recent tag (`${{ env.XCLIM_TESTDATA_TAG }}`) before merging.
+            On inspection, it seems that the `XCLIM_TESTDATA_BRANCH` environment variable is set to a tag that is not the latest in the `Ouranosinc/xclim-testdata` repository.
 
-            If this PR depends on changes in a new testing dataset branch, be sure to tag a new version of `Ouranosinc/xclim-testdata` with your changes merged to `main`.
+            This value must match the most recent tag (`${{ env.XCLIM_TESTDATA_TAG }}`) in order to merge this Pull Request.
+
+            If this PR depends on changes in a new testing dataset branch, be sure to tag a new version of `Ouranosinc/xclim-testdata` once your changes have been merged to its `main` branch.
           edit-mode: replace
       - name: Update Success Comment
         if: ${{ success() }}
@@ -64,7 +66,9 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             > **Note**
-            > It appears that this PR modifies the `XCLIM_TESTDATA_BRANCH` environment variable to the most recent tag (`${{ env.XCLIM_TESTDATA_TAG }}`).
+            > It appears that this Pull Request modifies the `main.yml` workflow.
+
+            On inspection, the `XCLIM_TESTDATA_BRANCH` environment variable is set to the most recent tag (`${{ env.XCLIM_TESTDATA_TAG }}`).
 
             No further action is required.
           edit-mode: replace

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,6 +47,8 @@ Internal changes
 * Some docstring adjustments to existing classes. (:pull:`1449`).
 * `identify` now associates Jupyter Notebooks as JSON files. Set `pre-commit` to ignore JSON-formatting of them. (:pull:`1449`).
 * Added a helper module ``_finder`` in the notebooks folder so that the working directory can always be found, with redundancies in place to prevent scripts from failing if the helper file is not found. (:pull:`1449`).
+* Added a manual cache-cleaning workflow (based on `GitHub cache-cleaning example <https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#managing-caches>`_), triggered when a branch has been merged. (:pull:`1462`).
+* Added a workflow for posting updates to the xclim Mastodon account (using `cbrgm/mastodon-github-action <https://github.com/cbrgm/mastodon-github-action>`_, triggered when a new version is published. (:pull:`1462`).
 
 Breaking changes
 ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Updates a few existing workflows for more intuitive behaviour
* Added a manual cache-cleaning workflow, triggered when a branch has been merged.
* Added a workflow for posting updates to the xclim Mastodon account on publish.

### Does this PR introduce a breaking change?

No.

### Other information:

* https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#managing-caches
* https://github.com/cbrgm/mastodon-github-action