### PR TITLE
Fix nimbus URL joining

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,7 @@ Bug fixes
 * Fixed an issue with ``nimbus`` that was causing URL path components to be improperly joined. (:pull:`1997`).
 
 Internal changes
-^^^^^^^^^^^^^^^^v
+^^^^^^^^^^^^^^^^
 * Changed french translations with word "pluvieux" to "avec précipitations". (:issue:`1960`, :pull:`1994`).
 
 v0.53.2 (2024-10-31)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Breaking changes
 Bug fixes
 ^^^^^^^^^
 * Fixed pickling issue with ``xclim.sdba.Grouper`` and other classes for usage with `dask>=2024.11`. (:issue:`1992`, :pull:`1993`).
+* Fixed an issue with ``nimbus`` that was causing URL path components to be improperly joined.
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,10 +13,10 @@ Breaking changes
 Bug fixes
 ^^^^^^^^^
 * Fixed pickling issue with ``xclim.sdba.Grouper`` and other classes for usage with `dask>=2024.11`. (:issue:`1992`, :pull:`1993`).
-* Fixed an issue with ``nimbus`` that was causing URL path components to be improperly joined.
+* Fixed an issue with ``nimbus`` that was causing URL path components to be improperly joined. (:pull:`1997`).
 
 Internal changes
-^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^v
 * Changed french translations with word "pluvieux" to "avec précipitations". (:issue:`1960`, :pull:`1994`).
 
 v0.53.2 (2024-10-31)

--- a/xclim/testing/utils.py
+++ b/xclim/testing/utils.py
@@ -435,7 +435,9 @@ def load_registry(
     dict
         Dictionary of filenames and hashes.
     """
-    remote_registry = audit_url(f"{repo}/{branch}/data/registry.txt")
+    if not branch.endswith("/"):
+        branch = f"{branch}/"
+    remote_registry = audit_url(urljoin(urljoin(repo, branch), "data/registry.txt"))
 
     if branch != default_testdata_version:
         custom_registry_folder = Path(
@@ -511,8 +513,9 @@ def nimbus(  # noqa: PR01
             "The `pooch` package is required to fetch the xclim testing data. "
             "You can install it with `pip install pooch` or `pip install xclim[dev]`."
         )
-
-    remote = audit_url(f"{repo}/{branch}/data")
+    if not branch.endswith("/"):
+        branch = f"{branch}/"
+    remote = audit_url(urljoin(urljoin(repo, branch), "data"))
     return pooch.create(
         path=cache_dir,
         base_url=remote,

--- a/xclim/testing/utils.py
+++ b/xclim/testing/utils.py
@@ -435,9 +435,12 @@ def load_registry(
     dict
         Dictionary of filenames and hashes.
     """
-    if not branch.endswith("/"):
-        branch = f"{branch}/"
-    remote_registry = audit_url(urljoin(urljoin(repo, branch), "data/registry.txt"))
+    remote_registry = audit_url(
+        urljoin(
+            urljoin(repo, branch if branch.endswith("/") else f"{branch}/"),
+            "data/registry.txt",
+        )
+    )
 
     if branch != default_testdata_version:
         custom_registry_folder = Path(
@@ -513,9 +516,9 @@ def nimbus(  # noqa: PR01
             "The `pooch` package is required to fetch the xclim testing data. "
             "You can install it with `pip install pooch` or `pip install xclim[dev]`."
         )
-    if not branch.endswith("/"):
-        branch = f"{branch}/"
-    remote = audit_url(urljoin(urljoin(repo, branch), "data"))
+    remote = audit_url(
+        urljoin(urljoin(repo, branch if branch.endswith("/") else f"{branch}/"), "data")
+    )
     return pooch.create(
         path=cache_dir,
         base_url=remote,


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGELOG.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Fixed an issue that was causing URLs to include a `//` between the repository and branch fields.

### Does this PR introduce a breaking change?

No.

### Other information:

While this was working fine for returning files already available on disk, when `nimbus` was fetching files remotely when launched from a Jupyter notebook, this was failing.

Related: https://github.com/Ouranosinc/xscen/pull/492