### PR TITLE
Fix docstring of frost free spell max length

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,8 +12,9 @@ Breaking changes
 
 Bug fixes
 ^^^^^^^^^
-* Conversion of units of multivariate DataArray is now properly handled in `sdba.TrainAdjust` and `sdba.Adjust`. There was a bug where the units could be changed before a conversion of the magntitudes could occur. (:pull:`1972`).
-* Fix for indicators that output "delta" Celsius degrees. (:pull:`1973`).
+* Fixed a bug where the units could be changed before a conversion of the magnitudes could occur. Conversion of units for multivariate ``DataArray`` is now properly handled in `sdba.TrainAdjust` and `sdba.Adjust`. (:pull:`1972`).
+* Fixed a units formatting bug with indicators that output "delta" Celsius degrees. (:pull:`1973`).
+* Corrected the ``"choices"`` of parameter ``op`` in the docstring of ``frost_free_spell_max_length``. (:pull:`1977`).
 
 v0.53.1 (2024-10-21)
 --------------------

--- a/xclim/indices/_threshold.py
+++ b/xclim/indices/_threshold.py
@@ -1426,8 +1426,8 @@ def frost_free_spell_max_length(
         Minimum number of days with temperatures above thresholds to qualify as a frost free day.
     freq : str
         Resampling frequency.
-    op : {"<", "<=", "lt", "le"}
-        Comparison operation. Default: "<".
+    op : {">", ">=", "gt", "ge"}
+        Comparison operation. Default: ">=".
     resample_before_rl : bool
         Determines if the resampling should take place before or after the run
         length encoding (or a similar algorithm) is applied to runs.


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [x] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGELOG.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Fix the "choices" of parameter `op` in the docstring of `frost_free_spell_max_length`. 

### Does this PR introduce a breaking change?
No. This should not affect most users. Only users using the `indicator.parameters[...].choices` explicitly would be affected, for example : `finch`.


### Other information:
