### PR TITLE
Ensure inputs of cosine of solar zenith angle are chunked when needed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@ New features and enhancements
 Bug fixes
 ^^^^^^^^^
 * Fixed a bug with ``n_escore=-1`` in ``xclim.sdba.adjustment.NpdfTransform`` (:issue:`1515`, :pull:`1515`).
+* If chunked inputs are passed to indicators ``mean_radiant_temperature``  and ``potential_evapotranspiration``, subcalculations of the solar angle will also use the same chunks, instead of a single one of the same size as the data (:issue:`1536`, :pull:`1542`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,11 +8,13 @@ import numpy as np
 import xarray as xr
 
 from xclim.core.utils import (
+    _chunk_like,
     ensure_chunk_size,
     nan_calc_percentiles,
     walk_map,
     wrapped_partial,
 )
+from xclim.testing.helpers import test_timeseries as _test_timeseries
 
 
 def test_walk_map():
@@ -110,3 +112,18 @@ class TestNanCalcPercentiles:
         # The expected is from R `quantile(arr, 0.5, type=8, na.rm = TRUE)`
         # Note that scipy mquantiles would give a different result here
         assert res[()] == 42.0
+
+
+def test_chunk_like():
+    da = _test_timeseries(
+        np.zeros(
+            100,
+        ),
+        "tas",
+    )
+    da = xr.concat([da] * 10, xr.DataArray(np.arange(10), dims=("lat",), name="lat"))
+
+    assert isinstance(da.lat.variable, xr.core.variable.IndexVariable)
+    t, l = _chunk_like(da.time, da.lat, chunks={"time": 10, "lat": 1})
+    assert t.chunks[0] == tuple([10] * 10)
+    assert l.chunks[0] == tuple([1] * 10)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -124,6 +124,6 @@ def test_chunk_like():
     da = xr.concat([da] * 10, xr.DataArray(np.arange(10), dims=("lat",), name="lat"))
 
     assert isinstance(da.lat.variable, xr.core.variable.IndexVariable)
-    t, l = _chunk_like(da.time, da.lat, chunks={"time": 10, "lat": 1})
+    t, la = _chunk_like(da.time, da.lat, chunks={"time": 10, "lat": 1})
     assert t.chunks[0] == tuple([10] * 10)
-    assert l.chunks[0] == tuple([1] * 10)
+    assert la.chunks[0] == tuple([1] * 10)

--- a/xclim/core/utils.py
+++ b/xclim/core/utils.py
@@ -879,7 +879,7 @@ def _chunk_like(*inputs: xr.DataArray | xr.Dataset, chunks: dict[str, int] | Non
 
     Will also ensure passed inputs are not IndexVariable types, so that they can be chunked.
     """
-    if chunks is None:
+    if not chunks:
         return tuple(inputs)
 
     outputs = []

--- a/xclim/core/utils.py
+++ b/xclim/core/utils.py
@@ -881,7 +881,9 @@ def _chunk_like(*inputs: xr.DataArray | xr.Dataset, chunks: dict[str, int]):
     """
     outputs = []
     for da in inputs:
-        if isinstance(da.variable, xr.core.variable.IndexVariable):
+        if isinstance(da, xr.DataArray) and isinstance(
+            da.variable, xr.core.variable.IndexVariable
+        ):
             da = xr.DataArray(da, dims=da.dims, coords=da.coords, name=da.name)
         outputs.append(da.chunk(**{d: c for d, c in chunks.items() if d in da.dims}))
     return tuple(outputs)

--- a/xclim/indices/_conversion.py
+++ b/xclim/indices/_conversion.py
@@ -1378,7 +1378,9 @@ def potential_evapotranspiration(
         tasmin = convert_units_to(tasmin, "degF")
         tasmax = convert_units_to(tasmax, "degF")
 
-        re = extraterrestrial_solar_radiation(tasmin.time, lat, chunks=tasmin.chunks)
+        re = extraterrestrial_solar_radiation(
+            tasmin.time, lat, chunks=tasmin.chunksizes
+        )
         re = convert_units_to(re, "cal cm-2 day-1")
 
         # Baier et Robertson(1965) formula
@@ -1397,7 +1399,9 @@ def potential_evapotranspiration(
 
         lv = 2.5  # MJ/kg
 
-        ra = extraterrestrial_solar_radiation(tasmin.time, lat, chunks=tasmin.chunks)
+        ra = extraterrestrial_solar_radiation(
+            tasmin.time, lat, chunks=tasmin.chunksizes
+        )
         ra = convert_units_to(ra, "MJ m-2 d-1")
 
         # Hargreaves and Samani (1985) formula
@@ -1415,7 +1419,7 @@ def potential_evapotranspiration(
         tasK = convert_units_to(tas, "K")
 
         ext_rad = extraterrestrial_solar_radiation(
-            tas.time, lat, solar_constant="1367 W m-2", chunks=tas.chunks
+            tas.time, lat, solar_constant="1367 W m-2", chunks=tas.chunksizes
         )
         latentH = 4185.5 * (751.78 - 0.5655 * tasK)
         radDIVlat = ext_rad / latentH
@@ -1972,7 +1976,13 @@ def mean_radiant_temperature(
 
     if stat == "sunlit":
         csza = cosine_of_solar_zenith_angle(
-            dates, dec, lat, lon=lon, stat="average", sunlit=True, chunks=rsds.chunks
+            dates,
+            dec,
+            lat,
+            lon=lon,
+            stat="average",
+            sunlit=True,
+            chunks=rsds.chunksizes,
         )
     elif stat == "instant":
         tc = time_correction_for_solar_angle(dates)
@@ -1983,7 +1993,7 @@ def mean_radiant_temperature(
             lon=lon,
             time_correction=tc,
             stat="instant",
-            chunks=rsds.chunks,
+            chunks=rsds.chunksizes,
         )
     else:
         raise NotImplementedError(

--- a/xclim/indices/_conversion.py
+++ b/xclim/indices/_conversion.py
@@ -14,7 +14,7 @@ from xclim.core.units import (
     rate2flux,
     units2pint,
 )
-from xclim.core.utils import Quantified
+from xclim.core.utils import Quantified, _chunk_like, uses_dask
 from xclim.indices.helpers import (
     _gather_lat,
     _gather_lon,
@@ -1378,7 +1378,8 @@ def potential_evapotranspiration(
         tasmin = convert_units_to(tasmin, "degF")
         tasmax = convert_units_to(tasmax, "degF")
 
-        re = extraterrestrial_solar_radiation(tasmin.time, lat)
+        time, lat = _chunk_like(tasmin.time, lat, chunks=tasmin.chunks)
+        re = extraterrestrial_solar_radiation(time, lat)
         re = convert_units_to(re, "cal cm-2 day-1")
 
         # Baier et Robertson(1965) formula
@@ -1397,7 +1398,8 @@ def potential_evapotranspiration(
 
         lv = 2.5  # MJ/kg
 
-        ra = extraterrestrial_solar_radiation(tasmin.time, lat)
+        time, lat = _chunk_like(tasmin.time, lat, chunks=tasmin.chunks)
+        ra = extraterrestrial_solar_radiation(time, lat)
         ra = convert_units_to(ra, "MJ m-2 d-1")
 
         # Hargreaves and Samani (1985) formula
@@ -1414,8 +1416,9 @@ def potential_evapotranspiration(
         tas = convert_units_to(tas, "degC")
         tasK = convert_units_to(tas, "K")
 
+        time, lat = _chunk_like(tas.time, lat, chunks=tas.chunks)
         ext_rad = extraterrestrial_solar_radiation(
-            tas.time, lat, solar_constant="1367 W m-2"
+            time, lat, solar_constant="1367 W m-2"
         )
         latentH = 4185.5 * (751.78 - 0.5655 * tasK)
         radDIVlat = ext_rad / latentH
@@ -1969,6 +1972,8 @@ def mean_radiant_temperature(
     lat = _gather_lat(rsds)
     lon = _gather_lon(rsds)
     dec = solar_declination(dates)
+    if uses_dask(dates, dec, lat, lon):
+        dates, dec, lat, lon = _chunk_like(dates, dec, lat, lon, chunks=rsds.chunks)
 
     if stat == "sunlit":
         csza = cosine_of_solar_zenith_angle(

--- a/xclim/indices/helpers.py
+++ b/xclim/indices/helpers.py
@@ -230,6 +230,8 @@ def cosine_of_solar_zenith_angle(
     sunlit: bool
         If True, only the sunlit part of the interval is considered in the integral or average.
         Does nothing if stat is "instant".
+    chunks : dict
+        Chunking to apply to
 
     Returns
     -------

--- a/xclim/indices/helpers.py
+++ b/xclim/indices/helpers.py
@@ -20,7 +20,7 @@ from xclim.core.calendar import (
     get_calendar,
 )
 from xclim.core.units import convert_units_to
-from xclim.core.utils import Quantified
+from xclim.core.utils import Quantified, _chunk_like
 
 
 def _wrap_radians(da):
@@ -199,6 +199,7 @@ def cosine_of_solar_zenith_angle(
     time_correction: xr.DataArray = None,
     stat: str = "average",
     sunlit: bool = False,
+    chunks: dict[str, int] | None = None,
 ) -> xr.DataArray:
     """Cosine of the solar zenith angle.
 
@@ -230,8 +231,9 @@ def cosine_of_solar_zenith_angle(
     sunlit: bool
         If True, only the sunlit part of the interval is considered in the integral or average.
         Does nothing if stat is "instant".
-    chunks : dict
-        Chunking to apply to
+    chunks : dictionary
+        When `time`,  `lat` and `lon` originate from coordinates of a large chunked dataset, this dataset's chunking
+        can be passed here to ensure the computation is also chunked.
 
     Returns
     -------
@@ -251,6 +253,8 @@ def cosine_of_solar_zenith_angle(
     declination = convert_units_to(declination, "rad")
     lat = _wrap_radians(convert_units_to(lat, "rad"))
     lon = convert_units_to(lon, "rad")
+    declination, lat, lon = _chunk_like(declination, lat, lon, chunks=chunks)
+
     S_IN_D = 24 * 3600
 
     if len(time) < 3 or xr.infer_freq(time) == "D":
@@ -359,6 +363,7 @@ def extraterrestrial_solar_radiation(
     lat: xr.DataArray,
     solar_constant: Quantified = "1361 W m-2",
     method="spencer",
+    chunks: dict[str, int] | None = None,
 ) -> xr.DataArray:
     """Extraterrestrial solar radiation.
 
@@ -377,6 +382,9 @@ def extraterrestrial_solar_radiation(
     method : {'spencer', 'simple'}
         Which method to use when computing the solar declination and the eccentricity
         correction factor. See :py:func:`solar_declination` and :py:func:`eccentricity_correction_factor`.
+    chunks : dictionary
+        When `times` and `lat` originate from coordinates of a large chunked dataset, passing the dataset's chunks here
+        will ensure the computation is chunked as well.
 
     Returns
     -------
@@ -393,7 +401,9 @@ def extraterrestrial_solar_radiation(
     return (
         gsc
         * rad_to_day
-        * cosine_of_solar_zenith_angle(times, ds, lat, stat="integral", sunlit=True)
+        * cosine_of_solar_zenith_angle(
+            times, ds, lat, stat="integral", sunlit=True, chunks=chunks
+        )
         * dr
     ).assign_attrs(units="J m-2 d-1")
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1536
- [x] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* New function `xc.core.utils._chunk_like` to chunk a list of inputs according to one chunk dictionary. It also circumvents https://github.com/pydata/xarray/issues/6204 by recreating DataArrays that where obtained from dimension coordinates.
* Generalization of `uses_dask` so it can accept a list of objects.
* Usage of `_chunk_like` to ensure the inputs of `cosine_of_solar_zenith_angle` are chunked when needed, in `mean_radiant_temperature` and `potential_evapotranspiration`.

The effect of this is simply that the  `cosine_of_solar_zenith_angle` will be performed on blocks of the same size as in the original data, even though its inputs (the dimension coordinate) did not carry that information. Before this PR, the calculation was done as a single block, of the same size as the full array.

### Does this PR introduce a breaking change?
No.

### Other information:
Dask might warn something like `PerformanceWarning: Increasing number of chunks by factor of NN`. Where NN should be the number of chunks along the `lat` dimension, if present. That exactly what we want,  so it's ok.