### PR TITLE
Reconfigure Builds and perform more doctests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -124,7 +124,7 @@ jobs:
             markers: -m 'not slow'
             os: windows-latest
           # macOS builds
-          - tox-env: py310-coverage-doctest
+          - tox-env: py310-coverage-lmoments-doctest
             python-version: "3.10"
             markers: -m 'not slow'
             os: macos-latest
@@ -140,7 +140,7 @@ jobs:
             python-version: "3.11"
             markers: -m 'not slow'
             os: ubuntu-latest
-          - tox-env: py312-coverage-numba-doctest
+          - tox-env: py312-coverage-lmoments-doctest
             python-version: "3.12"
             markers: -m 'not slow'
             os: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,8 +57,9 @@ jobs:
         uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install pylint and tox
-        run: pip install pylint tox~=4.0
+      - name: Install pip, pylint, and tox
+        run: |
+          python -m pip install flit pip~=24.0 pylint tox~=4.0
       - name: Run pylint
         run: |
           python -m pylint --rcfile=.pylintrc.toml --disable=import-error --exit-zero xclim
@@ -97,7 +98,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install tox
         run: |
-          python -m pip install tox~=4.0
+          python -m pip install flit pip~=24.0 tox~=4.0
       - name: Test with tox
         run: |
           python -m tox -e ${{ matrix.tox-env }}
@@ -180,7 +181,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install tox
         run: |
-          python -m pip install tox~=4.0 tox-gh flit
+          python -m pip install flit pip~=24.0 tox~=4.0 tox-gh
       - name: Test with tox
         run: |
           python -m tox -e ${{ matrix.tox-env }} -- ${{ matrix.markers }}
@@ -200,9 +201,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        include:
-          - python-version: "3.9"
-          - python-version: "3.12"
+        python-version: ["3.9", "3.12"]
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -118,17 +118,17 @@ jobs:
       matrix:
         include:
           # Windows builds
-          - tox-env: py39-prefetch-coverage
+          - tox-env: py39-coverage-prefetch
             python-version: "3.9"
             markers: -m 'not slow'
             os: windows-latest
           # macOS builds
-          - tox-env: py310-coverage
+          - tox-env: py310-coverage-doctest
             python-version: "3.10"
             markers: -m 'not slow'
             os: macos-latest
           # Linux builds
-          - tox-env: py39-coverage-sbck
+          - tox-env: py39-coverage-sbck-doctest
             python-version: "3.9"
             markers: -m 'not slow'
             os: ubuntu-latest
@@ -139,11 +139,11 @@ jobs:
             python-version: "3.11"
             markers: -m 'not slow'
             os: ubuntu-latest
-          - tox-env: py312-coverage-numba
+          - tox-env: py312-coverage-numba-doctest
             python-version: "3.12"
             markers: -m 'not slow'
             os: ubuntu-latest
-          - tox-env: notebooks_doctests
+          - tox-env: notebooks
             python-version: "3.10"
             os: ubuntu-latest
           - tox-env: offline-prefetch

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ env:
 
 concurrency:
   # For a given workflow, if we push to the same branch, cancel all previous builds on that branch except on main.
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -193,14 +193,15 @@ jobs:
 
   test-conda:
     needs: lint
-    name: test-conda-Python${{ matrix.python-version }}
+    name: Python${{ matrix.python-version }} (Conda, ${{ matrix.os }})
     if: |
       contains(github.event.pull_request.labels.*.name, 'approved') ||
       (github.event.review.state == 'approved') ||
       (github.event_name == 'push')
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest]
         python-version: ["3.9", "3.12"]
     defaults:
       run:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -180,7 +180,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install tox
         run: |
-          python -m pip install tox~=4.0
+          python -m pip install tox~=4.0 tox-gh flit
       - name: Test with tox
         run: |
           python -m tox -e ${{ matrix.tox-env }} -- ${{ matrix.markers }}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,10 +10,6 @@ Announcements
 ^^^^^^^^^^^^^
 * `xclim` has migrated its development branch name from `master` to `main`. (:issue:`1667`, :pull:`1669`).
 
