### PR TITLE
Use CHANGELOG.rst instead of CHANGES.rst

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@
     - This PR fixes #xyz
 - [ ] Tests for the changes have been added (for bug fixes / features)
   - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
-- [ ] CHANGES.rst has been updated (with summary of main changes)
+- [ ] CHANGELOG.rst has been updated (with summary of main changes)
   - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added
 
 ### What kind of change does this PR introduce?

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -8,7 +8,7 @@ on:
       - .*
       - .github/*/*.md
       - .github/*/*.yml
-      - CHANGES.rst
+      - CHANGELOG.rst
       - CI/*.txt
       - Makefile
       - docs/*/*.ipynb

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths-ignore:
-      - CHANGES.rst
+      - CHANGELOG.rst
       - CI/*.txt
       - Makefile
       - pyproject.toml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths-ignore:
-      - CHANGES.rst
+      - CHANGELOG.rst
       - README.rst
       - pyproject.toml
       - xclim/__init__.py

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
     paths-ignore:
-      - CHANGES.rst
+      - CHANGELOG.rst
       - README.rst
       - pyproject.toml
       - xclim/__init__.py

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,10 +6,6 @@ v0.51.0 (unreleased)
 --------------------
 Contributors to this version: Trevor James Smith (:user:`Zeitsperre`), Pascal Bourgault (:user:`aulemahal`).
 
-Bug fixes
-^^^^^^^^^
-* Units of degree-days computations with Fahrenheit input fixed to yield "°R d". Added a new ``xclim.core.units.ensure_absolute_temperature`` method to convert from delta to absolute temperatures. (:issue:`1789`, :pull:`1804`).
-
 New features and enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 * Added the `op` keyword to the `growing_season_{start|end}` indices and indicators, allowing for customizable threshold operators using `indices.generic.compare()`. (:issue:`1794`, :pull:`1796`).
@@ -17,6 +13,7 @@ New features and enhancements
 
 Bug fixes
 ^^^^^^^^^
+* Units of degree-days computations with Fahrenheit input fixed to yield "°R d". Added a new ``xclim.core.units.ensure_absolute_temperature`` method to convert from delta to absolute temperatures. (:issue:`1789`, :pull:`1804`).
 * Clarified a typo in the docstring formula for `xclim.indices.growing_season_length`. (:pull:`1796`).
 
 Internal changes
@@ -24,6 +21,7 @@ Internal changes
 * `netcdf4` has been pinned below v1.7 for test stability reasons. (:pull:`1791`).
 * `flake8-bandit`-like checks have been enabled via `ruff`, with fixes for a few security-related issues. (:pull:`1806`).
 * ``xclim.testing.utils`` now employs more secure URL auditing checks. (:pull:`1806`).
+* `CHANGES.rst` has been renamed to `CHANGELOG.rst`, adhering to suggestions from the `keepachangelog v.1.1.0 <https://keepachangelog.com/en/1.1.0/>`_ specifications. (:pull:`1806`).
 
 CI changes
 ^^^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,7 +21,7 @@ Internal changes
 * `netcdf4` has been pinned below v1.7 for test stability reasons. (:pull:`1791`).
 * `flake8-bandit`-like checks have been enabled via `ruff`, with fixes for a few security-related issues. (:pull:`1806`).
 * ``xclim.testing.utils`` now employs more secure URL auditing checks. (:pull:`1806`).
-* `CHANGES.rst` has been renamed to `CHANGELOG.rst`, adhering to suggestions from the `keepachangelog v.1.1.0 <https://keepachangelog.com/en/1.1.0/>`_ specifications. (:pull:`1806`).
+* `CHANGES.rst` has been renamed to `CHANGELOG.rst`, adhering to suggestions from the `keepachangelog v.1.1.0 <https://keepachangelog.com/en/1.1.0/>`_ specifications. (:pull:`1823`).
 
 CI changes
 ^^^^^^^^^^

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -253,7 +253,7 @@ Before you submit a pull request, please follow these guidelines:
     Ensure that your changes pass all tests prior to pushing your final commits to your branch.
     Code formatting errors are treated as build errors and will block your pull request from being accepted.
 
-#. The version changes (CHANGES.rst) should briefly describe changes introduced in the Pull request. Changes should be organized by type (ie: `New indicators`, `New features and enhancements`, `Breaking changes`, `Bug fixes`, `Internal changes`) and the GitHub Pull Request, GitHub Issue. Your name and/or GitHub handle should also be listed among the contributors to this version. This can be done as follows::
+#. The version changes (CHANGELOG.rst) should briefly describe changes introduced in the Pull request. Changes should be organized by type (ie: `New indicators`, `New features and enhancements`, `Breaking changes`, `Bug fixes`, `Internal changes`) and the GitHub Pull Request, GitHub Issue. Your name and/or GitHub handle should also be listed among the contributors to this version. This can be done as follows::
 
      Contributors to this version: John Jacob Jingleheimer Schmidt (:user:`username`).
 
@@ -367,7 +367,7 @@ This section serves as a reminder for the maintainers on how to prepare the libr
 
 When a new version has been minted (features have been successfully integrated test coverage and stability is adequate), maintainers should update the pip-installable package (wheel and source release) on PyPI as well as the binary on conda-forge.
 
-From a new branch (e.g. `prepare-v123`), open a Pull Request and make sure all your changes to support a new version are committed (**update the entry for newest version in CHANGES.rst**), Then run::
+From a new branch (e.g. `prepare-v123`), open a Pull Request and make sure all your changes to support a new version are committed (**update the entry for newest version in CHANGELOG.rst**), Then run::
 
     $ bump-my-version bump <option>  # possible options: major / minor / patch / release / build
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,0 +1,1 @@
+.. include:: ../CHANGELOG.rst

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,1 +1,0 @@
-.. include:: ../CHANGES.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,7 +40,7 @@ Leveraging xarray and dask, users can easily bias-adjust climate simulations ove
    :titlesonly:
 
    authors
-   changes
+   changelog
    security
    references
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,7 +184,7 @@ DEP004 = ["matplotlib", "pytest_socket"]
 [tool.flit.sdist]
 include = [
   "AUTHORS.rst",
-  "CHANGES.rst",
+  "CHANGELOG.rst",
   "CI/requirements_upstream.txt",
   "CITATION.cff",
   "CONTRIBUTING.rst",

--- a/xclim/testing/utils.py
+++ b/xclim/testing/utils.py
@@ -504,7 +504,7 @@ def publish_release_notes(
     if isinstance(changes, (str, Path)):
         changes_file = Path(changes).absolute()
     else:
-        changes_file = Path(__file__).absolute().parents[2].joinpath("CHANGES.rst")
+        changes_file = Path(__file__).absolute().parents[2].joinpath("CHANGELOG.rst")
 
     if not changes_file.exists():
         raise FileNotFoundError("Changelog file not found in xclim folder tree.")


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGES.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* CHANGES.rst is now CHANGELOG.rst

### Does this PR introduce a breaking change?

No. 

### Other information:

This change is to help synchronize the standards used across our GitHub projects.

https://keepachangelog.com/en/1.1.0/