### PR TITLE
MBCn:  `base_kws_vars` copied to avoid global changes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Bug fixes
 ^^^^^^^^^
 * Fixed pickling issue with ``xclim.sdba.Grouper`` and other classes for usage with `dask>=2024.11`. (:issue:`1992`, :pull:`1993`).
 * Fixed an issue with ``nimbus`` that was causing URL path components to be improperly joined. (:pull:`1997`).
+* `base_kws_vars` in `MBCn` is now copied inside the `adjust` function so that in-place changes do not change the dict globally.
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ Bug fixes
 ^^^^^^^^^
 * Fixed pickling issue with ``xclim.sdba.Grouper`` and other classes for usage with `dask>=2024.11`. (:issue:`1992`, :pull:`1993`).
 * Fixed an issue with ``nimbus`` that was causing URL path components to be improperly joined. (:pull:`1997`).
-* `base_kws_vars` in `MBCn` is now copied inside the `adjust` function so that in-place changes do not change the dict globally.
+* `base_kws_vars` in `MBCn` is now copied inside the `adjust` function so that in-place changes do not change the dict globally. (:pull:`1999`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/xclim/sdba/adjustment.py
+++ b/xclim/sdba/adjustment.py
@@ -1819,7 +1819,7 @@ class MBCn(TrainAdjust):
         period_dim=None,
     ):
         # set default values for non-specified parameters
-        base_kws_vars = deepcopy(base_kws_vars) or {}
+        base_kws_vars = {} if base_kws_vars is None else deepcopy(base_kws_vars)
         pts_dim = self.pts_dims[0]
         for v in sim[pts_dim].values:
             base_kws_vars.setdefault(v, {})

--- a/xclim/sdba/adjustment.py
+++ b/xclim/sdba/adjustment.py
@@ -5,7 +5,7 @@ Adjustment Methods
 """
 from __future__ import annotations
 
-import copy
+from copy import deepcopy
 from importlib.util import find_spec
 from inspect import signature
 from typing import Any
@@ -1819,7 +1819,7 @@ class MBCn(TrainAdjust):
         period_dim=None,
     ):
         # set default values for non-specified parameters
-        base_kws_vars = copy.deepcopy(base_kws_vars) or {}
+        base_kws_vars = deepcopy(base_kws_vars) or {}
         pts_dim = self.pts_dims[0]
         for v in sim[pts_dim].values:
             base_kws_vars.setdefault(v, {})

--- a/xclim/sdba/adjustment.py
+++ b/xclim/sdba/adjustment.py
@@ -5,6 +5,7 @@ Adjustment Methods
 """
 from __future__ import annotations
 
+import copy
 from importlib.util import find_spec
 from inspect import signature
 from typing import Any
@@ -1818,7 +1819,7 @@ class MBCn(TrainAdjust):
         period_dim=None,
     ):
         # set default values for non-specified parameters
-        base_kws_vars = base_kws_vars or {}
+        base_kws_vars = copy.deepcopy(base_kws_vars) or {}
         pts_dim = self.pts_dims[0]
         for v in sim[pts_dim].values:
             base_kws_vars.setdefault(v, {})


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] CHANGELOG.rst has been updated (with summary of main changes)
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Copy `base_kws_vars` inside the adjust function so that it doesn't change the dict globally.

### Does this PR introduce a breaking change?

No

### Other information:
