### PR TITLE
Use `_cumsum_reset_on_zero` instead of `rle` in `{first|last}_run`

### DIFF
--- a/xclim/indices/run_length.py
+++ b/xclim/indices/run_length.py
@@ -416,7 +416,7 @@ def _boundary_run(
     ufunc_1dim: str | bool,
     position: str,
 ) -> xr.DataArray:
-    """Return the index of the first item of the first run of at least a given length.
+    """Return the index of the first item of the first or last run of at least a given length.
 
     Parameters
     ----------
@@ -493,9 +493,10 @@ def _boundary_run(
         out = coord_transform(out, da)
 
     else:
-        # for "first" run, return "first" element in the run (and conversely for "last" run)
-        d = rle(da, dim=dim, index=position)
+        # _cusum_reset_on_zero() is an intermediate step in rle, which is sufficient here
+        d = _cumsum_reset_on_zero(da, dim=dim, index=position)
         d = xr.where(d >= window, 1, 0)
+        # for "first" run, return "first" element in the run (and conversely for "last" run)
         if freq is not None:
             out = d.resample({dim: freq}).map(find_boundary_run, position=position)
         else:


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1405
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] CHANGES.rst has been updated (with summary of main changes)
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Use an intermediate step instead of `rle` in first/last run computations

### Does this PR introduce a breaking change?
No

### Other information:
