### PR TITLE
Pin pint below v0.24

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -29,4 +29,4 @@ jobs:
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@0659a74c94536054bfa5aeb92241f70d680cc78e
+        uses: actions/dependency-review-action@72eb03d02c7872a771aacd928f3123ac62ad6d3a # v4.3.3

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,10 @@ v0.50.0 (unreleased)
 --------------------
 Contributors to this version: Trevor James Smith (:user:`Zeitsperre`).
 
+Breaking changes
+^^^^^^^^^^^^^^^^
+* `pint` has been pinned below v0.24 until `xclim` can be updated to support the latest version. (:issue:`1771`, :pull:`1772`).
+
 Internal changes
 ^^^^^^^^^^^^^^^^
 * Synchronized tooling versions across ``pyproject.toml`` and ``tox.ini`` and pinned them to the latest stable releases in GitHub Workflows. (:pull:`1744`).

--- a/environment.yml
+++ b/environment.yml
@@ -5,18 +5,17 @@ channels:
   - defaults
 dependencies:
   - python >=3.9
-  - astroid
   - boltons >=20.1
   - bottleneck >=1.3.1
   - cf_xarray >=0.6.1
   - cftime >=1.4.1
-  - Click >=8.1
+  - click >=8.1
   - dask >=2.6.0
   - jsonpickle
   - numba
   - numpy >=1.20.0
   - pandas >=2.2.0
-  - pint >=0.9
+  - pint >=0.10,<0.24
   - poppler >=0.67
   - pyarrow  # Strongly encouraged for Pandas v2.2.0+
   - pyyaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,13 +36,13 @@ dependencies = [
   # cf-xarray is differently named on conda-forge
   "cf-xarray>=0.6.1",
   "cftime>=1.4.1",
-  "Click>=8.1",
+  "click>=8.1",
   "dask[array]>=2.6",
   "jsonpickle",
   "numba",
   "numpy>=1.20.0",
   "pandas>=2.2",
-  "pint>=0.10",
+  "pint>=0.10,<0.24",
   "pyarrow", # Strongly encouraged for pandas v2.2.0+
   "pyyaml",
   "scikit-learn>=0.21.3",
@@ -88,7 +88,7 @@ dev = [
   "tox-gh >=1.3.1",
   "vulture ==2.11",
   "xdoctest",
-  "yamllint==1.35.1",
+  "yamllint ==1.35.1",
   # Documentation and examples
   "distributed >=2.0",
   "furo >=2023.9.10",
@@ -156,7 +156,7 @@ values = [
 
 [tool.codespell]
 skip = 'xclim/data/*.json,docs/_build,docs/notebooks/xclim_training/*.ipynb,docs/references.bib,__pycache__,*.gz,*.nc,*.png,*.svg,*.whl'
-ignore-words-list = "absolue,astroid,bloc,bui,callendar,degreee,environnement,hanel,inferrable,lond,nam,nd,ressources,sie,vas"
+ignore-words-list = "absolue,bloc,bui,callendar,degreee,environnement,hanel,inferrable,lond,nam,nd,ressources,sie,vas"
 
 [tool.coverage.run]
 relative_files = true


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR references #1771
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Pinned `pint` below v0.24 until we have time to adapt to their new API.
* Updated the `dependency-review` action

### Does this PR introduce a breaking change?

Yes, `pint` is now pinned and `astroid` has been removed from the `environment.yml` (was unused).

### Other information:

https://pint.readthedocs.io/en/stable/changes.html