### PR TITLE
Pin xarray and pandas to avoid frequency issues

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,8 @@ Contributors to this version: Juliette Lavoie (:user:`juliettelavoie`), Pascal B
 
 Announcements
 ^^^^^^^^^^^^^
-* To circumvent issues stemming from the change in the frequency code convention in pandas 2.2, we pinned xarray < 2023.11.0 and pandas < 2.2 for this release. The next release will invert the pins (>= 2023.11.0 and >= 2.2). Which also means this is the last version of xclim supporting python 3.8.
+* To circumvent issues stemming from changes to the frequency code convention in `pandas` v2.2, we have pinned `xarray` (<2023.11.0) and `pandas` (< 2.2) for this release. This change will be reverted in `xclim` v0.48.0 to support the newer versions (`xarray>= 2023.11.0` and `pandas>= 2.2`). 
+* `xclim` v0.47.0 will be the last release supporting Python3.8.
 
 New features and enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,10 @@ v0.47.0 (unreleased)
 --------------------
 Contributors to this version: Juliette Lavoie (:user:`juliettelavoie`), Pascal Bourgault (:user:`aulemahal`), Trevor James Smith (:user:`Zeitsperre`).
 
+Announcements
+^^^^^^^^^^^^^
+* To circumvent issues stemming from the change in the frequency code convention in pandas 2.2, we pinned xarray < 2023.11.0 and pandas < 2.2 for this release. The next release will invert the pins (>= 2023.11.0 and >= 2.2). Which also means this is the last version of xclim supporting python 3.8.
+
 New features and enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 * New functions ``xclim.ensembles.robustness_fractions`` and ``xclim.ensembles.robustness_categories``. The former will replace ``xclim.ensembles.change_significance`` which is now deprecated and will be removed in xclim 0.49 (:pull:`1514`).

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Contributors to this version: Juliette Lavoie (:user:`juliettelavoie`), Pascal B
 
 Announcements
 ^^^^^^^^^^^^^
-* To circumvent issues stemming from changes to the frequency code convention in `pandas` v2.2, we have pinned `xarray` (<2023.11.0) and `pandas` (< 2.2) for this release. This change will be reverted in `xclim` v0.48.0 to support the newer versions (`xarray>= 2023.11.0` and `pandas>= 2.2`). 
+* To circumvent issues stemming from changes to the frequency code convention in `pandas` v2.2, we have pinned `xarray` (<2023.11.0) and `pandas` (< 2.2) for this release. This change will be reverted in `xclim` v0.48.0 to support the newer versions (`xarray>= 2023.11.0` and `pandas>= 2.2`).
 * `xclim` v0.47.0 will be the last release supporting Python3.8.
 
 New features and enhancements

--- a/environment.yml
+++ b/environment.yml
@@ -16,14 +16,14 @@ dependencies:
     - lmoments3
     - numba
     - numpy >=1.16
-    - pandas >=0.23, <2.2
+    - pandas >=0.23,<2.2
     - pint >=0.9
     - poppler >=0.67
     - pyyaml
     - scikit-learn >=0.21.3
     - scipy >=1.2
     - statsmodels
-    - xarray >=2022.06.0, <2023.11.0
+    - xarray >=2022.06.0,<2023.11.0
     # Extras
     - eofs
     - flox

--- a/environment.yml
+++ b/environment.yml
@@ -16,14 +16,14 @@ dependencies:
     - lmoments3
     - numba
     - numpy >=1.16
-    - pandas >=0.23
+    - pandas >=0.23, <2.2
     - pint >=0.9
     - poppler >=0.67
     - pyyaml
     - scikit-learn >=0.21.3
     - scipy >=1.2
     - statsmodels
-    - xarray >=2022.06.0
+    - xarray >=2022.06.0, <2023.11.0
     # Extras
     - eofs
     - flox

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,13 +45,13 @@ dependencies = [
   "numba",
   "numpy>=1.16",
   "pandas>=0.23,<2.0; python_version == '3.8'",
-  "pandas>=0.23; python_version >= '3.9'",
+  "pandas>=0.23,<2.2; python_version >= '3.9'",
   "pint>=0.10",
   "pyyaml",
   "scikit-learn>=0.21.3",
   "scipy>=1.2",
   "statsmodels",
-  "xarray>=2022.06.0"
+  "xarray>=2022.06.0,<2023.11.0"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR is a temporary fix. #1534 will be fixed by inverting the pins in the next release (0.48).
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Pins xarray under 2023.11 and pandas under 2.2 (which is not yet released).

### Does this PR introduce a breaking change?

No.

I expect the "upstream" builds to fail, errors related to frequencies are ok and will be fixed in the near future.

### Other information:
The plan of inverting the pins in 0.48 implies that 0.47 will be the last version supporting python 3.8.
