### PR TITLE
Fix robustness fractions and categories attributes

### DIFF
--- a/tests/test_ensembles.py
+++ b/tests/test_ensembles.py
@@ -743,8 +743,9 @@ def test_robustness_fractions_empty():
 
 
 def test_robustness_categories():
-    changed = xr.DataArray([0.5, 0.8, 1, 1])
-    agree = xr.DataArray([1, 0.5, 0.5, 1])
+    lat = xr.DataArray([1, 2, 3, 4], dims=("lat",), attrs={"axis": "Y"}, name="lat")
+    changed = xr.DataArray([0.5, 0.8, 1, 1], dims=("lat",), coords={"lat": lat})
+    agree = xr.DataArray([1, 0.5, 0.5, 1], dims=("lat",), coords={"lat": lat})
 
     categories = ensembles.robustness_categories(changed, agree)
     np.testing.assert_array_equal(categories, [2, 3, 3, 1])
@@ -753,6 +754,7 @@ def test_robustness_categories():
         categories.flag_meanings
         == "robust_signal no_change_or_no_signal conflicting_signal"
     )
+    assert categories.lat.attrs["axis"] == "Y"
 
 
 def test_robustness_coefficient():

--- a/xclim/ensembles/_robustness.py
+++ b/xclim/ensembles/_robustness.py
@@ -376,7 +376,7 @@ def robustness_categories(
         99 is used as a fill value for points that do not fall in any category.
     """
     src = changed_or_fractions.copy()  # Ensure no inplace changing of coords...
-    if isinstance(src, xr.Dataset): 
+    if isinstance(src, xr.Dataset):
         # Output of robustness fractions
         changed = src.changed
         agree = src.agree
@@ -384,7 +384,7 @@ def robustness_categories(
         changed = src
 
     # Initial map is all 99, same shape as change_frac
-    robustness = xr.ones_like(changed, 'int', chunks=changed.chunks) * 99
+    robustness = xr.ones_like(changed, "int", chunks=changed.chunks) * 99
     # We go in reverse gear so that the first categories have precedence in the case of multiple matches.
     for i, ((chg_op, agr_op), (chg_thresh, agr_thresh)) in reversed(
         list(enumerate(zip(ops, thresholds), 1))

--- a/xclim/ensembles/_robustness.py
+++ b/xclim/ensembles/_robustness.py
@@ -384,7 +384,7 @@ def robustness_categories(
         changed = src
 
     # Initial map is all 99, same shape as change_frac
-    robustness = xr.ones_like(changed, "int", chunks=changed.chunks) * 99
+    robustness = (changed.copy() * 0).astype(int) + 99
     # We go in reverse gear so that the first categories have precedence in the case of multiple matches.
     for i, ((chg_op, agr_op), (chg_thresh, agr_thresh)) in reversed(
         list(enumerate(zip(ops, thresholds), 1))

--- a/xclim/ensembles/_robustness.py
+++ b/xclim/ensembles/_robustness.py
@@ -262,6 +262,11 @@ def robustness_fractions(  # noqa: C901
         )
         out = out.assign(pvals=pvals)
 
+    # Keep attrs on non-modified coordinates
+    for ncrd, crd in fut.coords.items():
+        if ncrd in out.coords:
+            out[ncrd].attrs.update(crd.attrs)
+
     return out
 
 
@@ -370,16 +375,16 @@ def robustness_categories(
         Categorical (int) array following the flag variables CF conventions.
         99 is used as a fill value for points that do not fall in any category.
     """
-    if isinstance(changed_or_fractions, xr.Dataset):
+    src = changed_or_fractions.copy()  # Ensure no inplace changing of coords...
+    if isinstance(src, xr.Dataset): 
         # Output of robustness fractions
-        changed = changed_or_fractions.changed
-        agree = changed_or_fractions.agree
+        changed = src.changed
+        agree = src.agree
     else:
-        changed = changed_or_fractions
+        changed = src
 
     # Initial map is all 99, same shape as change_frac
-    robustness = changed * 0 + 99
-
+    robustness = xr.ones_like(changed, 'int', chunks=changed.chunks) * 99
     # We go in reverse gear so that the first categories have precedence in the case of multiple matches.
     for i, ((chg_op, agr_op), (chg_thresh, agr_thresh)) in reversed(
         list(enumerate(zip(ops, thresholds), 1))
@@ -392,9 +397,9 @@ def robustness_categories(
             cond = compare(changed, chg_op, chg_thresh) & compare(
                 agree, agr_op, agr_thresh
             )
-        robustness = xr.where(cond, i, robustness)
+        robustness = xr.where(~cond, robustness, i, keep_attrs=True)
 
-    robustness = robustness.astype(np.uint8).assign_attrs(
+    robustness = robustness.assign_attrs(
         flag_values=list(range(1, len(categories) + 1)),
         _FillValue=99,
         flag_descriptions=categories,


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] CHANGES.rst has been updated (with summary of main changes)
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* This is a simple PR that fixes a problem with overwritten attributes on coordinates when calling `robustness_fractions` and `robustness_categories`. 

### Does this PR introduce a breaking change?
No

### Other information:
