### PR TITLE
Fix: QuantileDeltaMapping not working for seasonal grouping

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Bug fixes
 * Fixed bug with loess smoothing for an array full of NaNs. (:pull:`1699`).
 * Fixed and adapted ``time_bnds`` to the newest xarray. (:pull:`1700`).
 * Fixed "agreement fraction" in ``robustness_fractions`` to distinguish between negative change and no change. Added "negative" and "changed negative" fractions (:issue:`1690`, :pull:`1711`).
+* Fixed bug QuantileDeltaMapping adjustment not working for seasonal grouping (:issue:`1704`, :pull:`1716`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/tests/test_sdba/test_adjustment.py
+++ b/tests/test_sdba/test_adjustment.py
@@ -378,6 +378,37 @@ class TestQDM:
         # Test predict
         np.testing.assert_allclose(p, ref.transpose(*p.dims), rtol=0.1, atol=0.2)
 
+    def test_seasonal(self, series, random):
+        u = random.random(10000)
+        kind = '+'
+        name = 'tas'
+        # Define distributions
+        xd = uniform(loc=1, scale=1)
+        yd = uniform(loc=2, scale=4)
+
+        # Generate random numbers with u so we get exact results for comparison
+        x = xd.ppf(u)
+        y = yd.ppf(u)
+
+        # Test train
+        hist = sim = series(x, name)
+        ref = series(y, name)
+
+        QDM = QuantileDeltaMapping.train(
+            ref.astype("float32"),
+            hist.astype("float32"),
+            kind=kind,
+            group="time.season",
+            nquantiles=10,
+        )
+        p = QDM.adjust(sim.astype("float32"), interp="linear")
+
+        # Test predict
+        # Accept discrepancies near extremes
+        middle = (u > 1e-2) * (u < 0.99)
+        np.testing.assert_array_almost_equal(p[middle], ref[middle], 1)
+
+
     def test_cannon_and_diagnostics(self, cannon_2015_dist, cannon_2015_rvs):
         ref, hist, sim = cannon_2015_rvs(15000, random=False)
 

--- a/tests/test_sdba/test_adjustment.py
+++ b/tests/test_sdba/test_adjustment.py
@@ -380,8 +380,8 @@ class TestQDM:
 
     def test_seasonal(self, series, random):
         u = random.random(10000)
-        kind = '+'
-        name = 'tas'
+        kind = "+"
+        name = "tas"
         # Define distributions
         xd = uniform(loc=1, scale=1)
         yd = uniform(loc=2, scale=4)
@@ -407,7 +407,6 @@ class TestQDM:
         # Accept discrepancies near extremes
         middle = (u > 1e-2) * (u < 0.99)
         np.testing.assert_array_almost_equal(p[middle], ref[middle], 1)
-
 
     def test_cannon_and_diagnostics(self, cannon_2015_dist, cannon_2015_rvs):
         ref, hist, sim = cannon_2015_rvs(15000, random=False)

--- a/xclim/sdba/base.py
+++ b/xclim/sdba/base.py
@@ -295,6 +295,8 @@ class Grouper(Parametrizable):
         ind = da.indexes[self.dim]
         if self.prop == "week":
             i = da[self.dim].copy(data=ind.isocalendar().week).astype(int)
+        elif self.prop == "season":
+            i = da[self.dim].copy(data=ind.month % 12 // 3)
         else:
             i = getattr(ind, self.prop)
 


### PR DESCRIPTION
### Pull Request Checklist:
    
- This PR fixes #1704 
- [x] Added `test_seasonal` test to the QDM suit
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* In sdba/utils.py `interp_on_quantiles` seasons are now cast to integers to ensure we can add_cyclic_bounds. For this, I also had to overwrite the get_index function of the `Grouper` class. On a first class, I think that makes sense since in any case it doesn't make much sense to interp a string variable.

### Does this PR introduce a breaking change?
Hopefully not. 

