### PR TITLE
Handle exceptionally rare linear algebra error

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,7 @@ Internal changes
 * The `numpydoc` linting tool has been added to the development dependencies, linting checks, and the `pre-commit` configuration. (:pull:`1988`).
 * `xclim` now uses a `src` layout for the codebase. Structure-dependent functions, documentation, and build commands have been adapted to reflect these changes. (:pull:`1971`).
 * Added a more robust `yamllint` configuration to ensure that all YAML files are linted consistently. (:pull:`1971`).
+* Addressed a very rare singular matrix error that can happen in ``test_loess_smoothing_nan``.
 
 CI changes
 ^^^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,7 +33,7 @@ Internal changes
 * The `numpydoc` linting tool has been added to the development dependencies, linting checks, and the `pre-commit` configuration. (:pull:`1988`).
 * `xclim` now uses a `src` layout for the codebase. Structure-dependent functions, documentation, and build commands have been adapted to reflect these changes. (:pull:`1971`).
 * Added a more robust `yamllint` configuration to ensure that all YAML files are linted consistently. (:pull:`1971`).
-* Addressed a very rare singular matrix error that can happen in ``test_loess_smoothing_nan``.
+* Addressed a very rare singular matrix error that can happen in ``test_loess_smoothing_nan``. (:pull:`2015`).
 
 CI changes
 ^^^^^^^^^^

--- a/tests/test_sdba/test_loess.py
+++ b/tests/test_sdba/test_loess.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -84,4 +86,11 @@ def test_loess_smoothing_nan(use_dask):
 
     assert out.dims == da.dims
     # check that the output is all nan on the axis with nan in the input
-    assert np.isnan(out.values[0, 0]).all()
+    try:
+        assert np.isnan(out.values[0, 0]).all()
+    except np.linalg.LinAlgError:
+        msg = (
+            "This has roughly a 1/50,000,000 chance of occurring. Buy a lottery ticket!"
+        )
+        logging.error(msg)
+        pass


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGELOG.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Adds handling for a rare but mathematically possible error that has happened at least once in `xclim`

### Does this PR introduce a breaking change?

No.

### Other information:
```
  _______________________ test_loess_smoothing_nan[False] ________________________
  [gw2] darwin -- Python 3.11.9 /Users/runner/work/xclim/xclim/.tox/py311-coverage-extras/bin/python
  
  use_dask = False
  
      @pytest.mark.slow
      @pytest.mark.parametrize("use_dask", [True, False])
      def test_loess_smoothing_nan(use_dask):
          # create data with one axis full of nan
          data = np.random.randn(2, 2, 10)
          data[0, 0] = [np.nan] * 10
          da = xr.DataArray(
              data,
              dims=["scenario", "model", "time"],
              coords={"time": pd.date_range("2000-01-01", periods=10, freq="YS")},
          ).chunk({"time": -1})
      
          out = loess_smoothing(da)
      
          assert out.dims == da.dims
          # check that the output is all nan on the axis with nan in the input
  >       assert np.isnan(out.values[0, 0]).all()
  
  tests/test_sdba/test_loess.py:87: 
  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
  .tox/py311-coverage-extras/lib/python3.11/site-packages/xarray/core/dataarray.py:814: in values
      return self.variable.values
  .tox/py311-coverage-extras/lib/python3.11/site-packages/xarray/core/variable.py:566: in values
      return _as_array_or_item(self._data)
  .tox/py311-coverage-extras/lib/python3.11/site-packages/xarray/core/variable.py:363: in _as_array_or_item
      data = np.asarray(data)
  .tox/py311-coverage-extras/lib/python3.11/site-packages/dask/array/core.py:1709: in __array__
      x = self.compute()
  .tox/py311-coverage-extras/lib/python3.11/site-packages/dask/base.py:372: in compute
      (result,) = compute(self, traverse=False, **kwargs)
  .tox/py311-coverage-extras/lib/python3.11/site-packages/dask/base.py:660: in compute
      results = schedule(dsk, keys, **kwargs)
  .tox/py311-coverage-extras/lib/python3.11/site-packages/numpy/lib/_function_base_impl.py:2397: in __call__
      return self._call_as_normal(*args, **kwargs)
  .tox/py311-coverage-extras/lib/python3.11/site-packages/numpy/lib/_function_base_impl.py:2390: in _call_as_normal
      return self._vectorize_call(func=func, args=vargs)
  .tox/py311-coverage-extras/lib/python3.11/site-packages/numpy/lib/_function_base_impl.py:2471: in _vectorize_call
      res = self._vectorize_call_with_signature(func, args)
  .tox/py311-coverage-extras/lib/python3.11/site-packages/numpy/lib/_function_base_impl.py:2511: in _vectorize_call_with_signature
      results = func(*(arg[index] for arg in args))
  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
  
  >   raise np.linalg.LinAlgError(
          "Matrix is singular to machine precision.")
  E   numpy.linalg.LinAlgError: Matrix is singular to machine precision.
  
  .tox/py311-coverage-extras/lib/python3.11/site-packages/numba/np/linalg.py:899: LinAlgError
```
