### PR TITLE
Fix for Fahrenheit deltas, degree-days and others.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Contributors to this version: Trevor James Smith (:user:`Zeitsperre`), Pascal Bo
 
 Bug fixes
 ^^^^^^^^^
-* Units of degree-days computations with Fahrenheit input fixed to yield "°R d". Added a new ``core.units.ensure_absolute_temperature``  method to convert from delta to absolute temperatures (:issue:`1789`, :pull:`1804`).
+* Units of degree-days computations with Fahrenheit input fixed to yield "°R d". Added a new ``xclim.core.units.ensure_absolute_temperature`` method to convert from delta to absolute temperatures. (:issue:`1789`, :pull:`1804`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,11 @@ Changelog
 
 v0.51.0 (unreleased)
 --------------------
-Contributors to this version: Trevor James Smith (:user:`Zeitsperre`).
+Contributors to this version: Trevor James Smith (:user:`Zeitsperre`), Pascal Bourgault (:user:`aulemahal`).
+
+Bug fixes
+^^^^^^^^^
+* Units of degree-days computations with Fahrenheit input fixed to yield "°R d". Added a new ``core.units.ensure_absolute_temperature``  method to convert from delta to absolute temperatures (:issue:`1789`, :pull:`1804`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -332,6 +332,8 @@ def test_declare_relative_units():
         ("", "sum", "count", 365, "d"),
         ("kg m-2", "var", "var", 0, "kg2 m-4"),
         ("°C", "argmax", "doymax", 0, ""),
+        ("°C", "sum", "integral", 365, "K d"),
+        ("°F", "sum", "integral", 365, "d °R"),  # not sure why the order is different
     ],
 )
 def test_to_agg_units(in_u, opfunc, op, exp, exp_u):

--- a/xclim/core/units.py
+++ b/xclim/core/units.py
@@ -537,7 +537,7 @@ def to_agg_units(
     >>> degdays = dt.clip(0).sum("time")  # Integral of temperature above a threshold
     >>> degdays = to_agg_units(degdays, dt, op="integral")
     >>> degdays.units
-    'week delta_degC'
+    'K week'
 
     Which we can always convert to the more common "K days":
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1789
- [x] Tests for the changes have been added (for bug fixes / features)
  - [x] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* New function `ensure_absolute_temperature` that converts temperature units to their absolute counterpart _assuming_ they represented a delta. So °C becomes K and °F becomes °R. Anything else goes unmodified (including compound units like `°C m` (whatever that means)).
* Use this function in `to_agg_units` to ensure a correct output for `op` "std", "var" and "integral".

### Does this PR introduce a breaking change?
No

### Other information:
Pint has "delta_degC" and "delta_degF" for temperature differences, but CF does not. So this new function helps in the specific case where we know the data is delta-like, which happens for the given `op`.