### PR TITLE
Better indicators search

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,7 @@ Internal changes
 * The GitHub Workflows now use the `step-security/harden-runner` action to monitor source code, actions, and dependency safety. All workflows now employ more constrained permissions rule sets to prevent security issues. (:pull:`1577`, :pull:`1578`).
 * Updated the CONTRIBUTING.rst directions to showcase the new versioning system. (:issue:`1557`, :pull:`1573`).
 * The `codespell` library is now a development dependency for the `dev` installation recipe with configurations found within `pyproject.toml`. This is also now a linting step and integrated as a `pre-commit` hook. For more information, see the `codespell documentation <https://github.com/codespell-project/codespell>`_ (:pull:`1576`).
+* Climate indicators search page now prioritizes the "official" indicators (atmos, land, seaIce and generic), virtual submodules can be added to search through checkbox option.
 
 
 v0.47.0 (2023-12-01)

--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -98,3 +98,7 @@ code > .indName {
     margin: 5px;
     background-color: #ddd;
 }
+
+#incVirtModLbl {
+    display: inline;
+}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -9,7 +9,7 @@
 
 {% block scripts %}
 {% if "indicators" in sourcename %}
-  <script src="https://cdn.jsdelivr.net/npm/minisearch@6.1.0/dist/umd/index.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/minisearch@6.3.0/dist/umd/index.min.js"></script>
   <script type="text/javascript" src="./_static/indsearch.js"></script>
 {% endif %}
 {{ super() }}

--- a/docs/indicators.rst
+++ b/docs/indicators.rst
@@ -17,7 +17,7 @@ allows a simple free text search of all indicators. Click on the python names to
 .. raw:: html
 
     <input type="text" id="queryInput" onkeyup="indFilter()" placeholder="Search for titles, variables or keywords...">
-
+    <input type="checkbox" id="incVirtMod" onchange="indFilter()"><label id="incVirtModLbl" for="virtualModules">Include virtual submodules in results.</label>
     <div id="indTable">
     </div>
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1559
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Exclude virtual modules by default (anuclim, icclim, cf), add checkbox to include them
* Even when virtual modules are included, boost "official" indicators in the results.

I bumped the MiniSearch version to be able to use the "wildcard" option, which cover the case where no search query is given. This way, the boosting official indicators is done even with an empty query.

### Does this PR introduce a breaking change?
No.

### Other information:
