### PR TITLE
[bot] Update GitHub Action Versions

### DIFF
--- a/.github/workflows/actions-versions-updater.yml
+++ b/.github/workflows/actions-versions-updater.yml
@@ -14,12 +14,12 @@ jobs:
       - uses: actions/checkout@v4.1.0
         with:
           token: ${{ secrets.WORKFLOW_TOKEN }}
-          persist-credentials: false
+          persist-credentials: true
       - name: Run GitHub Actions Version Updater
         uses: saadmk11/github-actions-version-updater@v0.8.1
         with:
           token: ${{ secrets.WORKFLOW_TOKEN }}
-          committer_email: 'update-github-actions-bot@ouranos.ca'
-          committer_username: 'update-github-actions-bot'
+          committer_email: 'bumpversion[bot]@ouranos.ca'
+          committer_username: 'update-github-actions[bot]'
           pull_request_title: '[bot] Update GitHub Action Versions'
           pull_request_team_reviewers: "xclim-core"

--- a/.github/workflows/actions-versions-updater.yml
+++ b/.github/workflows/actions-versions-updater.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.0
+      - uses: actions/checkout@v4.1.1
         with:
           token: ${{ secrets.WORKFLOW_TOKEN }}
           persist-credentials: true

--- a/.github/workflows/actions-versions-updater.yml
+++ b/.github/workflows/actions-versions-updater.yml
@@ -19,7 +19,7 @@ jobs:
         uses: saadmk11/github-actions-version-updater@v0.8.1
         with:
           token: ${{ secrets.WORKFLOW_TOKEN }}
-          committer_email: 'bumpversion[bot]@ouranos.ca'
-          committer_username: 'update-github-actions[bot]'
+          committer_email: 'update-github-actions-bot@ouranos.ca'
+          committer_username: 'update-github-actions-bot'
           pull_request_title: '[bot] Update GitHub Action Versions'
           pull_request_team_reviewers: "xclim-core"

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -29,10 +29,10 @@ jobs:
     name: Bumpversion Patch
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.0
+      - uses: actions/checkout@v4.1.1
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v4.7.0
+      - uses: actions/setup-python@v4.7.1
         with:
           python-version: "3.x"
       - name: Config Commit Bot
@@ -50,7 +50,7 @@ jobs:
           NEW_VERSION="$(grep -E '__version__'  xclim/__init__.py | cut -d ' ' -f3)"
           echo "new_version=${NEW_VERSION}"
       - name: Push Changes
-        uses: ad-m/github-push-action@v0.6.0
+        uses: ad-m/github-push-action@v0.8.0
         with:
           force: false
           github_token: ${{ secrets.BUMPVERSION_TOKEN }}

--- a/.github/workflows/cache-cleaner.yml
+++ b/.github/workflows/cache-cleaner.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@v4.1.1
 
       - name: Cleanup
         run: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
           - 'python'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@v4.1.1
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@codeql-bundle-20230524

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -16,6 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@v4.1.1
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v3.1.0

--- a/.github/workflows/label_on_approval.yml
+++ b/.github/workflows/label_on_approval.yml
@@ -53,7 +53,7 @@ jobs:
           (steps.fc.outputs.comment-id == '') &&
           (!contains(github.event.pull_request.labels.*.name, 'approved')) &&
           (github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name)
-        uses: peter-evans/create-or-update-comment@v3.0.2
+        uses: peter-evans/create-or-update-comment@v3.1.0
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
@@ -64,7 +64,7 @@ jobs:
       - name: Update comment
         if: |
           contains(github.event.pull_request.labels.*.name, 'approved')
-        uses: peter-evans/create-or-update-comment@v3.0.2
+        uses: peter-evans/create-or-update-comment@v3.1.0
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,9 +40,9 @@ jobs:
         python-version:
           - "3.8"
     steps:
-      - uses: actions/checkout@v4.1.0
+      - uses: actions/checkout@v4.1.1
       - name: Set up Python${{ matrix.python-version }}
-        uses: actions/setup-python@v4.7.0
+        uses: actions/setup-python@v4.7.1
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install pylint and tox
@@ -64,9 +64,9 @@ jobs:
           - tox-env: "py39-coverage"
             python-version: "3.9"
     steps:
-      - uses: actions/checkout@v4.1.0
+      - uses: actions/checkout@v4.1.1
       - name: Set up Python${{ matrix.python-version }}
