### PR TITLE
Fix issue with xr.core.ops renamed in versions of xarray>=2025.3.0

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -163,6 +163,11 @@
       "name": "Wong, Jack Kit-tai",
       "affiliation": "University of Toronto, Toronto, Ontario, Canada",
       "orcid": "0000-0003-1408-1502"
+    },
+    {
+      "name": "de Bruijn, Jens",
+      "affiliation": "Vrije Universiteit, Amsterdam, The Netherlands",
+      "orcid": "0000-0003-3961-6382"
     }
   ],
   "keywords": [

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -50,3 +50,4 @@ Contributors
 * Sebastian Lehner <sebastian.lehner@geosphere.at> `@seblehner <https://github.com/seblehner>`_
 * Baptiste Hamon <baptiste.hamon@pg.canterbury.ac.nz> `@baptistehamon <https://github.com/baptistehamon>`_
 * Jack Kit-tai Wong <kit.tai.wong@gmail.com> `@jack-ktw <https://github.com/jack-ktw>`_
+* Jens de Bruijn <j.a.debruijn@outlook.com> `@jensdebruijn <https://github.com/jensdebruijn>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,12 +4,13 @@ Changelog
 
 v0.56.0 (unreleased)
 --------------------
-Contributors to this version: Trevor James Smith (:user:`Zeitsperre`), Hui-Min Wang (:user:`Hem-W`), Jack Kit-tai Wong(:user:`jack-ktw`), Adrien Lamarche (:user:`LamAdr`), Éric Dupuis (:user:`coxipi`).
+Contributors to this version: Trevor James Smith (:user:`Zeitsperre`), Hui-Min Wang (:user:`Hem-W`), Jack Kit-tai Wong(:user:`jack-ktw`), Adrien Lamarche (:user:`LamAdr`), Éric Dupuis (:user:`coxipi`), Jens de Bruijn (:user:`jensdebruijn`).
 
 Bug fixes
 ^^^^^^^^^
 * Fix installation instructions in the Contributing guide (:issue:`2088`, :pull:`2089`).
 * Fixed parameter order in typing.cast() causing intermittent errors in solar_zenith_angle calculation. (:issue:`2097`, :pull:`2098`)
+* `xclim` now uses directly `operator` instead of using `xarray`'s derived `get_op` function. A refactoring in `xarray` had changed the position of `get_op` which caused a bug.  (:issue:`2113`, :pull:`2114`).
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/src/xclim/indices/generic.py
+++ b/src/xclim/indices/generic.py
@@ -278,7 +278,10 @@ def get_op(op: str, constrain: Sequence[str] | None = None) -> Callable:
         if op not in constraints:
             raise ValueError(f"Operation `{op}` not permitted for indice.")
 
-    return xr.core.ops.get_op(binary_op)  # noqa
+    if xr.__version__ <= "2025.1.2":
+        return xr.core.ops.get_op(binary_op)
+    else:
+        return xr.computation.ops.get_op(binary_op)  # noqa
 
 
 def compare(

--- a/src/xclim/indices/generic.py
+++ b/src/xclim/indices/generic.py
@@ -7,9 +7,9 @@ Helper functions for common generic actions done in the computation of indices.
 
 from __future__ import annotations
 
+import operator
 import warnings
 from collections.abc import Callable, Sequence
-import operator
 
 import cftime
 import numpy as np
@@ -279,7 +279,7 @@ def get_op(op: str, constrain: Sequence[str] | None = None) -> Callable:
         if op not in constraints:
             raise ValueError(f"Operation `{op}` not permitted for indice.")
 
-    return  getattr(operator, f"__{binary_op}__")
+    return getattr(operator, f"__{binary_op}__")
 
 
 def compare(

--- a/src/xclim/indices/generic.py
+++ b/src/xclim/indices/generic.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import Callable, Sequence
+import operator
 
 import cftime
 import numpy as np
@@ -278,10 +279,7 @@ def get_op(op: str, constrain: Sequence[str] | None = None) -> Callable:
         if op not in constraints:
             raise ValueError(f"Operation `{op}` not permitted for indice.")
 
-    if xr.__version__ <= "2025.1.2":
-        return xr.core.ops.get_op(binary_op)
-    else:
-        return xr.computation.ops.get_op(binary_op)  # noqa
+    return  getattr(operator, f"__{binary_op}__")
 
 
 def compare(


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes [#2113 ](https://github.com/Ouranosinc/xclim/issues/2113)
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGELOG.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* This PR fixes an issue with an operation not being available in xarray versions later than 2025.3.0

### Does this PR introduce a breaking change?

No breaking changes

### Other information:
