### PR TITLE
pull_request_target workarounds, and labeling fixes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,4 +1,3 @@
-
 # label rules used by .github/workflows/label.yml
 
 # label 'ci' all automation-related steps and files
@@ -10,7 +9,10 @@ API:
   - xclim/cli.py
 
 CI:
-  - .*  # all '.<something>' files
+  - .editorconfig
+  - .pre-commit-config.yaml
+  - .readthedocs.yml
+  - .yamllint.yml
   - .github/workflows/*
   - docs/Makefile
   - pylintrc
@@ -34,5 +36,9 @@ indicators:
   - xclim/data/**/*.json
   - xclim/data/**/*.yml
 
+information:
+  - CONTRIBUTING.rst
+
 sdba:
   - xclim/sdba/**/*
+  - tests/test_sdba/*.py

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -23,21 +23,3 @@ jobs:
     - uses: actions/labeler@v4.3.0
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
-
-  label_approved:
-    name: Label on Approval
-    if: |
-      !contains(github.event.pull_request.labels.*.name, 'approved') &&
-      (github.event.review.state == 'approved') &&
-    runs-on: ubuntu-latest
-    steps:
-      - name: Label Approved
-        uses: actions/github-script@v6
-        with:
-          script: |
-            github.rest.issues.addLabels({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: ['approved']
-            })

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -23,3 +23,21 @@ jobs:
     - uses: actions/labeler@v4.3.0
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
+
+  label_approved:
+    name: Label on Approval
+    if: |
+      !contains(github.event.pull_request.labels.*.name, 'approved') &&
+      (github.event.review.state == 'approved') &&
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label Approved
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['approved']
+            })

--- a/.github/workflows/label_on_approval.yml
+++ b/.github/workflows/label_on_approval.yml
@@ -4,14 +4,27 @@ on:
   pull_request_review:
     types:
       - submitted
+  pull_request_target:
+    types:
+      - ready_for_review
+      - review_requested
+
+permissions:
+  checks: write
+  contents: read
+  pull-requests: write
 
 jobs:
-  approved:
+  label_approved:
     name: Label on Approval
-    if: github.event.review.state == 'approved'
+    if: |
+      (!contains(github.event.pull_request.labels.*.name, 'approved')) &&
+      (github.event.review.state == 'approved') &&
+      (github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v6.4.1
+      - name: Label Approved
+        uses: actions/github-script@v6.4.1
         with:
           script: |
             github.rest.issues.addLabels({
@@ -20,3 +33,43 @@ jobs:
               repo: context.repo.repo,
               labels: ['approved']
             })
+
+  comment_approved:
+    name: Comment Concerning Approved Tag
+    if: |
+      (github.event_name == 'pull_request_target') ||
+      (github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find comment
+        uses: peter-evans/find-comment@v2
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: This Pull Request is coming from a fork and must be manually tagged `approved` in order to perform additional testing
+      - name: Create comment
+        if: |
+          (steps.fc.outputs.comment-id == '') ||
+          (!contains(github.event.pull_request.labels.*.name, 'approved'))
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            > **Warning**
+            > This Pull Request is coming from a fork and must be manually tagged `approved` in order to perform additional testing.
+          edit-mode: replace
+      - name: Update comment
+        if: |
+          contains(github.event.pull_request.labels.*.name, 'approved')
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+
+            Pull Request is approved!
+          reactions: |
+            hooray
+          edit-mode: append

--- a/.github/workflows/label_on_approval.yml
+++ b/.github/workflows/label_on_approval.yml
@@ -68,7 +68,6 @@ jobs:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-
             Pull Request is approved!
           reactions: |
             hooray

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,7 +30,7 @@ Internal changes
 * Added handling for `pytest-socket`'s ``SocketBlockedError`` in ``xclim.testing.open_dataset`` when attempting to fetch md5 validation files for cached testing data while explicitly disabling internet sockets. (:issue:`1468`, :pull:`1473`).
 * Updated the testing data used in the `analogs.ipynb` notebook to use the testing data now found in `Ouranosinc/xclim-testdata`'s main branch. (`xclim-testdata PR/26 <https://github.com/Ouranosinc/xclim-testdata/pull/26>`_, :pull:`1473`).
 * Fixed an issue with automatic labelling that occurs when a Pull Request is made from a forked repository. (:pull:`1479`).
-* Changes to the ``.zenodo.json` file no longer are marked as CI-related changes. (:pull:`1479`).
+* Changes to the ``.zenodo.json`` file no longer are marked as CI-related changes. (:pull:`1479`).
 
 v0.45.0 (2023-09-05)
 --------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,8 @@ Internal changes
 * Added a `pytest` marker (``pytest.mark.requires_internet``) to allow for skipping of tests that depend on remote network calls to function properly. (:pull:`1473`).
 * Added handling for `pytest-socket`'s ``SocketBlockedError`` in ``xclim.testing.open_dataset`` when attempting to fetch md5 validation files for cached testing data while explicitly disabling internet sockets. (:issue:`1468`, :pull:`1473`).
 * Updated the testing data used in the `analogs.ipynb` notebook to use the testing data now found in `Ouranosinc/xclim-testdata`'s main branch. (`xclim-testdata PR/26 <https://github.com/Ouranosinc/xclim-testdata/pull/26>`_, :pull:`1473`).
+* Fixed an issue with automatic labelling that occurs when a Pull Request is made from a forked repository. (:pull:`1479`).
+* Changes to the ``.zenodo.json` file no longer are marked as CI-related changes. (:pull:`1479`).
 
 v0.45.0 (2023-09-05)
 --------------------


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Deals with a security-related bug/feature that prevents Pull Requests coming from forks from being tagged automatically.
* Prevents changes to the `.zenodo.json` file being labelled as `CI`-related.

### Does this PR introduce a breaking change?

No.

### Other information:

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
