### PR TITLE
Avoid FutureWarning for `dt.week`

### DIFF
--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -494,12 +494,12 @@ class TestAgroclimaticIndices:
 class TestStandardizedIndices:
     # gamma/APP reference results: Obtained with `monocongo/climate_indices` library
     # MS/fisk/ML reference results: Obtained with R package `SPEI`
-    # Using the method `APP` in XClim matches the method from monocongo, hence the very low
-    # tolerance possible.
+    # Using the method `APP` in XClim matches the method from monocongo, hence the very low tolerance possible.
     # Repeated tests with lower tolerance means we want a more precise comparison, so we compare
-    # the current version of XClim with the version where the test was implemented
+    # the current version of XClim with the version where the test was implemented.
+    # Additionally, xarray does not yet access "week" or "weekofyear" with groupby in a pandas-compatible way for cftime objects.
+    # See: https://github.com/pydata/xarray/discussions/6375
     @pytest.mark.slow
-    @pytest.mark.filterwarnings("ignore:dt.weekofyear and dt.week have been deprecated")
     @pytest.mark.parametrize(
         "freq, window, dist, method,  values, diff_tol",
         [

--- a/tests/test_sdba/test_base.py
+++ b/tests/test_sdba/test_base.py
@@ -63,7 +63,6 @@ def test_grouper_get_index(tas_series, group, interp, val90):
 
 # xarray does not yet access "week" or "weekofyear" with groupby in a pandas-compatible way for cftime objects.
 # See: https://github.com/pydata/xarray/discussions/6375
-@pytest.mark.filterwarnings("ignore:dt.weekofyear and dt.week have been deprecated")
 @pytest.mark.slow
 @pytest.mark.parametrize(
     "group,n",

--- a/xclim/indices/stats.py
+++ b/xclim/indices/stats.py
@@ -933,7 +933,7 @@ def standardized_index(
             da = da.rename(month="time").reindex(time=da_ref.time.dt.month)
             da["time"] = da_ref.time
         elif group == "time.week":
-            da = da.rename(week="time").reindex(time=da_ref.time.dt.week)
+            da = da.rename(week="time").reindex(time=da_ref.time.dt.isocalendar().week)
             da["time"] = da_ref.time
         # I don't think rechunking is necessary here, need to check
         return da if not uses_dask(da) else da.chunk({"time": -1})


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] CHANGELOG.rst has been updated (with summary of main changes)
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Changes the `dt.week` call to `dt.isocalendar().week` to avoid an (ancient) `FutureWarning` from xarray.

### Does this PR introduce a breaking change?
No. all xarray versions  we support have the `isocalender()` accessor.

### Other information:
