### PR TITLE
Remove faulty default in MRT and UTCI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,7 +61,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - tox-env: "py39"
+          - tox-env: "py39-coverage"
             python-version: "3.9"
     steps:
       - uses: actions/checkout@v4.1.0

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,10 @@ v0.46.0 (unreleased)
 --------------------
 Contributors to this version: Éric Dupuis (:user:`coxipi`), Trevor James Smith (:user:`Zeitsperre`), David Huard (:user:`huard`).
 
+Announcements
+^^^^^^^^^^^^^
+* The default mechanism for computing the Mean Radiant Temperature, a part of the Universal Thermal Climate Index (UTCI) was broken in xclim 0.44 and 0.45. This has been fixed by changing the default.
+
 New features and enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 * Add ``wind_power_potential`` to estimate the potential for wind power production given wind speed at the turbine hub height and turbine specifications, along with  ``wind_profile`` to estimate the wind speed at different heights based on wind speed at a reference height. (:issue:`1458`, :pull:`1471`)
@@ -22,6 +26,7 @@ Bug fixes
 * Optimization of indicators ``huglin_index`` and ``biologically_effective_degree_days`` when used with dask and flox. As a side effect, the indice functions (i.e. under ``xc.indices``) no longer mask incomplete periods. The indicators' output is unchanged under the default "check_missing" setting (:issue:`1494`, :pull:`1495`).
 * Fixed ``xclim.indices.run_length.lazy_indexing`` which would sometimes trigger the loading of auxiliary coordinates. (:issue:`1483`, :pull:`1484`).
 * Fixed a bug in the `pytest` configuration that could prevent testing data caching from occurring in systems where the platform-dependent cache directory is not found in the user's home. (:issue:`1468`, :pull:`1473`).
+* Remove nonsensical `stat='average'` option for ``mean_radiant_temperature``. (:issue:`1496`, :pull:`1501`).
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/tests/test_atmos.py
+++ b/tests/test_atmos.py
@@ -590,7 +590,7 @@ class TestUTCI:
             rsus=rsus,
             rlds=rlds,
             rlus=rlus,
-            stat="average",
+            stat="sunlit",
         )
 
         np.testing.assert_allclose(utci.isel(time=0), utci_exp, rtol=1e-03)
@@ -608,15 +608,13 @@ class TestMeanRadiantTemperature:
         # Expected values
         exp_sun = [276.911, 274.742, 243.202, 268.012, 278.505]
         exp_ins = [276.911, 274.742, 243.202, 268.012, 278.505]
-        exp_avg = [276.911, 274.742, 243.202, 268.017, 278.512]
 
         mrt_sun = atmos.mean_radiant_temperature(rsds, rsus, rlds, rlus, stat="sunlit")
         mrt_ins = atmos.mean_radiant_temperature(rsds, rsus, rlds, rlus, stat="instant")
-        mrt_avg = atmos.mean_radiant_temperature(rsds, rsus, rlds, rlus, stat="average")
+
         rtol = 1e-03
         np.testing.assert_allclose(mrt_sun.isel(time=0), exp_sun, rtol=rtol)
         np.testing.assert_allclose(mrt_ins.isel(time=0), exp_ins, rtol=rtol)
