### PR TITLE
Pin numpy below v2.0.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,7 @@ Breaking changes
     - ``interp_calendar`` : Use ``Dataset.interp_calendar`` or ``xarray.coding.calendar_ops.interp_calendar`` instead.
     - ``days_in_year`` : Use ``xarray.coding.calendar_ops._days_in_year`` instead.
     - ``datetime_to_decimal_year`` : Use ``xarray.coding.calendar_ops._datetime_to_decimal_year`` instead.
+* `numpy` has been pinned below v2.0.0 until `xclim` can be updated to support the latest version.
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - dask >=2.6.0
   - jsonpickle
   - numba
-  - numpy >=1.20.0
+  - numpy >=1.20.0,<2.0.0
   - pandas >=2.2.0
   - pint >=0.10,<0.24
   - poppler >=0.67

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
   "dask[array]>=2.6",
   "jsonpickle",
   "numba",
-  "numpy>=1.20.0",
+  "numpy>=1.20.0,<2.0.0",
   "pandas>=2.2",
   "pint>=0.10,<0.24",
   "pyarrow", # Strongly encouraged for pandas v2.2.0+

--- a/requirements_upstream.txt
+++ b/requirements_upstream.txt
@@ -2,4 +2,5 @@ bottleneck @ git+https://github.com/pydata/bottleneck.git@master
 cftime @ git+https://github.com/Unidata/cftime.git@master
 flox @ git+https://github.com/xarray-contrib/flox.git@main
 numba @ git+https://github.com/numba/numba.git@main
+numpy @ git+https://github.com/numpy/numpy.git@main
 xarray @ git+https://github.com/pydata/xarray.git@main


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] CHANGES.rst has been updated (with summary of main changes)
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Pins NumPy below v2.0.0 until `xclim` can be adjusted to the new API/ABI

### Does this PR introduce a breaking change?

Yes, `numpy` is now pinned.

### Other information:

https://numpy.org/devdocs/release/2.0.0-notes.html