### PR TITLE
Avoid unnecessary time frequency resampling

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 
 v0.56.0 (unreleased)
 --------------------
-Contributors to this version: Trevor James Smith (:user:`Zeitsperre`), Hui-Min Wang (:user:`Hem-W`), Jack Kit-tai Wong(:user:`jack-ktw`), Adrien Lamarche (:user:`LamAdr`), Éric Dupuis (:user:`coxipi`), Hui-Min Wang (:user:`Hem-W`).
+Contributors to this version: Trevor James Smith (:user:`Zeitsperre`), Hui-Min Wang (:user:`Hem-W`), Jack Kit-tai Wong(:user:`jack-ktw`), Adrien Lamarche (:user:`LamAdr`), Éric Dupuis (:user:`coxipi`).
 
 Bug fixes
 ^^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 
 v0.56.0 (unreleased)
 --------------------
-Contributors to this version: Trevor James Smith (:user:`Zeitsperre`), Hui-Min Wang (:user:`Hem-W`), Jack Kit-tai Wong(:user:`jack-ktw`), Adrien Lamarche (:user:`LamAdr`), Éric Dupuis (:user:`coxipi`).
+Contributors to this version: Trevor James Smith (:user:`Zeitsperre`), Hui-Min Wang (:user:`Hem-W`), Jack Kit-tai Wong(:user:`jack-ktw`), Adrien Lamarche (:user:`LamAdr`), Éric Dupuis (:user:`coxipi`), Hui-Min Wang (:user:`Hem-W`).
 
 Bug fixes
 ^^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Bug fixes
 ^^^^^^^^^
 * Fix installation instructions in the Contributing guide (:issue:`2088`, :pull:`2089`).
 * Fixed parameter order in typing.cast() causing intermittent errors in solar_zenith_angle calculation. (:issue:`2097`, :pull:`2098`)
+* Avoid unnecessary time resampling in `preprocess_standardized_index` when `freq` is not None but the same as the input data.
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ Bug fixes
 ^^^^^^^^^
 * Fix installation instructions in the Contributing guide (:issue:`2088`, :pull:`2089`).
 * Fixed parameter order in typing.cast() causing intermittent errors in solar_zenith_angle calculation. (:issue:`2097`, :pull:`2098`)
-* Avoid unnecessary time resampling in `preprocess_standardized_index` when `freq` is not None but the same as the input data.
+* Avoid unnecessary time resampling in `preprocess_standardized_index` when `freq` is not None but the same as the input data. (:issue:`2111`, :pull:`2112`)
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/src/xclim/indices/stats.py
+++ b/src/xclim/indices/stats.py
@@ -742,7 +742,7 @@ def preprocess_standardized_index(da: xr.DataArray, freq: str | None, window: in
         )
         group = "time.dayofyear"
 
-    if freq is not None:
+    if freq is not None and xr.infer_freq(da.time) != freq:
         da = da.resample(time=freq).mean(keep_attrs=True)
 
     if uses_dask(da) and len(da.chunks[da.get_axis_num("time")]) > 1:


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #2111 
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGELOG.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Avoid unnecessary time resampling in `preprocess_standardized_index` when `freq` is not None but the same as the input data.

### Does this PR introduce a breaking change?
No

### Other information:
I am thinking whether it is necessary to prompt users to install `flox` when they input dask datasets and require time resampling.