### PR TITLE
Fix/solar zenith time cast

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -158,6 +158,11 @@
       "name": "Hamon, Baptiste",
       "affiliation": "University of Canterbury, Christchurch, New Zealand",
       "orcid": "0009-0007-4530-9772"
+    },
+    {
+      "name": "Wong, Jack Kit-tai",
+      "affiliation": "University of Toronto, Toronto, Ontario, Canada",
+      "orcid": "0000-0003-1408-1502"
     }
   ],
   "keywords": [

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -49,4 +49,4 @@ Contributors
 * Faisal Mahmood <mahmood.faisal@ouranos.ca> <faisal.shovon.007@gmail.com> `@faimahsho <https://github.com/faimahsho>`_
 * Sebastian Lehner <sebastian.lehner@geosphere.at> `@seblehner <https://github.com/seblehner>`_
 * Baptiste Hamon <baptiste.hamon@pg.canterbury.ac.nz> `@baptistehamon <https://github.com/baptistehamon>`_
-* Jack Kit-tai Wong <kit.tai.wong@gmail.com> `@jack-ktw <http2://github.com/jack-ktw>`_
+* Jack Kit-tai Wong <kit.tai.wong@gmail.com> `@jack-ktw <https://github.com/jack-ktw>`_

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -49,3 +49,4 @@ Contributors
 * Faisal Mahmood <mahmood.faisal@ouranos.ca> <faisal.shovon.007@gmail.com> `@faimahsho <https://github.com/faimahsho>`_
 * Sebastian Lehner <sebastian.lehner@geosphere.at> `@seblehner <https://github.com/seblehner>`_
 * Baptiste Hamon <baptiste.hamon@pg.canterbury.ac.nz> `@baptistehamon <https://github.com/baptistehamon>`_
+* Jack Kit-tai Wong <kit.tai.wong@gmail.com> `@jack-ktw <http2://github.com/jack-ktw>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ Contributors to this version: Trevor James Smith (:user:`Zeitsperre`), Hui-Min W
 Bug fixes
 ^^^^^^^^^
 * Fix installation instructions in the Contributing guide (:issue:`2088`, :pull:`2089`).
-* Fixed parameter order in typing.cast() causing intermittent errors in solar_zenith_angle calculation. (:issue:`2097`, :pull:``)
+* Fixed parameter order in typing.cast() causing intermittent errors in solar_zenith_angle calculation. (:issue:`2097`, :pull:`2098`)
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,11 +4,12 @@ Changelog
 
 v0.56.0 (unreleased)
 --------------------
-Contributors to this version: Trevor James Smith (:user:`Zeitsperre`), Hui-Min Wang (:user:`Hem-W`).
+Contributors to this version: Trevor James Smith (:user:`Zeitsperre`), Hui-Min Wang (:user:`Hem-W`), Jack Kit-tai Wong(:user:`jack-ktw`).
 
 Bug fixes
 ^^^^^^^^^
 * Fix installation instructions in the Contributing guide (:issue:`2088`, :pull:`2089`).
+* Fixed parameter order in typing.cast() causing intermittent errors in solar_zenith_angle calculation. (:issue:`2097`, :pull:``)
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/src/xclim/indices/helpers.py
+++ b/src/xclim/indices/helpers.py
@@ -288,7 +288,7 @@ def cosine_of_solar_zenith_angle(
         h_e = np.pi - 1e-9  # just below pi
     else:
         if time.dtype == "O":  # cftime
-            time_as_s = time.copy(data=xr.CFTimeIndex(cast(time.values, np.ndarray)).asi8 / 1e6)
+            time_as_s = time.copy(data=xr.CFTimeIndex(cast(np.ndarray, time.values)).asi8 / 1e6)
         else:  # numpy
             time_as_s = time.copy(data=time.astype(float) / 1e9)
         h_s_utc = (((time_as_s % S_IN_D) / S_IN_D) * 2 * np.pi + np.pi).assign_attrs(units="rad")

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -81,8 +81,9 @@ def test_day_lengths(method):
                 np.testing.assert_allclose(dl.sel(time=e[0]).transpose(), np.array(e[1]), rtol=2e-1)
 
 
-def test_cosine_of_solar_zenith_angle():
-    time = xr.date_range("1900-01-01T00:30", "1900-01-03", freq="h")
+@pytest.mark.parametrize("calendar", ["standard", "noleap"])
+def test_cosine_of_solar_zenith_angle(calendar):
+    time = xr.date_range("1900-01-01T00:30", "1900-01-03", freq="h", calendar=calendar)
     time = xr.DataArray(time, dims=("time",), coords={"time": time}, name="time")
     lat = xr.DataArray([0, 45, 70], dims=("site",), name="lat", attrs={"units": "degree_north"})
     lon = xr.DataArray([-40, 0, 80], dims=("site",), name="lon", attrs={"units": "degree_east"})


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #2097
- [ ] Tests for the changes have been added (for bug fixes / features) 
  - Note: The bug was discovered during parallel processing of multiple datasets, and appeared randomly.
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGELOG.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`2097`) and pull request (:pull:`2098`) has been added

### What kind of change does this PR introduce?

Bug fix: Correct parameter order in typing.cast() causing intermittent errors in solar_zenith_angle calculation

### Does this PR introduce a breaking change?

No

### Other information:

his fix corrects a parameter ordering issue in the typing.cast() function call which was causing intermittent errors when processing multiple climate datasets in parallel. The fix is minimal and simply swaps the parameters to match the correct typing.cast(type, value) signature.
