### PR TITLE
Running `pip check` in conda environments shouldn't fail

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -45,7 +45,7 @@ jobs:
           echo "current_version=${CURRENT_VERSION}"
       - name: Bump Patch Version
         run: |
-          pip install bump2version
+          python -m pip install bump2version
           echo "running `bump2version patch`"
           NEW_VERSION="$(grep -E '__version__'  xclim/__init__.py | cut -d ' ' -f3)"
           echo "new_version=${NEW_VERSION}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -169,7 +169,7 @@ jobs:
       - name: Check versions
         run: |
           conda list
-          python -m xclim show_version_info
+          xclim show_version_info
           python -m pip check || true
       - name: Test with pytest
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -168,7 +168,7 @@ jobs:
         run: |
           conda list
           xclim show_version_info
-          pip check
+          pip check || true
       - name: Test with pytest
         run: |
           pytest --numprocesses=logical --durations=10 --cov=xclim --cov-report=term-missing

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,9 +48,11 @@ jobs:
       - name: Install pylint and tox
         run: pip install pylint tox~=4.0
       - name: Run pylint
-        run: pylint --rcfile=pylintrc --disable=import-error --exit-zero xclim
+        run: |
+          python -m pylint --rcfile=pylintrc --disable=import-error --exit-zero xclim
       - name: Run linting suite
-        run: tox -e lint
+        run: |
+          python -m tox -e lint
 
   test-py39:
     name: test-${{ matrix.tox-env }} (Python${{ matrix.python-version }})
@@ -71,10 +73,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install tox
         run: |
-          pip install tox~=4.0
+          python -m pip install tox~=4.0
       - name: Test with tox
         run: |
-          tox -e ${{ matrix.tox-env }}
+          python -m tox -e ${{ matrix.tox-env }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_FLAG_NAME: run-{{ matrix.tox-env }}
@@ -120,10 +122,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install tox
         run: |
-          pip install tox~=4.0
+          python -m pip install tox~=4.0
       - name: Test with tox
         run: |
-          tox -e ${{ matrix.tox-env }} -- ${{ matrix.markers }}
+          python -m tox -e ${{ matrix.tox-env }} -- ${{ matrix.markers }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_FLAG_NAME: run-{{ matrix.tox-env }}
@@ -167,11 +169,11 @@ jobs:
       - name: Check versions
         run: |
           conda list
-          xclim show_version_info
-          pip check || true
+          python -m xclim show_version_info
+          python -m pip check || true
       - name: Test with pytest
         run: |
-          pytest --numprocesses=logical --durations=10 --cov=xclim --cov-report=term-missing
+          python -m pytest --numprocesses=logical --durations=10 --cov=xclim --cov-report=term-missing
 #      - name: Install tox
 #        shell: bash -l {0}
 #        run: |
@@ -203,8 +205,8 @@ jobs:
     steps:
       - name: Coveralls Finished
         run: |
-          pip install --upgrade coveralls
-          coveralls --finish
+          python -m pip install --upgrade coveralls
+          python -m coveralls --finish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_SERVICE_NAME: github

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -20,8 +20,10 @@ jobs:
         with:
           python-version: "3.x"
       - name: Install packaging libraries
-        run: pip install flit
+        run: |
+          python -m pip install flit
       - name: Build a binary wheel and a source tarball
-        run: flit build
+        run: |
+          python -m flit build
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@v1.8.10

--- a/.github/workflows/tag-testpypi.yml
+++ b/.github/workflows/tag-testpypi.yml
@@ -20,9 +20,11 @@ jobs:
         with:
           python-version: "3.x"
       - name: Install packaging libraries
-        run: pip install flit
+        run: |
+          python -m pip install flit
       - name: Build a binary wheel and a source tarball
-        run: flit build
+        run: |
+          python -m flit build
       - name: Publish distribution 📦 to Test PyPI
         uses: pypa/gh-action-pypi-publish@v1.8.10
         with:

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -63,13 +63,13 @@ jobs:
       - name: Check versions
         run: |
           conda list
-          xclim show_version_info
-          pip check
+          python -m xclim show_version_info
+          python -m pip check
       - name: Run Tests
         if: success()
         id: status
         run: |
-          pytest --numprocesses=logical --durations=10 --cov=xclim --cov-report=term-missing --report-log output-${{ matrix.python-version }}-log.jsonl
+          python -m pytest --numprocesses=logical --durations=10 --cov=xclim --cov-report=term-missing --report-log output-${{ matrix.python-version }}-log.jsonl
       - name: Generate and publish the report
         if: |
           failure()

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Bug fixes
 Internal changes
 ^^^^^^^^^^^^^^^^
 * Pinned `cf-xarray` below v0.8.5 in Python3.8 installation to further extend legacy support. (:pull:`1519`).
+* `pip check` in conda builds in GitHub workflows have been temporarily set to always pass. (:pull:`1531`).
 
 v0.46.0 (2023-10-24)
 --------------------

--- a/README.rst
+++ b/README.rst
@@ -131,8 +131,8 @@ This package was created with Cookiecutter_ and the `audreyfeldroy/cookiecutter-
         :target: https://gitter.im/Ouranosinc/xclim?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge
         :alt: Gitter Chat
 
-.. |build| image:: https://github.com/Ouranosinc/xclim/workflows/xclim/badge.svg
-        :target: https://github.com/Ouranosinc/xclim/actions
+.. |build| image:: https://github.com/Ouranosinc/xclim/actions/workflows/main.yml/badge.svg
+        :target: https://github.com/Ouranosinc/xclim/actions/workflows/main.yml
         :alt: Build Status
 
 .. |coveralls| image:: https://coveralls.io/repos/github/Ouranosinc/xclim/badge.svg


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Forces the results of `pip check` for conda builds to always `exit 0`
* Use `python -m` for calling workflow python commands
* Fixes the malformed link to the build status

### Does this PR introduce a breaking change?

No.

### Other information:

It seems that there's a bit of a lag on the conda side of things when it comes to dependencies. The bug causing these failures has been addressed upstream: https://github.com/conda/conda/pull/13258