### PR TITLE
Fix TypeError when adjusting with preloaded training dataset

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -41,3 +41,4 @@ Contributors
 * Maliko Tanguy <malngu@ceh.ac.uk> `@malngu <https://github.com/malngu>`_
 * Christopher Whelan `@qwhelan <https://github.com/qwhelan>`_
 * Dante Castro <dante.castro@hereon.de> `@profesorpaiche <https://github.com/profesorpaiche>`_
+* Sascha Hofmann <sascha.hofmann@lobelia.earth> `@saschahofmann <https://github.com/saschahofmann>`_

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Announcements
 Bug fixes
 ^^^^^^^^^
 * Fixed an bug in sdba's ``map_groups`` that prevented passing DataArrays with cftime coordinates if the ``sdba_encode_cf`` option was True. (:issue:`1673`, :pull:`1674`).
+* Fixed bug (:issue:`1678`, :pull:`1679`) in sdba where a loaded training dataset could not be used for adjustment
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/xclim/sdba/base.py
+++ b/xclim/sdba/base.py
@@ -611,7 +611,7 @@ def map_blocks(  # noqa: C901
                     {
                         dim: chunks.get(dim)
                         for dim in reduced_dims
-                        if len(chunks.get(dim)) > 1
+                        if len(chunks.get(dim, [])) > 1
                     }
                 )
                 if badchunks:


### PR DESCRIPTION
See issue #1678 for an explanation of the problem

Now, returns an empty list if a reduced dimension is not in the dataset chunks in xclim/sdba/base.py map_blocks when checking for badchunks.

### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1678 
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

Returns an empty list if a reduced dimension is not in the dataset chunks in xclim/sdba/base.py map_blocks when checking for badchunks

### Does this PR introduce a breaking change?
No.
