### PR TITLE
Fix data flags var name generation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,7 @@ Bug fixes
 * Fixed ``xclim.indices.run_length.lazy_indexing`` which would sometimes trigger the loading of auxiliary coordinates. (:issue:`1483`, :pull:`1484`).
 * Indicators ``snd_season_length`` and ``snw_season_length`` will return 0 instead of NaN if all inputs have a (non-NaN) zero snow depth (or water-equivalent thickness). (:pull:`1492`, :issue:`1491`)
 * Fixed a bug in the `pytest` configuration that could prevent testing data caching from occurring in systems where the platform-dependent cache directory is not found in the user's home. (:issue:`1468`, :pull:`1473`).
+* Fix ``xclim.core.dataflags.data_flags`` variable name generation (:pull:`1507`).
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -151,3 +151,20 @@ class TestDataFlags:
 
         df_flagged = df.ecad_compliant(bad_ds)
         np.testing.assert_array_equal(df_flagged.ecad_qc_flag, False)
+
+    def test_names(self, pr_series):
+        pr = pr_series(np.zeros(365), start="1971-01-01")
+        flgs = df.data_flags(
+            pr,
+            flags={
+                "values_op_thresh_repeating_for_n_or_more_days": {
+                    "op": "==",
+                    "n": 5,
+                    "thresh": "-5.1 mm d-1",
+                }
+            },
+        )
+        assert (
+            list(flgs.data_vars.keys())[0]
+            == "values_eq_minus5point1_repeating_for_5_or_more_days"
+        )

--- a/xclim/core/dataflags.py
+++ b/xclim/core/dataflags.py
@@ -42,6 +42,8 @@ class DataQualityException(Exception):
         Message prepended to the error messages.
     """
 
+    flag_array: xarray.Dataset = None
+
     def __init__(
         self,
         flag_array: xarray.Dataset,

--- a/xclim/indices/generic.py
+++ b/xclim/indices/generic.py
@@ -34,6 +34,7 @@ from . import run_length as rl
 
 __all__ = [
     "aggregate_between_dates",
+    "binary_ops",
     "compare",
     "count_level_crossings",
     "count_occurrences",


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes a issue raised in private communication by @RondeauG 
- [x] Tests for the changes have been added (for bug fixes / features)
  - [x] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

Changes how the data flags variable names are generated.

In the previous version, every kwargs was sent to `str2pint`. We were relying on a `try: except` to catch those kwargs that weren't quantities. This had the caveat of requiring an explicit list of possible errors. @RondeauG  had a case where `op='>='` was triggering a `ValueError`, which wasn't listed.

I changed this "implicit" parsing to an "explicit" one:
- Data flags declare the variable name as a templated string.
- Parameters are iterated through and handled according to their "InputKind"
    - "Quantified" inputs are handled as before, but all others are passed as-is.

This required:
- Changing the registering decorator to accept a templated string argument
- Correctly annotating the inputs, which lead to adding missing thresholds to the declared units

### Does this PR introduce a breaking change?
Yes, I made the arbitrary choice of changing how we stringify the minus sign:

```
Input thresh : -5.1 mm
Template : "values_greater_{thresh}"
Before : "values_greater__minus_5point1"
This PR: "values_greater_minus5point1"
```
However, I don't think this will affect many projects.

### Other information:
@RondeauG , could you try this new branch with your code ? (That's why I made you a reviewer)