### PR TITLE
Apply SciPy-like repository suggestions

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,21 +1,25 @@
-* xclim version:
-* Python version:
-* Operating System:
+- xclim version:
+- Python version:
+- Operating System:
 
 ### Description
+
 <!--Describe what you were trying to get done.
 Tell us what happened, what went wrong, and what you expected to happen.-->
 
-
 ### What I Did
+
 <!--Paste the command(s) you ran and the output.
 If there was a crash, please include the traceback below.-->
+
 ```
 $ pip install foo --bar
 ```
 
 ### What I Received
+
 <!--Paste the output or the stack trace of the problem you experienced here.-->
+
 ```
 Traceback (most recent call last):
   File "/path/to/file/script.py", line 3326, in run_code

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,13 +3,19 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
       time: '12:00'
-    open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: pip
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
       time: '12:00'
-    open-pull-requests-limit: 5
+    groups:
+      python:
+        patterns:
+          - "*"

--- a/.github/publish-mastodon-template.md
+++ b/.github/publish-mastodon-template.md
@@ -2,3 +2,4 @@ New #xclim release: {{ .version }} 🎉
 
 Latest source code available at: https://github.com/Ouranosinc/xclim/releases/tag/{{ .version }}
 Check out the docs for more information: https://xclim.readthedocs.io/en/stable/
+

--- a/.github/publish-mastodon-template.md
+++ b/.github/publish-mastodon-template.md
@@ -2,4 +2,3 @@ New #xclim release: {{ .version }} 🎉
 
 Latest source code available at: https://github.com/Ouranosinc/xclim/releases/tag/{{ .version }}
 Check out the docs for more information: https://xclim.readthedocs.io/en/stable/
-

--- a/.github/workflows/publish-mastodon.yml
+++ b/.github/workflows/publish-mastodon.yml
@@ -70,7 +70,7 @@ jobs:
         id: render_template
         uses: chuhlomin/render-template@807354a04d9300c9c2ac177c0aa41556c92b3f75 # v1.10
         with:
-          template: .github/publish-mastodon.template.md
+          template: .github/publish-mastodon-template.md
           vars: |
             version: ${{ env.version }}
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,7 +85,7 @@ repos:
     rev: 0.7.17
     hooks:
       - id: mdformat
-        exclude: '.github/\w+.md|docs/paper/paper.md'
+        exclude: '.github/\w+.md|.github/publish-mastodon-template.md|docs/paper/paper.md'
   - repo: https://github.com/keewis/blackdoc
     rev: v0.3.9
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,15 +36,11 @@ repos:
     rev: 24.8.0
     hooks:
       - id: black
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.6.3
     hooks:
       - id: ruff
-        args: [ '--fix' ]
+        args: [ '--fix', '--show-fixes' ]
   - repo: https://github.com/pylint-dev/pylint
     rev: v3.2.7
     hooks:
@@ -68,20 +64,34 @@ repos:
         additional_dependencies: [ 'pyupgrade==3.16.0' ]
       - id: nbqa-black
         additional_dependencies: [ 'black==24.4.2' ]
-      - id: nbqa-isort
-        additional_dependencies: [ 'isort==5.13.2' ]
   - repo: https://github.com/kynan/nbstripout
     rev: 0.7.1
     hooks:
       - id: nbstripout
         files: '.ipynb'
         args: [ '--extra-keys', 'metadata.kernelspec' ]
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.10.0
+    hooks:
+#      - id: python-check-blanket-noqa
+#      - id: python-check-blanket-type-ignore
+      - id: python-no-eval
+      - id: python-no-log-warn
+      - id: python-use-type-annotations
+      - id: rst-directive-colons
+      - id: rst-inline-touching-normal
+      - id: text-unicode-replacement-char
+  - repo: https://github.com/executablebooks/mdformat
+    rev: 0.7.17
+    hooks:
+      - id: mdformat
   - repo: https://github.com/keewis/blackdoc
     rev: v0.3.9
     hooks:
       - id: blackdoc
-        additional_dependencies: [ 'black==24.4.2' ]
+        additional_dependencies: [ 'black==24.8.0' ]
         exclude: '(xclim/indices/__init__.py|docs/installation.rst)'
+      - id: blackdoc-autoupdate-black
   - repo: https://github.com/codespell-project/codespell
     rev: v2.3.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
-        exclude: '.ipynb|.github/publish-mastodon.template.md'
+        exclude: '.ipynb|.github/publish-mastodon-template.md'
       - id: check-json
       - id: check-toml
       - id: check-yaml
@@ -85,6 +85,7 @@ repos:
     rev: 0.7.17
     hooks:
       - id: mdformat
+        exclude: '.github/\w+.md|docs/paper/paper.md'
   - repo: https://github.com/keewis/blackdoc
     rev: v0.3.9
     hooks:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -355,7 +355,7 @@ New features and enhancements
     * Optimized and noticeably faster calculation.
     * Can be computed in two steps: first compute fit parameters with ``xclim.indices.stats.standardized_index_fit_params``, then use the output in the standardized indices functions.
     * The standardized index values are now clipped to ±8.21. This reflects the ``float64`` precision of the computation when cumulative distributed function values are inverted to a normal distribution and avoids returning infinite values.
-    * An offset parameter is now available to account for negative water balance values``xclim.indices.standardized_precipitation_evapotranspiration_index``.
+    * An offset parameter is now available to account for negative water balance values ``xclim.indices.standardized_precipitation_evapotranspiration_index``.
 
 Bug fixes
 ^^^^^^^^^
@@ -1428,7 +1428,7 @@ New features and enhancements
 Breaking changes
 ^^^^^^^^^^^^^^^^
 * The `tropical_nights` indice is being deprecated in favour of `tn_days_above` with ``thresh="20 degC"``. The indicator remains valid, now wrapping this new indice.
-* Results of ``sdba.Grouper.apply`` for ``Grouper``s without a group (ex: ``Grouper('time')``) will contain a ``group`` singleton dimension.
+* Results of ``sdba.Grouper.apply`` for ``Grouper`` without a group (ex: ``Grouper('time')``) will contain a ``group`` singleton dimension.
 * The `daily_freezethaw_cycles` indice is being deprecated in favour of ``multiday_temperature_swing`` with temp thresholds at 0 degC and ``window=1, op="sum"``. The indicator remains valid, now wrapping this new indice.
 * CMIP6 variable names have been adopted whenever possible in xclim. Changes are:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -39,6 +39,12 @@ Internal changes
 * The codebase has been adjusted to address many `pylint`-related warnings and errors. In some cases, `casting` was used to redefine some `numpy` and `xarray` objects. (:issue:`1719`, :pull:`1881`).
 * ``xclim.core`` now uses absolute imports for clarity and some objects commonly used in the module have been moved to hidden submodules. (:issue:`1719`, :pull:`1881`).
 * ``xclim.core.indicator.Parameter`` has a new attribute ``compute_name`` while ``xclim.core.indicator.Indicator`` lost its ``_variable_mapping``. The translation from parameter (and variable) names in the indicator to the names on the compute function is handled by ``Indicator._get_compute_args``. (:pull:`1885`).
+* Adopted many linting and formatting suggestions from the Scientific Python `repo-review <https://github.com/scientific-python/repo-review>`_ tool: (:pull:`1910`)
+    * Applied several linting suggestions adopted by the `scipy` community.
+    * Replaced `isort` with `ruff`-based import-sorting formatting.
+    * Added formatting for `Markdown` files.
+    * Added the `bugbear`, `pyupgrade` checks to the `ruff` formatter.
+    * Adjusted `mypy` checks to be more standardized.
 
 CI changes
 ^^^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,12 +21,9 @@ Bug fixes
 
 Breaking changes
 ^^^^^^^^^^^^^^^^
-* `transform` argument of `OTC/dOTC` classes (and child functions) is changed to `normalization`, and `numIterMax` is changed to `num_iter_max` in `utils.optimal_transport` (:pull:`1896`).
-
-Breaking changes
-^^^^^^^^^^^^^^^^
 * `platformdirs` is no longer a direct dependency of `xclim`, but `pooch` is required to use many of the new testing functions (installable via `pip install pooch` or `pip install 'xclim[dev]'`). (:pull:`1889`).
 * The following previously-deprecated functions have now been removed from `xclim`: ``xclim.core.calendar.convert_calendar``, ``xclim.core.calendar.date_range``, ``xclim.core.calendar.date_range_like``, ``xclim.core.calendar.interp_calendar``, ``xclim.core.calendar.days_in_year``, ``xclim.core.calendar.datetime_to_decimal_year``. For guidance on how to migrate to alternatives, see the `version 0.50.0 Breaking changes <#v0-50-0-2024-06-17>`_. (:issue:`1010`, :pull:`1845`).
+* `transform` argument of `OTC/dOTC` classes (and child functions) is changed to `normalization`, and `numIterMax` is changed to `num_iter_max` in `utils.optimal_transport` (:pull:`1896`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^
@@ -46,6 +43,7 @@ Internal changes
 CI changes
 ^^^^^^^^^^
 * The `pip` cache, `tox` environments, and the `xclim-testdata` cache are now saved between workflow runs (using `actions/cache`) to reduce the time spent installing dependencies and downloading testing data. (:pull:`1906`).
+
 v0.52.2 (2024-09-16)
 --------------------
 Contributors to this version: Pascal Bourgault (:user:`aulemahal`).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -17,23 +17,23 @@ diverse, inclusive, and healthy community.
 Examples of behavior that contributes to a positive environment for our
 community include:
 
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes,
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
   and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the
+- Focusing on what is best not just for us as individuals, but for the
   overall community
 
 Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery, and sexual attention or
+- The use of sexualized language or imagery, and sexual attention or
   advances of any kind
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or email
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
   address, without their explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
+- Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
 ## Enforcement Responsibilities
@@ -121,8 +121,8 @@ https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
 Community Impact Guidelines were inspired by [Mozilla's code of conduct
 enforcement ladder](https://github.com/mozilla/diversity).
 
-[homepage]: https://www.contributor-covenant.org
-
 For answers to common questions about this code of conduct, see the FAQ at
 https://www.contributor-covenant.org/faq. Translations are available at
 https://www.contributor-covenant.org/translations.
+
+[homepage]: https://www.contributor-covenant.org

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,6 @@ clean-test: ## remove test and coverage artifacts
 
 lint: ## check style with flake8 and black
 	black --check xclim tests
-	isort --check xclim tests
 	ruff check xclim tests
 	flake8 --config=.flake8 xclim tests
 	vulture xclim tests

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,27 +12,29 @@ Please follow these steps to report a security vulnerability:
 
 1. **Email**: Email [github-support@ouranos.ca](mailto:github-support@ouranos.ca) with a detailed description of the vulnerability. If applicable, please include any steps or a proof-of-concept to help us understand and reproduce the issue.
 
-2. **Encryption (Optional)**: If you are concerned about the sensitivity of the information you are sharing, you can use the PGP key found below to encrypt your communication.
+1. **Encryption (Optional)**: If you are concerned about the sensitivity of the information you are sharing, you can use the PGP key found below to encrypt your communication.
 
-3. **Response**: We will acknowledge your email within 48 hours and work with you to understand and confirm the vulnerability.
+1. **Response**: We will acknowledge your email within 48 hours and work with you to understand and confirm the vulnerability.
 
-4. **Fix and Disclosure**: Once the vulnerability is confirmed, we will work to address it promptly. We appreciate your patience as we investigate and implement a fix. Once resolved, we will coordinate the disclosure and provide credit to the reporter unless they prefer to remain anonymous.
+1. **Fix and Disclosure**: Once the vulnerability is confirmed, we will work to address it promptly. We appreciate your patience as we investigate and implement a fix. Once resolved, we will coordinate the disclosure and provide credit to the reporter unless they prefer to remain anonymous.
 
 ## PGP Encryption Key
 
 You can use the following PGP key to encrypt your communications with us:
 
-    -----BEGIN PGP PUBLIC KEY BLOCK-----
+```
+-----BEGIN PGP PUBLIC KEY BLOCK-----
 
-    mDMEZamQrhYJKwYBBAHaRw8BAQdA+saPvmvr1MYe1nQy3n3QDcRE9T7UzTJ1XH31
-    EI4Zb6u0Mk91cmFub3MgR2l0SHViIFN1cHBvcnQgPGdpdGh1Yi1zdXBwb3J0QG91
-    cmFub3MuY2E+iJkEExYKAEEWIQSeAu+Cbjupx79jy9VeVFD6o5TVcwUCZamQrgIb
-    AwUJCWYBgAULCQgHAgIiAgYVCgkICwIEFgIDAQIeBwIXgAAKCRBeVFD6o5TVc4ho
-    AQDXjDkx0b3A7yl6PQ4hBJ2uYzw0UWbml7mUwVdhMmdZkQD/VJZQNWrCQeOtYEM8
-    icZJYwR/OsKFOWqlDytusGGtjwa4OARlqZCuEgorBgEEAZdVAQUBAQdAa41Zabjz
-    P9O+p6tI69Cnft6U5om3+qCcMo8amTqauH0DAQgHiH4EGBYKACYWIQSeAu+Cbjup
-    x79jy9VeVFD6o5TVcwUCZamQrgIbDAUJCWYBgAAKCRBeVFD6o5TVcwmaAQClDxW6
-    2gir7lhRXAcO+vmRImpGd29TrkcQVh+ak7VlwQEA706d7Kusiorlf/h8pLSoNMmS
-    kuLGmHpUJ8NVGppU+wo=
-    =wuxr
-    -----END PGP PUBLIC KEY BLOCK-----
+mDMEZamQrhYJKwYBBAHaRw8BAQdA+saPvmvr1MYe1nQy3n3QDcRE9T7UzTJ1XH31
+EI4Zb6u0Mk91cmFub3MgR2l0SHViIFN1cHBvcnQgPGdpdGh1Yi1zdXBwb3J0QG91
+cmFub3MuY2E+iJkEExYKAEEWIQSeAu+Cbjupx79jy9VeVFD6o5TVcwUCZamQrgIb
+AwUJCWYBgAULCQgHAgIiAgYVCgkICwIEFgIDAQIeBwIXgAAKCRBeVFD6o5TVc4ho
+AQDXjDkx0b3A7yl6PQ4hBJ2uYzw0UWbml7mUwVdhMmdZkQD/VJZQNWrCQeOtYEM8
+icZJYwR/OsKFOWqlDytusGGtjwa4OARlqZCuEgorBgEEAZdVAQUBAQdAa41Zabjz
+P9O+p6tI69Cnft6U5om3+qCcMo8amTqauH0DAQgHiH4EGBYKACYWIQSeAu+Cbjup
+x79jy9VeVFD6o5TVcwUCZamQrgIbDAUJCWYBgAAKCRBeVFD6o5TVcwmaAQClDxW6
+2gir7lhRXAcO+vmRImpGd29TrkcQVh+ak7VlwQEA706d7Kusiorlf/h8pLSoNMmS
+kuLGmHpUJ8NVGppU+wo=
+=wuxr
+-----END PGP PUBLIC KEY BLOCK-----
+```

--- a/docs/notebooks/benchmarks/sdba_quantile.ipynb
+++ b/docs/notebooks/benchmarks/sdba_quantile.ipynb
@@ -106,7 +106,7 @@
     "    for size in np.arange(250, 2000 + 250, 250):\n",
     "        da = tx.isel(time=slice(0, size))\n",
     "        t0 = time.time()\n",
-    "        for ii in range(num_tests):\n",
+    "        for _i in range(num_tests):\n",
     "            sdba.nbutils.quantile(da, **kws).compute()\n",
     "        timed[use_fnq].append([size, time.time() - t0])\n",
     "\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,11 +224,13 @@ exclude = [
 ]
 
 [tool.mypy]
-python_version = 3.9
-show_error_codes = true
-warn_return_any = true
-warn_unused_configs = true
+python_version = "3.9"
+enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 plugins = ["numpy.typing.mypy_plugin"]
+strict = true
+warn_return_any = true
+warn_unreachable = true
+warn_unused_configs = true
 
 [[tool.mypy.overrides]]
 module = [
@@ -247,13 +249,18 @@ module = [
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]
+minversion = "7.0"
 addopts = [
+  "-ra",
   "--verbose",
   "--color=yes",
   "--numprocesses=0",
   "--maxprocesses=8",
-  "--dist=worksteal"
+  "--dist=worksteal",
+  "--strict-config",
+  "--strict-markers"
 ]
+log_cli_level = "INFO"
 norecursedirs = ["docs/notebooks/*"]
 filterwarnings = ["ignore::UserWarning"]
 testpaths = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -252,7 +252,6 @@ ignore_missing_imports = true
 minversion = "7.0"
 addopts = [
   "-ra",
-  "--verbose",
   "--color=yes",
   "--numprocesses=0",
   "--maxprocesses=8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,12 +223,6 @@ exclude = [
   "pylintrc"
 ]
 
-[tool.isort]
-profile = "black"
-py_version = 39
-append_only = true
-add_imports = "from __future__ import annotations"
-
 [tool.mypy]
 python_version = 3.9
 show_error_codes = true
@@ -275,7 +269,6 @@ markers = [
 [tool.ruff]
 src = ["xclim"]
 line-length = 150
-target-version = "py39"
 exclude = [
   ".git",
   "build",
@@ -296,18 +289,22 @@ extend-select = [
   "RUF022" # unsorted-dunder-all
 ]
 ignore = [
+  "B028", # no-explicit-stacklevel
   "D205", # blank-line-after-summary
   "D400", # ends-in-period
   "D401" # non-imperative-mood
 ]
 preview = true
 select = [
+  "B", # bugbear
   "C90", # mccabe-complexity
   "D", # docstrings
   "E", # pycodestyle errors
   "F", # pyflakes
+  "I", # imports
   "N802", # invalid-function-name
   "S", # bandit
+  "UP", # pyupgrade
   "W" # pycodestyle warnings
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -327,11 +327,11 @@ scipy = "sp"
 xarray = "xr"
 
 [tool.ruff.lint.isort]
-known-first-party = ["xclim"]
 case-sensitive = true
 detect-same-package = false
-lines-after-imports = 2
-no-lines-before = ["future", "standard-library"]
+known-first-party = ["xclim"]
+no-lines-before = ["future"]
+required-imports = ["from __future__ import annotations"]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 20

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -272,6 +272,7 @@ markers = [
   "requires_docs: mark tests that can only be run with documentation present (deselect with '-m \"not requires_docs\"')",
   "requires_internet: mark tests that require internet access (deselect with '-m \"not requires_internet\"')"
 ]
+xfail_strict = true
 
 [tool.ruff]
 src = ["xclim"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,10 +23,10 @@ from xclim.testing.utils import (
     TESTDATA_REPO_URL,
     default_testdata_cache,
     gather_testing_data,
+    testing_setup_warnings,
 )
 from xclim.testing.utils import nimbus as _nimbus
 from xclim.testing.utils import open_dataset as _open_dataset
-from xclim.testing.utils import testing_setup_warnings
 
 
 @pytest.fixture

--- a/tests/test_analog.py
+++ b/tests/test_analog.py
@@ -256,7 +256,7 @@ class TestKLDIV:
 
         out = []
         n = 500
-        for i in range(500):
+        for _i in range(500):
             out.append(
                 xca.kldiv(
                     p.rvs(n, random_state=random), q.rvs(n, random_state=random), k=k

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -43,7 +43,7 @@ def test_indices():
     runner = CliRunner()
     results = runner.invoke(cli, ["indices"])
 
-    for name, ind in xclim.core.indicator.registry.items():
+    for name in xclim.core.indicator.registry:
         assert name.lower() in results.output
 
 

--- a/tests/test_locales.py
+++ b/tests/test_locales.py
@@ -143,7 +143,7 @@ def test_xclim_translations(locale, official_indicators):
             continue
         # Both global attrs are present
         is_complete = {"title", "abstract"}.issubset(set(trans))
-        for attrs, transattrs in zip(indcls.cf_attrs, trans["cf_attrs"]):
+        for _attrs, transattrs in zip(indcls.cf_attrs, trans["cf_attrs"]):
             if {"long_name", "description"} - set(transattrs.keys()):
                 is_complete = False
 

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -269,9 +269,8 @@ class TestOfficialYaml(yamale.YamaleTestCase):
 # It's not really slow, but this is an unstable test (when it fails) and we might not want to execute it on all builds
 @pytest.mark.slow
 def test_encoding():
-    import sys
-
     import _locale
+    import sys
 
     # remove xclim
     del sys.modules["xclim"]

--- a/tests/test_run_length.py
+++ b/tests/test_run_length.py
@@ -95,7 +95,7 @@ def ufunc(request):
 @pytest.mark.parametrize("index", ["first", "last"])
 def test_rle(ufunc, use_dask, index):
     if use_dask and ufunc:
-        pytest.xfail("rle_1d is not implemented for dask arrays.")
+        pytest.skip("rle_1d is not implemented for dask arrays.")
 
     values = np.zeros((10, 365, 4, 4))
     time = pd.date_range("2000-01-01", periods=365, freq="D")

--- a/tests/test_sdba/test_adjustment.py
+++ b/tests/test_sdba/test_adjustment.py
@@ -242,6 +242,7 @@ class TestDQM:
     @pytest.mark.xfail(
         raises=ValueError,
         reason="This test sometimes fails due to a block/indexing error",
+        strict=False,
     )
     @pytest.mark.parametrize("kind,name", [(ADDITIVE, "tas"), (MULTIPLICATIVE, "pr")])
     @pytest.mark.parametrize("add_dims", [True, False])

--- a/tests/test_sdba/test_loess.py
+++ b/tests/test_sdba/test_loess.py
@@ -5,12 +5,14 @@ import pandas as pd
 import pytest
 import xarray as xr
 
-from xclim.sdba.loess import _constant_regression  # noqa
-from xclim.sdba.loess import _gaussian_weighting  # noqa
-from xclim.sdba.loess import _linear_regression  # noqa
-from xclim.sdba.loess import _loess_nb  # noqa
-from xclim.sdba.loess import _tricube_weighting  # noqa
-from xclim.sdba.loess import loess_smoothing
+from xclim.sdba.loess import (
+    _constant_regression,  # noqa
+    _gaussian_weighting,  # noqa
+    _linear_regression,  # noqa
+    _loess_nb,  # noqa
+    _tricube_weighting,  # noqa
+    loess_smoothing,
+)
 
 
 @pytest.mark.slow

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -252,13 +252,11 @@ def test_amount2lwethickness(snw_series):
     snw = snw_series(np.ones(365), start="2019-01-01")
 
     swe = amount2lwethickness(snw, out_units="mm")
-    # FIXME: Asserting these statements shows that they are not equal
-    assert swe.attrs["standard_name"] == "lwe_thickness_of_snowfall_amount"
+    assert swe.attrs["standard_name"] == "lwe_thickness_of_surface_snow_amount"
     np.testing.assert_allclose(swe, 1)
 
     snw = lwethickness2amount(swe)
-    # FIXME: Asserting these statements shows that they are not equal
-    assert snw.attrs["standard_name"] == "snowfall_amount"
+    assert snw.attrs["standard_name"] == "surface_snow_amount"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -253,12 +253,12 @@ def test_amount2lwethickness(snw_series):
 
     swe = amount2lwethickness(snw, out_units="mm")
     # FIXME: Asserting these statements shows that they are not equal
-    swe.attrs["standard_name"] == "lwe_thickness_of_snowfall_amount"
+    assert swe.attrs["standard_name"] == "lwe_thickness_of_snowfall_amount"
     np.testing.assert_allclose(swe, 1)
 
     snw = lwethickness2amount(swe)
     # FIXME: Asserting these statements shows that they are not equal
-    snw.attrs["standard_name"] == "snowfall_amount"
+    assert snw.attrs["standard_name"] == "snowfall_amount"
 
 
 @pytest.mark.parametrize(

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,6 @@ deps =
     flake8-rst-docstrings
     black[jupyter]==24.4.2
     blackdoc==0.3.9
-    isort==5.13.2
     nbqa
     ruff==0.4.10
     vulture==2.11
@@ -44,7 +43,6 @@ deps =
 commands_pre =
 commands =
     black --check xclim tests
-    isort --check xclim tests
     ruff check xclim tests
     flake8 --config=.flake8 xclim tests
     vulture xclim tests

--- a/xclim/cli.py
+++ b/xclim/cli.py
@@ -104,7 +104,7 @@ def _process_indicator(indicator, ctx, **params):
     try:
         out = indicator(**params)
     except MissingVariableError as err:
-        raise click.BadArgumentUsage(err.args[0])
+        raise click.BadArgumentUsage(err.args[0]) from err
 
     if isinstance(out, tuple):
         dsout = dsout.assign(**{var.name: var for var in out})

--- a/xclim/core/indicator.py
+++ b/xclim/core/indicator.py
@@ -104,17 +104,17 @@ import re
 import warnings
 import weakref
 from collections import OrderedDict, defaultdict
+from collections.abc import Sequence
 from copy import deepcopy
 from dataclasses import asdict, dataclass
 from functools import reduce
 from inspect import Parameter as _Parameter
-from inspect import Signature
+from inspect import Signature, signature
 from inspect import _empty as _empty_default  # noqa
-from inspect import signature
 from os import PathLike
 from pathlib import Path
 from types import ModuleType
-from typing import Any, Callable, Optional, Sequence, Union
+from typing import Any, Callable, Optional, Union
 
 import numpy as np
 import xarray

--- a/xclim/core/units.py
+++ b/xclim/core/units.py
@@ -1271,7 +1271,7 @@ def declare_relative_units(**units_by_name) -> Callable:
 
             return out
 
-        setattr(wrapper, "relative_units", units_by_name)
+        wrapper.relative_units = units_by_name
         return wrapper
 
     return dec
@@ -1351,7 +1351,7 @@ def declare_units(**units_by_name) -> Callable:
 
             return out
 
-        setattr(wrapper, "in_units", units_by_name)
+        wrapper.in_units = units_by_name
         return wrapper
 
     return dec

--- a/xclim/sdba/processing.py
+++ b/xclim/sdba/processing.py
@@ -771,7 +771,7 @@ def stack_variables(ds: xr.Dataset, rechunk: bool = True, dim: str = "multivar")
     # sort to have coherent order with different datasets
     data_vars = sorted(ds.data_vars.items(), key=lambda e: e[0])
     nvar = len(data_vars)
-    for i, (nm, var) in enumerate(data_vars):
+    for i, (_nm, var) in enumerate(data_vars):
         for name, attr in var.attrs.items():
             attrs.setdefault(f"_{name}", [None] * nvar)[i] = attr
 

--- a/xclim/testing/conftest.py
+++ b/xclim/testing/conftest.py
@@ -20,10 +20,10 @@ from xclim.testing.utils import (
     TESTDATA_CACHE_DIR,
     TESTDATA_REPO_URL,
     gather_testing_data,
+    testing_setup_warnings,
 )
 from xclim.testing.utils import nimbus as _nimbus
 from xclim.testing.utils import open_dataset as _open_dataset
-from xclim.testing.utils import testing_setup_warnings
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/xclim/testing/utils.py
+++ b/xclim/testing/utils.py
@@ -247,7 +247,8 @@ def publish_release_notes(
             r":user:`([a-zA-Z0-9_.-]+)`": r"[@\1](https://github.com/\1)",
         }
     else:
-        raise NotImplementedError()
+        msg = f"Formatting style not supported: {style}"
+        raise NotImplementedError(msg)
 
     for search, replacement in hyperlink_replacements.items():
         changes = re.sub(search, replacement, changes)
@@ -573,11 +574,9 @@ def open_dataset(
             return _open_dataset(audit_url(dap_target, context="OPeNDAP"), **kwargs)
         except URLError:
             raise
-        except OSError:
-            raise OSError(
-                "OPeNDAP file not read. Verify that the service is available: %s"
-                % dap_target
-            )
+        except OSError as err:
+            msg = f"OPeNDAP file not read. Verify that the service is available: {dap_target}"
+            raise OSError(msg) from err
 
     local_file = Path(cache_dir).joinpath(name)
     if not local_file.exists():
@@ -585,11 +584,9 @@ def open_dataset(
             local_file = nimbus(branch=branch, repo=repo, cache_dir=cache_dir).fetch(
                 name
             )
-        except OSError:
-            raise OSError(
-                "File not found locally. Verify that the testing data is available in remote: %s"
-                % local_file
-            )
+        except OSError as err:
+            msg = f"File not found locally. Verify that the testing data is available in remote: {local_file}"
+            raise OSError(msg) from err
     try:
         ds = _open_dataset(local_file, **kwargs)
         return ds
@@ -633,13 +630,13 @@ def populate_testing_data(
             msg = f"File `{file}` not accessible in remote repository."
             logging.error(msg)
             errored_files.append(file)
-        except SocketBlockedError as e:  # noqa
+        except SocketBlockedError as err:  # noqa
             msg = (
                 "Unable to access registry file online. Testing suite is being run with `--disable-socket`. "
                 "If you intend to run tests with this option enabled, please download the file beforehand with the "
                 "following console command: `$ xclim prefetch_testing_data`."
             )
-            raise SocketBlockedError(msg) from e
+            raise SocketBlockedError(msg) from err
         else:
             logging.info("Files were downloaded successfully.")
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGELOG.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Applies several linting suggestions adopted by the `scipy` community
* Replaces `isort` with `ruff` formatting
* Adds Markdown file formatting
* Adds a few strongly encouraged `ruff` checks (`bugbear`, `pyupgrade`)
* Adjust `mypy` checks

### Does this PR introduce a breaking change?

Yes. `isort` is no longer required. Code checks are marginally stricter.

### Other information:

https://github.com/scientific-python/repo-review

If we wanted to replace `black` as well, this is feasible with `ruff`, as it nearly replicates its functionality 1-to-1. To be revisited.

I've staged the `python-check-blanket-noqa` and `python-check-blanket-type-ignore` hooks since there are several instances where these won't work (`numba`-based code blocks). These statements should be followed up on at some point, likely when we address more things with `mypy`.

Repo checks:
```
(xclim) ~/git/xclim git:[repo-suggestions]
python -m repo_review
General:

 • Detected build backend: flit_core.buildapi                                                                                                                                                                                    
 • Detected license(s): Apache Software License                                                                                                                                                                                  

├── PY001 Has a pyproject.toml ✅
├── PY002 Has a README.(md|rst) file ✅
├── PY003 Has a LICENSE* file ✅
├── PY004 Has docs folder ✅
├── PY005 Has tests folder ✅
├── PY006 Has pre-commit config ✅
└── PY007 Supports an easy task runner (nox or tox) ✅

PyProject:
├── PP002 Has a proper build-system table ✅
├── PP003 Does not list wheel as a build-dep ✅
├── PP301 Has pytest in pyproject ✅
├── PP302 Sets a minimum pytest to at least 6 ✅
├── PP303 Sets the test paths ✅
├── PP304 Sets the log level in pytest ✅
├── PP305 Specifies xfail_strict ✅                                                                                                                                                                                                                       
├── PP306 Specifies strict config ✅
├── PP307 Specifies strict markers ✅
├── PP308 Specifies useful pytest summary ✅
└── PP309 Filter warnings specified ✅

GitHub Actions:
├── GH100 Has GitHub Actions config ✅
├── GH101 Has nice names ✅
├── GH102 Auto-cancel on repeated PRs ✅
├── GH103 At least one workflow with manual dispatch trigger ✅
├── GH104 Use unique names for upload-artifact ✅
├── GH200 Maintained by Dependabot ✅
├── GH210 Maintains the GitHub action versions with Dependabot ✅
├── GH211 Do not pin core actions as major versions ✅
└── GH212 Require GHA update grouping ✅

Pre-commit:
├── PC100 Has pre-commit-hooks ✅
├── PC110 Uses black or ruff-format ✅
├── PC111 Uses blacken-docs ❌
│   Must have https://github.com/adamchainz/blacken-docs in .pre-commit-config.yaml                                                                                                                                              
├── PC140 Uses a type checker ❌
│   Must have https://github.com/pre-commit/mirrors-mypy in .pre-commit-config.yaml                                                                                                                                              
├── PC160 Uses a spell checker ✅
├── PC170 Uses PyGrep hooks (only needed if rST present) ✅
├── PC180 Uses a markdown formatter ✅
├── PC190 Uses Ruff ✅
├── PC191 Ruff show fixes if fixes enabled ✅
└── PC901 Custom pre-commit CI message ✅

MyPy:
├── MY100 Uses MyPy (pyproject config) ✅
├── MY101 MyPy strict mode ✅
├── MY102 MyPy show_error_codes deprecated ✅
├── MY103 MyPy warn unreachable ✅
├── MY104 MyPy enables ignore-without-code ✅
├── MY105 MyPy enables redundant-expr ✅
└── MY106 MyPy enables truthy-bool ✅

Ruff:
├── RF001 Has Ruff config ✅
├── RF002 Target version must be set ✅
├── RF003 src directory doesn't need to be specified anymore (0.6+) [skipped]
├── RF101 Bugbear must be selected ✅
├── RF102 isort must be selected ✅
├── RF103 pyupgrade must be selected ✅
├── RF201 Avoid using deprecated config settings ✅
└── RF202 Use (new) lint config section ✅

Documentation:
├── RTD100 Uses ReadTheDocs (pyproject config) ✅
├── RTD101 You have to set the RTD version number to 2 ✅
├── RTD102 You have to set the RTD build image ✅
└── RTD103 You have to set the RTD python version ✅
```