### PR TITLE
Pin dask higher, skip dask v2024.11.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ Contributors to this version: Trevor James Smith (:user:`Zeitsperre`),
 
 Breaking changes
 ----------------
-* The minimum required version of `dask` has been increased to `2024.8.1`. `dask` version `2024.11.0` is now excluded due to a regression in the `dask` library.
+* The minimum required version of `dask` has been increased to `2024.8.1`. `dask` version `2024.11.0` is now excluded due to a regression in the `dask` library. (:pull:`1991`).
 
 v0.53.2 (2024-10-31)
 --------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog
 =========
 
+v0.54.0 (unreleased)
+--------------------
+Contributors to this version: Trevor James Smith (:user:`Zeitsperre`),
+
+Breaking changes
+----------------
+* The minimum required version of `dask` has been increased to `2024.8.1`. `dask` version `2024.11.0` is now excluded due to a regression in the `dask` library.
+
 v0.53.2 (2024-10-31)
 --------------------
 Contributors to this version: Éric Dupuis (:user:`coxipi`), Pascal Bourgault (:user:`aulemahal`), Trevor James Smith (:user:`Zeitsperre`).

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ Contributors to this version: Trevor James Smith (:user:`Zeitsperre`),
 
 Breaking changes
 ----------------
-* The minimum required version of `dask` has been increased to `2024.8.1`. `dask` version `2024.11.0` is now excluded due to a regression in the `dask` library. (:pull:`1991`).
+* The minimum required version of `dask` has been increased to `2024.8.1`. `dask` versions at or above `2024.11` are not yet supported. (:issue:`1992`, :pull:`1991`).
 
 v0.53.2 (2024-10-31)
 --------------------

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - cf_xarray >=0.9.3
   - cftime >=1.4.1
   - click >=8.1
-  - dask >=2.6.0
+  - dask >=2024.8.1,!=2024.11.0
   - filelock >=3.14.0
   - jsonpickle >=3.1.0
   - numba >=0.54.1

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - cf_xarray >=0.9.3
   - cftime >=1.4.1
   - click >=8.1
-  - dask >=2024.8.1,!=2024.11.0
+  - dask >=2024.8.1,<2024.11.0
   - filelock >=3.14.0
   - jsonpickle >=3.1.0
   - numba >=0.54.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
   "cf-xarray >=0.9.3", # cf-xarray is differently named on conda-forge
   "cftime >=1.4.1",
   "click >=8.1",
-  "dask[array] >=2024.8.1,!=2024.11.0",
+  "dask[array] >=2024.8.1,<2024.11.0",
   "filelock >=3.14.0",
   "jsonpickle >=3.1.0",
   "numba >=0.54.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
   "cf-xarray >=0.9.3", # cf-xarray is differently named on conda-forge
   "cftime >=1.4.1",
   "click >=8.1",
-  "dask[array] >=2.6",
+  "dask[array] >=2024.8.1,!=2024.11.0",
   "filelock >=3.14.0",
   "jsonpickle >=3.1.0",
   "numba >=0.54.1",
@@ -128,7 +128,6 @@ xclim = "xclim.cli:cli"
 
 [tool.black]
 target-version = [
-  "py39",
   "py310",
   "py311",
   "py312"


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGELOG.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Sets the lowest `dask` pin to the version that dropped Python 3.9 support.
* Temporarily pins `dask` below version `2024.11.0` as this version has changed chunking behaviour.

### Does this PR introduce a breaking change?

Not really. It should not affect relatively recent builds/installations.

### Other information:

https://numpy.org/neps/nep-0029-deprecation_policy.html
https://docs.dask.org/en/stable/changelog.html#v2024-11-1