### PR TITLE
Enable select_resample_op for unitless data

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,7 +25,8 @@ Internal changes
 
 Bug fixes
 ^^^^^^^^^
-* Fixed an issue in ``xclim.core.units.to_agg_units`` that broke the resampling when computing on unitless data
+* Fixed an issue in ``xclim.core.units.to_agg_units`` that broke the resampling when computing on unitless data (:pull:`2060`).
+
 v0.54.0 (2024-12-16)
 --------------------
 Contributors to this version: Trevor James Smith (:user:`Zeitsperre`), Pascal Bourgault (:user:`aulemahal`), Éric Dupuis (:user:`coxipi`), Sascha Hofmann (:user:`saschahofmann`).

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,9 @@ Internal changes
 * Adjusted the ``TestOfficialYaml`` test to use a dynamic method for finding the installed location of `xclim`. (:pull:`2028`).
 * Adjusted two tests for better handling when running in Windows environments. (:pull:`2057`).
 
+Bug fixes
+^^^^^^^^^
+* Fixed an issue in ``xclim.core.units.to_agg_units`` that broke the resampling when computing on unitless data
 v0.54.0 (2024-12-16)
 --------------------
 Contributors to this version: Trevor James Smith (:user:`Zeitsperre`), Pascal Bourgault (:user:`aulemahal`), Éric Dupuis (:user:`coxipi`), Sascha Hofmann (:user:`saschahofmann`).

--- a/src/xclim/core/units.py
+++ b/src/xclim/core/units.py
@@ -666,6 +666,9 @@ def to_agg_units(
     >>> degdays.units
     'd K'
     """
+    if "units" not in orig.attrs:
+        return out
+
     is_difference = True if op in ["std", "var"] else None
 
     if op in ["amin", "min", "amax", "max", "mean", "sum", "std"]:


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGELOG.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* `to_agg_units` now returns the resampled data without units if the original data was unitless
I could imagine that maybe you don't ever want unitless data in which this can be closed but if not then this is an easy fix.


### Does this PR introduce a breaking change?
I don't think so.


### Reproducible example
Before this change this example was breaking with a `KeyError`
```python
from xclim.indices.generic import select_resample_op
import xarray as xr
import numpy as np

time = xr.cftime_range("2000-01-01", "2000-12-31", freq="D", calendar="noleap")
da = xr.DataArray(np.random.random_sample((time.size,)), coords={"time": time})

select_resample_op(da, op='max', freq='MS')
```