### PR TITLE
Proper fix for loess linalg error - non-random tests

### DIFF
--- a/tests/test_sdba/test_loess.py
+++ b/tests/test_sdba/test_loess.py
@@ -74,7 +74,20 @@ def test_loess_smoothing(use_dask, open_dataset):
 @pytest.mark.parametrize("use_dask", [True, False])
 def test_loess_smoothing_nan(use_dask):
     # create data with one axis full of nan
-    data = np.random.randn(2, 2, 10)
+    # (random array taken from np.random.randn)
+    data = np.array(
+        [
+            -0.993, -0.980, -0.452, -0.076,  0.447,
+             0.389,  2.408,  0.966, -0.793,  0.090,
+            -0.173,  1.713, -1.579,  0.454, -0.272,
+            -0.005, -0.926, -2.022, -1.661, -0.493,
+            -0.643,  0.891,  0.194,  0.086,  0.983,
+            -1.048,  2.032,  1.174, -0.441, -0.204,
+            -1.126,  0.933,  1.987,  0.638,  0.789,
+             0.767,  0.676, -1.028,  1.422,  0.453,
+        ]
+    )
+    data = data.reshape(2,2,10)
     data[0, 0] = [np.nan] * 10
     da = xr.DataArray(
         data,
@@ -86,11 +99,4 @@ def test_loess_smoothing_nan(use_dask):
 
     assert out.dims == da.dims
     # check that the output is all nan on the axis with nan in the input
-    try:
-        assert np.isnan(out.values[0, 0]).all()
-    except np.linalg.LinAlgError:
-        msg = (
-            "This has roughly a 1/50,000,000 chance of occurring. Buy a lottery ticket!"
-        )
-        logging.error(msg)
-        pass
+    assert np.isnan(out.values[0, 0]).all()


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixed exceptionally rare linalgebra error from #2015 in a better way
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] CHANGELOG.rst has been updated (with summary of main changes)
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?
- Non-random tests are, in my opinion, better than random tests. This fixes the data for test_loess_smoothing_nan to be something known to work. Loess_smoothing does not work on singular matrices (which are very rare to occur randomly, but *do* occur).
- Also removes the too harsh condition on np.linalg.LinAlgError, which could occur for other reasons than singular matrices.
* ...

### Does this PR introduce a breaking change?


### Other information:
