### PR TITLE
Fix adapt_freq example in notebook

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,6 +47,7 @@ Bug fixes
 * Fixed bug QuantileDeltaMapping adjustment not working for seasonal grouping (:issue:`1704`, :pull:`1716`).
 * The codebase has been adjusted to address several (~400) `mypy`-related errors attributable to inaccurate function call signatures and variable name shadowing. (:issue:`1719`, :pull:`1721`).
 * ``xclim.core.formatting.generate_indicator_docstring`` has been modified to ensure that the `numpy`-docstrings of all Indicators are consistent in their formatting. (:pull:`1731`).
+* Fixed documentation example for frequency adaptation with `sdba`. (:issue:`1740`, :pull:`1742`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/docs/notebooks/sdba-advanced.ipynb
+++ b/docs/notebooks/sdba-advanced.ipynb
@@ -678,11 +678,11 @@
     "from xclim import sdba\n",
     "\n",
     "group = sdba.Grouper(\"time.dayofyear\", window=31)\n",
-    "sim_ad, pth, dP0 = sdba.processing.adapt_freq(\n",
-    "    pr_ref, pr_sim, thresh=\"0.05 mm d-1\", group=group\n",
+    "hist_ad, pth, dP0 = sdba.processing.adapt_freq(\n",
+    "    pr_ref, pr_hist, thresh=\"0.05 mm d-1\", group=group\n",
     ")\n",
     "QM_ad = sdba.EmpiricalQuantileMapping.train(\n",
-    "    pr_ref, sim_ad, nquantiles=15, kind=\"*\", group=group\n",
+    "    pr_ref, hist_ad, nquantiles=15, kind=\"*\", group=group\n",
     ")\n",
     "scen_ad = QM_ad.adjust(pr_sim)\n",
     "\n",
@@ -698,7 +698,7 @@
    "source": [
     "In the figure above, `scen` occasionally has small peaks where `sim` is 0, indicating that there are more \"dry days\" (days with almost no precipitation) in `hist` than in `ref`. The frequency-adaptation [Themeßl et al. (2010)](https://doi.org/10.1007/s10584-011-0224-4) performed in the step above only worked partially.  \n",
     "\n",
-    "The reason for this is the following. The first step above combines precipitations in 365 overlapping blocks of 31 days * Y years, one block for each day of the year. Each block is adapted, and the 16th day-of-year slice (at the center of the block) is assigned to the corresponding day-of-year in the adapted dataset `sim_ad`. As we proceed to the training, we re-form those 31 days * Y years blocks, but this step does not invert the last one: There can still be more zeroes in the simulation than in the reference. \n",
+    "The reason for this is the following. The first step above combines precipitations in 365 overlapping blocks of 31 days * Y years, one block for each day of the year. Each block is adapted, and the 16th day-of-year slice (at the center of the block) is assigned to the corresponding day-of-year in the adapted dataset `hist_ad`. As we proceed to the training, we re-form those 31 days * Y years blocks, but this step does not invert the last one: There can still be more zeroes in the simulation than in the reference. \n",
     "\n",
     "To alleviate this issue, another way of proceeding is to perform a frequency adaptation on the blocks, and then use the same blocks in the training step, as we show below.\n"
    ]
@@ -714,7 +714,7 @@
     "\n",
     "QM_ad = sdba.EmpiricalQuantileMapping.train(\n",
     "    pr_ref,\n",
-    "    sim_ad,\n",
+    "    pr_hist,\n",
     "    nquantiles=15,\n",
     "    kind=\"*\",\n",
     "    group=group,\n",

--- a/docs/notebooks/sdba.ipynb
+++ b/docs/notebooks/sdba.ipynb
@@ -279,11 +279,11 @@
    "outputs": [],
    "source": [
     "# 2nd try with adapt_freq\n",
-    "hist_aa, pth, dP0 = sdba.processing.adapt_freq(\n",
+    "hist_ad, pth, dP0 = sdba.processing.adapt_freq(\n",
     "    pr_ref, pr_hist, thresh=\"0.05 mm d-1\", group=\"time\"\n",
     ")\n",
     "QM_ad = sdba.EmpiricalQuantileMapping.train(\n",
-    "    pr_ref, hist_aa, nquantiles=15, kind=\"*\", group=\"time\"\n",
+    "    pr_ref, hist_ad, nquantiles=15, kind=\"*\", group=\"time\"\n",
     ")\n",
     "scen_ad = QM_ad.adjust(pr_sim)\n",
     "\n",

--- a/docs/notebooks/sdba.ipynb
+++ b/docs/notebooks/sdba.ipynb
@@ -269,7 +269,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In the figure above, `scen` has small peaks where `sim` is 0. This problem originates from the fact that there are more \"dry days\" (days with almost no precipitation) in `hist` than in `ref`. The next example works around the problem using frequency-adaptation, as described in [Themeßl et al. (2010)](https://doi.org/10.1007/s10584-011-0224-4)."
+    "In the figure above, `scen` has small peaks where `sim` is 0. This problem originates from the fact that there are more \"dry days\" (days with almost no precipitation) in `hist` than in `ref`. The next example works around the problem using frequency-adaptation, as described in [Themeßl et al. (2012)](https://doi.org/10.1007/s10584-011-0224-4)."
    ]
   },
   {
@@ -279,11 +279,11 @@
    "outputs": [],
    "source": [
     "# 2nd try with adapt_freq\n",
-    "sim_ad, pth, dP0 = sdba.processing.adapt_freq(\n",
-    "    pr_ref, pr_sim, thresh=\"0.05 mm d-1\", group=\"time\"\n",
+    "hist_aa, pth, dP0 = sdba.processing.adapt_freq(\n",
+    "    pr_ref, pr_hist, thresh=\"0.05 mm d-1\", group=\"time\"\n",
     ")\n",
     "QM_ad = sdba.EmpiricalQuantileMapping.train(\n",
-    "    pr_ref, sim_ad, nquantiles=15, kind=\"*\", group=\"time\"\n",
+    "    pr_ref, hist_aa, nquantiles=15, kind=\"*\", group=\"time\"\n",
     ")\n",
     "scen_ad = QM_ad.adjust(pr_sim)\n",
     "\n",
@@ -686,7 +686,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.12.2"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1740
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [x] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?
In the frequency adaptation example, `pr_sim` was sent to  `adapt_freq` and then to the `train`. However, this should be `hist` instead.

### Does this PR introduce a breaking change?
No.

### Other information:
Also changed the year in the citation.