### PR TITLE
Fix nan handling in dOTC

### DIFF
--- a/tests/test_sdba/test_adjustment.py
+++ b/tests/test_sdba/test_adjustment.py
@@ -893,53 +893,6 @@ class TestOTC:
         scen_sbck = scen_sbck.to_numpy()
         assert np.allclose(scen, scen_sbck)
 
-    def test_shape(self, random, series):
-        pytest.importorskip("ot")
-        pytest.importorskip("SBCK", minversion="0.4.0")
-        ref_ns = 300
-        hist_ns = 200
-        ref_u = random.random(ref_ns)
-        hist_u = random.random(hist_ns)
-
-        ref_xd = uniform(loc=1000, scale=100)
-        ref_yd = norm(loc=0, scale=100)
-        ref_zd = norm(loc=500, scale=100)
-        hist_xd = norm(loc=-500, scale=100)
-        hist_yd = uniform(loc=-1000, scale=100)
-        hist_zd = uniform(loc=-10, scale=100)
-
-        ref_x = ref_xd.ppf(ref_u)
-        ref_y = ref_yd.ppf(ref_u)
-        ref_z = ref_zd.ppf(ref_u)
-        hist_x = hist_xd.ppf(hist_u)
-        hist_y = hist_yd.ppf(hist_u)
-        hist_z = hist_zd.ppf(hist_u)
-
-        ref_na = 10
-        hist_na = 15
-        ref_idx = random.choice(range(ref_ns), size=ref_na, replace=False)
-        ref_x[ref_idx] = None
-        hist_idx = random.choice(range(hist_ns), size=hist_na, replace=False)
-        hist_x[hist_idx] = None
-
-        ref_x = series(ref_x, "tas").rename("x")
-        ref_y = series(ref_y, "tas").rename("y")
-        ref_z = series(ref_z, "tas").rename("z")
-        ref = xr.merge([ref_x, ref_y, ref_z])
-        ref = stack_variables(ref)
-
-        hist_x = series(hist_x, "tas").rename("x")
-        hist_y = series(hist_y, "tas").rename("y")
-        hist_z = series(hist_z, "tas").rename("z")
-        hist = xr.merge([hist_x, hist_y, hist_z])
-        hist = stack_variables(hist)
-
-        scen = OTC.adjust(ref, hist)
-
-        assert scen.shape == (3, hist_ns - hist_na)
-        hist = unstack_variables(hist)
-        assert not np.isin(hist.x[hist.x.isnull()].time.values, scen.time.values).any()
-
 
 # TODO: Add tests for normalization methods
 class TestdOTC:
@@ -1025,70 +978,6 @@ class TestdOTC:
         scen = scen.to_numpy().T
         scen_sbck = scen_sbck.to_numpy()
         assert np.allclose(scen, scen_sbck)
-
-    def test_shape(self, random, series):
-        pytest.importorskip("ot")
-        pytest.importorskip("SBCK", minversion="0.4.0")
-        ref_ns = 300
-        hist_ns = 200
-        sim_ns = 400
-        ref_u = random.random(ref_ns)
-        hist_u = random.random(hist_ns)
-        sim_u = random.random(sim_ns)
-
-        ref_xd = uniform(loc=1000, scale=100)
-        ref_yd = norm(loc=0, scale=100)
-        ref_zd = norm(loc=500, scale=100)
-        hist_xd = norm(loc=-500, scale=100)
-        hist_yd = uniform(loc=-1000, scale=100)
-        hist_zd = uniform(loc=-10, scale=100)
-        sim_xd = norm(loc=0, scale=100)
-        sim_yd = uniform(loc=0, scale=100)
-        sim_zd = uniform(loc=10, scale=100)
-
-        ref_x = ref_xd.ppf(ref_u)
-        ref_y = ref_yd.ppf(ref_u)
-        ref_z = ref_zd.ppf(ref_u)
-        hist_x = hist_xd.ppf(hist_u)
-        hist_y = hist_yd.ppf(hist_u)
-        hist_z = hist_zd.ppf(hist_u)
-        sim_x = sim_xd.ppf(sim_u)
-        sim_y = sim_yd.ppf(sim_u)
-        sim_z = sim_zd.ppf(sim_u)
-
-        ref_na = 10
-        hist_na = 15
-        sim_na = 20
-        ref_idx = random.choice(range(ref_ns), size=ref_na, replace=False)
-        ref_x[ref_idx] = None
-        hist_idx = random.choice(range(hist_ns), size=hist_na, replace=False)
-        hist_x[hist_idx] = None
-        sim_idx = random.choice(range(sim_ns), size=sim_na, replace=False)
-        sim_x[sim_idx] = None
-
-        ref_x = series(ref_x, "tas").rename("x")
-        ref_y = series(ref_y, "tas").rename("y")
-        ref_z = series(ref_z, "tas").rename("z")
-        ref = xr.merge([ref_x, ref_y, ref_z])
-        ref = stack_variables(ref)
-
-        hist_x = series(hist_x, "tas").rename("x")
-        hist_y = series(hist_y, "tas").rename("y")
-        hist_z = series(hist_z, "tas").rename("z")
-        hist = xr.merge([hist_x, hist_y, hist_z])
-        hist = stack_variables(hist)
-
-        sim_x = series(sim_x, "tas").rename("x")
-        sim_y = series(sim_y, "tas").rename("y")
-        sim_z = series(sim_z, "tas").rename("z")
-        sim = xr.merge([sim_x, sim_y, sim_z])
-        sim = stack_variables(sim)
-
-        scen = dOTC.adjust(ref, hist, sim)
-
-        assert scen.shape == (3, sim_ns - sim_na)
-        sim = unstack_variables(sim)
-        assert not np.isin(sim.x[sim.x.isnull()].time.values, scen.time.values).any()
 
     # just check it runs
     def test_different_times(self, tasmax_series, tasmin_series):

