### PR TITLE
Add support for method argument in ensemble_percentile

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,12 @@ New indicators
 * New ``snw_season_length`` and ``snd_season_length`` computing the duration between the start and the end of the snow season, both defined as the first day of a continuous period with snow above/under a threshold. Previous versions of these indicators were renamed ``snw_days_above`` and ``snd_days_above`` to better reflect what they computed : the number of days with snow above a given threshold (with no notion of continuity). (:issue:`1703`, :pull:`1708`).
 * Added ``atmos.duff_moisture_code``, part of the Canadian Forest Fire Weather Index System. It was already an output of the `atmos.cffwis_indices`, but now has its own standalone indicator. (:issue:`1698`, :pull:`1712`).
 
+New features and enhancements
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+* `ensemble_percentiles` now takes a `method` argument, accepting
+  'interpolated_inverted_cdf', 'hazen', 'weibull', 'linear'  (default),
+  'median_unbiased' and 'normal_unbiased'. (:issue:`1694`, :pull:`1732`).
+
 Breaking changes
 ^^^^^^^^^^^^^^^^
 * The previously deprecated functions ``xclim.sdba.processing.construct_moving_yearly_window`` and ``xclim.sdba.processing.unpack_moving_yearly_window`` have been removed. These functions have been replaced by ``xclim.core.calendar.stack_periods`` and ``xclim.core.calendar.unstack_periods``. (:pull:`1717`).

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,17 +13,14 @@ Announcements
 New features and enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 * Indicator ``xclim.atmos.potential_evapotranspiration`` and indice ``xclim.indices.potential_evapotranspiration`` now accept a new value (`DA02`) for argument `method` implementing potential evapotranspiration based on Droogers and Allen (2002). (:issue:`1710`, :pull:`1723`).
+* `ensemble_percentiles` now takes a `method` argument, accepting
+  'interpolated_inverted_cdf', 'hazen', 'weibull', 'linear'  (default),
+  'median_unbiased' and 'normal_unbiased'. (:issue:`1694`, :pull:`1732`).
 
 New indicators
 ^^^^^^^^^^^^^^
 * New ``snw_season_length`` and ``snd_season_length`` computing the duration between the start and the end of the snow season, both defined as the first day of a continuous period with snow above/under a threshold. Previous versions of these indicators were renamed ``snw_days_above`` and ``snd_days_above`` to better reflect what they computed : the number of days with snow above a given threshold (with no notion of continuity). (:issue:`1703`, :pull:`1708`).
 * Added ``atmos.duff_moisture_code``, part of the Canadian Forest Fire Weather Index System. It was already an output of the `atmos.cffwis_indices`, but now has its own standalone indicator. (:issue:`1698`, :pull:`1712`).
-
-New features and enhancements
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-* `ensemble_percentiles` now takes a `method` argument, accepting
-  'interpolated_inverted_cdf', 'hazen', 'weibull', 'linear'  (default),
-  'median_unbiased' and 'normal_unbiased'. (:issue:`1694`, :pull:`1732`).
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/tests/test_ensembles.py
+++ b/tests/test_ensembles.py
@@ -176,6 +176,20 @@ class TestEnsembleStats:
             ),
             out1["tg_mean_p90"].isel(time=0, lon=5, lat=5),
         )
+
+        # Specify method
+        np.testing.assert_array_almost_equal(
+            mquantiles(
+                ens["tg_mean"].isel(time=0, lon=5, lat=5),
+                alphap=0.5,
+                betap=0.5,
+                prob=0.90,
+            ),
+            ensembles.ensemble_percentiles(
+                ens.isel(time=0, lon=5, lat=5), values=[90], method="hazen"
+            ).tg_mean_p90,
+        )
+
         assert np.all(out1["tg_mean_p90"] > out1["tg_mean_p50"])
         assert np.all(out1["tg_mean_p50"] > out1["tg_mean_p10"])
 

--- a/xclim/ensembles/_base.py
+++ b/xclim/ensembles/_base.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from glob import glob
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import numpy as np
 import xarray as xr
@@ -217,7 +217,14 @@ def ensemble_percentiles(
     min_members: int | None = 1,
     weights: xr.DataArray | None = None,
     split: bool = True,
-    method: str = "linear",
+    method: Literal[
+        "linear",
+        "interpolated_inverted_cdf",
+        "hazen",
+        "weibull",
+        "median_unbiased",
+        "normal_unbiased",
+    ] = "linear",
 ) -> xr.DataArray | xr.Dataset:
     """Calculate ensemble statistics between a results from an ensemble of climate simulations.
 
@@ -246,16 +253,8 @@ def ensemble_percentiles(
     split : bool
         Whether to split each percentile into a new variable
         or concatenate the output along a new "percentiles" dimension.
-    method : str, optional
-        This parameter specifies the method to use for estimating the percentile, see the `numpy.percentile`
-        documentation for more information. The following methods are supported
-
-          - 'interpolated_inverted_cdf'
-          - 'hazen'
-          - 'weibull'
-          - 'linear'  (default)
-          - 'median_unbiased'
-          - 'normal_unbiased'
+    method : {"linear", "interpolated_inverted_cdf", "hazen", "weibull", "median_unbiased", "normal_unbiased"}
+        Method to use for estimating the percentile, see the `numpy.percentile` documentation for more information.
 
     Returns
     -------


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1694 
- [x] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Add method argument to ensemble_percentile. I chose to expose `method` rather than `alpha`, `beta` as it felt more user friendly, since this is what numpy and xarray use. 

### Does this PR introduce a breaking change?
No

### Other information:

Raise an error if used with weights. 

Note that `test_calc_perc` takes 26 sec. on my laptop to run. I think the test could be sped up by restricting computations to the things that are ultimately checked. 
