### PR TITLE
Remove deprecated `mf_file` call signatures

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,7 +32,7 @@ Breaking changes
 * `pytest-socket` is now a required development dependency for running `"offline"` tests or the `"offline"` configuration of the `tox` testing suite. This has been added to the `dev` installation recipe. (:issue:`1468`, :pull:`1473`).
 * For better transparency and control in development, the `tox` configuration has been adapted to allow passing of markers directly to the `pytest` call. Positional arguments must be passed to tox after the `--` separator to select/deselect tests (e.g. ``'tox -e py38 -- -m "not slow"'``). (:pull:`1473`).
 * For better accuracy, the `tox -e black` recipe has been renamed to `tox -e lint`, as this configuration already included several other linting checks. (:pull:`1473`).
-* The `mf_file` call signature (deprecated in `xclim` v0.43.0) found in ``xclim.ensembles.create_ensemble`` (and ``xclim.ensembles._ens_align_dataset``) has been removed.
+* The `mf_file` call signature (deprecated in `xclim` v0.43.0) found in ``xclim.ensembles.create_ensemble`` (and ``xclim.ensembles._ens_align_dataset``) has been removed. (:pull:`1506`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,7 @@ Breaking changes
 * `pytest-socket` is now a required development dependency for running `"offline"` tests or the `"offline"` configuration of the `tox` testing suite. This has been added to the `dev` installation recipe. (:issue:`1468`, :pull:`1473`).
 * For better transparency and control in development, the `tox` configuration has been adapted to allow passing of markers directly to the `pytest` call. Positional arguments must be passed to tox after the `--` separator to select/deselect tests (e.g. ``'tox -e py38 -- -m "not slow"'``). (:pull:`1473`).
 * For better accuracy, the `tox -e black` recipe has been renamed to `tox -e lint`, as this configuration already included several other linting checks. (:pull:`1473`).
+* The `mf_file` call signature (deprecated in `xclim` v0.43.0) found in ``xclim.ensembles.create_ensemble`` (and ``xclim.ensembles._ens_align_dataset``) has been removed.
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -138,13 +138,21 @@ Ready to contribute? Here's how to set up `xclim` for local development.
     # To run pre-commit hooks manually:
     $ pre-commit run --all-files
 
-  Instead of ``pre-commit``, you could also verify your changes manually with `black`, `flake8`, `flake8-rst-docstrings`, `pydocstyle`, and `yamllint`::
+  Instead of ``pre-commit``, you can also verify your changes using the `Make` recipe for code linting checks::
 
-    $ black --check --target-version py38 xclim tests
-    $ black --check --target-version py38 --include "\.ipynb$" docs
-    $ flake8 xclim tests
-    $ pydocstyle --config=setup.cfg xclim xclim
-    $ yamllint --config-file .yamllint.yaml xclim
+    $ make lint
+
+  Or, alternatively, you can check individual hooks manually with `black`, `isort`, `ruff`, `flake8`, `flake8-rst-docstrings`, `nbqa`, `blackdoc`, and `yamllint`::
+
+	$ black --check xclim tests
+	$ isort --check xclim tests
+	$ ruff xclim tests
+	$ flake8 --config=setup.cfg xclim tests
+	$ nbqa black --check docs
+	$ nbqa isort --check docs
+	$ blackdoc --check --exclude=xclim/indices/__init__.py xclim
+	$ blackdoc --check docs
+	$ yamllint --config-file=.yamllint.yaml xclim
 
 6. When features or bug fixes have been contributed, unit tests and doctests have been added, or notebooks have been updated, use ``$ pytest`` to test them::
 

--- a/tests/test_ensembles.py
+++ b/tests/test_ensembles.py
@@ -252,8 +252,7 @@ class TestEnsembleStats:
         for n in ensemble_dataset_objects["nc_files_simple"]:
             ds = open_dataset(n)
             ds_all.append(ds)
-        with pytest.warns(FutureWarning):
-            ens = ensembles.create_ensemble(ds_all, mf_flag=False)
+        ens = ensembles.create_ensemble(ds_all, multifile=False)
 
         out1 = ensembles.ensemble_mean_std_max_min(ens)
         np.testing.assert_array_equal(

--- a/xclim/core/indicator.py
+++ b/xclim/core/indicator.py
@@ -1344,7 +1344,7 @@ class Indicator(IndicatorRegistrar):
 
     @property
     def is_generic(self):
-        """Return True if the indicator is "generic", meaning that it can accepts variable with any units."""
+        """Return True if the indicator is "generic", meaning that it can accept variables with any units."""
         return not hasattr(self.compute, "in_units")
 
     def _show_deprecation_warning(self):

--- a/xclim/ensembles/_base.py
+++ b/xclim/ensembles/_base.py
@@ -4,7 +4,6 @@ Ensembles Creation and Statistics
 """
 from __future__ import annotations
 
-import warnings
 from glob import glob
 from pathlib import Path
 from typing import Any, Sequence

--- a/xclim/ensembles/_base.py
+++ b/xclim/ensembles/_base.py
@@ -24,7 +24,6 @@ def create_ensemble(
     calendar: str | None = None,
     realizations: Sequence[Any] | None = None,
     cal_kwargs: dict | None = None,
-    mf_flag: bool | str = "UNSET",  # noqa
     **xr_kwargs,
 ) -> xr.Dataset:
     r"""Create an xarray dataset of an ensemble of climate simulation from a list of netcdf files.
@@ -103,15 +102,6 @@ def create_ensemble(
             "Passing `realizations` is not supported when `datasets` "
             "is a glob pattern, as the final order is random."
         )
-
-    if mf_flag != "UNSET":
-        warnings.warn(
-            "The `mf_flag` argument is being deprecated in favour of `multifile` in `create.ensemble()`. "
-            "This change will be made effective from `xclim>=0.43.0`. Please update your scripts accordingly",
-            FutureWarning,
-            stacklevel=3,
-        )
-        multifile = mf_flag
 
     ds = _ens_align_datasets(
         datasets,
@@ -350,7 +340,6 @@ def _ens_align_datasets(
     resample_freq: str | None = None,
     calendar: str = "default",
     cal_kwargs: dict | None = None,
-    mf_flag: bool | str = "UNSET",  # noqa
     **xr_kwargs,
 ) -> list[xr.Dataset]:
     r"""Create a list of aligned xarray Datasets for ensemble Dataset creation.
@@ -385,15 +374,6 @@ def _ens_align_datasets(
 
     if isinstance(datasets, str):
         datasets = glob(datasets)
-
-    if mf_flag != "UNSET":
-        warnings.warn(
-            "The `mf_flag` argument is being deprecated in favour of `multifile` in `_ens_align_datasets()`. "
-            "This change will be made effective from `xclim>=0.43.0`. Please update your scripts accordingly",
-            FutureWarning,
-            stacklevel=3,
-        )
-        multifile = mf_flag
 
     ds_all = []
     calendars = []


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* The `mf_file` call signature (deprecated in `xclim` v0.43.0) found in ``xclim.ensembles.create_ensemble`` (and ``xclim.ensembles._ens_align_dataset``) has been removed.

### Does this PR introduce a breaking change?

This call signature has been deprecated for some time, so no.

### Other information:
