### PR TITLE
Add missing formatting words and operations for generic stats

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,11 +4,15 @@ Changelog
 
 v0.49.0 (unreleased)
 --------------------
-Contributors to this version: Trevor James Smith (:user:`Zeitsperre`).
+Contributors to this version: Trevor James Smith (:user:`Zeitsperre`), Pascal Bourgault (:user:`aulemahal`).
 
 Announcements
 ^^^^^^^^^^^^^
 * `xclim` has migrated its development branch name from `master` to `main`. (:issue:`1667`, :pull:`1669`).
+
+Internal changes
+^^^^^^^^^^^^^^^^
+* Added "doymin" and "doymax" to the possible operations of ``generic.stats``. Fixed a warning issue when ``op`` was "integral". (:pull:`1672`).
 
 v0.48.2 (2024-02-26)
 --------------------

--- a/tests/test_generic_indicators.py
+++ b/tests/test_generic_indicators.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
 from xclim import generic, set_options
 
@@ -84,10 +85,14 @@ class TestReturnLevel:
 class TestStats:
     """See other tests in test_land::TestStats"""
 
-    def test_simple(self, pr_series, random):
+    @pytest.mark.parametrize(
+        "op,word",
+        [("min", "Minimum"), ("integral", "Integral"), ("doymin", "Day of minimum")],
+    )
+    def test_simple(self, pr_series, random, op, word):
         pr = pr_series(random.random(400))
-        out = generic.stats(pr, freq="YS", op="min", season="MAM")
-        assert out.units == pr.units
+        out = generic.stats(pr, freq="YS", op=op)
+        assert out.long_name == f"{word} of variable"
 
     def test_ndq(self, ndq_series):
         out = generic.stats(ndq_series, freq="YS", op="min", season="MAM")

--- a/xclim/core/formatting.py
+++ b/xclim/core/formatting.py
@@ -186,7 +186,11 @@ default_formatter = AttrFormatter(
         "m10": ["october"],
         "m11": ["november"],
         "m12": ["december"],
-        # Arguments to "op / reducer / stat"
+        # Arguments to "op / reducer / stat" (for example for generic.stats)
+        "integral": ["integrated", "integral"],
+        "count": ["count"],
+        "doymin": ["day of minimum"],
+        "doymax": ["day of maximum"],
         "mean": ["average"],
         "max": ["maximal", "maximum"],
         "min": ["minimal", "minimum"],

--- a/xclim/data/fr.json
+++ b/xclim/data/fr.json
@@ -117,7 +117,7 @@
       "intégrée",
       "intégrés",
       "intégrées",
-      "integrale"
+      "intégrale"
     ],
     "count": [
       "décompte"

--- a/xclim/data/fr.json
+++ b/xclim/data/fr.json
@@ -112,6 +112,22 @@
     "m12": [
       "decembre"
     ],
+    "integral": [
+      "intégré",
+      "intégrée",
+      "intégrés",
+      "intégrées",
+      "integrale"
+    ],
+    "count": [
+      "décompte"
+    ],
+    "doymin": [
+      "jour du minimum"
+    ],
+    "doymax": [
+      "jour du maximum"
+    ],
     "mean": [
       "moyen",
       "moyenne",

--- a/xclim/indices/generic.py
+++ b/xclim/indices/generic.py
@@ -93,6 +93,8 @@ def select_resample_op(
     """
     da = select_time(da, **indexer)
     r = da.resample(time=freq)
+    if op in _xclim_ops:
+        op = _xclim_ops[op]
     if isinstance(op, str):
         out = getattr(r, op.replace("integral", "sum"))(dim="time", keep_attrs=True)
     else:
@@ -162,6 +164,9 @@ def doymin(da: xr.DataArray) -> xr.DataArray:
     i = da.argmin(dim="time")
     out = da.time.dt.dayofyear.isel(time=i, drop=True)
     return to_agg_units(out, da, "doymin")
+
+
+_xclim_ops = {"doymin": doymin, "doymax": doymax}
 
 
 def default_freq(**indexer) -> str:


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes an issue raised by chat by @RondeauG 
- [x] Tests for the changes have been added (for bug fixes / features
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Adds "integral", "count", "doymin" and "doymax" to the formattable words known by xclim. This would allow customizing long names and description. This mostly touches `generic.stats` for the moment.
    - I couldn't find how to word "count" and "doym??" as adjective...
* I realized `doymin` was not accessible to ` generic.stats`, so I added a mechanism to do it. 

### Does this PR introduce a breaking change?
No. It kinda only removes a warning for now : When `op='integral'` in `generic.stats`, the previous code raised a warning  and then puts "integral"... which is what my added mapping does too.

### Other information:
