### PR TITLE
Fix indicator outputting delta degC

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,11 +4,12 @@ Changelog
 
 v0.54 (unpublished)
 --------------------
-Contributors to this version: Éric (:user:`coxipi`).
+Contributors to this version: Éric (:user:`coxipi`), Pascal Bourgault (:user:`aulemahal`).
 
 Bug fixes
 ^^^^^^^^^
 * Conversion of units of multivariate DataArray is now properly handled in `sdba.TrainAdjust` and `sdba.Adjust`. There was a bug where the units could be changed before a conversion of the magntitudes could occur. (:pull:`1972`).
+* Fix for indicators that output "delta" Celsius degrees.
 
 v0.53.1 (2024-10-21)
 --------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,9 +2,9 @@
 Changelog
 =========
 
-v0.54 (unpublished)
+v0.54.0 (unreleased)
 --------------------
-Contributors to this version: Éric (:user:`coxipi`), Pascal Bourgault (:user:`aulemahal`).
+Contributors to this version: Éric Dupuis (:user:`coxipi`), Pascal Bourgault (:user:`aulemahal`).
 
 Bug fixes
 ^^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ Contributors to this version: Éric (:user:`coxipi`), Pascal Bourgault (:user:`a
 Bug fixes
 ^^^^^^^^^
 * Conversion of units of multivariate DataArray is now properly handled in `sdba.TrainAdjust` and `sdba.Adjust`. There was a bug where the units could be changed before a conversion of the magntitudes could occur. (:pull:`1972`).
-* Fix for indicators that output "delta" Celsius degrees.
+* Fix for indicators that output "delta" Celsius degrees. (:pull:`1973`).
 
 v0.53.1 (2024-10-21)
 --------------------

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -286,6 +286,20 @@ def test_temp_unit_conversion(tas_series):
     np.testing.assert_array_almost_equal(txk, txc + 273.15)
 
 
+def test_temp_diff_unit_conversion(tasmax_series, tasmin_series):
+    tx = tasmax_series(np.arange(365) + 1, start="2001-01-01")
+    tn = tasmin_series(np.arange(365), start="2001-01-01")
+    txC = convert_units_to(tx, "degC")
+    tnC = convert_units_to(tn, "degC")
+
+    ind = xclim.atmos.daily_temperature_range.from_dict(
+        {"units": "degC"}, "dtr_degC", "test"
+    )
+    out = ind(tasmax=txC, tasmin=tnC)
+    assert out.attrs["units"] == "degC"
+    assert out.attrs["units_metadata"] == "temperature: difference"
+
+
 def test_multiindicator(tas_series):
     tas = tas_series(np.arange(366), start="2000-01-01")
     tmin, tmax = multiTemp(tas, freq="YS")

--- a/xclim/core/indicator.py
+++ b/xclim/core/indicator.py
@@ -853,7 +853,7 @@ class Indicator(IndicatorRegistrar):
 
         # Convert to output units
         outs = [
-            convert_units_to(out, attrs["units"], self.context)
+            convert_units_to(out, attrs, self.context)
             for out, attrs in zip(outs, out_attrs, strict=False)
         ]
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGELOG.rst has been updated (with summary of main changes)
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

Before this fix: an indicator that outputs "degC" but as a "temperature: difference" would bug. The compute function would return a dataset with proper units and proper "units_metadata" attribute and then the indicator would try to convert the data to the expected units, but doing so it would only give the units to  `convert_units_to`. It would not give the `units_metadata` attribute.

thus, `convert_units_to` was taking the compute function output and getting "delta_degC", as expected, but then it was not able to convert to "degC", of course.

This change passes the whole attrs to  `convert_units_to` so it can understand that the expected units are a difference.

### Does this PR introduce a breaking change?
No.

We have no current indicator that output "degC" as "difference" (dtr outputs Kelvins), but the problem would emerge in custom indicators or with `sdba.measures.bias` where units are not explicitly set, so the "expected ones" are inferred from the compute function's output. Before this fix, the `units_metadata` attribute was dropped at that point, triggering the bug described above.


### Other information:
