### PR TITLE
Pin xarray to deal with `polyfit`/`polyval` regression

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ v0.54.0 (unreleased)
 --------------------
 Contributors to this version: Éric Dupuis (:user:`coxipi`), Pascal Bourgault (:user:`aulemahal`).
 
+Breaking changes
+^^^^^^^^^^^^^^^^
+* Due to a regression affecting symmetry of ``polyfit`` and ``polyval`` in `xarray`, `xclim` now requires `xarray>=2023.11.0,!=2024.10.0` (see: `pydata/xarray PR/9691 <https://github.com/pydata/xarray/pull/9691>`_. (:pull:`1972`).
+
 Bug fixes
 ^^^^^^^^^
 * Conversion of units of multivariate DataArray is now properly handled in `sdba.TrainAdjust` and `sdba.Adjust`. There was a bug where the units could be changed before a conversion of the magntitudes could occur. (:pull:`1972`).

--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,7 @@ dependencies:
   - scikit-learn >=1.1.0
   - scipy >=1.9.0
   - statsmodels >=0.14.2
-  - xarray >=2023.11.0
+  - xarray >=2023.11.0,!=2024.10.0
   - yamale >=5.0.0
   # Extras
   - fastnanquantile >=0.0.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
   "scikit-learn >=1.1.0",
   "scipy >=1.9.0",
   "statsmodels >=0.14.2",
-  "xarray >=2023.11.0",
+  "xarray >=2023.11.0,!=2024.10.0",
   "yamale >=5.0.0"
 ]
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGELOG.rst has been updated (with summary of main changes)
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Pins `xarray` such that version 2024.10.0 is not compatible with `xclim`.

### Does this PR introduce a breaking change?

Yes. `xarray` v2024.10.0 is considered to be broken according to our configurations. The pin will stay in place until we drop `xarray` newer than this version.

### Other information:

https://github.com/pydata/xarray/issues/9690
https://github.com/pydata/xarray/pull/9691

The issue is currently fixed upstream, so the next release of `xarray` should have no issues.