### PR TITLE
Fix importlib.resources deprecations for py 3.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,9 +70,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install tox
-        run: pip install tox~=4.0
+        run: |
+          pip install tox~=4.0
       - name: Test with tox
-        run: tox -e ${{ matrix.tox-env }}
+        run: |
+          tox -e ${{ matrix.tox-env }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_FLAG_NAME: run-{{ matrix.tox-env }}
@@ -116,10 +118,16 @@ jobs:
         uses: actions/setup-python@v4.7.0
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install importlib-resources
+        if: contains(matrix.tox-env, 'py38')
+        run: |
+          pip install importlib-resources
       - name: Install tox
-        run: pip install tox~=4.0
+        run: |
+          pip install tox~=4.0
       - name: Test with tox
-        run: tox -e ${{ matrix.tox-env }} -- ${{ matrix.markers }}
+        run: |
+          tox -e ${{ matrix.tox-env }} -- ${{ matrix.markers }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_FLAG_NAME: run-{{ matrix.tox-env }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -118,10 +118,6 @@ jobs:
         uses: actions/setup-python@v4.7.0
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install importlib-resources
-        if: contains(matrix.tox-env, 'py38')
-        run: |
-          pip install importlib-resources
       - name: Install tox
         run: |
           pip install tox~=4.0

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,7 @@ Internal changes
 * GitHub testing workflows now use `Concurrency` instead of the styfle/cancel-workflow-action to cancel redundant workflows. (:pull:`1487`).
 * The `pkg_resources` library has been replaced for the `packaging` library when version comparisons have been performed, and a few warning messages have been silenced in the testing suite. (:issue:`1489`, :pull:`1490`).
 * New ``xclim.testing.helpers.assert_lazy`` context manager to assert the laziness of code blocks. (:pull:`1484`).
+* Added a fix for the deprecation warnings that `importlib.resources` throws, made backwards-compatible for Python3.8 with `importlib_resources` backport. (:pull:`1485`).
 
 v0.45.0 (2023-09-05)
 --------------------

--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,7 @@ dependencies:
     - cftime>=1.4.1
     - Click >=8.1
     - dask>=2.6.0
+    - importlib-resources  # For Python3.8
     - jsonpickle
     - lmoments3
     - numba

--- a/environment.yml
+++ b/environment.yml
@@ -43,6 +43,7 @@ dependencies:
     - ipython
     - matplotlib
     - mypy
+    - nbqa
     - nbsphinx
     - nbval
     - nc-time-axis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
   "cftime>=1.4.1",
   "Click>=8.1",
   "dask[array]>=2.6",
+  "importlib-resources; python_version == '3.8'",
   "jsonpickle",
   "lmoments3>=1.0.5",
   "numba",

--- a/xclim/__init__.py
+++ b/xclim/__init__.py
@@ -1,7 +1,10 @@
 """Climate indices computation package based on Xarray."""
 from __future__ import annotations
 
-from importlib.resources import files as _files
+try:
+    from importlib.resources import files as _files
+except ImportError:
+    from importlib_resources import files as _files
 
 from xclim.core import units  # noqa
 from xclim.core.indicator import build_indicator_module_from_yaml

--- a/xclim/__init__.py
+++ b/xclim/__init__.py
@@ -1,7 +1,7 @@
 """Climate indices computation package based on Xarray."""
 from __future__ import annotations
 
-from importlib.resources import contents, path
+from importlib.resources import files as _files
 
 from xclim.core import units  # noqa
 from xclim.core.indicator import build_indicator_module_from_yaml
@@ -14,19 +14,15 @@ __email__ = "logan.travis@ouranos.ca"
 __version__ = "0.45.3-beta"
 
 
+_module_data = _files("xclim.data")
+
 # Load official locales
-for filename in contents("xclim.data"):
+for filename in _module_data.glob("??.json"):
     # Only select <locale>.json and not <module>.<locale>.json
-    if filename.endswith(".json") and filename.count(".") == 1:
-        locale = filename.split(".")[0]
-        with path("xclim.data", filename) as f:
-            load_locale(f, locale)
+    load_locale(filename, filename.stem)
 
 
 # Virtual modules creation:
-with path("xclim.data", "icclim.yml") as f:
-    build_indicator_module_from_yaml(f.with_suffix(""), mode="raise")
-with path("xclim.data", "anuclim.yml") as f:
-    build_indicator_module_from_yaml(f.with_suffix(""), mode="raise")
-with path("xclim.data", "cf.yml") as f:
-    build_indicator_module_from_yaml(f.with_suffix(""), mode="raise")
+build_indicator_module_from_yaml(_module_data / "icclim", mode="raise")
+build_indicator_module_from_yaml(_module_data / "anuclim", mode="raise")
+build_indicator_module_from_yaml(_module_data / "cf", mode="raise")

--- a/xclim/core/units.py
+++ b/xclim/core/units.py
@@ -11,9 +11,9 @@ import functools
 import logging
 import re
 import warnings
-from importlib.resources import open_text
+from importlib.resources import files
 from inspect import _empty, signature  # noqa
-from typing import Any, Callable, Tuple
+from typing import Any, Callable
 
 import numpy as np
 import pint
@@ -112,7 +112,8 @@ hydro.add_transformation(
 units.add_context(hydro)
 
 
-CF_CONVERSIONS = safe_load(open_text("xclim.data", "variables.yml"))["conversions"]
+with (files("xclim.data") / "variables.yml").open() as f:
+    CF_CONVERSIONS = safe_load(f)["conversions"]
 _CONVERSIONS = {}
 
 

--- a/xclim/core/units.py
+++ b/xclim/core/units.py
@@ -11,7 +11,12 @@ import functools
 import logging
 import re
 import warnings
-from importlib.resources import files
+
+try:
+    from importlib.resources import files
+except ImportError:
+    from importlib_resources import files
+
 from inspect import _empty, signature  # noqa
 from typing import Any, Callable
 

--- a/xclim/core/utils.py
+++ b/xclim/core/utils.py
@@ -13,11 +13,11 @@ import warnings
 from collections import defaultdict
 from enum import IntEnum
 from functools import partial
-from importlib.resources import open_text
+from importlib.resources import files
 from inspect import Parameter, _empty  # noqa
 from io import StringIO
 from pathlib import Path
-from typing import Callable, Mapping, NewType, Sequence, TypeVar
+from typing import Callable, NewType, Sequence, TypeVar
 
 import numpy as np
 import xarray as xr
@@ -37,8 +37,9 @@ DayOfYearStr = NewType("DayOfYearStr", str)
 #: Type annotation for thresholds and other not-exactly-a-variable quantities
 Quantified = TypeVar("Quantified", xr.DataArray, str, Quantity)
 
-VARIABLES = safe_load(open_text("xclim.data", "variables.yml"))["variables"]
-"""Official variables definitions.
+with (files("xclim.data") / "variables.yml").open() as f:
+    VARIABLES = safe_load(f)["variables"]
+    """Official variables definitions.
 
 A mapping from variable name to a dict with the following keys:
 

--- a/xclim/core/utils.py
+++ b/xclim/core/utils.py
@@ -13,7 +13,12 @@ import warnings
 from collections import defaultdict
 from enum import IntEnum
 from functools import partial
-from importlib.resources import files
+
+try:
+    from importlib.resources import files
+except ImportError:
+    from importlib_resources import files
+
 from inspect import Parameter, _empty  # noqa
 from io import StringIO
 from pathlib import Path

--- a/xclim/testing/helpers.py
+++ b/xclim/testing/helpers.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import os
 import warnings
-from importlib.resources import open_text
 from pathlib import Path
 
 import numpy as np
@@ -12,6 +11,7 @@ import xarray as xr
 from yaml import safe_load
 
 from xclim.core import calendar
+from xclim.core.utils import VARIABLES
 from xclim.indices import (
     longwave_upwelling_radiation_from_net_downwelling,
     shortwave_upwelling_radiation_from_net_downwelling,
@@ -232,13 +232,12 @@ def test_timeseries(
     else:
         coords = pd.date_range(start, periods=len(values), freq=freq)
 
-    data_on_var = safe_load(open_text("xclim.data", "variables.yml"))["variables"]
-    if variable in data_on_var:
+    if variable in VARIABLES:
         attrs = {
-            a: data_on_var[variable].get(a, "")
+            a: VARIABLES[variable].get(a, "")
             for a in ["description", "standard_name", "cell_methods"]
         }
-        attrs["units"] = data_on_var[variable]["canonical_units"]
+        attrs["units"] = VARIABLES[variable]["canonical_units"]
 
     else:
         warnings.warn(f"Variable {variable} not recognised. Attrs will not be filled.")

--- a/xclim/testing/utils.py
+++ b/xclim/testing/utils.py
@@ -6,7 +6,6 @@ Testing and Tutorial Utilities' Module
 from __future__ import annotations
 
 import hashlib
-import importlib
 import json
 import logging
 import os
@@ -14,6 +13,7 @@ import platform
 import re
 import sys
 import warnings
+from importlib import import_module
 from io import StringIO
 from pathlib import Path
 from shutil import copy
@@ -563,7 +563,7 @@ def show_versions(
             if modname in sys.modules:
                 mod = sys.modules[modname]
             else:
-                mod = importlib.import_module(modname)
+                mod = import_module(modname)
         except (KeyError, ModuleNotFoundError):
             deps_blob.append((modname, None))
         else:


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?
Fix for the deprecation warnings that `importlib.resources` throws. It changes how we open and parse our module data files.


### Does this PR introduce a breaking change?
Yes, the deprecation concerns python 3.9 and above, so this needs to be merged only when we pin python above 3.8.

### Other information:
I made this PR so I don't lose the changes I had already made, but there's no rush at all.