-Breaking changes
-^^^^^^^^^^^^^^^^
-* Added the `tox-gh` dependency to the development installation recipe. This will soon be required for running the `tox` test ensemble on GitHub Workflows. (:pull:`1709`).
-
 Bug fixes
 ^^^^^^^^^
 * Fixed an bug in sdba's ``map_groups`` that prevented passing DataArrays with cftime coordinates if the ``sdba_encode_cf`` option was True. (:issue:`1673`, :pull:`1674`).
@@ -26,6 +22,7 @@ Internal changes
 * Added "doymin" and "doymax" to the possible operations of ``generic.stats``. Fixed a warning issue when ``op`` was "integral". (:pull:`1672`).
 * Reorganized GitHub CI build matrices to run the doctests more consistently. (:pull:`1709`).
 * Removed the experimental `numba` and `llvm` dependency installation steps in the `tox.ini` file. Added `numba@main` to the upstream dependencies. (:pull:`1709`).
+* Added the `tox-gh` dependency to the development installation recipe. This will soon be required for running the `tox` test ensemble on GitHub Workflows. (:pull:`1709`).
 
 v0.48.2 (2024-02-26)
 --------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@ Announcements
 ^^^^^^^^^^^^^
 * `xclim` has migrated its development branch name from `master` to `main`. (:issue:`1667`, :pull:`1669`).
 
+Breaking changes
+^^^^^^^^^^^^^^^^
+* Added the `tox-gh` dependency to the development installation recipe. This will soon be required for running the `tox` test ensemble on GitHub Workflows. (:pull:`1709`).
+
 Bug fixes
 ^^^^^^^^^
 * Fixed an bug in sdba's ``map_groups`` that prevented passing DataArrays with cftime coordinates if the ``sdba_encode_cf`` option was True. (:issue:`1673`, :pull:`1674`).
@@ -20,7 +24,8 @@ Bug fixes
 Internal changes
 ^^^^^^^^^^^^^^^^
 * Added "doymin" and "doymax" to the possible operations of ``generic.stats``. Fixed a warning issue when ``op`` was "integral". (:pull:`1672`).
-
+* Reorganized GitHub CI build matrices to run the doctests more consistently. (:pull:`1709`).
+* Removed the experimental `numba` and `llvm` dependency installation steps in the `tox.ini` file. Added `numba@main` to the upstream dependencies. (:pull:`1709`).
 
 v0.48.2 (2024-02-26)
 --------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ dev = [
   "tokenize-rt",
   "tox >=4.0",
   # "tox-conda",  # Will be added when a tox@v4.0+ compatible plugin is released.
+  "tox-gh >=1.3.1",
   "xdoctest",
   "yamllint",
   # Documentation and examples

--- a/requirements_upstream.txt
+++ b/requirements_upstream.txt
@@ -1,4 +1,5 @@
 bottleneck @ git+https://github.com/pydata/bottleneck.git@master
 cftime @ git+https://github.com/Unidata/cftime.git@master
 flox @ git+https://github.com/xarray-contrib/flox.git@main
+numba @ git+https://github.com/numba/numba.git@main
 xarray @ git+https://github.com/pydata/xarray.git@main

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ min_version = 4.0
 env_list =
     lint
     docs
-    notebooks_doctests
+    notebooks
     offline-prefetch
     py39-upstream-doctest
     py310
@@ -65,11 +65,11 @@ allowlist_externals =
 ;deps =
 ;extras =
 
-[testenv:notebooks_doctests{-coverage,}]
-description = Run notebooks and doctests with pytest under {basepython}
+[testenv:notebooks]
+description = Run notebooks with pytest under {basepython}
 commands =
     pytest --no-cov --nbval --dist=loadscope --rootdir=tests/ --ignore=docs/notebooks/example.ipynb docs/notebooks
-    pytest --rootdir=tests/ --xdoctest xclim
+commands_post =
 
 [testenv:offline{-prefetch,}{-coverage,}]
 description = Run tests with pytest under {basepython}, preventing socket connections (except for unix sockets for async support)
@@ -117,8 +117,8 @@ commands_pre =
     xclim --help
 commands =
     prefetch: xclim prefetch_testing_data
-    doctest: pytest --no-cov --rootdir=tests/ --xdoctest xclim
     pytest {posargs}
+    doctest: pytest --rootdir=tests/ --xdoctest xclim
 commands_post =
     coverage: - coveralls
 allowlist_externals =

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ env_list =
 labels =
     test = py39, py310-upstream-doctest, py311, notebooks_doctests, offline-prefetch
 requires =
-    pip >= 23.3.0
+    pip >= 24.0
     flit
 opts = -vv
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,14 +6,22 @@ env_list =
     notebooks
     offline-prefetch
     py39-upstream-doctest
-    py310
+    py310-doctest
     py311-lmoments
-    py312-numba
+    py312-lmoments-doctest
 labels =
     test = py39, py310-upstream-doctest, py311, notebooks_doctests, offline-prefetch
 requires =
-    pip >= 23.0
+    pip >= 23.3.0
+    flit
 opts = -vv
+
+[gh]
+python =
+    3.12 = py312-coverage-lmoments-doctest
+    3.11 = py311-coverage-lmoments-sbck-doctest, offline-coverage-prefetch
+    3.10 = py310-coverage-lmoments-doctest, notebooks
+    3.9 = py39-coverage-sbck-doctest, lint, docs
 
 [testenv:lint]
 description = Run code quality compliance tests under {basepython}
@@ -65,7 +73,7 @@ allowlist_externals =
 ;deps =
 ;extras =
 
-[testenv:notebooks]
+[testenv:notebooks{-prefetch,}]
 description = Run notebooks with pytest under {basepython}
 commands =
     pytest --no-cov --nbval --dist=loadscope --rootdir=tests/ --ignore=docs/notebooks/example.ipynb docs/notebooks
@@ -74,7 +82,6 @@ commands_post =
 [testenv:offline{-prefetch,}{-coverage,}]
 description = Run tests with pytest under {basepython}, preventing socket connections (except for unix sockets for async support)
 commands:
-    prefetch: xclim prefetch_testing_data
     python -c 'print("Running offline tests with positional arguments: --disable-socket --allow-unix-socket --m \"not requires_internet\"")'
     python -c 'print("These can be overwritten with: tox -e offline -- -m \"some other marker statement\"")'
     pytest --disable-socket --allow-unix-socket {posargs:-m 'not requires_internet'}
@@ -99,14 +106,11 @@ passenv =
     XCLIM_*
 extras = dev
 deps =
-    # FIXME: Remove when numba 0.59.0 is released
-    numba: numba==0.59.0rc1
-    numba: llvmlite==0.42.0rc1
     coverage: coveralls
     upstream: -rrequirements_upstream.txt
     sbck: pybind11
     lmoments: lmoments3
-    notebooks_doctests: lmoments3
+    notebooks: lmoments3
 install_command = python -m pip install --no-user {opts} {packages}
 download = True
 commands_pre =
@@ -115,6 +119,7 @@ commands_pre =
     xclim show_version_info
     python -m pip check
     xclim --help
+    prefetch: xclim prefetch_testing_data
 commands =
     prefetch: xclim prefetch_testing_data
     pytest {posargs}
@@ -123,3 +128,4 @@ commands_post =
     coverage: - coveralls
 allowlist_externals =
     git
+    xclim


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Splits the `notebooks` recipe in the `tox.ini` file
* Sets the GitHub Workflows to test the doctests across more builds
* Stages the `tox-gh` plugin for eventual integration

### Does this PR introduce a breaking change?

Yes, `tox-gh` is now a development dependency and the `"notebooks_doctests"` `tox` recipe has been replaced with `"notebooks"`, while `doctest` has been made into a modifier for typical `tox` runs to also run the documentation examples.

### Other information:

https://github.com/tox-dev/tox-gh