### PR TITLE
Snow season and days above

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@ Announcements
 ^^^^^^^^^^^^^
 * `xclim` has migrated its development branch name from `master` to `main`. (:issue:`1667`, :pull:`1669`).
 
+New indicators
+^^^^^^^^^^^^^^
+* New ``snw_season_length`` and ``snd_season_length`` computing the duration between the start and the end of the snow season, both defined as the first day of a continuous period with snow above/under a threshold. Previous versions of these indicators were renamed ``snw_days_above`` and ``snd_days_above`` to better reflect what they computed : the number of days with snow above a given threshold (with no notion of continuity). (:issue:`1703`, :pull:`1708`).
+
 Bug fixes
 ^^^^^^^^^
 * Fixed an bug in sdba's ``map_groups`` that prevented passing DataArrays with cftime coordinates if the ``sdba_encode_cf`` option was True. (:issue:`1673`, :pull:`1674`).

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -2820,21 +2820,27 @@ class TestSnowMaxDoy:
 
 
 class TestSnowCover:
-    @pytest.mark.parametrize("length", [0, 10])
+    @pytest.mark.parametrize("length", [0, 15])
     def test_snow_season_length(self, snd_series, snw_series, length):
         a = np.zeros(366)
-        a[10 : 10 + length] = 0.3
+        a[20 : 20 + length] = 0.3
         snd = snd_series(a)
         # kg m-2 = 1000 kg m-3 * 1 m
         snw = snw_series(1000 * a)
 
         out = xci.snd_season_length(snd)
         assert len(out) == 2
-        assert out[0] == length
+        if length == 0:
+            assert out.isnull().all()
+        else:
+            assert out[0] == length
 
         out = xci.snw_season_length(snw)
         assert len(out) == 2
-        assert out[0] == length
+        if length == 0:
+            assert out.isnull().all()
+        else:
+            assert out[0] == length
 
     def test_continous_snow_season_start(self, snd_series, snw_series):
         a = np.arange(366) / 100.0
@@ -2851,7 +2857,7 @@ class TestSnowCover:
 
         out = xci.snw_season_start(snw)
         assert len(out) == 2
-        np.testing.assert_array_equal(out, [snw.time.dt.dayofyear[0].data + 2, np.nan])
+        np.testing.assert_array_equal(out, [snw.time.dt.dayofyear[0].data + 1, np.nan])
         for attr in ["units", "is_dayofyear", "calendar"]:
             assert attr in out.attrs.keys()
         assert out.attrs["units"] == ""

--- a/tests/test_snow.py
+++ b/tests/test_snow.py
@@ -19,7 +19,7 @@ class TestSnowDepthCoverDuration:
     def test_simple(self, snd_series):
         snd = snd_series(np.ones(110), start="2001-01-01")
 
-        out = land.snd_season_length(snd, freq="ME")
+        out = land.snd_days_above(snd, freq="ME")
         assert out.units == "days"
         np.testing.assert_array_equal(out, [31, 28, 31, np.nan])
 
@@ -30,16 +30,17 @@ class TestSnowWaterCoverDuration:
     )
     def test_simple(self, snw_series, factor, exp):
         snw = snw_series(np.ones(110) * factor, start="2001-01-01")
-        out = land.snw_season_length(snw, freq="ME")
+        out = land.snw_days_above(snw, freq="ME")
         assert out.units == "days"
         np.testing.assert_array_equal(out, exp)
 
 
-class TestContinuousSnowDepthCoverStartEnd:
+class TestContinuousSnowDepthSeason:
     def test_simple(self, snd_series):
         a = np.zeros(365)
         # snow depth
         a[100:200] = 0.03
+        a[150:160] = 0
         snd = snd_series(a, start="2001-07-01")
         snd = snd.expand_dims(lat=[0, 1, 2])
 
@@ -51,12 +52,17 @@ class TestContinuousSnowDepthCoverStartEnd:
         assert out.units == ""
         np.testing.assert_array_equal(out.isel(lat=0), snd.time.dt.dayofyear[200])
 
