### PR TITLE
Workflow security fixes

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -6,10 +6,10 @@ on:
       - main
     paths-ignore:
       - .*
-      - .github/*/*.md
-      - .github/*/*.yml
       - .github/*.md
       - .github/*.yml
+      - .github/*/*.md
+      - .github/*/*.yml
       - CHANGELOG.rst
       - CI/*.in
       - CI/*.txt
@@ -56,6 +56,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           token: ${{ steps.token_generator.outputs.token }}
+          persist-credentials: false
       - name: Set up Python3
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
@@ -68,17 +69,12 @@ jobs:
           git_user_signingkey: true
           git_commit_gpgsign: true
           trust_level: 5
-      - name: Current Version
-        run: |
-          CURRENT_VERSION="$(grep -E '__version__'  src/xclim/__init__.py | cut -d ' ' -f3)"
-          echo "current_version=${CURRENT_VERSION}"
-          echo "CURRENT_VERSION=${CURRENT_VERSION}" >> $GITHUB_ENV
       - name: Install CI libraries
         run: |
           python -m pip install --require-hashes -r CI/requirements_ci.txt
       - name: Conditional Bump
         run: |
-          if [[ ${{ env.CURRENT_VERSION }} =~ -dev(\.\d+)? ]]; then
+          if [[ $(bump-my-version show-bump | head -n 2 | tail -n 1 | cut -d' ' -f1) =~ -dev(\.\d+)? ]]; then
             echo "Development version (ends in 'dev(\.\d+)?'), bumping 'build' version"
             bump-my-version bump build
           else
@@ -87,9 +83,9 @@ jobs:
           fi
           NEW_VERSION="$(grep -E '__version__'  src/xclim/__init__.py | cut -d ' ' -f3)"
           echo "new_version=${NEW_VERSION}"
-          echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_ENV
       - name: Push Changes
         uses: ad-m/github-push-action@d91a481090679876dfc4178fef17f286781251df # v0.8.0
         with:
           force: false
           branch: ${{ github.ref }}
+          github_token: '${{ token_generator.outputs.token }}'

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -74,15 +74,15 @@ jobs:
           python -m pip install --require-hashes -r CI/requirements_ci.txt
       - name: Conditional Bump
         run: |
-          if [[ $(bump-my-version show-bump | head -n 2 | tail -n 1 | cut -d' ' -f1) =~ -dev(\.\d+)? ]]; then
+          CURRENT_VERSION=$(bump-my-version show current_version)
+          if [[ ${CURRENT_VERSION} =~ -dev(\.\d+)? ]]; then
             echo "Development version (ends in 'dev(\.\d+)?'), bumping 'build' version"
             bump-my-version bump build
           else
             echo "Version is stable, bumping 'patch' version"
             bump-my-version bump patch
           fi
-          NEW_VERSION="$(grep -E '__version__'  src/xclim/__init__.py | cut -d ' ' -f3)"
-          echo "new_version=${NEW_VERSION}"
+          echo "new_version=$(bump-my-version show current_version)"
       - name: Push Changes
         uses: ad-m/github-push-action@d91a481090679876dfc4178fef17f286781251df # v0.8.0
         with:

--- a/.github/workflows/cache-cleaner.yml
+++ b/.github/workflows/cache-cleaner.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Cleanup
         run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,17 +5,17 @@ on:
     branches:
       - main
     paths-ignore:
+      - .github/*/*.yml
+      - .pre-commit-config.yaml
       - CHANGELOG.rst
       - CI/*.txt
       - Makefile
-      - pyproject.toml
-      - tox.ini
-      - src/xclim/__init__.py
       - docs/*/*.ipynb
       - docs/*/*.py
       - docs/*/*.rst
-      - .github/*/*.yml
-      - .pre-commit-config.yaml
+      - pyproject.toml
+      - src/xclim/__init__.py
+      - tox.ini
   pull_request:
     branches:
       - main
@@ -51,14 +51,20 @@ jobs:
             objects.githubusercontent.com:443
             pypi.org:443
             uploads.github.com:443
+
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@1245696032ecf7d39f87d54daa406e22ddf769a8
         with:
           languages: ${{ matrix.language }}
+
       - name: Autobuild
         uses: github/codeql-action/autobuild@1245696032ecf7d39f87d54daa406e22ddf769a8
+
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@1245696032ecf7d39f87d54daa406e22ddf769a8

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -41,6 +41,8 @@ jobs:
 
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Dependency Review
         uses: actions/dependency-review-action@3b139cfc5fae8b618d3eae3675e383bb1769c019 # v4.5.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,6 +63,8 @@ jobs:
         continue-on-error: true
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Set up Python3
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
@@ -138,6 +140,8 @@ jobs:
         continue-on-error: true
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Set up Python${{ matrix.python-version }}
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
@@ -263,6 +267,8 @@ jobs:
         continue-on-error: true
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Install Eigen3 (SBCK)
         if: ${{ matrix.python-version == '3.11' && matrix.os == 'ubuntu-latest' }}
         run: |
@@ -367,6 +373,8 @@ jobs:
         continue-on-error: true
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Setup Conda (Micromamba) with Python${{ matrix.python-version }}
         uses: mamba-org/setup-micromamba@06375d89d211a1232ef63355742e9e2e564bc7f7 # v2.0.2
         with:

--- a/.github/workflows/publish-mastodon.yml
+++ b/.github/workflows/publish-mastodon.yml
@@ -26,12 +26,14 @@ jobs:
 
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Get Release Description
         run: |
           # Fetch the release information using the GitHub API
           RELEASE_INFO=$(curl -sH "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/repos/${{ github.repository }}/releases/tags/${{ github.event.release.tag_name }}")
+            "https://api.github.com/repos/${{ github.repository }}/releases/tags/${TAG_NAME}")
 
           # Extract the release description from the response
           RELEASE_DESCRIPTION=$(echo "$RELEASE_INFO" | jq -r .body)
@@ -43,6 +45,8 @@ jobs:
           CONTRIBUTORS=$(echo "$CLEANED_DESCRIPTION" | head -n 1)
 
           echo "contributors=${CONTRIBUTORS}" >> $GITHUB_ENV
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
 
       - name: Prepare Message
         id: render_template
@@ -55,7 +59,10 @@ jobs:
 
       - name: Message Preview
         run: |
-          echo "${{ steps.render_template.outputs.result }}${{ env.contributors }}"
+          echo "${TEMPLATE}${CONTRIBUTORS}"
+        env:
+          TEMPLATE: ${{ steps.render_template.outputs.result }}
+          CONTRIBUTORS: ${{ env.contributors }}
 
       - name: Send toot to Mastodon
         uses: cbrgm/mastodon-github-action@50b70e53ab0871a90fe364ff96e783c7e3633f15 # v2.1.11

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -30,6 +30,8 @@ jobs:
             upload.pypi.org:443
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Set up Python3
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -16,7 +16,9 @@ on:
       - main
 
 # Declare default permissions as read only.
-permissions: read-all
+# Read-all permission is not technically needed for this workflow.
+permissions:
+  contents: read
 
 jobs:
   analysis:

--- a/.github/workflows/tag-testpypi.yml
+++ b/.github/workflows/tag-testpypi.yml
@@ -30,6 +30,8 @@ jobs:
             test.pypi.org:443
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Set up Python3
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:

--- a/.github/workflows/testdata-version.yml
+++ b/.github/workflows/testdata-version.yml
@@ -31,6 +31,8 @@ jobs:
             github.com:443
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Find xclim-testdata Tag and CI Testing Branch
         run: |
           XCLIM_TESTDATA_TAG="$( \
@@ -43,8 +45,11 @@ jobs:
           echo "XCLIM_TESTDATA_BRANCH=${XCLIM_TESTDATA_BRANCH}" >> $GITHUB_ENV
       - name: Report Versions Found
         run: |
-          echo "Latest xclim-testdata tag: ${{ env.XCLIM_TESTDATA_TAG }}"
-          echo "Tag for xclim-testdata in CI: ${{ env.XCLIM_TESTDATA_BRANCH }}"
+          echo "Latest xclim-testdata tag: ${XCLIM_TESTDATA_TAG}"
+          echo "Tag for xclim-testdata in CI: ${XCLIM_TESTDATA_BRANCH}"
+        env:
+          XCLIM_TESTDATA_TAG: ${{ env.XCLIM_TESTDATA_TAG }}
+          XCLIM_TESTDATA_BRANCH: ${{ env.XCLIM_TESTDATA_BRANCH }}
       - name: Find Comment
         uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
         id: fc

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -69,6 +69,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0 # Fetch all history for all branches and tags.
+          persist-credentials: false
       - name: Setup Conda (Micromamba) with Python${{ matrix.python-version }}
         uses: mamba-org/setup-micromamba@06375d89d211a1232ef63355742e9e2e564bc7f7 # v2.0.2
         with:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,6 +40,9 @@ Internal changes
 CI changes
 ^^^^^^^^^^
 * Added the `green-coding-solutions/eco-ci-energy-estimation` GitHub Action to the workflows to establish energy and carbon usage of CI activity. (:pull:`1863`).
+* Various workflow security fixes: (:pull:`2023`)
+    * Simplified the `bump-version.yml` version string parsing to harden against template injection.
+    * Further de-escalated privileges for most workflows.
 
 New features and enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGELOG.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* De-escalates the privileges of steps in workflows by restricting credentials
* Reduces the risk of template injection in `run` steps
* Simplifies the `bump-my-version` logic

### Does this PR introduce a breaking change?

It should not.

### Other information:

Changes suggested here were determined from analysis using https://github.com/woodruffw/zizmor

There are a handful of workflows that require `pull_request_target` triggers. This is insecure since it runs actions in the parent repo that can be influenced by configurations stemming from forks. The only way to fully secure this would be to try using [reusable workflows](https://docs.github.com/en/actions/sharing-automations/reusing-workflows). This would be a medium-effort task, with gains across all Ouranos repositories. 