### PR TITLE
Update to organization-scope Personal Access Token

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -78,5 +78,5 @@ jobs:
         uses: ad-m/github-push-action@v0.8.0
         with:
           force: false
-          github_token: ${{ secrets.BUMPVERSION_TOKEN }}
+          github_token: ${{ secrets.BUMP_VERSION_TOKEN }}
           branch: ${{ github.ref }}


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] CHANGES.rst has been updated (with summary of main changes)
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Updates Workflows to use Organization-scoped Personal Access Tokens

### Does this PR introduce a breaking change?

No.

### Other information:

The `ACTIONS_VERSIONS_UPDATER_TOKEN` and the `BUMP_VERSION_TOKEN` are Organization-scoped (`Ouranosinc`) personal access tokens with the following permissions for repositories `xclim`, `xscen`, `miranda`, `figanos`, and `raven-hydro`:

ACTIONS_VERSIONS_UPDATER_TOKEN:
 - Contents: Read and Write
 - Metadata: Read-Only
 - Pull Requests: Read and Write
 - Workflows: Read and Write

BUMP_VERSION_TOKEN:
 - Contents: Read and Write
 - Metadata: Read-Only
 - Pull Requests: Read and Write

**Both are set to expire on January 1st, 2025**. After this point, anyone with maintainer access can generate new tokens and ask the `Ouranosinc` admins to update the tokens so that workflows continue operating as normal.

For more information: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens