### PR TITLE
Synchronize code formatters with `pre-commit`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
       - id: yamllint
         args: [ '--config-file=.yamllint.yaml' ]
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.12.1
+    rev: 24.1.0
     hooks:
       - id: black
   - repo: https://github.com/PyCQA/isort
@@ -41,7 +41,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.13
+    rev: v0.1.14
     hooks:
       - id: ruff
   - repo: https://github.com/pylint-dev/pylint
@@ -61,7 +61,7 @@ repos:
       - id: nbqa-pyupgrade
         args: [ '--py38-plus' ]
       - id: nbqa-black
-        additional_dependencies: [ 'black==23.12.1' ]
+        additional_dependencies: [ 'black==24.1.0' ]
       - id: nbqa-isort
   - repo: https://github.com/kynan/nbstripout
     rev: 0.6.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,7 +73,7 @@ repos:
     rev: v0.3.9
     hooks:
       - id: blackdoc
-        additional_dependencies: [ 'black==23.12.1' ]
+        additional_dependencies: [ 'black==24.1.0' ]
         exclude: '(xclim/indices/__init__.py|docs/installation.rst)'
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.18.1

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,7 +48,7 @@ Internal changes
     * A new GitHub Workflow (``workflow-warning.yml``) has been added to warn maintainers when a forked repository has been used to open a Pull Request that modifies GitHub Workflows.
     * `pylint` has been configured to provide some overhead checks of the `xclim` codebase as well as run as part of `xclim`'s `pre-commit` hooks.
     * Some small adjustments to code organization to address `pylint` errors.
-* `dev` formatting tools (`black`, `blackdoc`, `isort`) are now pinned to their `pre-commit` hook version equivalents.
+* `dev` formatting tools (`black`, `blackdoc`, `isort`) are now pinned to their `pre-commit` hook version equivalents in both `pyproject.toml` and `tox.ini`.
 
 v0.47.0 (2023-12-01)
 --------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,7 +25,7 @@ Breaking changes
 * `xclim`'s units registry and units formatting are now extended from `cf-xarray`. The exponent sign "^" is now never added in the ``units`` attribute. For example, square meters are given as "m2" instead of "m^2" by xclim, both are still accepted as input. (:issue:`1010`, :pull:`1590`).
 * `yamale` is now listed as a core dependency (was previously listed in the `dev` installation recipe). (:issue:`1595`, :pull:`1596`).
 * Due to a licensing limitation, the calculation of empirical orthogonal function  based on `eofs` (``xclim.sdba.properties.first_eof``) has been removed from `xclim`. (:issue:`1620`, :pull:`1621`).
-* `black` formatting style has been updated to the 2024 stable conventions. `isort` has been added to the `dev` installation recipe.
+* `black` formatting style has been updated to the 2024 stable conventions. `isort` has been added to the `dev` installation recipe. (:pull:`1626`).
 
 Bug fixes
 ^^^^^^^^^
@@ -48,7 +48,7 @@ Internal changes
     * A new GitHub Workflow (``workflow-warning.yml``) has been added to warn maintainers when a forked repository has been used to open a Pull Request that modifies GitHub Workflows.
     * `pylint` has been configured to provide some overhead checks of the `xclim` codebase as well as run as part of `xclim`'s `pre-commit` hooks.
     * Some small adjustments to code organization to address `pylint` errors.
-* `dev` formatting tools (`black`, `blackdoc`, `isort`) are now pinned to their `pre-commit` hook version equivalents in both `pyproject.toml` and `tox.ini`.
+* `dev` formatting tools (`black`, `blackdoc`, `isort`) are now pinned to their `pre-commit` hook version equivalents in both `pyproject.toml` and `tox.ini`. (:pull:`1626`).
 
 v0.47.0 (2023-12-01)
 --------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,7 @@ Breaking changes
 * `xclim`'s units registry and units formatting are now extended from `cf-xarray`. The exponent sign "^" is now never added in the ``units`` attribute. For example, square meters are given as "m2" instead of "m^2" by xclim, both are still accepted as input. (:issue:`1010`, :pull:`1590`).
 * `yamale` is now listed as a core dependency (was previously listed in the `dev` installation recipe). (:issue:`1595`, :pull:`1596`).
 * Due to a licensing limitation, the calculation of empirical orthogonal function  based on `eofs` (``xclim.sdba.properties.first_eof``) has been removed from `xclim`. (:issue:`1620`, :pull:`1621`).
+* `black` formatting style has been updated to the 2024 stable conventions. `isort` has been added to the `dev` installation recipe.
 
 Bug fixes
 ^^^^^^^^^
@@ -47,6 +48,7 @@ Internal changes
     * A new GitHub Workflow (``workflow-warning.yml``) has been added to warn maintainers when a forked repository has been used to open a Pull Request that modifies GitHub Workflows.
     * `pylint` has been configured to provide some overhead checks of the `xclim` codebase as well as run as part of `xclim`'s `pre-commit` hooks.
     * Some small adjustments to code organization to address `pylint` errors.
+* `dev` formatting tools (`black`, `blackdoc`, `isort`) are now pinned to their `pre-commit` hook version equivalents.
 
 v0.47.0 (2023-12-01)
 --------------------

--- a/docs/autodoc_indicator.py
+++ b/docs/autodoc_indicator.py
@@ -4,6 +4,7 @@ By default, indicator instances are skipped by autodoc because their subclass is
 
 Based on https://github.com/powerline/powerline/blob/83d855d3d73498c47553afeba212415990d95c54/docs/source/powerline_autodoc.py
 """
+
 from __future__ import annotations
 
 from sphinx.domains.python import PyFunction, PyXRefRole

--- a/environment.yml
+++ b/environment.yml
@@ -29,9 +29,9 @@ dependencies:
   # Extras
   - flox
   # Testing and development dependencies
-  - black >=22.12
-  - blackdoc
-  - bump-my-version
+  - black ==24.1.0
+  - blackdoc ==0.3.9
+#  - bump-my-version  # The conda package is not as up-to-date as the PyPI package.
   - cairosvg
   - codespell
   - coverage
@@ -43,6 +43,7 @@ dependencies:
   - h5netcdf
   - ipykernel
   - ipython
+  - isort ==5.13.2
   - matplotlib
   - mypy
   - nbqa
@@ -68,11 +69,12 @@ dependencies:
   - sphinx-rtd-theme >=1.0
   - sphinxcontrib-bibtex
   - tokenize-rt
-  - tox
+  - tox >=4.0
 #  - tox-conda  # Will be added when a tox@v4.0+ compatible plugin is released.
   - xdoctest
   - yamllint
   - pip
   - pip:
+    - bump-my-version >=0.17.1  # The conda package is not as up-to-date as the PyPI package.
     - flake8-alphabetize
     - sphinxcontrib-svg2pdfconverter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,9 +59,9 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
   # Dev tools and testing
-  "black >=23.3.0",
-  "blackdoc",
-  "bump-my-version",
+  "black ==24.1.0",
+  "blackdoc ==0.3.9",
+  "bump-my-version >=0.17.1",
   "codespell",
   "coverage[toml]",
   "flake8",
@@ -69,6 +69,7 @@ dev = [
   "flake8-rst-docstrings",
   "h5netcdf",
   "ipython",
+  "isort ==5.13.2",
   "mypy",
   "nbqa",
   "nbval",
@@ -83,7 +84,7 @@ dev = [
   "pytest-xdist[psutil] >=3.2",
   "ruff >=0.1.0",
   "tokenize-rt",
-  "tox",
+  "tox >=4.0",
   # "tox-conda",  # Will be added when a tox@v4.0+ compatible plugin is released.
   "xdoctest",
   "yamllint",

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -1,4 +1,5 @@
 """Tests for generic indices."""
+
 from __future__ import annotations
 
 import numpy as np

--- a/tests/test_land.py
+++ b/tests/test_land.py
@@ -1,4 +1,5 @@
 """Tests for indicators in `land` realm."""
+
 from __future__ import annotations
 
 import numpy as np

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,4 +1,5 @@
 """Tests for statistical indices."""
+
 from __future__ import annotations
 
 import numpy as np

--- a/tox.ini
+++ b/tox.ini
@@ -21,13 +21,15 @@ description = Run code quality compliance tests under {basepython}
 skip_install = True
 extras =
 deps =
+    codespell
     flake8
+    flake8-alphabetize
     flake8-rst-docstrings
-    black[jupyter]
-    blackdoc
-    isort
+    black[jupyter]==24.1.0
+    blackdoc==0.3.9
+    isort==5.13.2
     nbqa
-    ruff
+    ruff>=0.1.0
     yamllint
 commands_pre =
 commands =
@@ -38,6 +40,7 @@ commands =
     nbqa black --check docs
     blackdoc --check --exclude=xclim/indices/__init__.py xclim
     blackdoc --check docs
+    codespell xclim tests docs
     yamllint --config-file=.yamllint.yaml xclim
 commands_post =
 

--- a/xclim/__init__.py
+++ b/xclim/__init__.py
@@ -1,4 +1,5 @@
 """Climate indices computation package based on Xarray."""
+
 from __future__ import annotations
 
 try:

--- a/xclim/analog.py
+++ b/xclim/analog.py
@@ -1,4 +1,5 @@
 """Spatial Analogues module."""
+
 # TODO: Hellinger distance
 # TODO: Mahalanobis distance
 # TODO: Comment on "significance" of results.

--- a/xclim/cli.py
+++ b/xclim/cli.py
@@ -3,6 +3,7 @@
 Command Line Interface module
 =============================
 """
+
 from __future__ import annotations
 
 import sys

--- a/xclim/core/__init__.py
+++ b/xclim/core/__init__.py
@@ -1,4 +1,5 @@
 """Core module."""
+
 from __future__ import annotations
 
 from . import missing

--- a/xclim/core/bootstrapping.py
+++ b/xclim/core/bootstrapping.py
@@ -1,4 +1,5 @@
 """Module comprising the bootstrapping algorithm for indicators."""
+
 from __future__ import annotations
 
 import warnings

--- a/xclim/core/calendar.py
+++ b/xclim/core/calendar.py
@@ -4,6 +4,7 @@ Calendar Handling Utilities
 
 Helper function to handle dates, times and different calendars with xarray.
 """
+
 from __future__ import annotations
 
 import datetime as pydt
@@ -1013,12 +1014,14 @@ def resample_doy(doy: xr.DataArray, arr: xr.DataArray | xr.Dataset) -> xr.DataAr
 
 
 def time_bnds(  # noqa: C901
-    time: xr.DataArray
-    | xr.Dataset
-    | CFTimeIndex
-    | pd.DatetimeIndex
-    | DataArrayResample
-    | DatasetResample,
+    time: (
+        xr.DataArray
+        | xr.Dataset
+        | CFTimeIndex
+        | pd.DatetimeIndex
+        | DataArrayResample
+        | DatasetResample
+    ),
     freq: str | None = None,
     precision: str | None = None,
 ):
@@ -1768,9 +1771,11 @@ def stack_periods(
         periods.append(
             slice(
                 strd_slc.start + win_slc.start,
-                (strd_slc.start + win_slc.stop)
-                if win_slc.stop is not None
-                else da.time.size,
+                (
+                    (strd_slc.start + win_slc.stop)
+                    if win_slc.stop is not None
+                    else da.time.size
+                ),
             )
         )
 

--- a/xclim/core/cfchecks.py
+++ b/xclim/core/cfchecks.py
@@ -4,6 +4,7 @@ CF-Convention Checking
 
 Utilities designed to verify the compliance of metadata with the CF-Convention.
 """
+
 from __future__ import annotations
 
 import fnmatch

--- a/xclim/core/datachecks.py
+++ b/xclim/core/datachecks.py
@@ -4,6 +4,7 @@ Data Checks
 
 Utilities designed to check the validity of data inputs.
 """
+
 from __future__ import annotations
 
 from typing import Sequence

--- a/xclim/core/dataflags.py
+++ b/xclim/core/dataflags.py
@@ -4,6 +4,7 @@ Data Flags
 
 Pseudo-indicators designed to analyse supplied variables for suspicious/erroneous indicator values.
 """
+
 from __future__ import annotations
 
 from decimal import Decimal

--- a/xclim/core/formatting.py
+++ b/xclim/core/formatting.py
@@ -2,6 +2,7 @@
 Formatting Utilities for Indicators
 ===================================
 """
+
 from __future__ import annotations
 
 import datetime as dt

--- a/xclim/core/indicator.py
+++ b/xclim/core/indicator.py
@@ -97,6 +97,7 @@ the mapping of `data.input` simply links an argument name from the function give
 to one of those official variables.
 
 """
+
 from __future__ import annotations
 
 import re
@@ -1755,9 +1756,11 @@ def build_indicator_module_from_yaml(  # noqa: C901
     elif translations is not None:
         # A mapping was passed, we read paths is any.
         translations = {
-            lng: read_locale_file(trans, module=module_name, encoding=encoding)
-            if isinstance(trans, (str, Path))
-            else trans
+            lng: (
+                read_locale_file(trans, module=module_name, encoding=encoding)
+                if isinstance(trans, (str, Path))
+                else trans
+            )
             for lng, trans in translations.items()
         }
 

--- a/xclim/core/locales.py
+++ b/xclim/core/locales.py
@@ -43,6 +43,7 @@ all other entries (translations of frequent parameters and all indicator entries
 For xclim-provided translations (for now only French), all indicators must have en entry and the "attrs_mapping"
 entries must match exactly the default formatter. Those default translations are found in the `xclim/locales` folder.
 """
+
 from __future__ import annotations
 
 import json

--- a/xclim/core/missing.py
+++ b/xclim/core/missing.py
@@ -22,6 +22,7 @@ of indicators. Once registered, algorithms can be used within indicators by sett
 To define another missing value algorithm, subclass :py:class:`MissingBase` and decorate it with
 :py:func:`xclim.core.options.register_missing_method`.
 """
+
 from __future__ import annotations
 
 import numpy as np

--- a/xclim/core/options.py
+++ b/xclim/core/options.py
@@ -4,6 +4,7 @@ Options Submodule
 
 Global or contextual options for xclim, similar to xarray.set_options.
 """
+
 from __future__ import annotations
 
 from inspect import signature

--- a/xclim/core/units.py
+++ b/xclim/core/units.py
@@ -1092,8 +1092,7 @@ def declare_relative_units(**units_by_name) -> Callable:
     .. code-block:: python
 
         @declare_relative_units(thresh="<da>", thresh2="<da> / [time]")
-        def func(da, thresh, thresh2):
-            ...
+        def func(da, thresh, thresh2): ...
 
     The decorator will check that `thresh` has units compatible with those of da
     and that `thresh2` has units compatible with the time derivative of da.
@@ -1200,8 +1199,7 @@ def declare_units(**units_by_name) -> Callable:
     .. code-block:: python
 
         @declare_units(tas="[temperature]")
-        def func(tas):
-            ...
+        def func(tas): ...
 
     The decorator will check that `tas` has units of temperature (C, K, F).
 

--- a/xclim/core/units.py
+++ b/xclim/core/units.py
@@ -5,6 +5,7 @@ Units Handling Submodule
 `xclim`'s `pint`-based unit registry is an extension of the registry defined in `cf-xarray`.
 This module defines most unit handling methods.
 """
+
 from __future__ import annotations
 
 import logging

--- a/xclim/core/utils.py
+++ b/xclim/core/utils.py
@@ -4,6 +4,7 @@ Miscellaneous Indices Utilities
 
 Helper functions for the indices computations, indicator construction and other things.
 """
+
 from __future__ import annotations
 
 import functools
@@ -806,9 +807,9 @@ def adapt_clix_meta_yaml(  # noqa: C901
                             ),
                             "units": param["units"],
                         }
-                        rename_params[
-                            f"{{{name}}}"
-                        ] = f"{{{list(param['data'].keys())[0]}}}"
+                        rename_params[f"{{{name}}}"] = (
+                            f"{{{list(param['data'].keys())[0]}}}"
+                        )
                     else:
                         # Value
                         data["parameters"][name] = f"{param['data']} {param['units']}"

--- a/xclim/ensembles/__init__.py
+++ b/xclim/ensembles/__init__.py
@@ -7,6 +7,7 @@ This submodule defines some useful methods for dealing with ensembles of climate
 In xclim, an "ensemble" is a `Dataset` or a `DataArray` where multiple climate realizations
 or models are concatenated along the `realization` dimension.
 """
+
 from __future__ import annotations
 
 from ._base import create_ensemble, ensemble_mean_std_max_min, ensemble_percentiles

--- a/xclim/ensembles/_base.py
+++ b/xclim/ensembles/_base.py
@@ -2,6 +2,7 @@
 Ensembles Creation and Statistics
 =================================
 """
+
 from __future__ import annotations
 
 from glob import glob
@@ -277,9 +278,9 @@ def ensemble_percentiles(
             # Smart rechunk on dimension where chunks are the largest
             chk_dim, chks = max(
                 enumerate(ens.chunks),
-                key=lambda kv: 0
-                if kv[0] == ens.get_axis_num("realization")
-                else max(kv[1]),
+                key=lambda kv: (
+                    0 if kv[0] == ens.get_axis_num("realization") else max(kv[1])
+                ),
             )
             ens = ens.chunk(
                 {"realization": -1, ens.dims[chk_dim]: len(chks) * ens.realization.size}

--- a/xclim/ensembles/_reduce.py
+++ b/xclim/ensembles/_reduce.py
@@ -5,6 +5,7 @@ Ensemble Reduction
 Ensemble reduction is the process of selecting a subset of members from an ensemble in order to reduce the volume of
 computation needed while still covering a good portion of the simulated climate variability.
 """
+
 from __future__ import annotations
 
 from warnings import warn
@@ -88,9 +89,11 @@ def make_criteria(ds: xarray.Dataset | xarray.DataArray):
                 crd,
                 np.concatenate(
                     [
-                        da[crd].values
-                        if crd in da.coords
-                        else [np.NaN] * da.criteria.size
+                        (
+                            da[crd].values
+                            if crd in da.coords
+                            else [np.NaN] * da.criteria.size
+                        )
                         for da in stacked.values()
                     ],
                 ),
@@ -421,9 +424,7 @@ def _calc_rsq(z, method, make_graph, n_sim, random_state, sample_weights):
                 random_state=random_state,
             )
             kmeans = kmeans.fit(z, sample_weight=sample_weights)
-            sumd[
-                nclust
-            ] = (
+            sumd[nclust] = (
                 kmeans.inertia_
             )  # sum of the squared distance between each simulation and the nearest cluster centroid
 

--- a/xclim/ensembles/_robustness.py
+++ b/xclim/ensembles/_robustness.py
@@ -6,6 +6,7 @@ Robustness metrics are used to estimate the confidence of the climate change sig
 This submodule is inspired by and tries to follow the guidelines of the IPCC, more specifically
 the 12th chapter of the Working Group 1's contribution to the AR5 :cite:p:`collins_long-term_2013` (see box 12.1).
 """
+
 from __future__ import annotations
 
 import warnings

--- a/xclim/indicators/__init__.py
+++ b/xclim/indicators/__init__.py
@@ -1,4 +1,5 @@
 """Indicators module."""
+
 # The actual code for importing virtual modules is in the top-level __init__.
 # This is for import reasons: we need to make sure all normal indicators are created before.
 from __future__ import annotations

--- a/xclim/indicators/atmos/__init__.py
+++ b/xclim/indicators/atmos/__init__.py
@@ -10,6 +10,7 @@ The concept followed here is to define Indicator subclasses for each input varia
 for each indicator.
 
 """
+
 from __future__ import annotations
 
 from ._conversion import *

--- a/xclim/indicators/atmos/_conversion.py
+++ b/xclim/indicators/atmos/_conversion.py
@@ -1,4 +1,5 @@
 """Atmospheric conversion definitions."""
+
 from __future__ import annotations
 
 from inspect import _empty  # noqa

--- a/xclim/indicators/atmos/_precip.py
+++ b/xclim/indicators/atmos/_precip.py
@@ -1,4 +1,5 @@
 """Precipitation indicator definitions."""
+
 from __future__ import annotations
 
 from inspect import _empty  # noqa

--- a/xclim/indicators/atmos/_synoptic.py
+++ b/xclim/indicators/atmos/_synoptic.py
@@ -1,4 +1,5 @@
 """Synoptic indicator definitions."""
+
 from __future__ import annotations
 
 from xclim import indices

--- a/xclim/indicators/atmos/_temperature.py
+++ b/xclim/indicators/atmos/_temperature.py
@@ -1,4 +1,5 @@
 """Temperature indicator definitions."""
+
 from __future__ import annotations
 
 from xclim import indices

--- a/xclim/indicators/generic/__init__.py
+++ b/xclim/indicators/generic/__init__.py
@@ -2,6 +2,7 @@
 Generic Indicators
 ==================
 """
+
 from __future__ import annotations
 
 from ._stats import *

--- a/xclim/indicators/land/__init__.py
+++ b/xclim/indicators/land/__init__.py
@@ -2,6 +2,7 @@
 Land Indicators
 ===============
 """
+
 from __future__ import annotations
 
 from ._snow import *

--- a/xclim/indicators/land/_streamflow.py
+++ b/xclim/indicators/land/_streamflow.py
@@ -1,4 +1,5 @@
 """Streamflow indicator definitions."""
+
 from __future__ import annotations
 
 from xclim.core.cfchecks import check_valid

--- a/xclim/indicators/seaIce/__init__.py
+++ b/xclim/indicators/seaIce/__init__.py
@@ -2,6 +2,7 @@
 Ice-related indicators
 ======================
 """
+
 from __future__ import annotations
 
 from ._seaice import *

--- a/xclim/indicators/seaIce/_seaice.py
+++ b/xclim/indicators/seaIce/_seaice.py
@@ -2,6 +2,7 @@
 Sea ice indicators
 ------------------
 """
+
 from __future__ import annotations
 
 from xclim import indices

--- a/xclim/indices/__init__.py
+++ b/xclim/indices/__init__.py
@@ -1,4 +1,5 @@
 """Indices module."""
+
 from __future__ import annotations
 
 from ._agro import *

--- a/xclim/indices/fire/_cffwis.py
+++ b/xclim/indices/fire/_cffwis.py
@@ -123,6 +123,7 @@ as _all_ seasons are used, even the very short shoulder seasons.
 ...     dmc_dry_factor=2,
 ... )
 """
+
 # This file is structured in the following way:
 # Section 1: individual codes, numba-accelerated and vectorized functions.
 # Section 2: Larger computing functions (the FWI iterator and the fire_season iterator)
@@ -1162,8 +1163,9 @@ def overwintering_drought_code(
     last_dc: xr.DataArray,
     winter_pr: xr.DataArray,
     carry_over_fraction: xr.DataArray | float = default_params["carry_over_fraction"],
-    wetting_efficiency_fraction: xr.DataArray
-    | float = default_params["wetting_efficiency_fraction"],
+    wetting_efficiency_fraction: xr.DataArray | float = default_params[
+        "wetting_efficiency_fraction"
+    ],
     min_dc: xr.DataArray | float = default_params["dc_start"],
 ) -> xr.DataArray:
     """Compute season-starting drought code based on previous season's last drought code and total winter precipitation.

--- a/xclim/indices/generic.py
+++ b/xclim/indices/generic.py
@@ -4,6 +4,7 @@ Generic Indices Submodule
 
 Helper functions for common generic actions done in the computation of indices.
 """
+
 from __future__ import annotations
 
 import warnings

--- a/xclim/indices/helpers.py
+++ b/xclim/indices/helpers.py
@@ -4,6 +4,7 @@ Indices Helper Functions Submodule
 
 Functions that encapsulate some geophysical logic but could be shared by many indices.
 """
+
 from __future__ import annotations
 
 from inspect import stack

--- a/xclim/indices/run_length.py
+++ b/xclim/indices/run_length.py
@@ -4,6 +4,7 @@ Run-Length Algorithms Submodule
 
 Computation of statistics on runs of True values in boolean arrays.
 """
+
 from __future__ import annotations
 
 from datetime import datetime

--- a/xclim/indices/stats.py
+++ b/xclim/indices/stats.py
@@ -1,4 +1,5 @@
 """Statistic-related functions. See the `frequency_analysis` notebook for examples."""
+
 from __future__ import annotations
 
 import warnings

--- a/xclim/sdba/__init__.py
+++ b/xclim/sdba/__init__.py
@@ -3,6 +3,7 @@
 SDBA submodule
 ==============
 """
+
 from __future__ import annotations
 
 from . import adjustment, detrending, measures, processing, properties, utils

--- a/xclim/sdba/_adjustment.py
+++ b/xclim/sdba/_adjustment.py
@@ -4,6 +4,7 @@ Adjustment Algorithms
 
 This file defines the different steps, to be wrapped into the Adjustment objects.
 """
+
 from __future__ import annotations
 
 import numpy as np

--- a/xclim/sdba/_processing.py
+++ b/xclim/sdba/_processing.py
@@ -5,6 +5,7 @@ Compute Functions Submodule
 Here are defined the functions wrapped by map_blocks or map_groups.
 The user-facing, metadata-handling functions should be defined in processing.py.
 """
+
 from __future__ import annotations
 
 from typing import Sequence

--- a/xclim/sdba/base.py
+++ b/xclim/sdba/base.py
@@ -2,6 +2,7 @@
 Base Classes and Developer Tools
 ================================
 """
+
 from __future__ import annotations
 
 from inspect import _empty, signature  # noqa

--- a/xclim/sdba/detrending.py
+++ b/xclim/sdba/detrending.py
@@ -2,6 +2,7 @@
 Detrending Objects Utilities
 ============================
 """
+
 from __future__ import annotations
 
 import xarray as xr

--- a/xclim/sdba/loess.py
+++ b/xclim/sdba/loess.py
@@ -2,6 +2,7 @@
 LOESS Smoothing Submodule
 =========================
 """
+
 from __future__ import annotations
 
 from typing import Callable

--- a/xclim/sdba/measures.py
+++ b/xclim/sdba/measures.py
@@ -6,6 +6,7 @@ through statistical properties or directly. This framework for the diagnostic te
 `VALUE <http://www.value-cost.eu/>`_ project.
 
 """
+
 from __future__ import annotations
 
 from typing import Sequence

--- a/xclim/sdba/utils.py
+++ b/xclim/sdba/utils.py
@@ -2,6 +2,7 @@
 Statistical Downscaling and Bias Adjustment Utilities
 =====================================================
 """
+
 from __future__ import annotations
 
 import itertools

--- a/xclim/testing/__init__.py
+++ b/xclim/testing/__init__.py
@@ -1,4 +1,5 @@
 """Helpers for testing xclim."""
+
 from __future__ import annotations
 
 from . import diagnostics, helpers

--- a/xclim/testing/helpers.py
+++ b/xclim/testing/helpers.py
@@ -1,4 +1,5 @@
 """Module for loading testing data."""
+
 from __future__ import annotations
 
 import os

--- a/xclim/testing/sdba_utils.py
+++ b/xclim/testing/sdba_utils.py
@@ -2,6 +2,7 @@
 SDBA Testing Utilities Module
 =============================
 """
+
 from __future__ import annotations
 
 import collections

--- a/xclim/testing/utils.py
+++ b/xclim/testing/utils.py
@@ -2,6 +2,7 @@
 Testing and Tutorial Utilities' Module
 ======================================
 """
+
 # Some of this code was copied and adapted from xarray
 from __future__ import annotations
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR addresses a problem occurring in #1625 
- [x] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Updates the pre-commit hook versions.
* `black` is now using year-2024 style conventions. 
* Pins the `dev` recipe-listed code formatters (`black`, `blackdoc`, `isort`) to match their `pre-commit` equivalents.
* Updates these pinned versions in the `tox.ini`.
* `isort` (currently used in Makefile) has been added to the `dev` recipe and `environment.yml`
* Set the `environment.yml` to use the `PyPI`-provided `bump-my-version` package.

### Does this PR introduce a breaking change?

Yes. `black` 24.1.0 introduces several aesthetic changes to the code. `isort` is now listed as a dependency. Both `black` and `isort` (and `blackdoc`) are now pinned to prevent `pre-commit` and `tox` formatting disagreements.

### Other information:

https://github.com/psf/black/releases/tag/24.1.0
https://github.com/callowayproject/bump-my-version/issues/129