### PR TITLE
Datetime fixes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ Bug fixes
     + All other uses of `xarray`'s internal API were also removed (:pull:`2116`).
 * Fixed an issue with star-annotated call signatures to maintain Python 3.10 compatibility. (:pull:`2116`).
 * Fixed `to_agg_units` that was converting units of temperature differences prematurely, without changing accordingly the values in the related DataArrays. (:issue:`2121`, :pull:`2122`).
-* ``get_calendar`` now supports pandas' ``DatetimeIndex``. xclim no longer uses ``xarray.cftime_range``, which has been deprecated. (:pull:`2130`).
+* ``get_calendar`` now supports pandas' ``DatetimeIndex``. `xclim` no longer uses ``xarray.cftime_range``, which has been deprecated. (:pull:`2130`).
 * Avoid unnecessary time resampling in `preprocess_standardized_index` when `freq` is not None but the same as the input data. (:issue:`2111`, :pull:`2112`)
 * Fixed an issue with ``fire_season`` that made it fail with datasets having non-uniform chunks. (:issue:`2129`, :pull:`2132`).
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Bug fixes
     + All other uses of `xarray`'s internal API were also removed (:pull:`2116`).
 * Fixed an issue with star-annotated call signatures to maintain Python 3.10 compatibility. (:pull:`2116`).
 * Fixed `to_agg_units` that was converting units of temperature differences prematurely, without changing accordingly the values in the related DataArrays. (:issue:`2121`, :pull:`2122`).
+* ``get_calendar`` now supports pandas' ``DatetimeIndex``. xclim no longer uses ``xarray.cftime_range``, which has been deprecated. (:pull:`2130`).
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/src/xclim/core/calendar.py
+++ b/src/xclim/core/calendar.py
@@ -146,6 +146,8 @@ def get_calendar(obj: Any, dim: str = "time") -> str:
         return obj[dim].dt.calendar
     if isinstance(obj, xr.CFTimeIndex):
         obj = obj.values[0]
+    elif isinstance(obj, pd.DatetimeIndex):
+        return "standard"
     else:
         obj = np.take(obj, 0)
         # Take zeroth element, overcome cases when arrays or lists are passed.

--- a/src/xclim/core/units.py
+++ b/src/xclim/core/units.py
@@ -617,7 +617,7 @@ def to_agg_units(out: xr.DataArray, orig: xr.DataArray, op: str, dim: str = "tim
     `to_agg_units` will infer the units from the sampling rate along "time", so
     we ensure the final units are correct:
 
-    >>> time = xr.cftime_range("2001-01-01", freq="D", periods=365)
+    >>> time = xr.date_range("2001-01-01", freq="D", periods=365)
     >>> tas = xr.DataArray(
     ...     np.arange(365),
     ...     dims=("time",),
@@ -634,7 +634,7 @@ def to_agg_units(out: xr.DataArray, orig: xr.DataArray, op: str, dim: str = "tim
 
     Similarly, here we compute the total heating degree-days, but we have weekly data:
 
-    >>> time = xr.cftime_range("2001-01-01", freq="7D", periods=52)
+    >>> time = xr.date_range("2001-01-01", freq="7D", periods=52)
     >>> tas = xr.DataArray(
     ...     np.arange(52) + 10,
     ...     dims=("time",),
@@ -853,7 +853,7 @@ def rate2amount(
     --------
     The following converts a daily array of precipitation in mm/h to the daily amounts in mm:
 
-    >>> time = xr.cftime_range("2001-01-01", freq="D", periods=365)
+    >>> time = xr.date_range("2001-01-01", freq="D", periods=365)
     >>> pr = xr.DataArray([1] * 365, dims=("time",), coords={"time": time}, attrs={"units": "mm/h"})
     >>> pram = rate2amount(pr)
     >>> pram.units
@@ -1088,7 +1088,7 @@ def rate2flux(
     The following converts an array of snowfall rate in mm/s to snowfall flux in kg m-2 s-1,
     assuming a density of 100 kg m-3:
 
-    >>> time = xr.cftime_range("2001-01-01", freq="D", periods=365)
+    >>> time = xr.date_range("2001-01-01", freq="D", periods=365)
     >>> prsnd = xr.DataArray([1] * 365, dims=("time",), coords={"time": time}, attrs={"units": "mm/s"})
     >>> prsn = rate2flux(prsnd, density="100 kg m-3", out_units="kg m-2 s-1")
     >>> prsn.units
@@ -1138,7 +1138,7 @@ def flux2rate(
     The following converts an array of snowfall flux in kg m-2 s-1 to snowfall flux in mm/s,
     assuming a density of 100 kg m-3:
 
-    >>> time = xr.cftime_range("2001-01-01", freq="D", periods=365)
+    >>> time = xr.date_range("2001-01-01", freq="D", periods=365)
     >>> prsn = xr.DataArray(
     ...     [0.1] * 365,
     ...     dims=("time",),

--- a/src/xclim/indices/run_length.py
+++ b/src/xclim/indices/run_length.py
@@ -1660,12 +1660,13 @@ def index_of_date(
     """
     if date is None:
         return np.array([default])
-    try:
+    if len(date.split("-")) == 2:
+        date = f"2000-{date}"
+        date = datetime.strptime(date, "%Y-%m-%d")
+        year_cond = True
+    else:
         date = datetime.strptime(date, "%Y-%m-%d")
         year_cond = time.dt.year == date.year
-    except ValueError:
-        date = datetime.strptime(date, "%m-%d")
-        year_cond = True
 
     idxs = np.where(year_cond & (time.dt.month == date.month) & (time.dt.day == date.day))[0]
     if max_idxs is not None and idxs.size > max_idxs:

--- a/src/xclim/indices/run_length.py
+++ b/src/xclim/indices/run_length.py
@@ -1661,7 +1661,7 @@ def index_of_date(
     if date is None:
         return np.array([default])
     if len(date.split("-")) == 2:
-        date = f"2000-{date}"
+        date = f"1840-{date}"
         date = datetime.strptime(date, "%Y-%m-%d")
         year_cond = True
     else:

--- a/src/xclim/testing/helpers.py
+++ b/src/xclim/testing/helpers.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
-import pandas as pd
 import xarray as xr
 from dask.callbacks import Callback
 
@@ -131,7 +130,7 @@ def add_example_file_paths() -> dict[str, str | list[xr.DataArray]]:
     }
 
     # For core.utils.load_module example
-    sixty_years = xr.cftime_range("1990-01-01", "2049-12-31", freq="D")
+    sixty_years = xr.date_range("1990-01-01", "2049-12-31", freq="D")
     namespace["temperature_datasets"] = [
         xr.DataArray(
             12 * np.random.random_sample(sixty_years.size) + 273,
@@ -214,10 +213,7 @@ def test_timeseries(
     xr.DataArray or xr.Dataset
         A DataArray or Dataset with time, lon and lat dimensions.
     """
-    if calendar or cftime:
-        coords = xr.cftime_range(start, periods=len(values), freq=freq, calendar=calendar or "standard")
-    else:
-        coords = pd.date_range(start, periods=len(values), freq=freq)
+    coords = xr.date_range(start, periods=len(values), freq=freq, calendar=calendar or "standard", use_cftime=cftime)
 
     if variable in VARIABLES:
         attrs = {a: VARIABLES[variable].get(a, "") for a in ["description", "standard_name", "cell_methods"]}

--- a/src/xclim/testing/helpers.py
+++ b/src/xclim/testing/helpers.py
@@ -183,7 +183,7 @@ def test_timeseries(
     units: str | None = None,
     freq: str = "D",
     as_dataset: bool = False,
-    cftime: bool = False,
+    cftime: bool | None = None,
     calendar: str | None = None,
 ) -> xr.DataArray | xr.Dataset:
     """
@@ -204,7 +204,7 @@ def test_timeseries(
     as_dataset : bool
         Whether to return a Dataset or a DataArray. Default is False.
     cftime : bool
-        Whether to use cftime or not. Default is False.
+        Whether to use cftime or not. Default is None, which uses cftime only for non-standard calendars.
     calendar : str or None
         Whether to use a calendar. If a calendar is provided, cftime is used.
 

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -37,12 +37,12 @@ def time_range_kwargs(request):
 
 @pytest.fixture()
 def datetime_index(time_range_kwargs):
-    return pd.date_range(**time_range_kwargs)
+    return xr.date_range(**time_range_kwargs)
 
 
 @pytest.fixture()
 def cftime_index(time_range_kwargs):
-    return xr.cftime_range(**time_range_kwargs)
+    return xr.date_range(use_cftime=True, **time_range_kwargs)
 
 
 def da(index):
@@ -69,18 +69,14 @@ def test_time_bnds(freq, datetime_index, cftime_index):
     assert_array_equal(cftime_ends, out_periods.end_time)
 
 
-@pytest.mark.parametrize("typ", ["pd", "xr"])
-def test_time_bnds_irregular(typ):
+@pytest.mark.parametrize("use_cftime", [True, False])
+def test_time_bnds_irregular(use_cftime):
     """Test time_bnds for irregular `middle of the month` time series."""
-    if typ == "xr":
-        start = xr.cftime_range("1990-01-01", periods=24, freq="MS")
-        # Well. xarray string parsers do not support sub-second resolution, but cftime does.
-        end = xr.cftime_range("1990-01-01T23:59:59", periods=24, freq="ME") + pd.Timedelta(0.999999, "s")
-    elif typ == "pd":
-        start = pd.date_range("1990-01-01", periods=24, freq="MS")
-        end = pd.date_range("1990-01-01 23:59:59.999999999", periods=24, freq="ME")
-    else:
-        raise ValueError("`typ` must be 'pd' or 'xr'")
+    start = xr.date_range("1990-01-01", periods=24, freq="MS", use_cftime=use_cftime)
+    # Well. xarray string parsers do not support sub-second resolution, but cftime does.
+    end = xr.date_range("1990-01-01T23:59:59", periods=24, freq="ME", use_cftime=use_cftime) + pd.Timedelta(
+        0.999999, "s"
+    )
 
     time = start + (end - start) / 2
 
@@ -165,7 +161,7 @@ def test_adjust_doy_360_to_366():
 def test_adjust_doy__max_93_to_max_94():
     # GIVEN
     source = xr.DataArray(np.arange(92), coords=[np.arange(152, 244)], dims="dayofyear")
-    time = xr.cftime_range("2000-06-01", periods=92, freq="D", calendar="all_leap")
+    time = xr.date_range("2000-06-01", periods=92, freq="D", calendar="all_leap")
     target = xr.DataArray(np.arange(len(time)), coords=[time], dims="time")
     # WHEN
     out = adjust_doy_calendar(source, target)
@@ -183,7 +179,7 @@ def test_adjust_doy__leap_to_noleap_djf():
         coords=[np.concatenate([np.arange(1, 61), np.arange(335, 367)])],
         dims="dayofyear",
     )
-    time = xr.cftime_range("2000-12-01", periods=91, freq="D", calendar="noleap")
+    time = xr.date_range("2000-12-01", periods=91, freq="D", calendar="noleap")
     no_leap_target = xr.DataArray(np.arange(len(time)), coords=[time], dims="time")
     # WHEN
     out = adjust_doy_calendar(leap_source, no_leap_target)
@@ -197,7 +193,7 @@ def test_adjust_doy__leap_to_noleap_djf():
 
 def test_adjust_doy_366_to_360():
     source = xr.DataArray(np.arange(366), coords=[np.arange(1, 367)], dims="dayofyear")
-    time = xr.cftime_range("2000", periods=360, freq="D", calendar="360_day")
+    time = xr.date_range("2000", periods=360, freq="D", calendar="360_day")
     target = xr.DataArray(np.arange(len(time)), coords=[time], dims="time")
 
     out = adjust_doy_calendar(source, target)
@@ -242,7 +238,7 @@ def test_get_calendar(file, cal, maxdoy, open_dataset):
         (pd.Timestamp.now(), "standard"),
         (cftime.DatetimeAllLeap(2000, 1, 1), "all_leap"),
         (np.array([cftime.DatetimeNoLeap(2000, 1, 1)]), "noleap"),
-        (xr.cftime_range("2000-01-01", periods=4, freq="D"), "standard"),
+        (xr.date_range("2000-01-01", periods=4, freq="D"), "standard"),
     ],
 )
 def test_get_calendar_nonxr(obj, cal):

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -75,7 +75,7 @@ def test_time_bnds_irregular(use_cftime):
     start = xr.date_range("1990-01-01", periods=24, freq="MS", use_cftime=use_cftime)
     # Well. xarray string parsers do not support sub-second resolution, but cftime does.
     end = xr.date_range("1990-01-01T23:59:59", periods=24, freq="ME", use_cftime=use_cftime) + pd.Timedelta(
-        0.999999, "s"
+        0.999999999, "s"
     )
 
     time = start + (end - start) / 2

--- a/tests/test_ensembles.py
+++ b/tests/test_ensembles.py
@@ -19,7 +19,6 @@ import sys
 from pathlib import Path
 
 import numpy as np
-import pandas as pd
 import pytest
 import xarray as xr
 from scipy.stats.mstats import mquantiles
@@ -100,12 +99,12 @@ class TestEnsembleStats:
         assert ens_mean.where(~(np.isnan(ens_mean)), drop=True).time.dt.year.max() == 2050
 
     @pytest.mark.parametrize(
-        "timegen,calkw",
-        [(xr.cftime_range, {"calendar": "360_day"}), (pd.date_range, {})],
+        "calkw",
+        [{"calendar": "360_day"}, {}],
     )
-    def test_create_unaligned_times(self, timegen, calkw):
-        t1 = timegen("2000-01-01", periods=24, freq="ME", **calkw)
-        t2 = timegen("2000-01-01", periods=24, freq="MS", **calkw)
+    def test_create_unaligned_times(self, calkw):
+        t1 = xr.date_range("2000-01-01", periods=24, freq="ME", **calkw)
+        t2 = xr.date_range("2000-01-01", periods=24, freq="MS", **calkw)
 
         d1 = xr.DataArray(np.arange(24), dims=("time",), coords={"time": t1}, name="tas")
         d2 = xr.DataArray(np.arange(24), dims=("time",), coords={"time": t2}, name="tas")
@@ -569,9 +568,9 @@ def robust_data(random):
         ]
     )
     ref = xr.DataArray(ref, dims=("lon", "realization", "time"), name="tas")
-    ref["time"] = xr.cftime_range("2000-01-01", periods=40, freq="YS")
+    ref["time"] = xr.date_range("2000-01-01", periods=40, freq="YS", use_cftime=True)
     fut = xr.DataArray(fut, dims=("lon", "realization", "time"), name="tas")
-    fut["time"] = xr.cftime_range("2040-01-01", periods=40, freq="YS")
+    fut["time"] = xr.date_range("2040-01-01", periods=40, freq="YS", use_cftime=True)
     return ref, fut
 
 

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -989,10 +989,7 @@ class TestStandardizedIndices:
         )
         ssi = xci.standardized_streamflow_index(q, params=params)
         ssi = ssi.isel(time=slice(-11, -1, 2)).values.flatten()
-        try:
-            np.testing.assert_allclose(ssi, values, rtol=0, atol=diff_tol)
-        except AssertionError as err:
-            raise ValueError(f"Failed with params: {params.sel(month=2).values}") from err
+        np.testing.assert_allclose(ssi, values, rtol=0, atol=diff_tol)
 
     # TODO: Find another package to test against
     # For now, we just take a snapshot of what xclim produces when this function
@@ -1177,7 +1174,7 @@ class TestStandardizedIndices:
         # In the previous computation, the first {window-1} values are NaN because the rolling is performed
         # on the period [1998,2000]. Here, the computation is performed on the period [1950,2000],
         # *then* subsetted to [1998,2000], so it doesn't have NaNs for the first values
-        nan_window = xr.cftime_range(spei1.time.values[0], periods=window - 1, freq=freq)
+        nan_window = xr.date_range(spei1.time.values[0], periods=window - 1, freq=freq, use_cftime=True)
         spei2.loc[{"time": spei2.time.isin(nan_window)}] = (
             np.nan
         )  # select time based on the window is necessary when `drop=True`

--- a/tests/test_missing.py
+++ b/tests/test_missing.py
@@ -16,7 +16,7 @@ class test_expected_count:
     def test_3hourly_input(self, random):
         """Creating array with 21 days of 3h"""
         n = 21 * 8
-        time = xr.cftime_range(start="2002-01-01", periods=n, freq="3h")
+        time = xr.date_range(start="2002-01-01", periods=n, freq="3h")
         ts = xr.DataArray(random.random(n), dims="time", coords={"time": time})
         count = missing.expected_count(ts, freq="MS", src_timestep="3h")
         # Make sure count is 31  * 8, because we're requesting a MS freq.
@@ -25,14 +25,14 @@ class test_expected_count:
     def test_monthly_input(self, random):
         """Creating array with 11 months."""
         n = 11
-        time = xr.cftime_range(start="2002-01-01", periods=n, freq="ME")
+        time = xr.date_range(start="2002-01-01", periods=n, freq="ME")
         ts = xr.DataArray(random.random(n), dims="time", coords={"time": time})
         count = missing.expected_count(ts, freq="YS", src_timestep="ME")
         # Make sure count is 12, because we're requesting a YS freq.
         assert count == 12
 
         n = 5
-        time = xr.cftime_range(start="2002-06-01", periods=n, freq="MS")
+        time = xr.date_range(start="2002-06-01", periods=n, freq="MS")
         ts = xr.DataArray(random.random(n), dims="time", coords={"time": time})
         count = missing.expected_count(ts, freq="YS", src_timestep="MS", season="JJA")
         assert count == 3
@@ -40,7 +40,7 @@ class test_expected_count:
     def test_seasonal_input(self, random):
         """Creating array with 11 seasons."""
         n = 11
-        time = xr.cftime_range(start="2002-04-01", periods=n, freq="QS-JAN")
+        time = xr.date_range(start="2002-04-01", periods=n, freq="QS-JAN")
         ts = xr.DataArray(random.random(n), dims="time", coords={"time": time})
         count = missing.expected_count(ts, freq="YS", src_timestep="QS-JAN")
         # Make sure count is 12, because we're requesting a YS freq.
@@ -157,7 +157,7 @@ class TestMissingAnyFills:
 
     def test_seasonal(self, random):
         n = 11
-        time = xr.cftime_range(start="2002-01-01", periods=n, freq="QS-JAN")
+        time = xr.date_range(start="2002-01-01", periods=n, freq="QS-JAN")
         ts = xr.DataArray(random.random(n), dims="time", coords={"time": time})
         out = missing.missing_any(ts, freq="YS")
         np.testing.assert_array_equal(out, [False, False, True])

--- a/tests/test_run_length.py
+++ b/tests/test_run_length.py
@@ -586,7 +586,7 @@ class TestRunsWithDates:
         [("standard", [61, 60]), ("365_day", [60, 60]), ("366_day", [61, 61])],
     )
     def test_run_with_dates_different_calendars(self, calendar, expected):
-        time = xr.cftime_range("2004-01-01", end="2005-12-31", freq="D", calendar=calendar)
+        time = xr.date_range("2004-01-01", end="2005-12-31", freq="D", calendar=calendar, use_cftime=True)
         tas = np.zeros(time.size)
         start = np.where((time.day == 1) & (time.month == 3))[0]
         tas[start[0] : start[0] + 250] = 5

--- a/tests/test_sdba/test_adjustment.py
+++ b/tests/test_sdba/test_adjustment.py
@@ -671,7 +671,7 @@ class TestPrincipalComponents:
         sim_y = sim_x + norm.rvs(loc=1, scale=1, size=(m, n), random_state=random)
 
         ref = xr.DataArray([ref_x, ref_y], dims=("lat", "lon", "time"), attrs={"units": "degC"})
-        ref["time"] = xr.cftime_range("1990-01-01", periods=n, calendar="noleap")
+        ref["time"] = xr.date_range("1990-01-01", periods=n, calendar="noleap")
         sim = xr.DataArray([sim_x, sim_y], dims=("lat", "lon", "time"), attrs={"units": "degC"})
         sim["time"] = ref["time"]
 
@@ -757,7 +757,7 @@ class TestExtremeValues:
             return xr.DataArray(
                 base,
                 dims=("time",),
-                coords={"time": xr.cftime_range("1990-01-01", periods=n, calendar="noleap")},
+                coords={"time": xr.date_range("1990-01-01", periods=n, calendar="noleap")},
                 attrs={"units": "mm/day", "thresh": qv},
             )
 
@@ -805,7 +805,7 @@ class TestExtremeValues:
         new_scen.load()
 
     def test_nan_values(self):
-        times = xr.cftime_range("1990-01-01", periods=365, calendar="noleap")
+        times = xr.date_range("1990-01-01", periods=365, calendar="noleap")
         ref = xr.DataArray(
             np.arange(365),
             dims=("time"),
@@ -1012,7 +1012,7 @@ class TestSBCKutils:
                 "tasmax": xr.DataArray(ref_y, dims=("lon", "time"), attrs={"units": "degC"}),
             }
         )
-        ref["time"] = xr.cftime_range("1990-01-01", periods=n, calendar="noleap")
+        ref["time"] = xr.date_range("1990-01-01", periods=n, calendar="noleap")
 
         hist = xr.Dataset(
             {
@@ -1028,7 +1028,7 @@ class TestSBCKutils:
                 "tasmax": xr.DataArray(sim_y, dims=("lon", "time"), attrs={"units": "degC"}),
             }
         )
-        sim["time"] = xr.cftime_range("2090-01-01", periods=n, calendar="noleap")
+        sim["time"] = xr.date_range("2090-01-01", periods=n, calendar="noleap")
 
         if use_dask:
             ref = ref.chunk({"lon": 1})

--- a/tests/test_sdba/test_detrending.py
+++ b/tests/test_sdba/test_detrending.py
@@ -79,7 +79,7 @@ def test_rollingmean_detrend(series):
     x = xr.DataArray(
         np.sin(2 * np.pi * np.arange(11 * 365) / 365),
         dims=("time",),
-        coords={"time": xr.cftime_range("2010-01-01", periods=11 * 365, freq="D", calendar="noleap")},
+        coords={"time": xr.date_range("2010-01-01", periods=11 * 365, freq="D", calendar="noleap")},
     )
     w = windows.get_window("triang", 11, False)
     det = RollingMeanDetrend(group=Grouper("time.dayofyear", window=3), win=11, weights=w)

--- a/tests/test_sdba/test_sdba_utils.py
+++ b/tests/test_sdba/test_sdba_utils.py
@@ -84,7 +84,7 @@ def test_interp_on_quantiles_constant(interp, expi, extrap, expe):
     newx = xr.DataArray(
         np.linspace(240, 200, num=41) - 0.5,
         dims=("time",),
-        coords={"time": xr.cftime_range("1900-03-01", freq="D", periods=41)},
+        coords={"time": xr.date_range("1900-03-01", freq="D", periods=41)},
     )
     newx = newx.where(newx > 201)  # Put some NaNs in newx
 
@@ -114,7 +114,7 @@ def test_interp_on_quantiles_constant(interp, expi, extrap, expe):
 
 
 def test_interp_on_quantiles_monthly(random):
-    t = xr.cftime_range("2000-01-01", "2030-12-31", freq="D", calendar="noleap")
+    t = xr.date_range("2000-01-01", "2030-12-31", freq="D", calendar="noleap")
     ref = xr.DataArray(
         (
             -20 * np.cos(2 * np.pi * t.dayofyear / 365)
@@ -171,7 +171,7 @@ def test_interp_on_quantiles_constant_with_nan(interp, expi, extrap, expe):
     newx = xr.DataArray(
         np.linspace(240, 200, num=41) - 0.5,
         dims=("time",),
-        coords={"time": xr.cftime_range("1900-03-01", freq="D", periods=41)},
+        coords={"time": xr.date_range("1900-03-01", freq="D", periods=41)},
     )
     newx = newx.where(newx > 201)  # Put some NaNs in newx
 

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -19,7 +19,7 @@ def fitda(request, random):
     x = np.arange(nx)
     y = np.arange(ny)
 
-    time = xr.cftime_range("2045-02-02", periods=nt, freq="D")
+    time = xr.date_range("2045-02-02", periods=nt, freq="D")
 
     da = xr.DataArray(
         random.lognormal(2, 1, (nt, nx, ny)),
@@ -79,7 +79,7 @@ def weibull_min(request):
         ],
         dims=("time",),
     )
-    da = da.assign_coords(time=xr.cftime_range("2045-02-02", periods=da.time.size, freq="D"))
+    da = da.assign_coords(time=xr.date_range("2045-02-02", periods=da.time.size, freq="D"))
 
     if request.param:
         da = da.chunk()
@@ -113,7 +113,7 @@ def genextreme(request):
         ],
         dims=("time",),
     )
-    da = da.assign_coords(time=xr.cftime_range("2045-02-02", periods=da.time.size, freq="D"))
+    da = da.assign_coords(time=xr.date_range("2045-02-02", periods=da.time.size, freq="D"))
 
     if request.param:
         da = da.chunk()
@@ -267,7 +267,7 @@ class TestPWMFit:
         da = xr.DataArray(
             dc(**par).rvs(size=n, random_state=random),
             dims=("time",),
-            coords={"time": xr.cftime_range("1980-01-01", periods=n)},
+            coords={"time": xr.date_range("1980-01-01", periods=n)},
         )
         if use_dask:
             da = da.chunk()
@@ -328,7 +328,7 @@ def test_parametric_quantile(use_dask, random):
     r = xr.DataArray(
         d.rvs(n, random_state=random),
         dims=("time",),
-        coords={"time": xr.cftime_range(start="1980-01-01", periods=n)},
+        coords={"time": xr.date_range(start="1980-01-01", periods=n)},
         attrs={"history": "Mosquito bytes per minute"},
     )
     expected = d.ppf(per)
@@ -350,7 +350,7 @@ def test_parametric_cdf(use_dask, random):
     r = xr.DataArray(
         d.rvs(n, random_state=random),
         dims=("time",),
-        coords={"time": xr.cftime_range(start="1980-01-01", periods=n)},
+        coords={"time": xr.date_range(start="1980-01-01", periods=n)},
         attrs={"history": "Mosquito bytes per minute"},
     )
     if use_dask:

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -358,7 +358,7 @@ def test_to_agg_units(in_u, opfunc, op, exp, exp_u):
     da = xr.DataArray(
         np.ones((365,)),
         dims=("time",),
-        coords={"time": xr.cftime_range("1993-01-01", periods=365, freq="D")},
+        coords={"time": xr.date_range("1993-01-01", periods=365, freq="D")},
         attrs={"units": in_u},
     )
     if units(in_u).dimensionality == "[temperature]":


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] Tests for the changes have been added (for bug fixes / features)
  - [x] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGELOG.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Removes usage of `xr.cftime_range` which is deprecated. Most calls were in the tests.
* Avoids `strptime` without year information.
* Add `pd.DatetimeIndex` case to  `get_calendar` (I think this worked previously, but it wasn't tested).
*  `test_timeseries` defaults to `cftime=None` (usage of cftime is determined by the requested calendar)

### Does this PR introduce a breaking change?
No

### Other information:
