### PR TITLE
Add builds for windows and macOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -118,7 +118,7 @@ jobs:
       matrix:
         include:
           # Windows builds
-          - tox-env: py39-coverage
+          - tox-env: py39-prefetch-coverage
             python-version: "3.9"
             markers: -m 'not slow'
             os: windows-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,26 +113,43 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'approved') ||
       (github.event.review.state == 'approved') ||
       (github.event_name == 'push')
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         include:
+          # Windows builds
+          - tox-env: py39-coverage
+            python-version: "3.9"
+            markers: -m 'not slow'
+            os: windows-latest
+          # macOS builds
+          - tox-env: py310-coverage
+            python-version: "3.10"
+            markers: -m 'not slow'
+            os: macos-latest
+          # Linux builds
           - tox-env: py39-coverage-sbck
             python-version: "3.9"
             markers: -m 'not slow'
+            os: ubuntu-latest
           - tox-env: py310-coverage  # No markers -- includes slow tests
             python-version: "3.10"
+            os: ubuntu-latest
           - tox-env: py311-coverage-sbck
             python-version: "3.11"
             markers: -m 'not slow'
+            os: ubuntu-latest
           - tox-env: py312-coverage-numba
             python-version: "3.12"
             markers: -m 'not slow'
+            os: ubuntu-latest
           - tox-env: notebooks_doctests
             python-version: "3.10"
+            os: ubuntu-latest
           - tox-env: offline-prefetch
             python-version: "3.11"
             markers: -m 'not slow and not requires_internet'
+            os: ubuntu-latest
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
@@ -168,7 +185,7 @@ jobs:
           python -m tox -e ${{ matrix.tox-env }} -- ${{ matrix.markers }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COVERALLS_FLAG_NAME: run-{{ matrix.tox-env }}
+          COVERALLS_FLAG_NAME: run-{{ matrix.tox-env }}-{{ matrix.os }}
           COVERALLS_PARALLEL: true
           COVERALLS_SERVICE_NAME: github
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,7 +108,7 @@ jobs:
 
   test-pypi:
     needs: lint
-    name: test-${{ matrix.tox-env }} (Python${{ matrix.python-version }})
+    name: ${{ matrix.tox-env }} (Python${{ matrix.python-version }}, ${{ matrix.os }})
     if: |
       contains(github.event.pull_request.labels.*.name, 'approved') ||
       (github.event.review.state == 'approved') ||

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,6 +47,7 @@ Bug fixes
 * Fix the daily case `freq='D'` of ``xclim.stats.preprocess_standardized_index`` (:issue:`1602`  :pull:`1607`).
 * Several spelling mistakes have been corrected within the documentation and codebase. (:pull:`1576`).
 * Added missing ``xclim.ensembles.robustness_fractions`` and ``xclim.ensembles.robistness_categoris`` in api doc section. (:pull:`1630`).
+* Fixed an issue that can occur when fetching the testing data and running tests on Windows systems. Adapted a few existing tests for Windows support. (:pull:`1648`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^
@@ -64,6 +65,8 @@ Internal changes
     * Some small adjustments to code organization to address `pylint` errors.
 * `dev` formatting tools (`black`, `blackdoc`, `isort`) are now pinned to their `pre-commit` hook version equivalents in both ``pyproject.toml`` and ``tox.ini``. (:pull:`1626`).
 * `black`, `isort`, and `pyupgrade` code formatters no longer target Python3.8 coding style conventions. (:pull:`1565`).
+* The GitHub Workflows now include builds to run tests against both Windows and MacOS. (:pull:`1648`).
+* `prefetch` is now available as a `tox` environment modifier in order to download the testing data before launching `pytest` (e.g. `py3x-prefetch`). This is . (:pull:`1648`).
 
 v0.47.0 (2023-12-01)
 --------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import os
 import re
 import shutil
+import sys
 import time
 import warnings
 from datetime import datetime as dt
@@ -474,7 +475,15 @@ def gather_session_data(threadsafe_data_dir, worker_id, xdoctest_namespace):
     ):
         if helpers.PREFETCH_TESTING_DATA:
             print("`XCLIM_PREFETCH_TESTING_DATA` set. Prefetching testing data...")
-        if worker_id in ["master"]:
+        if (
+            sys.platform == "win32"
+            and not _default_cache_dir.joinpath(helpers.TESTDATA_BRANCH).exists()
+        ):
+            raise OSError(
+                "UNIX-style file-locking is not supported on Windows. "
+                "Consider running `$ xclim prefetch_testing_data` to download testing data."
+            )
+        elif worker_id in ["master"]:
             helpers.populate_testing_data(branch=helpers.TESTDATA_BRANCH)
         else:
             _default_cache_dir.mkdir(exist_ok=True, parents=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -475,10 +475,7 @@ def gather_session_data(threadsafe_data_dir, worker_id, xdoctest_namespace):
     ):
         if helpers.PREFETCH_TESTING_DATA:
             print("`XCLIM_PREFETCH_TESTING_DATA` set. Prefetching testing data...")
-        if (
-            sys.platform == "win32"
-            and not _default_cache_dir.joinpath(helpers.TESTDATA_BRANCH).exists()
-        ):
+        if sys.platform == "win32":
             raise OSError(
                 "UNIX-style file-locking is not supported on Windows. "
                 "Consider running `$ xclim prefetch_testing_data` to download testing data."

--- a/tests/test_testing_utils.py
+++ b/tests/test_testing_utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import platform
+import sys
 from pathlib import Path
 
 import numpy as np
@@ -100,7 +101,11 @@ class TestFileAssertions:
         test_data = Path(__file__).parent / "data"
         callendar = test_data / "callendar_1938.txt"
         md5_sum = utilities.file_md5_checksum(callendar)
-        assert md5_sum == "9a5d9f94d76d4f9d9b7aaadbe8cbf541"  # noqa
+        if sys.platform == "win32":
+            # Windows has a different line ending (CR-LF) than Unix (LF)
+            assert md5_sum == "38083271c2d4c85dea6bd6baf23d34de"  # noqa
+        else:
+            assert md5_sum == "9a5d9f94d76d4f9d9b7aaadbe8cbf541"  # noqa
 
 
 class TestReleaseSupportFuncs:

--- a/tox.ini
+++ b/tox.ini
@@ -112,6 +112,7 @@ commands_pre =
     python -m pip list
     xclim show_version_info
     python -m pip check
+    xclim --help
 commands =
     prefetch: xclim prefetch_testing_data
     doctest: pytest --no-cov --rootdir=tests/ --xdoctest xclim

--- a/tox.ini
+++ b/tox.ini
@@ -113,6 +113,7 @@ commands_pre =
     xclim show_version_info
     python -m pip check
 commands =
+    prefetch: xclim prefetch_testing_data
     doctest: pytest --no-cov --rootdir=tests/ --xdoctest xclim
     pytest {posargs}
 commands_post =


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR doesn't address #1500 finally
- [x] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Adds both a Windows and macOS build to check the testing suite against different platforms.
* the `.lock` file generated in the cache is now removed after the testing data has been copied, and the file lock has been released.
* The `prefetch` argument for `tox` is now available for general testing environments.

### Does this PR introduce a breaking change?

No.

### Other information:

The `approved` tag is listed here to ensure that the relevant builds are being triggered. This PR still requires review approval.

In order to run Windows build tests, `$ xclim prefetch_testing_data` must be called first to gather the testing data.

Did you know that Windows doesn't support Unix-style File Locking (`fcntl`)? This was what was preventing asynchronous handling of testing data fetching from working.