-        uses: actions/setup-python@v4.7.0
+        uses: actions/setup-python@v4.7.1
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install tox
@@ -108,14 +108,14 @@ jobs:
             python-version: "3.11"
             markers: -m 'not slow and not requires_internet'
     steps:
-      - uses: actions/checkout@v4.1.0
+      - uses: actions/checkout@v4.1.1
       - name: Install Eigen3
         if: contains(matrix.tox-env, 'sbck')
         run: |
           sudo apt-get update
           sudo apt-get install libeigen3-dev
       - name: Set up Python${{ matrix.python-version }}
-        uses: actions/setup-python@v4.7.0
+        uses: actions/setup-python@v4.7.1
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install tox
@@ -147,9 +147,9 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v4.1.0
+      - uses: actions/checkout@v4.1.1
       - name: Setup Conda (Micromamba) with Python${{ matrix.python-version }}
-        uses: mamba-org/setup-micromamba@v1.4.4
+        uses: mamba-org/setup-micromamba@v1.6.0
         with:
           cache-downloads: true
           cache-environment: true

--- a/.github/workflows/publish-mastodon.yml
+++ b/.github/workflows/publish-mastodon.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v4.1.0
+      uses: actions/checkout@v4.1.1
 
     - name: Current Version
       if: ${{ !github.event.inputs.version-tag }}

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -14,9 +14,9 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.0
+      - uses: actions/checkout@v4.1.1
       - name: Set up Python3
-        uses: actions/setup-python@v4.7.0
+        uses: actions/setup-python@v4.7.1
         with:
           python-version: "3.x"
       - name: Install packaging libraries

--- a/.github/workflows/tag-testpypi.yml
+++ b/.github/workflows/tag-testpypi.yml
@@ -14,9 +14,9 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.0
+      - uses: actions/checkout@v4.1.1
       - name: Set up Python3
-        uses: actions/setup-python@v4.7.0
+        uses: actions/setup-python@v4.7.1
         with:
           python-version: "3.x"
       - name: Install packaging libraries

--- a/.github/workflows/testdata_version.yml
+++ b/.github/workflows/testdata_version.yml
@@ -14,7 +14,7 @@ jobs:
     name: Check Latest xclim-testdata Tag
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.0
+      - uses: actions/checkout@v4.1.1
       - name: Find xclim-testdata Tag and CI Testing Branch
         run: |
           XCLIM_TESTDATA_TAG="$( \
@@ -44,7 +44,7 @@ jobs:
             core.setFailed('Configured `xclim-testdata` tag is not `latest`.')
       - name: Update Failure Comment
         if: ${{ failure() }}
-        uses: peter-evans/create-or-update-comment@v3.0.2
+        uses: peter-evans/create-or-update-comment@v3.1.0
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
@@ -60,7 +60,7 @@ jobs:
           edit-mode: replace
       - name: Update Success Comment
         if: ${{ success() }}
-        uses: peter-evans/create-or-update-comment@v3.0.2
+        uses: peter-evans/create-or-update-comment@v3.1.0
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -34,11 +34,11 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v4.1.0
+      - uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 0 # Fetch all history for all branches and tags.
       - name: Setup Conda (Micromamba) with Python${{ matrix.python-version }}
-        uses: mamba-org/setup-micromamba@v1.4.4
+        uses: mamba-org/setup-micromamba@v1.6.0
         with:
           cache-downloads: true
           cache-environment: true


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v4.7.1](https://github.com/actions/setup-python/releases/tag/v4.7.1)** on 2023-10-02T10:59:39Z
* **[ad-m/github-push-action](https://github.com/ad-m/github-push-action)** published a new release **[v0.8.0](https://github.com/ad-m/github-push-action/releases/tag/v0.8.0)** on 2023-10-10T04:56:58Z
* **[mamba-org/setup-micromamba](https://github.com/mamba-org/setup-micromamba)** published a new release **[v1.6.0](https://github.com/mamba-org/setup-micromamba/releases/tag/v1.6.0)** on 2023-10-25T10:35:59Z
* **[peter-evans/create-or-update-comment](https://github.com/peter-evans/create-or-update-comment)** published a new release **[v3.1.0](https://github.com/peter-evans/create-or-update-comment/releases/tag/v3.1.0)** on 2023-10-19T15:30:21Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.1](https://github.com/actions/checkout/releases/tag/v4.1.1)** on 2023-10-17T15:53:17Z
