### PR TITLE
Add a GPG key to the helper bot

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -58,10 +58,14 @@ jobs:
         uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
           python-version: "3.x"
-      - name: Config Commit Bot
-        run: |
-          git config --local user.email "ouranos-helper-bot@ouranos.ca"
-          git config --local user.name "ouranos-helper-bot"
+      - name: Import GPG Key
+        uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4 # v6.1.0
+        with:
+          gpg_private_key: ${{ secrets.OURANOS_HELPER_BOT_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.OURANOS_HELPER_BOT_GPG_PRIVATE_KEY_PASSWORD }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          trust_level: 5
       - name: Current Version
         run: |
           CURRENT_VERSION="$(grep -E '__version__'  xclim/__init__.py | cut -d ' ' -f3)"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,7 @@ Internal changes
 * Version bumping and project triage is now handled by the Ouranos Helper GitHub App. (:pull:`1790`).
 * `netcdf4` has been pinned below v1.7 for test stability reasons. (:pull:`1791`).
 * `bump-my-version` has been updated to v0.23.0. (:pull:`1790`).
+* The Ouranos Helper GitHub App now provides verified commits. (:issue:`1811`, :pull:`1812`).
 
 v0.50.0 (2024-06-17)
 --------------------


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1811 
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Provides access to a GPG key with a verified email to the Helper Bot
* The Ouranos Helper Bot now signs commits for verification purposes

### Does this PR introduce a breaking change?

No. The Ouranos Helper Bot should now have verified commits!

### Other information:

This was a rather involved process:

* Managers of the Ouranos Helper Bot may create GPG keys for the provided support email (via the command line).
* This GPG key is set to expire eventually, so the administrator (myself or authors) may need to re-verify this email and regenerate GPG keys.
  * This support email can be verified by someone listed as a GitHub App Manager and associated with their personal account.
  * If ever this support email account changes owners, a new GPG key will need to be generated and the email account will need to re-associated with the new owner under their account emails (and re-verified).

For any other questions, feel free to ask.