### PR TITLE
Sum is a sum

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,7 +39,7 @@ Breaking changes
 * `black` formatting style has been updated to the 2024 stable conventions. `isort` has been added to the `dev` installation recipe. (:pull:`1626`).
 * The indice and indicator for ``winter_storm`` has been removed (deprecated since `xclim` v0.46.0 in favour of ``snd_storm_days``). (:pull:`1565`).
 * `xclim` has dropped support for `scipy` version below v1.9.0 and `numpy` versions below v1.20.0. (:pull:`1565`).
-* For generic function ``select_resample_op`` and ``core.units.to_agg_units``, operation "sum" will now return the same units as the input, and not implicitely translate to an "integral". (:issue:`1645`).
+* For generic function ``select_resample_op`` and ``core.units.to_agg_units``, operation "sum" will now return the same units as the input, and not implicitely translate to an "integral". (:issue:`1645`, :pull:`1649`).
 
 Bug fixes
 ^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,7 +39,7 @@ Breaking changes
 * `black` formatting style has been updated to the 2024 stable conventions. `isort` has been added to the `dev` installation recipe. (:pull:`1626`).
 * The indice and indicator for ``winter_storm`` has been removed (deprecated since `xclim` v0.46.0 in favour of ``snd_storm_days``). (:pull:`1565`).
 * `xclim` has dropped support for `scipy` version below v1.9.0 and `numpy` versions below v1.20.0. (:pull:`1565`).
-* For generic function ``select_resample_op`` and ``core.units.to_agg_units``, operation "sum" will now return the same units as the input, and not implicitely translate to an "integral". (:issue:`1645`, :pull:`1649`).
+* For generic function ``select_resample_op`` and ``core.units.to_agg_units``, operation "sum" will now return the same units as the input, and not implicitly be translated to an "integral". (:issue:`1645`, :pull:`1649`).
 
 Bug fixes
 ^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,7 @@ Breaking changes
 * `black` formatting style has been updated to the 2024 stable conventions. `isort` has been added to the `dev` installation recipe. (:pull:`1626`).
 * The indice and indicator for ``winter_storm`` has been removed (deprecated since `xclim` v0.46.0 in favour of ``snd_storm_days``). (:pull:`1565`).
 * `xclim` has dropped support for `scipy` version below v1.9.0 and `numpy` versions below v1.20.0. (:pull:`1565`).
+* For generic function ``select_resample_op`` and ``core.units.to_agg_units``, operation "sum" will now return the same units as the input, and not implicitely translate to an "integral". (:issue:`1645`).
 
 Bug fixes
 ^^^^^^^^^

--- a/tests/test_atmos.py
+++ b/tests/test_atmos.py
@@ -280,7 +280,7 @@ def test_wind_power_potential_from_3h_series():
     power = out * 100
     power.attrs["units"] = "MW"
     annual_power = convert_units_to(
-        select_resample_op(power, op="sum", freq="D"), "MWh"
+        select_resample_op(power, op="integral", freq="D"), "MWh"
     )
     assert (annual_power == 100 * 24).all()
 

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -22,6 +22,7 @@ from xclim.core.units import (
     pint_multiply,
     rate2amount,
     str2pint,
+    to_agg_units,
     units,
     units2pint,
 )
@@ -317,3 +318,28 @@ def test_declare_relative_units():
 
     with pytest.raises(ValidationError):
         index_full_mm("1 mm", "2 Pa", "3 mm/s")
+
+
+@pytest.mark.parametrize(
+    "in_u,opfunc,op,exp,exp_u",
+    [
+        ("m/h", "sum", "integral", 8760, "m"),
+        ("m/h", "sum", "sum", 365, "m/h"),
+        ("K", "mean", "mean", 1, "K"),
+        ("", "sum", "count", 365, "d"),
+        ("", "sum", "count", 365, "d"),
+        ("kg m-2", "var", "var", 0, "kg2 m-4"),
+        ("°C", "argmax", "doymax", 0, ""),
+    ],
+)
+def test_to_agg_units(in_u, opfunc, op, exp, exp_u):
+    da = xr.DataArray(
+        np.ones((365,)),
+        dims=("time",),
+        coords={"time": xr.cftime_range("1993-01-01", periods=365, freq="D")},
+        attrs={"units": in_u},
+    )
+
+    out = to_agg_units(getattr(da, opfunc)(), da, op)
+    np.testing.assert_allclose(out, exp)
+    assert out.attrs["units"] == exp_u

--- a/xclim/core/units.py
+++ b/xclim/core/units.py
@@ -472,7 +472,7 @@ def to_agg_units(
         used to infer the sampling units and get the variable units.
     op : {'min', 'max', 'mean', 'std', 'var', 'doymin', 'doymax',  'count', 'integral', 'sum'}
         The type of aggregation operation performed. "integral" is mathematically equivalent to "sum",
-        but the units are multipled by the timestep of the data (requires an inferrable frequency).
+        but the units are multiplied by the timestep of the data (requires an inferrable frequency).
     dim : str
         The time dimension along which the aggregation was performed.
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1645
- [x] Tests for the changes have been added (for bug fixes / features)
  - [x] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* `to_agg_units` will not change the units when the aggregation is `"sum"`.
* Fixed the units when the initial data has a temporal dimensionality (ex "m/s") and an `"integral"` is performed. The output units were previously not reduced, yielding things like "d m s-1". 

### Does this PR introduce a breaking change?
Yes, but `select_resample_op` is rarely used by the user directly. And we could consider that this is in fact a _fix_ from a previous ambiguous situation. No internal calls to `to_agg_units` were using `"sum"`.