### PR TITLE
[bot] Update GitHub Action Versions

### DIFF
--- a/.github/workflows/cache-cleaner.yml
+++ b/.github/workflows/cache-cleaner.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.6.0
 
       - name: Cleanup
         run: |

--- a/.github/workflows/publish-mastodon.yml
+++ b/.github/workflows/publish-mastodon.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v3.6.0
 
     - name: Current Version
       run: |
@@ -21,7 +21,7 @@ jobs:
 
     - name: Send toot to Mastodon
       id: mastodon
-      uses: cbrgm/mastodon-github-action@v1
+      uses: cbrgm/mastodon-github-action@v1.0.3
       with:
         message: |
           New #xclim release: v${{ env.current_version }} 🎉


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.6.0](https://github.com/actions/checkout/releases/tag/v3.6.0)** on 2023-08-24T13:56:41Z
* **[cbrgm/mastodon-github-action](https://github.com/cbrgm/mastodon-github-action)** published a new release **[v1.0.3](https://github.com/cbrgm/mastodon-github-action/releases/tag/v1.0.3)** on 2023-01-10T23:22:53Z
