### PR TITLE
Fix fire season with non-uniform chunks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,7 +15,7 @@ Bug fixes
 * Fixed an issue with star-annotated call signatures to maintain Python 3.10 compatibility. (:pull:`2116`).
 * Fixed `to_agg_units` that was converting units of temperature differences prematurely, without changing accordingly the values in the related DataArrays. (:issue:`2121`, :pull:`2122`).
 * Avoid unnecessary time resampling in `preprocess_standardized_index` when `freq` is not None but the same as the input data. (:issue:`2111`, :pull:`2112`)
-* Fixed an issue with ``fire_season`` that made it fail with datasets having non-uniform chunks. (:issue:`2129`, :pull:`2131`).
+* Fixed an issue with ``fire_season`` that made it fail with datasets having non-uniform chunks. (:issue:`2129`, :pull:`2132`).
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 
 v0.56.0 (unreleased)
 --------------------
-Contributors to this version: Trevor James Smith (:user:`Zeitsperre`), Hui-Min Wang (:user:`Hem-W`), Jack Kit-tai Wong(:user:`jack-ktw`), Adrien Lamarche (:user:`LamAdr`), Éric Dupuis (:user:`coxipi`), Jens de Bruijn (:user:`jensdebruijn`).
+Contributors to this version: Trevor James Smith (:user:`Zeitsperre`), Hui-Min Wang (:user:`Hem-W`), Jack Kit-tai Wong(:user:`jack-ktw`), Adrien Lamarche (:user:`LamAdr`), Éric Dupuis (:user:`coxipi`), Jens de Bruijn (:user:`jensdebruijn`), Pascal Bourgault (:user:`aulemahal`).
 
 Bug fixes
 ^^^^^^^^^
@@ -15,6 +15,7 @@ Bug fixes
 * Fixed an issue with star-annotated call signatures to maintain Python 3.10 compatibility. (:pull:`2116`).
 * Fixed `to_agg_units` that was converting units of temperature differences prematurely, without changing accordingly the values in the related DataArrays. (:issue:`2121`, :pull:`2122`).
 * Avoid unnecessary time resampling in `preprocess_standardized_index` when `freq` is not None but the same as the input data. (:issue:`2111`, :pull:`2112`)
+* Fixed an issue with ``fire_season`` that made it fail with datasets having non-uniform chunks. (:issue:`2129`, :pull:`2131`).
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/src/xclim/indices/fire/_cffwis.py
+++ b/src/xclim/indices/fire/_cffwis.py
@@ -1669,7 +1669,7 @@ def fire_season(
         ds = ds.unify_chunks()
     ds = ds.transpose(..., "time")
 
-    tmpl = xr.full_like(tas, np.nan)
+    tmpl = xr.full_like(ds.tas, np.nan)
     out = ds.map_blocks(_apply_fire_season, template=tmpl, kwargs=kwargs)
     out.attrs["units"] = ""
     return out


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #2129
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGELOG.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?
It seems the `map_blocks` template must be constructed with the same dimension order as the input. I think this could be seen as an issue from xarray, but at least this PR fixes the usage in xclim.

### Does this PR introduce a breaking change?
No.

### Other information:
