### PR TITLE
Spei, proper use of `loc` parameter in scipy dists

### DIFF
--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -695,6 +695,8 @@ class TestAgroclimaticIndices:
             tas = tasmax - 2.5
             tasmin = tasmax - 5
             wb = xci.water_budget(pr, None, tasmin, tasmax, tas)
+            # offset like in climate indices library
+            wb = wb + convert_units_to("1 mm/d", wb)
 
         params = xci.stats.standardized_index_fit_params(
             wb.sel(time=slice("1950", "1980")),
@@ -702,7 +704,6 @@ class TestAgroclimaticIndices:
             window=window,
             dist=dist,
             method=method,
-            offset="1 mm/d",
         )
         spei = xci.standardized_precipitation_evapotranspiration_index(
             wb.sel(time=slice("1998", "2000")), params=params

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -696,7 +696,7 @@ class TestAgroclimaticIndices:
             tasmin = tasmax - 5
             wb = xci.water_budget(pr, None, tasmin, tasmax, tas)
             # offset like in climate indices library
-            wb = wb + convert_units_to("1 mm/d", wb)
+            wb = wb + convert_units_to("1 mm/d", wb, context="hydro")
 
         params = xci.stats.standardized_index_fit_params(
             wb.sel(time=slice("1950", "1980")),


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] CHANGES.rst has been updated (with summary of main changes)
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Spei used to rely on an offset to ensure that distribution of values are positive when using distributions such as `gamma, fisk`. Now, instead, we properly use the `loc` parameter in those distributions that generalize the distributions and allow negative values. For instance, the `gamma` disitribution is a 2-parameter function, but in ``scipy`` it's generalized to 3 parameters, with a `loc` parameter. This extends the support of `gamma` from $x \in [0,\infty]$ to $x \in [\text{loc}, \infty]$. 

The code was already compatible with this idea, just had to change ``_fit_start`` so it can compute estimates of the parameters in the cases with negatives values.

### Does this PR introduce a breaking change?
Yes, removing the offset from SPEI. 

### Other information:
