### PR TITLE
Add vulture to find dead code

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
         args: ['--py39-plus']
         exclude: 'xclim/core/indicator.py'
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -41,7 +41,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.5
+    rev: v0.3.7
     hooks:
       - id: ruff
   - repo: https://github.com/pylint-dev/pylint
@@ -55,6 +55,10 @@ repos:
       - id: flake8
         additional_dependencies: [ 'flake8-alphabetize', 'flake8-rst-docstrings ']
         args: [ '--config=.flake8' ]
+  - repo: https://github.com/jendrikseipp/vulture
+    rev: 'v2.11'
+    hooks:
+      - id: vulture
   - repo: https://github.com/nbQA-dev/nbQA
     rev: 1.8.5
     hooks:
@@ -87,7 +91,7 @@ repos:
     hooks:
       - id: gitleaks
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.28.1
+    rev: 0.28.2
     hooks:
       - id: check-github-workflows
       - id: check-readthedocs

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@ Announcements
 ^^^^^^^^^^^^^
 * `xclim` has migrated its development branch name from `master` to `main`. (:issue:`1667`, :pull:`1669`).
 
+Breaking changes
+^^^^^^^^^^^^^^^^
+* The previously deprecated functions ``xclim.sdba.processing.construct_moving_yearly_window`` and ``xclim.sdba.processing.unpack_moving_yearly_window`` have been removed. These functions have been replaced by ``xclim.core.calendar.stack_periods`` and ``xclim.core.calendar.unstack_periods``. (:pull:`1717`).
+
 Bug fixes
 ^^^^^^^^^
 * Fixed an bug in sdba's ``map_groups`` that prevented passing DataArrays with cftime coordinates if the ``sdba_encode_cf`` option was True. (:issue:`1673`, :pull:`1674`).
@@ -24,6 +28,7 @@ Internal changes
 * Reorganized GitHub CI build matrices to run the doctests more consistently. (:pull:`1709`).
 * Removed the experimental `numba` and `llvm` dependency installation steps in the `tox.ini` file. Added `numba@main` to the upstream dependencies. (:pull:`1709`).
 * Added the `tox-gh` dependency to the development installation recipe. This will soon be required for running the `tox` test ensemble on GitHub Workflows. (:pull:`1709`).
+* Added the `vulture` static code analysis tool for finding dead code to the development dependency list and linters (makefile, tox and pre-commit hooks). (:pull:`1717`).
 
 v0.48.2 (2024-02-26)
 --------------------

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ lint: ## check style with flake8 and black
 	isort --check xclim tests
 	ruff xclim tests
 	flake8 --config=.flake8 xclim tests
+	vulture xclim tests
 	nbqa black --check docs
 	blackdoc --check --exclude=xclim/indices/__init__.py xclim
 	blackdoc --check docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -312,3 +312,11 @@ max-doc-length = 180
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"
+
+[tool.vulture]
+exclude = []
+ignore_decorators = ["@pytest.fixture"]
+ignore_names = []
+min_confidence = 90
+paths = ["xclim", "tests"]
+sort_by_size = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ dev = [
   "tox >=4.0",
   # "tox-conda",  # Will be added when a tox@v4.0+ compatible plugin is released.
   "tox-gh >=1.3.1",
+  "vulture",
   "xdoctest",
   "yamllint",
   # Documentation and examples

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -374,7 +374,7 @@ def test_release_notes_failure(method, error):
     assert error in results.output
 
 
-def test_show_version_info(capsys):
+def test_show_version_info():
     runner = CliRunner()
     results = runner.invoke(cli, ["show_version_info"])
     assert "INSTALLED VERSIONS" in results.output

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -47,7 +47,7 @@ def test_indicator_docstring():
 
 def test_update_xclim_history(atmosds):
     @fmt.update_xclim_history
-    def func(da, arg1, arg2=None, arg3=None):  # noqa:
+    def func(da, arg1, arg2=None, arg3=None):  # noqa: F841
         return da
 
     out = func(atmosds.tas, 1, arg2=[1, 2], arg3=None)

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -47,7 +47,7 @@ def test_indicator_docstring():
 
 def test_update_xclim_history(atmosds):
     @fmt.update_xclim_history
-    def func(da, arg1, arg2=None, arg3=None):
+    def func(da, arg1, arg2=None, arg3=None):  # noqa:
         return da
 
     out = func(atmosds.tas, 1, arg2=[1, 2], arg3=None)

--- a/tests/test_sdba/conftest.py
+++ b/tests/test_sdba/conftest.py
@@ -105,7 +105,7 @@ def qds_month():
 
 
 @pytest.fixture
-def ref_hist_sim_tuto(socket_enabled):
+def ref_hist_sim_tuto(socket_enabled):  # noqa: F841
     """Return ref, hist, sim time series of air temperature.
 
     socket_enabled is a fixture that enables the use of the internet to download the tutorial dataset while the

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -291,7 +291,9 @@ def test_declare_units():
 
 
 def test_declare_relative_units():
-    def index(data: xr.DataArray, thresh: Quantified, dthreshdt: Quantified):
+    def index(
+        data: xr.DataArray, thresh: Quantified, dthreshdt: Quantified  # noqa: F841
+    ):
         return xr.DataArray(1, attrs={"units": "rad"})
 
     index_relative = declare_relative_units(thresh="<data>", dthreshdt="<data>/[time]")(

--- a/tox.ini
+++ b/tox.ini
@@ -37,6 +37,7 @@ deps =
     isort==5.13.2
     nbqa
     ruff>=0.1.0
+    vulture
     yamllint
 commands_pre =
 commands =
@@ -44,6 +45,7 @@ commands =
     isort --check xclim tests
     ruff xclim tests
     flake8 --config=.flake8 xclim tests
+    vulture xclim tests
     nbqa black --check docs
     blackdoc --check --exclude=xclim/indices/__init__.py xclim
     blackdoc --check docs

--- a/xclim/core/calendar.py
+++ b/xclim/core/calendar.py
@@ -885,10 +885,10 @@ def is_offset_divisor(divisor: str, offset: str):
         return False
     # Reconstruct offsets anchored at the start of the period
     # to have comparable quantities, also get "offset" objects
-    mA, bA, sA, aA = parse_offset(divisor)
+    mA, bA, _sA, aA = parse_offset(divisor)
     offAs = pd.tseries.frequencies.to_offset(construct_offset(mA, bA, True, aA))
 
-    mB, bB, sB, aB = parse_offset(offset)
+    mB, bB, _sB, aB = parse_offset(offset)
     offBs = pd.tseries.frequencies.to_offset(construct_offset(mB, bB, True, aB))
     tB = pd.date_range("1970-01-01T00:00:00", freq=offBs, periods=13)
 

--- a/xclim/core/indicator.py
+++ b/xclim/core/indicator.py
@@ -510,7 +510,7 @@ class Indicator(IndicatorRegistrar):
         return super().__new__(new)
 
     @staticmethod
-    def _parse_indice(compute, passed_parameters):
+    def _parse_indice(compute, passed_parameters):  # noqa: F841
         """Parse the compute function.
 
         - Metadata is extracted from the docstring

--- a/xclim/core/options.py
+++ b/xclim/core/options.py
@@ -224,7 +224,8 @@ class set_options:
         """Context management."""
         return
 
-    def _update(self, kwargs):
+    @staticmethod
+    def _update(kwargs):
         """Update values."""
         for k, v in kwargs.items():
             if k in _SETTERS:
@@ -232,6 +233,6 @@ class set_options:
             else:
                 OPTIONS[k] = v
 
-    def __exit__(self, option_type, value, traceback):
+    def __exit__(self, option_type, value, traceback):  # noqa: F841
         """Context management."""
         self._update(self.old)

--- a/xclim/core/units.py
+++ b/xclim/core/units.py
@@ -63,7 +63,7 @@ units = deepcopy(cf_xarray.units.units)
 # g is the most versatile float format.
 units.default_format = "gcf"
 # Switch this flag back to False. Not sure what that implies, but it breaks some tests.
-units.force_ndarray_like = False
+units.force_ndarray_like = False  # noqa: F841
 # Another alias not included by cf_xarray
 units.define("@alias percent = pct")
 

--- a/xclim/indices/fire/_cffwis.py
+++ b/xclim/indices/fire/_cffwis.py
@@ -892,7 +892,7 @@ def fire_weather_ufunc(  # noqa: C901
     ffmc0: xr.DataArray | None = None,
     winter_pr: xr.DataArray | None = None,
     season_mask: xr.DataArray | None = None,
-    start_dates: str | xr.DataArray | None = None,
+    start_dates: str | xr.DataArray | None = None,  # noqa: F841
     indexes: Sequence[str] | None = None,
     season_method: str | None = None,
     overwintering: bool = False,

--- a/xclim/sdba/__init__.py
+++ b/xclim/sdba/__init__.py
@@ -9,12 +9,7 @@ from __future__ import annotations
 from . import adjustment, detrending, measures, processing, properties, utils
 from .adjustment import *
 from .base import Grouper
-from .processing import (
-    construct_moving_yearly_window,
-    stack_variables,
-    unpack_moving_yearly_window,
-    unstack_variables,
-)
+from .processing import stack_variables, unstack_variables
 
 # TODO: ISIMIP ? Used for precip freq adjustment in biasCorrection.R
 # Hempel, S., Frieler, K., Warszawski, L., Schewe, J., & Piontek, F. (2013). A trend-preserving bias correction &ndash;


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Adds a hook to use vulture, a tool for finding dead code segments using static analysis and confidence intervals
* Updates the pre-commit hooks to latest versions
* Removes the obsolete `construct_moving_yearly_window` and `unpack_moving_yearly_window` functions

### Does this PR introduce a breaking change?

No, the removed functions have been slated for removal for around since the end of year 2023.

### Other information:

https://github.com/jendrikseipp/vulture