+        out = land.snd_season_length(snd)
+        assert out.units == "days"
+        np.testing.assert_array_equal(out.isel(lat=0), 100)
 
-class TestContinuousSnowWaterCoverStartEnd:
+
+class TestContinuousSnowWaterSeason:
     def test_simple(self, snw_series):
         a = np.zeros(365)
         # snow amount
         a[100:200] = 0.03 * 1000
+        a[150:160] = 0
         snw = snw_series(a, start="2001-07-01")
         snw = snw.expand_dims(lat=[0, 1, 2])
 
@@ -67,6 +73,10 @@ class TestContinuousSnowWaterCoverStartEnd:
         out = land.snw_season_end(snw)
         assert out.units == ""
         np.testing.assert_array_equal(out.isel(lat=0), snw.time.dt.dayofyear[200])
+
+        out = land.snw_season_length(snw)
+        assert out.units == "days"
+        np.testing.assert_array_equal(out.isel(lat=0), 100)
 
 
 class TestSndMaxDoy:

--- a/xclim/data/fr.json
+++ b/xclim/data/fr.json
@@ -1005,9 +1005,9 @@
   },
   "SND_SEASON_LENGTH": {
     "long_name": "Durée de couvert de neige",
-    "description": "Nombre {freq:m} de jours où l'épaisseur de neige est au-dessus ou égale à {thresh}.",
+    "description": "La saison débute lorsque l'épaisseur de neige est au-dessus de {thresh} durant {window} jours et se termine lorsqu'elle redescend sous {thresh} durant {window} jours.",
     "title": "Durée du couvert de neige (épaisseur)",
-    "abstract": "Nombre de jours pendant lesquels l'épaisseur de neige est au-dessus ou égale à un seuil donné."
+    "abstract": "Durée de la saison de neige, qui débute lorsque la quantité de neige est au-dessus d'un seuil donné durant un nombre de jours donnés et qui se termine lorsqu'elle redescend sous le seuil pour la même durée."
   },
   "SND_SEASON_START": {
     "long_name": "Date du début du couvert de neige continu",
@@ -1021,11 +1021,17 @@
     "title": "Date du fin du couvert de neige (épaisseur)",
     "abstract": "Première date à partir de laquelle l'épaisseur de neige est sous à un seuil donné pendant un nombre de jours consécutifs suite au début du couvert de neige."
   },
+  "SND_DAYS_ABOVE": {
+    "long_name": "Nombre de jours avec de la neige au sol.",
+    "description": "Nombre {freq:m} de jours avec au moins {thresh} de neige au sol.",
+    "title": "Nombre de jours avec de la neige au sol (épaisseur)",
+    "abstract": "Nombre de jours avec une épaisseur de neige au sol au-dessus d'un seuil donné."
+  },
   "SNW_SEASON_LENGTH": {
     "long_name": "Durée de couvert de neige",
-    "description": "Nombre {freq:m} de jours où la quantité de neige est au-dessus ou égale à {thresh}.",
+    "description": "La saison débute lorsque la quantité de neige est au-dessus de {thresh} durant {window} jours et se termine lorsqu'elle redescend sous {thresh} durant {window} jours.",
     "title": "Durée du couvert de neige (quantité)",
-    "abstract": "Nombre de jours pendant lesquels la quantité de neige est au-dessus ou égale à un seuil donné."
+    "abstract": "Durée de la saison de neige, qui débute lorsque l'épaisseur de neige est au-dessus d'un seuil donné durant un nombre de jours donnés et qui se termine lorsqu'elle redescend sous le seuil pour la même durée."
   },
   "SNW_SEASON_START": {
     "long_name": "Date du début du couvert de neige continu",
@@ -1038,6 +1044,12 @@
     "description": "Première date à laquelle la quantité de neige passe sous {thresh} pendant au moins {window} jours consécutifs suite à l'établissement du couvert de neige.",
     "title": "Date du fin du couvert de neige (quantité)",
     "abstract": "Première date à partir de laquelle la quantité de neige est sous à un seuil donné pendant un nombre de jours consécutifs suite au début du couvert de neige."
+  },
+  "SNW_DAYS_ABOVE": {
+    "long_name": "Nombre de jours avec de la neige au sol.",
+    "description": "Nombre {freq:m} de jours avec au moins {thresh} de neige au sol.",
+    "title": "Nombre de jours avec de la neige au sol (quantité)",
+    "abstract": "Nombre de jours avec une quantité de neige au sol au-dessus d'un seuil donné."
   },
   "SND_MAX": {
     "long_name": "Épaisseur de neige maximale",

--- a/xclim/indicators/land/_snow.py
+++ b/xclim/indicators/land/_snow.py
@@ -6,6 +6,7 @@ from xclim.indicators.atmos._conversion import Converter  # noqa
 
 __all__ = [
     "blowing_snow",
+    "snd_days_above",
     "snd_max_doy",
     "snd_season_end",
     "snd_season_length",
@@ -14,6 +15,7 @@ __all__ = [
     "snd_to_snw",
     "snow_depth",
     "snow_melt_we_max",
+    "snw_days_above",
     "snw_max",
     "snw_max_doy",
     "snw_season_end",
@@ -43,8 +45,10 @@ snd_season_length = SnowWithIndexing(
     identifier="snd_season_length",
     units="days",
     long_name="Snow cover duration",
-    description="The {freq} number of days with snow depth greater than or equal to {thresh}.",
-    abstract="Number of days when the snow depth is greater than or equal to a given threshold.",
+    description=(
+        "The duration of the snow season, starting with at least {window} days with snow depth above {thresh} "
+        "and ending with at least {window} days with snow depth under {thresh}."
+    ),
     compute=xci.snd_season_length,
 )
 
@@ -53,8 +57,10 @@ snw_season_length = SnowWithIndexing(
     identifier="snw_season_length",
     units="days",
     long_name="Snow cover duration",
-    description="The {freq} number of days with snow amount greater than or equal to {thresh}.",
-    abstract="Number of days when the snow amount is greater than or equal to a given threshold.",
+    description=(
+        "The duration of the snow season, starting with at least {window} days with snow amount above {thresh} "
+        "and ending with at least {window} days with snow amount under {thresh}."
+    ),
     compute=xci.snw_season_length,
 )
 
@@ -230,4 +236,25 @@ snw_to_snd = Converter(
     description="The approximation of daily snow depth from snow amount and density.",
     var_name="snd",
     compute=xci.snw_to_snd,
+)
+
+
+snd_days_above = SnowWithIndexing(
+    title="Days with snow (depth)",
+    identifier="snd_days_above",
+    units="days",
+    long_name="Number of days with snow",
+    description="The {freq} number of days with snow depth greater than or equal to {thresh}.",
+    abstract="Number of days when the snow depth is greater than or equal to a given threshold.",
+    compute=xci.snd_days_above,
+)
+
+snw_days_above = SnowWithIndexing(
+    title="Days with snow (amount)",
+    identifier="snw_days_above",
+    units="days",
+    long_name="Number of days with snow",
+    description="The {freq} number of days with snow amount greater than or equal to {thresh}.",
+    abstract="Number of days when the snow amount is greater than or equal to a given threshold.",
+    compute=xci.snw_days_above,
 )

--- a/xclim/indices/_threshold.py
+++ b/xclim/indices/_threshold.py
@@ -75,12 +75,14 @@ __all__ = [
     "rprctot",
     "sea_ice_area",
     "sea_ice_extent",
+    "snd_days_above",
     "snd_season_end",
     "snd_season_length",
     "snd_season_start",
     "snd_storm_days",
     "snowfall_frequency",
     "snowfall_intensity",
+    "snw_days_above",
     "snw_season_end",
     "snw_season_length",
     "snw_season_start",
@@ -352,12 +354,8 @@ def snd_season_end(
 ) -> xarray.DataArray:
     r"""End date of continuous snow depth cover.
 
-    First day after the start of the continuous snow depth cover when snow depth is below a threshold (default: 2 cm)
-    for at least `N` (default: 14) consecutive days.
-
-    Warnings
-    --------
-    The default `freq` is valid for the northern hemisphere.
+    First day after the start of the continuous snow depth cover when snow depth is below a threshold
+    for at least `N` consecutive days.
 
     Parameters
     ----------
@@ -368,14 +366,12 @@ def snd_season_end(
     window : int
         Minimum number of days with snow depth below threshold.
     freq : str
-        Resampling frequency.
+        Resampling frequency. The default value is chosen for the northern hemisphere.
 
     Returns
     -------
     xarray.DataArray, [dimensionless]
-        First day after the start of the continuous snow depth cover when the snow depth
-        goes below a threshold for a minimum duration.
-        If there is no such day, returns np.nan.
+        First day after the start of the continuous snow depth cover.
 
     References
     ----------
@@ -398,19 +394,14 @@ def snd_season_end(
 @declare_units(snw="[mass]/[area]", thresh="[mass]/[area]")
 def snw_season_end(
     snw: xarray.DataArray,
-    thresh: Quantified = "20.00 kg m-2",
+    thresh: Quantified = "4 kg m-2",
     window: int = 14,
     freq: str = "YS-JUL",
 ) -> xarray.DataArray:
-    r"""End date of continuous snow water cover.
+    r"""End date of continuous snow cover.
 
     First day after the start of the continuous snow water cover
-    when snow water is below a threshold (Current default:  20 kg m-2. xclim >=0.47.0 default: 4 kg m-2)
-    for at least `N` (default: 14) consecutive days.
-
-    Warnings
-    --------
-    The default `freq` is valid for the northern hemisphere.
+    when snow water is below a threshold for at least `N` consecutive days.
 
     Parameters
     ----------
@@ -421,23 +412,17 @@ def snw_season_end(
     window : int
         Minimum number of days with snow water below threshold.
     freq : str
-        Resampling frequency.
+        Resampling frequency. The default value is chosen for the northern hemisphere.
 
     Returns
     -------
     xarray.DataArray, [dimensionless]
-        First day after the start of the continuous snow water cover when the snow water
-        goes below a threshold for a minimum duration.
-        If there is no such day, returns np.nan.
+        First day after the start of the continuous snow amount cover.
 
     References
     ----------
     :cite:cts:`chaumont_elaboration_2017`
     """
-    if thresh == "20.00 kg m-2":
-        warnings.warn(
-            "The default value for this threshold will change in xclim>=0.47.0, from `20 kg m-2` to `4 kg m-2`."
-        )
     valid = at_least_n_valid(snw.where(snw > 0), n=1, freq=freq)
 
     thresh = convert_units_to(thresh, snw)
@@ -461,12 +446,8 @@ def snd_season_start(
 ) -> xarray.DataArray:
     r"""Start date of continuous snow depth cover.
 
-    Day of year when snow depth is above or equal to a threshold (default: 2 cm)
-    for at least `N` (default: 14) consecutive days.
-
-    Warnings
-    --------
-    The default `freq` is valid for the northern hemisphere.
+    Day of year when snow depth is above or equal to a threshold
+    for at least `N` consecutive days.
 
     Parameters
     ----------
@@ -477,13 +458,12 @@ def snd_season_start(
     window : int
         Minimum number of days with snow depth above or equal to threshold.
     freq : str
-        Resampling frequency.
+        Resampling frequency. The default value is chosen for the northern hemisphere.
 
     Returns
     -------
     xarray.DataArray, [dimensionless]
         First day of the year when the snow depth is superior to a threshold for a minimum duration.
-        If there is no such day, returns np.nan.
 
     References
     ----------
@@ -511,18 +491,14 @@ def snd_season_start(
 @declare_units(snw="[mass]/[area]", thresh="[mass]/[area]")
 def snw_season_start(
     snw: xarray.DataArray,
-    thresh: Quantified = "20.00 kg m-2",
+    thresh: Quantified = "4 kg m-2",
     window: int = 14,
     freq: str = "YS-JUL",
 ) -> xarray.DataArray:
     r"""Start date of continuous snow water cover.
 
-    Day of year when snow water is above or equal to a threshold  (Current default:  20 kg m-2. xclim >=0.47.0 default: 4 kg m-2)
-    for at least `N` (default: 14) consecutive days.
-
-    Warnings
-    --------
-    The default `freq` is valid for the northern hemisphere.
+    Day of year when snow water is above or equal to a threshold
+    for at least `N` consecutive days.
 
     Parameters
     ----------
@@ -531,25 +507,20 @@ def snw_season_start(
     thresh : str
         Threshold snow amount.
     window : int
-        Minimum number of days with snow water above or equal to threshold.
+        Minimum number of days with snow amount above or equal to threshold.
     freq : str
         Resampling frequency.
 
     Returns
     -------
     xarray.DataArray, [dimensionless]
-        First day of the year when the snow water is superior to a threshold for a minimum duration.
-        If there is no such day, returns np.nan.
+        First day of the year when the snow amount is superior to a threshold for a minimum duration.
 
     References
     ----------
     :cite:cts:`chaumont_elaboration_2017`
 
     """
-    if thresh == "20.00 kg m-2":
-        warnings.warn(
-            "The default value for this threshold will change in xclim>=0.47.0, from `20 kg m-2` to `4 kg m-2`."
-        )
     valid = at_least_n_valid(snw.where(snw > 0), n=1, freq=freq)
 
     thresh = convert_units_to(thresh, snw)
@@ -567,6 +538,96 @@ def snw_season_start(
     )
     out.attrs.update(units="", is_dayofyear=np.int32(1), calendar=get_calendar(snw))
     return out.where(~valid)
+
+
+@declare_units(snd="[length]", thresh="[length]")
+def snd_season_length(
+    snd: xarray.DataArray,
+    thresh: Quantified = "2 cm",
+    window: int = 14,
+    freq: str = "YS-JUL",
+) -> xarray.DataArray:
+    r"""Snow season length.
+
+    The season starts when snow depth is above a threshold for at least `N` consecutive days
+    and stops when it drops below the same threshold for the same number of days.
+
+    Parameters
+    ----------
+    snd : xarray.DataArray
+        Surface snow thickness.
+    thresh : Quantified
+        Threshold snow thickness.
+    window : int
+        Minimum number of days with snow depth above and below threshold.
+    freq : str
+        Resampling frequency. The default value is chosen for the northern hemisphere.
+
+    Returns
+    -------
+    xarray.DataArray, [days]
+        Length of the snow season.
+
+    References
+    ----------
+    :cite:cts:`chaumont_elaboration_2017`
+    """
+    valid = at_least_n_valid(snd.where(snd > 0), n=1, freq=freq)
+
+    thresh = convert_units_to(thresh, snd)
+    cond = snd >= thresh
+
+    out = (
+        cond.resample(time=freq)
+        .map(rl.season, window=window, dim="time", coord="dayofyear")
+        .length
+    )
+    return to_agg_units(out.where(~valid), snd, "count")
+
+
+@declare_units(snw="[mass]/[area]", thresh="[mass]/[area]")
+def snw_season_length(
+    snw: xarray.DataArray,
+    thresh: Quantified = "4 kg m-2",
+    window: int = 14,
+    freq: str = "YS-JUL",
+) -> xarray.DataArray:
+    r"""Snow season length.
+
+    The season starts when the snow amount is above a threshold for at least `N` consecutive days
+    and stops when it drops below the same threshold for the same number of days.
+
+    Parameters
+    ----------
+    snw : xarray.DataArray
+        Surface snow amount.
+    thresh : Quantified
+        Threshold snow amount.
+    window : int
+        Minimum number of days with snow amount above and below threshold.
+    freq : str
+        Resampling frequency. The default value is chosen for the northern hemisphere.
+
+    Returns
+    -------
+    xarray.DataArray, [days]
+        Length of the snow season.
+
+    References
+    ----------
+    :cite:cts:`chaumont_elaboration_2017`
+    """
+    valid = at_least_n_valid(snw.where(snw > 0), n=1, freq=freq)
+
+    thresh = convert_units_to(thresh, snw)
+    cond = snw >= thresh
+
+    out = (
+        cond.resample(time=freq)
+        .map(rl.season, window=window, dim="time", coord="dayofyear")
+        .length
+    )
+    return to_agg_units(out.where(~valid), snw, "count")
 
 
 @declare_units(snd="[length]", thresh="[length]")
@@ -2101,7 +2162,7 @@ def hot_spell_frequency(
 
 
 @declare_units(snd="[length]", thresh="[length]")
-def snd_season_length(
+def snd_days_above(
     snd: xarray.DataArray,
     thresh: Quantified = "2 cm",
     freq: str = "YS-JUL",
@@ -2111,10 +2172,6 @@ def snd_season_length(
 
     Number of days where surface snow depth is greater or equal to given threshold (default: 2 cm).
 
-    Warnings
-    --------
-    The default `freq` is valid for the northern hemisphere.
-
     Parameters
     ----------
     snd : xarray.DataArray
@@ -2122,14 +2179,14 @@ def snd_season_length(
     thresh : Quantified
         Threshold snow thickness.
     freq : str
-        Resampling frequency.
+        Resampling frequency. The default value is chosen for the northern hemisphere.
     op : {">", ">=", "gt", "ge"}
         Comparison operation. Default: ">=".
 
     Returns
     -------
     xarray.DataArray, [time]
-        Number of days where snow depth is greater than or equal to threshold.
+        Number of days where snow depth is greater than or equal to {thresh}.
     """
     valid = at_least_n_valid(snd, n=1, freq=freq)
     thresh = convert_units_to(thresh, snd)
@@ -2138,19 +2195,15 @@ def snd_season_length(
 
 
 @declare_units(snw="[mass]/[area]", thresh="[mass]/[area]")
-def snw_season_length(
+def snw_days_above(
     snw: xarray.DataArray,
-    thresh: Quantified = "20.00 kg m-2",
+    thresh: Quantified = "4 kg m-2",
     freq: str = "YS-JUL",
     op: str = ">=",
 ) -> xarray.DataArray:
-    """The number of days with snow water above a threshold.
+    """The number of days with snow amount above a threshold.
 
-    Number of days where surface snow water is greater or equal to given threshold (Current default:  20 kg m-2. xclim >=0.47.0 default: 4 kg m-2).
-
-    Warnings
-    --------
-    The default `freq` is valid for the northern hemisphere.
+    Number of days where surface snow amount is greater or equal to given threshold.
 
     Parameters
     ----------
@@ -2159,20 +2212,16 @@ def snw_season_length(
     thresh : str
         Threshold snow amount.
     freq : str
-        Resampling frequency.
+        Resampling frequency. The default value is chosen for the northern hemisphere.
     op : {">", ">=", "gt", "ge"}
         Comparison operation. Default: ">=".
 
     Returns
     -------
     xarray.DataArray, [time]
-        Number of days where snow water is greater than or equal to threshold.
+        Number of days where snow amount is greater than or equal to {thresh}.
 
     """
-    if thresh == "20.00 kg m-2":
-        warnings.warn(
-            "The default value for this threshold will change in xclim>=0.47.0, from `20 kg m-2` to `4 kg m-2`."
-        )
     valid = at_least_n_valid(snw, n=1, freq=freq)
     thresh = convert_units_to(thresh, snw)
     out = threshold_count(snw, op, thresh, freq)


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1703
- [x] Tests for the changes have been added (for bug fixes / features)
  - [x] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Renames old `sn[dw]_season_length` to `sn[dw]_days_above`, which better reflects what they actually do.
* Implement `sn[dw]_season_length` as an actual season length : duraction between a start and an end, both defined as the first days of a period of minimum length continuously above/under a given threshold.
* Rephrase the documentation of these indicators and of the start/end variants.
* Update the threshold of `snw`, like we said we'd do in 0.47 (youpsi).

### Does this PR introduce a breaking change?
Yes. An indicator name now points to another computation.

### Other information: