### PR TITLE
Fix subdaily rate2amount,  add hydro transformation from lwe thickness to amount

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,8 @@ New features and enhancements
 
 Bug fixes
 ^^^^^^^^^
+* Fixed ``rate2amount`` and ``amount2rate`` for sub-daily frequencies. (:issue:`1962`, :pull:`1963`).
+* Added the liquid water equivalent thickness ("[length]") to amount ("[mass]/[area]") transformation to the ``hydro`` context (the inverse operation was already there). (:pull:`1963`).
 * Fixed a small inefficiency in ``_otc_adjust``, and the `standardize` method of `OTC/dOTC` is now applied on individual variable  (:pull:`1890`, :pull:`1896`).
 * Remove deprecated cells in the tutorial notebook `sdba.ipynb` (:pull:`1895`).
 

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -234,6 +234,20 @@ def test_rate2amount(pr_series):
         np.testing.assert_array_equal(am_ys, 86400 * np.array([365, 366, 365]))
 
 
+@pytest.mark.parametrize(
+    "srcfreq, exp", [("h", 3600), ("min", 60), ("s", 1), ("ns", 1e-9)]
+)
+def test_rate2amount_subdaily(srcfreq, exp):
+    pr = xr.DataArray(
+        np.ones(1000),
+        dims=("time",),
+        coords={"time": xr.date_range("2019-01-01", periods=1000, freq=srcfreq)},
+        attrs={"units": "kg m-2 s-1"},
+    )
+    am = rate2amount(pr)
+    np.testing.assert_array_equal(am, exp)
+
+
 def test_amount2rate(pr_series):
     pr = pr_series(np.ones(365 + 366 + 365), start="2019-01-01")
     am = rate2amount(pr)

--- a/xclim/core/units.py
+++ b/xclim/core/units.py
@@ -91,6 +91,11 @@ hydro.add_transformation(
     lambda ureg, x: x / (1000 * ureg.kg / ureg.m**3),
 )
 hydro.add_transformation(
+    "[length]",
+    "[mass] / [length]**2",
+    lambda ureg, x: x * (1000 * ureg.kg / ureg.m**3),
+)
+hydro.add_transformation(
     "[mass] / [length]**2 / [time]",
     "[length] / [time]",
     lambda ureg, x: x / (1000 * ureg.kg / ureg.m**3),
@@ -461,12 +466,11 @@ def cf_conversion(
 FREQ_UNITS = {
     "D": "d",
     "W": "week",
-    "h": "h",
 }
 """
 Resampling frequency units for :py:func:`xclim.core.units.infer_sampling_units`.
 
-Mapping from offset base to CF-compliant unit. Only constant-length frequencies are included.
+Mapping from offset base to CF-compliant unit. Only constant-length frequencies that are not also pint units are included
 """
 
 
@@ -718,7 +722,7 @@ def _rate_and_amount_converter(
                 "can be used as the sampling rate, pass `sampling_rate_from_coord=True`."
             ) from err
     if freq is not None:
-        multi, base, start_anchor, _ = parse_offset(freq)
+        _, base, start_anchor, _ = parse_offset(freq)
         if base in ["M", "Q", "A", "Y"]:
             start = time.indexes[dim][0]
             if not start_anchor:
@@ -743,7 +747,7 @@ def _rate_and_amount_converter(
                 attrs=time.attrs,
             )
         else:
-            m, u = multi, FREQ_UNITS[base]
+            m, u = infer_sampling_units(da, freq)
 
     out: xr.DataArray
     # Freq is month, season or year, which are not constant units, or simply freq is not inferrable.

--- a/xclim/core/units.py
+++ b/xclim/core/units.py
@@ -470,7 +470,7 @@ FREQ_UNITS = {
 """
 Resampling frequency units for :py:func:`xclim.core.units.infer_sampling_units`.
 
-Mapping from offset base to CF-compliant unit. Only constant-length frequencies that are not also pint units are included
+Mapping from offset base to CF-compliant unit. Only constant-length frequencies that are not also pint units are included.
 """
 
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1962
- [x] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGELOG.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* The `_rate_to_amount_converter` relied on the `FREQ_UNITS`  directly, now it goes through `infer_sampling_units` instead. In exchange for slightly more code, this fixes the issue for sub-daily freqs and gives a better error for frequencies xclim can't understand.
* Add the "lwe thickness  -> amount" hydro transformation. The inverse was already there. This is to go from a thickness of liquid water (ex: mm of rain) to an amount (ex: kg m-2), by multiplying by the liquid water density (1000 kg m-3).

### Does this PR introduce a breaking change?
No.