--- a/xclim/sdba/_adjustment.py
+++ b/xclim/sdba/_adjustment.py
@@ -988,6 +988,12 @@ def _otc_adjust(
     ----------
     :cite:cts:`sdba-robin_2021`
     """
+    # nans are removed and put back in place at the end
+    X_og = X.copy()
+    mask = (~np.isnan(X)).all(axis=1)
+    X = X[mask]
+    Y = Y[(~np.isnan(Y)).all(axis=1)]
+
     # Initialize parameters
     if bin_width is None:
         bin_width = u.bin_width_estimator([Y, X])
@@ -1042,7 +1048,11 @@ def _otc_adjust(
     if jitter_inside_bins:
         out += np.random.uniform(low=-bin_width / 2, high=bin_width / 2, size=out.shape)
 
-    return out
+    # reintroduce nans
+    Xadj = X_og
+    Xadj[mask] = out
+    Xadj[~mask] = np.nan
+    return Xadj
 
 
 @map_groups(scen=[Grouper.DIM])
@@ -1102,9 +1112,9 @@ def otc_adjust(
             )
 
     ref_map = {d: f"ref_{d}" for d in dim}
-    ref = ref.rename(ref_map).stack(dim_ref=ref_map.values()).dropna(dim="dim_ref")
+    ref = ref.rename(ref_map).stack(dim_ref=ref_map.values())
 
-    hist = hist.stack(dim_hist=dim).dropna(dim="dim_hist")
+    hist = hist.stack(dim_hist=dim)
 
     if isinstance(bin_width, dict):
         bin_width = {
@@ -1134,12 +1144,7 @@ def otc_adjust(
         vectorize=True,
     )
 
-    # Pad dim differences with NA to please map_blocks
-    ref = ref.unstack().rename({v: k for k, v in ref_map.items()})
     scen = scen.unstack().rename("scen")
-    for d in dim:
-        full_d = xr.concat([ref[d], scen[d]], dim=d).drop_duplicates(d)
-        scen = scen.reindex({d: full_d})
 
     return scen.to_dataset()
 
@@ -1193,6 +1198,12 @@ def _dotc_adjust(
     ----------
     :cite:cts:`sdba-robin_2021`
     """
+    # nans are removed and put back in place at the end
+    X1_og = X1.copy()
+    mask = ~np.isnan(X1).any(axis=1)
+    X1 = X1[mask]
+    X0 = X0[~np.isnan(X0).any(axis=1)]
+    Y0 = Y0[~np.isnan(Y0).any(axis=1)]
     # Initialize parameters
     if isinstance(bin_width, dict):
         _bin_width = u.bin_width_estimator([Y0, X0, X1])
@@ -1259,7 +1270,7 @@ def _dotc_adjust(
             Y1[:, j] = Y0[:, j] + motion[:, j]
 
     # Map sim to the evolution of ref
-    Z1 = _otc_adjust(
+    out = _otc_adjust(
         X1,
         Y1,
         bin_width=bin_width,
@@ -1268,6 +1279,10 @@ def _dotc_adjust(
         jitter_inside_bins=jitter_inside_bins,
         normalization=normalization,
     )
+    # reintroduce nans
+    Z1 = X1_og
+    Z1[mask] = out
+    Z1[~mask] = np.nan
 
     return Z1
 
@@ -1339,14 +1354,12 @@ def dotc_adjust(
 
     # Drop data added by map_blocks and prepare for apply_ufunc
     hist_map = {d: f"hist_{d}" for d in dim}
-    hist = (
-        hist.rename(hist_map).stack(dim_hist=hist_map.values()).dropna(dim="dim_hist")
-    )
+    hist = hist.rename(hist_map).stack(dim_hist=hist_map.values())
 
     ref_map = {d: f"ref_{d}" for d in dim}
-    ref = ref.rename(ref_map).stack(dim_ref=ref_map.values()).dropna(dim="dim_ref")
+    ref = ref.rename(ref_map).stack(dim_ref=ref_map.values())
 
-    sim = sim.stack(dim_sim=dim).dropna(dim="dim_sim")
+    sim = sim.stack(dim_sim=dim)
 
     if kind is not None:
         kind = {
@@ -1387,12 +1400,6 @@ def dotc_adjust(
         vectorize=True,
     )
 
-    # Pad dim differences with NA to please map_blocks
-    hist = hist.unstack().rename({v: k for k, v in hist_map.items()})
-    ref = ref.unstack().rename({v: k for k, v in ref_map.items()})
     scen = scen.unstack().rename("scen")
-    for d in dim:
-        full_d = xr.concat([hist[d], ref[d], scen[d]], dim=d).drop_duplicates(d)
-        scen = scen.reindex({d: full_d})
 
     return scen.to_dataset()

--- a/xclim/sdba/adjustment.py
+++ b/xclim/sdba/adjustment.py
@@ -401,7 +401,6 @@ class Adjust(BaseAdjustment):
             # If `ref,hist, sim` are in the same `map_groups` call, they must have the same time
             # As long as `sim` has the same time dimension, we can temporarily replace its time
             # with the reference time
-            print("here")
             sim_time = sim.time
             sim["time"] = ref["time"]
 

--- a/xclim/sdba/adjustment.py
+++ b/xclim/sdba/adjustment.py
@@ -401,6 +401,7 @@ class Adjust(BaseAdjustment):
             # If `ref,hist, sim` are in the same `map_groups` call, they must have the same time
             # As long as `sim` has the same time dimension, we can temporarily replace its time
             # with the reference time
+            print("here")
             sim_time = sim.time
             sim["time"] = ref["time"]
 
@@ -1433,8 +1434,7 @@ class OTC(Adjust):
     """
 
     _allow_diff_calendars = False
-    # TODO: uncomment after fixing OTC/dOTC, next PR
-    # _allow_diff_time_sizes = False
+    _allow_diff_time_sizes = False
 
     @classmethod
     def _adjust(
@@ -1468,7 +1468,10 @@ class OTC(Adjust):
 
         if isinstance(adapt_freq_thresh, str):
             adapt_freq_thresh = {v: adapt_freq_thresh for v in hist[pts_dim].values}
-        if adapt_freq_thresh is not None:
+        adapt_freq_thresh = (
+            {} if adapt_freq_thresh is None else deepcopy(adapt_freq_thresh)
+        )
+        if adapt_freq_thresh != {}:
             _, units = cls._harmonize_units(sim)
             for var, thresh in adapt_freq_thresh.items():
                 adapt_freq_thresh[var] = str(
@@ -1486,14 +1489,6 @@ class OTC(Adjust):
             group=group,
             pts_dim=pts_dim,
         ).scen
-
-        if adapt_freq_thresh is not None:
-            for var in adapt_freq_thresh.keys():
-                adapt_freq_thresh[var] = adapt_freq_thresh[var] + " " + units[var]
-
-        for d in scen.dims:
-            if d != pts_dim:
-                scen = scen.dropna(dim=d)
 
         return scen
 
@@ -1592,8 +1587,7 @@ class dOTC(Adjust):
     """
 
     _allow_diff_calendars = False
-    # TODO: uncomment after fixing OTC/dOTC, next PR
-    # _allow_diff_time_sizes = False
+    _allow_diff_time_sizes = False
 
     @classmethod
     def _adjust(
@@ -1635,7 +1629,10 @@ class dOTC(Adjust):
 
         if isinstance(adapt_freq_thresh, str):
             adapt_freq_thresh = {v: adapt_freq_thresh for v in hist[pts_dim].values}
-        if adapt_freq_thresh is not None:
+        adapt_freq_thresh = (
+            {} if adapt_freq_thresh is None else deepcopy(adapt_freq_thresh)
+        )
+        if adapt_freq_thresh != {}:
             _, units = cls._harmonize_units(sim)
             for var, thresh in adapt_freq_thresh.items():
                 adapt_freq_thresh[var] = str(
@@ -1655,14 +1652,6 @@ class dOTC(Adjust):
             group=group,
             pts_dim=pts_dim,
         ).scen
-
-        if adapt_freq_thresh is not None:
-            for var in adapt_freq_thresh.keys():
-                adapt_freq_thresh[var] = adapt_freq_thresh[var] + " " + units[var]
-
-        for d in scen.dims:
-            if d != pts_dim:
-                scen = scen.dropna(dim=d, how="all")
 
         return scen
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] CHANGELOG.rst has been updated (with summary of main changes)
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

*nans are now removed and put back in place at a lower level. This simplifies the handling of times. 

### Does this PR introduce a breaking change?

I'm not sure, I should check if the previous method was handling nans correctly. I have a suspicion that it was not. But this way is simpler, more in-line with other xclim methods, and technically what we want

### Other information:

The motivation behind this is that we want to be able to use different time but same size for `ref` and `sim` so they can be passed to a `map_groups` function. Apparently, the handling of nans was messing with the relative sizes of `ref` ,`sim`. Before the computation, they were the same (by construction) and at some intermediary step, they ended up with different dimensions. Maybe the dimensions were ultimately restored, but I was nervous about this, and I think this new implementation is more simple.
