### PR TITLE
Pin pytest below v8.0, use bump-my-version conda package

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -57,7 +57,7 @@ dependencies:
   - pre-commit
   - pybtex
   - pylint
-  - pytest <8.0  # pinned due to breakage with xdoctest. See:
+  - pytest <8.0  # Pinned due to breakage with xdoctest. See: https://github.com/Erotemic/xdoctest/issues/151
   - pytest-cov
   - pytest-socket
   - pytest-xdist >=3.2

--- a/environment.yml
+++ b/environment.yml
@@ -29,9 +29,9 @@ dependencies:
   # Extras
   - flox
   # Testing and development dependencies
-  - black ==24.1.0
+  - black ==24.1.1
   - blackdoc ==0.3.9
-#  - bump-my-version  # The conda package is not as up-to-date as the PyPI package.
+  - bump-my-version >=0.17.1
   - cairosvg
   - codespell
   - coverage
@@ -57,7 +57,7 @@ dependencies:
   - pre-commit
   - pybtex
   - pylint
-  - pytest
+  - pytest <8.0  # pinned due to breakage with xdoctest. See:
   - pytest-cov
   - pytest-socket
   - pytest-xdist >=3.2
@@ -76,6 +76,5 @@ dependencies:
   - yamllint
   - pip
   - pip:
-    - bump-my-version >=0.17.1  # The conda package is not as up-to-date as the PyPI package.
     - flake8-alphabetize
     - sphinxcontrib-svg2pdfconverter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ dev = [
   "pre-commit >=2.9",
   "pybtex",
   "pylint",
-  "pytest <8.0",
+  "pytest <8.0", # Pinned due to breakage with xdoctest. See: https://github.com/Erotemic/xdoctest/issues/151
   "pytest-cov",
   "pytest-socket",
   "pytest-xdist[psutil] >=3.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ dev = [
   "pre-commit >=2.9",
   "pybtex",
   "pylint",
-  "pytest",
+  "pytest <8.0",
   "pytest-cov",
   "pytest-socket",
   "pytest-xdist[psutil] >=3.2",


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] CHANGES.rst has been updated (with summary of main changes)
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Pins `pytest` below v8.0 due to breakage with `xdoctest`
* Now using the `bump-my-version` Conda-forge package

### Does this PR introduce a breaking change?

No.

### Other information:

https://github.com/Erotemic/xdoctest/issues/151