### PR TITLE
Fixing missing=0 in convert calendar

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@ New features and enhancements
 * Added uncertainty partitioning method `lafferty_sriver` from Lafferty and Sriver (2023), which can partition uncertainty related to the downscaling method. (:issue:`1497`, :pull:`1529`).
 * Validate YAML indicators description before trying to build module. (:issue:`1523`, :pull:`1560`).
 
+Bug fixes
+^^^^^^^^^
+* Fixed passing ``missing=0`` to ``xclim.core.calendar.convert_calendar`` (:issue:`1562`, :pull:`1563`).
 
 
 v0.47.0 (2023-12-01)

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -413,10 +413,11 @@ def test_convert_calendar_missing(source, target, freq):
     da_src = xr.DataArray(
         np.linspace(0, 1, src.size), dims=("time",), coords={"time": src}
     )
-    out = convert_calendar(da_src, target, missing=np.nan, align_on="date")
+    out = convert_calendar(da_src, target, missing=0, align_on="date")
     assert xr.infer_freq(out.time) == freq
     if source == "360_day":
         assert out.time[-1].dt.day == 31
+        assert out[-1] == 0
 
 
 def test_convert_calendar_and_doy():

--- a/xclim/core/calendar.py
+++ b/xclim/core/calendar.py
@@ -503,7 +503,9 @@ def convert_calendar(
         target = date_range_like(source[dim], cal_tgt)
 
     if isinstance(target, xr.DataArray):
-        out = out.reindex({dim: target}, fill_value=missing or np.nan)
+        out = out.reindex(
+            {dim: target}, fill_value=missing if missing is not None else np.nan
+        )
 
     # Copy attrs but change remove `calendar` is still present.
     out[dim].attrs.update(source[dim].attrs)


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1562, fixes https://github.com/Ouranosinc/ESPO-Internal/issues/3
- [x] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* When `missing=0` is passed to `convert_calendar`, it is used instead of replaced by `np.NaN` by faulty expression.

### Does this PR introduce a breaking change?
No.

### Other information:
Xarray's implementation does not have this problem.