### PR TITLE
include statistics indices in documentation, cleanup docstrings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -232,8 +232,7 @@ nbsphinx_allow_errors = False
 templates_path = ["_templates"]
 
 # The suffix(es) of source filenames.
-# If a list of string, all suffixes will be understood as restructured text variants.
-source_suffix = [".rst"]
+source_suffix = {".rst": "restructuredtext", ".md": "markdown"}
 
 # The root toctree document.
 root_doc = "index"

--- a/docs/indices.rst
+++ b/docs/indices.rst
@@ -55,6 +55,11 @@ Indices submodules
    :undoc-members:
    :show-inheritance:
 
+.. automodule:: xclim.indices.stats
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Fire indices submodule
 ^^^^^^^^^^^^^^^^^^^^^^
 Indices related to fire and fire weather. Currently, submodules exist for calculating indices from the Canadian Forest Fire Weather Index System and the McArthur Forest Fire Danger (Mark 5) System. All fire indices can be accessed from the :py:mod:`xclim.indices` module.


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1913 
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] CHANGELOG.rst has been updated (with summary of main changes)
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Adds the `xclim.indices.stats` module to the `indices` documentation
* Updates the `source_suffix` entry to be consistent with changes to `Sphinx`

### Does this PR introduce a breaking change?

No.

### Other information:

I made some light changes to the docstrings, but there are a lot of violations of `numpydoc` standard in general throughout the library. Will be opening another PR to address these.