### PR TITLE
Fix time_bnds for xarray 2024.03

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Bug fixes
 ^^^^^^^^^
 * Fixed an bug in sdba's ``map_groups`` that prevented passing DataArrays with cftime coordinates if the ``sdba_encode_cf`` option was True. (:issue:`1673`, :pull:`1674`).
 * Fixed bug (:issue:`1678`, :pull:`1679`) in sdba where a loaded training dataset could not be used for adjustment
+* Fixed and adapted ``time_bnds`` to the newest xarray. (:pull:`1700`)
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -61,6 +61,7 @@ def da(index):
 @pytest.mark.parametrize("freq", ["6480h", "302431min", "23144781s"])
 def test_time_bnds(freq, datetime_index, cftime_index):
     da_datetime = da(datetime_index).resample(time=freq)
+    out_time = da_datetime.mean().time
     da_cftime = da(cftime_index).resample(time=freq)
 
     cftime_bounds = time_bnds(da_cftime, freq=freq)
@@ -72,14 +73,18 @@ def test_time_bnds(freq, datetime_index, cftime_index):
     # cftime resolution goes down to microsecond only, code below corrects
     # that to allow for comparison with pandas datetime
     cftime_ends += np.timedelta64(999, "ns")
+    out_periods = out_time.indexes["time"].to_period(freq)
+    datetime_starts = out_periods
     if hasattr(da_datetime, "_full_index"):
         datetime_starts = da_datetime._full_index.to_period(freq).start_time
         datetime_ends = da_datetime._full_index.to_period(freq).end_time
     else:
         datetime_starts = (
-            da_datetime.groupers[0].group_as_index.to_period(freq).start_time
+            da_datetime.groupers[0].grouper.group_as_index.to_period(freq).start_time
         )
-        datetime_ends = da_datetime.groupers[0].group_as_index.to_period(freq).end_time
+        datetime_ends = (
+            da_datetime.groupers[0].grouper.group_as_index.to_period(freq).end_time
+        )
     assert_array_equal(cftime_starts, datetime_starts)
     assert_array_equal(cftime_ends, datetime_ends)
 

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -61,7 +61,7 @@ def da(index):
 @pytest.mark.parametrize("freq", ["6480h", "302431min", "23144781s"])
 def test_time_bnds(freq, datetime_index, cftime_index):
     da_datetime = da(datetime_index).resample(time=freq)
-    out_time = da_datetime.mean().time
+    out_time = da_datetime.mean()
     da_cftime = da(cftime_index).resample(time=freq)
 
     cftime_bounds = time_bnds(da_cftime, freq=freq)
@@ -74,19 +74,8 @@ def test_time_bnds(freq, datetime_index, cftime_index):
     # that to allow for comparison with pandas datetime
     cftime_ends += np.timedelta64(999, "ns")
     out_periods = out_time.indexes["time"].to_period(freq)
-    datetime_starts = out_periods
-    if hasattr(da_datetime, "_full_index"):
-        datetime_starts = da_datetime._full_index.to_period(freq).start_time
-        datetime_ends = da_datetime._full_index.to_period(freq).end_time
-    else:
-        datetime_starts = (
-            da_datetime.groupers[0].grouper.group_as_index.to_period(freq).start_time
-        )
-        datetime_ends = (
-            da_datetime.groupers[0].grouper.group_as_index.to_period(freq).end_time
-        )
-    assert_array_equal(cftime_starts, datetime_starts)
-    assert_array_equal(cftime_ends, datetime_ends)
+    assert_array_equal(cftime_starts, out_periods.start_time)
+    assert_array_equal(cftime_ends, out_periods.end_time)
 
 
 @pytest.mark.parametrize("typ", ["pd", "xr"])

--- a/xclim/core/calendar.py
+++ b/xclim/core/calendar.py
@@ -1077,6 +1077,9 @@ def time_bnds(  # noqa: C901
     elif isinstance(time, (DataArrayResample, DatasetResample)):
         for grouper in time.groupers:
             if "time" in grouper.dims:
+                if hasattr(grouper, "grouper"):
+                    # xarray >= 2024.03
+                    grouper = grouper.grouper
                 time = grouper.group_as_index
                 break
         else:

--- a/xclim/core/calendar.py
+++ b/xclim/core/calendar.py
@@ -1077,11 +1077,14 @@ def time_bnds(  # noqa: C901
     elif isinstance(time, (DataArrayResample, DatasetResample)):
         for grouper in time.groupers:
             if "time" in grouper.dims:
-                if hasattr(grouper, "grouper"):
-                    # xarray >= 2024.03
-                    grouper = grouper.grouper
-                time = grouper.group_as_index
+                datetime = grouper.unique_coord.data
+                freq = freq or grouper.grouper.freq
+                if datetime.dtype == "O":
+                    time = xr.CFTimeIndex(datetime)
+                else:
+                    time = pd.DatetimeIndex(datetime)
                 break
+
         else:
             raise ValueError(
                 'Got object resampled along another dimension than "time".'


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1675
- [x] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] CHANGES.rst has been updated (with summary of main changes)
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Fix `time_bnds`. While trying to adapt the code to xarray >= 2024.03, I realized that it wasn't giving the good output! If the resampling frequency was a multiple of the original frequency, it did work, but not otherwise.
* In the tests, remove all calls to the private api.

I don't know how to remove all private API calls from  `time_bnds`. The easiest option is to call a resampling function on the `Resample` object but that beats the purpose of accepting these objects in the first place. The point was to construct the bounds without executing the resampling itself.  However, I'm not sure this feature is actually useful... The current proposition uses code that is common to 2023.10 and 2024.03, at least that's better than before.

### Does this PR introduce a breaking change?
No.

### Other information:
