### PR TITLE
No change is different from negative change

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,8 @@ Bug fixes
 * Fixed an bug in sdba's ``map_groups`` that prevented passing DataArrays with cftime coordinates if the ``sdba_encode_cf`` option was True. (:issue:`1673`, :pull:`1674`).
 * Fixed bug (:issue:`1678`, :pull:`1679`) in sdba where a loaded training dataset could not be used for adjustment
 * Fixed bug with loess smoothing for an array full of NaNs. (:pull:`1699`).
-* Fixed and adapted ``time_bnds`` to the newest xarray. (:pull:`1700`)
+* Fixed and adapted ``time_bnds`` to the newest xarray. (:pull:`1700`).
+* Fixed "agreement fraction" in ``robustness_fractions`` to distinguish between negative change and no change. Added "negative" and "changed negative" fractions (:issue:`1690`, :pull:`1711`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/tests/test_ensembles.py
+++ b/tests/test_ensembles.py
@@ -735,13 +735,14 @@ def test_robustness_fractions_weighted(robust_data):
 
 
 def test_robustness_fractions_delta(robust_data):
-    delta = xr.DataArray([-2, 1, -2, -1], dims=("realization",))
+    delta = xr.DataArray([-2, 1, -2, -1, 0, 0], dims=("realization",))
     fracs = ensembles.robustness_fractions(delta, test="threshold", abs_thresh=1.5)
-    np.testing.assert_array_equal(fracs.changed, [0.5])
+    np.testing.assert_array_equal(fracs.changed, [2 / 6])
     np.testing.assert_array_equal(fracs.changed_positive, [0.0])
-    np.testing.assert_array_equal(fracs.positive, [0.25])
-    np.testing.assert_array_equal(fracs.agree, [0.75])
+    np.testing.assert_array_equal(fracs.positive, [1 / 6])
+    np.testing.assert_array_equal(fracs.agree, [3 / 6])
 
+    delta = xr.DataArray([-2, 1, -2, -1], dims=("realization",))
     weights = xr.DataArray([4, 3, 2, 1], dims=("realization",))
     fracs = ensembles.robustness_fractions(
         delta, test="threshold", abs_thresh=1.5, weights=weights


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1690 
- [x] Tests for the changes have been added (for bug fixes / features)
  - [x] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?
In `robustness_fractions`

* Computes the fraction of negative change explicitly and returns it 
* The agreement fraction is the maximum of the positive, negative or no change fractions.

### Does this PR introduce a breaking change?
Yes, `agree_frac` has changed. However, it now better reflects its definition and usual expectations. And the case where "no change" is the largest group should not be very frequent, it usually happens with zero-bounded indicators.


### Other information:
