### PR TITLE
handle all nan case for loess smoothing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 
 v0.49.0 (unreleased)
 --------------------
-Contributors to this version: Trevor James Smith (:user:`Zeitsperre`), Pascal Bourgault (:user:`aulemahal`).
+Contributors to this version: Trevor James Smith (:user:`Zeitsperre`), Pascal Bourgault (:user:`aulemahal`), Juliette Lavoie (:user:`juliettelavoie`).
 
 Announcements
 ^^^^^^^^^^^^^
@@ -14,6 +14,7 @@ Bug fixes
 ^^^^^^^^^
 * Fixed an bug in sdba's ``map_groups`` that prevented passing DataArrays with cftime coordinates if the ``sdba_encode_cf`` option was True. (:issue:`1673`, :pull:`1674`).
 * Fixed bug (:issue:`1678`, :pull:`1679`) in sdba where a loaded training dataset could not be used for adjustment
+* Fixed bug with loess smoothing for an array full of NaNs. (:pull:`1699`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/xclim/sdba/loess.py
+++ b/xclim/sdba/loess.py
@@ -95,6 +95,8 @@ def _loess_nb(
         out = np.full(x.size, np.NaN)
         y = y[~nan]
         x = x[~nan]
+        if x.size == 0:
+            return out
 
     n = x.size
     yest = np.zeros(n)


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Trying to fix https://stackoverflowteams.com/c/ouranos/questions/103
* When the axis is only nan and skipna=True, don't even try to calculate a loess (because it fails), just return nan.

### Does this PR introduce a breaking change?
before the all nan case would fail.

### Other information:

