### PR TITLE
[bot] Update GitHub Action Versions

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -18,4 +18,4 @@ jobs:
       - name: 'Checkout Repository'
         uses: actions/checkout@v4.1.1
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v3.1.0
+        uses: actions/dependency-review-action@v3.1.4

--- a/.github/workflows/first_pull_request.yml
+++ b/.github/workflows/first_pull_request.yml
@@ -10,7 +10,7 @@ jobs:
     name: Welcome
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v6.4.1
+      - uses: actions/github-script@v7.0.1
         with:
           script: |
             // Get a list of all issues created by the PR opener

--- a/.github/workflows/label_on_approval.yml
+++ b/.github/workflows/label_on_approval.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Label Approved
-        uses: actions/github-script@v6.4.1
+        uses: actions/github-script@v7.0.1
         with:
           script: |
             github.rest.issues.addLabels({

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -26,4 +26,4 @@ jobs:
         run: |
           python -m flit build
       - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.8.10
+        uses: pypa/gh-action-pypi-publish@v1.8.11

--- a/.github/workflows/tag-testpypi.yml
+++ b/.github/workflows/tag-testpypi.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           python -m flit build
       - name: Publish distribution 📦 to Test PyPI
-        uses: pypa/gh-action-pypi-publish@v1.8.10
+        uses: pypa/gh-action-pypi-publish@v1.8.11
         with:
           repository-url: https://test.pypi.org/legacy/
           skip-existing: true

--- a/.github/workflows/testdata_version.yml
+++ b/.github/workflows/testdata_version.yml
@@ -38,7 +38,7 @@ jobs:
           body-includes: It appears that this Pull Request modifies the `main.yml` workflow.
       - name: Compare Versions
         if: ${{( env.XCLIM_TESTDATA_TAG != env.XCLIM_TESTDATA_BRANCH )}}
-        uses: actions/github-script@v6.4.1
+        uses: actions/github-script@v7.0.1
         with:
           script: |
             core.setFailed('Configured `xclim-testdata` tag is not `latest`.')


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish)** published a new release **[v1.8.11](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.8.11)** on 2023-11-29T02:41:33Z
* **[actions/dependency-review-action](https://github.com/actions/dependency-review-action)** published a new release **[v3.1.4](https://github.com/actions/dependency-review-action/releases/tag/v3.1.4)** on 2023-11-28T07:14:33Z
* **[actions/github-script](https://github.com/actions/github-script)** published a new release **[v7.0.1](https://github.com/actions/github-script/releases/tag/v7.0.1)** on 2023-11-17T22:21:53Z