-        np.testing.assert_allclose(mrt_avg.isel(time=0), exp_avg, rtol=rtol)
 
 
 class TestLateFrostDays:

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -3358,9 +3358,7 @@ def test_universal_thermal_climate_index(
     np.testing.assert_allclose(utci, utci_exp, rtol=1e-03)
 
 
-@pytest.mark.parametrize(
-    "stat,expected", [("sunlit", 295.0), ("instant", 294.9)]
-)
+@pytest.mark.parametrize("stat,expected", [("sunlit", 295.0), ("instant", 294.9)])
 def test_mean_radiant_temperature(
     rsds_series,
     rsus_series,

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -3359,7 +3359,7 @@ def test_universal_thermal_climate_index(
 
 
 @pytest.mark.parametrize(
-    "stat,expected", [("sunlit", 295.0), ("instant", 294.9), ("average", 295.1)]
+    "stat,expected", [("sunlit", 295.0), ("instant", 294.9)]
 )
 def test_mean_radiant_temperature(
     rsds_series,

--- a/xclim/indices/_conversion.py
+++ b/xclim/indices/_conversion.py
@@ -1771,7 +1771,7 @@ def universal_thermal_climate_index(
     rsus: xr.DataArray = None,
     rlds: xr.DataArray = None,
     rlus: xr.DataArray = None,
-    stat: str = "average",
+    stat: str = "sunlit",
     mask_invalid: bool = True,
 ) -> xr.DataArray:
     r"""Universal thermal climate index (UTCI).
@@ -1801,12 +1801,10 @@ def universal_thermal_climate_index(
     rlus : xr.DataArray, optional
         Surface Upwelling Longwave Radiation
         This is necessary if mrt is not None.
-    stat : {'average', 'instant', 'sunlit'}
-        Which statistic to apply. If "average", the average of the cosine of the
-        solar zenith angle is calculated. If "instant", the instantaneous cosine
+    stat : {'instant', 'sunlit'}
+        Which statistic to apply. If "instant", the instantaneous cosine
         of the solar zenith angle is calculated. If "sunlit", the cosine of the
         solar zenith angle is calculated during the sunlit period of each interval.
-        If "instant", the instantaneous cosine of the solar zenith angle is calculated.
         This is necessary if mrt is not None.
     mask_invalid: bool
         If True (default), UTCI values are NaN where any of the inputs are outside
@@ -1923,7 +1921,7 @@ def mean_radiant_temperature(
     rsus: xr.DataArray,
     rlds: xr.DataArray,
     rlus: xr.DataArray,
-    stat: str = "average",
+    stat: str = "sunlit",
 ) -> xr.DataArray:
     r"""Mean radiant temperature.
 
@@ -1939,12 +1937,10 @@ def mean_radiant_temperature(
         Surface Downwelling Longwave Radiation
     rlus : xr.DataArray
         Surface Upwelling Longwave Radiation
-    stat : {'average', 'instant', 'sunlit'}
-        Which statistic to apply. If "average", the average of the cosine of the
-        solar zenith angle is calculated. If "instant", the instantaneous cosine
+    stat : {'instant', 'sunlit'}
+        Which statistic to apply. If "instant", the instantaneous cosine
         of the solar zenith angle is calculated. If "sunlit", the cosine of the
         solar zenith angle is calculated during the sunlit period of each interval.
-        If "instant", the instantaneous cosine of the solar zenith angle is calculated.
 
     Returns
     -------
@@ -1987,15 +1983,9 @@ def mean_radiant_temperature(
         )
         csza_i = csza.copy()
         csza_s = csza.copy()
-    elif stat == "average":
-        csza = cosine_of_solar_zenith_angle(
-            dates, dec, lat, stat="average", sunlit=False
-        )
-        csza_i = csza.copy()
-        csza_s = csza.copy()
     else:
         raise NotImplementedError(
-            "Argument 'stat' must be one of 'average', 'instant' or 'sunlit'."
+            "Argument 'stat' must be one of 'instant' or 'sunlit'."
         )
 
     fdir_ratio = _fdir_ratio(dates, csza_i, csza_s, rsds)

--- a/xclim/indices/helpers.py
+++ b/xclim/indices/helpers.py
@@ -197,7 +197,7 @@ def cosine_of_solar_zenith_angle(
     lat: Quantified,
     lon: Quantified = "0 °",
     time_correction: xr.DataArray = None,
-    stat: str = "integral",
+    stat: str = "average",
     sunlit: bool = False,
 ) -> xr.DataArray:
     """Cosine of the solar zenith angle.
@@ -222,10 +222,10 @@ def cosine_of_solar_zenith_angle(
     time_correction : xr.DataArray, optional
         Time correction for solar angle. See :py:func:`time_correction_for_solar_angle`
         This is necessary if stat is "instant".
-    stat : {'integral', 'average', 'instant'}
+    stat : {'average', 'integral', 'instant'}
         Which daily statistic to return.
-        If "integral", this returns the integral of the cosine of the zenith angle
         If "average", this returns the average of the cosine of the zenith angle
+        If "integral", this returns the integral of the cosine of the zenith angle
         If "instant", this returns the instantaneous cosine of the zenith angle
     sunlit: bool
         If True, only the sunlit part of the interval is considered in the integral or average.


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1496
- [x] Tests for the changes have been added (for bug fixes / features)
  - [x] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?
I believe #1399 changed the meanings of argument `stat` which made the default option of `mean_radiant_temperature` incorrect. This PR removes the "average" option and changes the default to 'sunlit'.

### Does this PR introduce a breaking change?
Yes, outputs will change. However, I think previous output was incorrect. An announcement has been added to the CHANGES.

### Other information:
