### PR TITLE
Allow unequal periods in `infer_sampling_units` and `stack_periods`.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 
 v0.57.0 (unreleased)
 --------------------
-Contributors to this version: Éric Dupuis (:user:`coxipi`), Trevor James Smith (:user:`Zeitsperre`), Juliette Lavoie (:user: `juliettelavoie`).
+Contributors to this version: Éric Dupuis (:user:`coxipi`), Trevor James Smith (:user:`Zeitsperre`), Juliette Lavoie (:user: `juliettelavoie`), Pascal Bourgault (:user:`aulemahal`).
 
 New indicators
 ^^^^^^^^^^^^^^
@@ -15,6 +15,7 @@ New indicators
 Bug fixes
 ^^^^^^^^^
 * Adjustments were made to the `docs` install recipe to ensure that the `xclim` documentation builds correctly. The minimum required Python for rendering the documentation is now 3.11. (:pull:`2141`).
+* ``xclim.core.calendar.stack_periods`` was fixed to work with larger-than-daily source timesteps. Users are still encouraged to use `da.resample(time=FREQ).construct('period')` when possible instead. (:issue:`2148`, :pull:`2150`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 
 v0.57.0 (unreleased)
 --------------------
-Contributors to this version: Éric Dupuis (:user:`coxipi`), Trevor James Smith (:user:`Zeitsperre`), Juliette Lavoie (:user: `juliettelavoie`), Pascal Bourgault (:user:`aulemahal`).
+Contributors to this version: Éric Dupuis (:user:`coxipi`), Trevor James Smith (:user:`Zeitsperre`), Juliette Lavoie (:user:`juliettelavoie`), Pascal Bourgault (:user:`aulemahal`).
 
 New indicators
 ^^^^^^^^^^^^^^
@@ -15,7 +15,7 @@ New indicators
 Bug fixes
 ^^^^^^^^^
 * Adjustments were made to the `docs` install recipe to ensure that the `xclim` documentation builds correctly. The minimum required Python for rendering the documentation is now 3.11. (:pull:`2141`).
-* ``xclim.core.calendar.stack_periods`` was fixed to work with larger-than-daily source timesteps. Users are still encouraged to use `da.resample(time=FREQ).construct('period')` when possible instead. (:issue:`2148`, :pull:`2150`).
+* ``xclim.core.calendar.stack_periods`` was fixed to work with larger-than-daily source timesteps. Users are still encouraged to use `da.resample(time=FREQ).construct('period')` when possible. (:issue:`2148`, :pull:`2150`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/src/xclim/core/calendar.py
+++ b/src/xclim/core/calendar.py
@@ -1636,11 +1636,12 @@ def unstack_periods(da: xr.DataArray | xr.Dataset, dim: str = "period") -> xr.Da
         compare_offsets(src_freq, "<", "MS")
         or (compare_offsets(src_freq, ">=", "YS") and da.time.dt.calendar in uniform_calendars)
     ):
-        warnings.warn(
+        msg = (
             "xclim is not able to unstack periods that were constructed from non-uniform time steps. "
             f"(Found : {src_freq} with calendar {da.time.dt.calendar}). "
             "Results won't fit with the original coordinates passed to `stack_periods`."
         )
+        warnings.warn(msg)
 
     if unequal_lengths:
         try:

--- a/src/xclim/core/units.py
+++ b/src/xclim/core/units.py
@@ -477,7 +477,7 @@ FREQ_UNITS = {
     "s": "s",
     "ms": "ms",
     "us": "us",
-    "ns": "ns"
+    "ns": "ns",
 }
 """
 Resampling frequency units for :py:func:`xclim.core.units.infer_sampling_units`.
@@ -519,18 +519,18 @@ def infer_sampling_units(
     freq = xr.infer_freq(dimmed)
     if freq is None:
         if deffreq is None:
-            raise ValueError('Unable to find the sampling frequency of the data.')
+            raise ValueError("Unable to find the sampling frequency of the data.")
         freq = deffreq
 
     multi, base, _, _ = parse_offset(freq)
-    if base == 'Q':
+    if base == "Q":
         multi = multi * 3
-        base = 'M'
+        base = "M"
     if base in FREQ_UNITS:
         u = FREQ_UNITS[base]
     else:
         raise ValueError(f"Sampling frequency {freq} has no corresponding pint or CF units.")
-    if u == 'd' and multi == 7
+    if u == "d" and multi == 7:
         # Special case for weekly frequency. xarray's CFTimeOffsets do not have "W".
         u = "week"
     return multi, u

--- a/src/xclim/core/units.py
+++ b/src/xclim/core/units.py
@@ -470,8 +470,14 @@ def cf_conversion(standard_name: str, conversion: str, direction: Literal["to", 
 FREQ_UNITS = {
     "Y": "year",
     "M": "month",
-    "D": "d",
     "W": "week",
+    "D": "d",
+    "h": "h",
+    "min": "min",
+    "s": "s",
+    "ms": "ms",
+    "us": "us",
+    "ns": "ns"
 }
 """
 Resampling frequency units for :py:func:`xclim.core.units.infer_sampling_units`.
@@ -482,7 +488,7 @@ Mapping from offset base to CF-compliant unit.
 
 def infer_sampling_units(
     da: xr.DataArray,
-    deffreq: str | None = "D",
+    deffreq: str | None = None,
     dim: str = "time",
 ) -> tuple[int, str]:
     """
@@ -512,20 +518,22 @@ def infer_sampling_units(
     dimmed = getattr(da, dim)
     freq = xr.infer_freq(dimmed)
     if freq is None:
+        if deffreq is None:
+            raise ValueError('Unable to find the sampling frequency of the data.')
         freq = deffreq
 
     multi, base, _, _ = parse_offset(freq)
     if base == 'Q':
         multi = multi * 3
         base = 'M'
-    try:
-        out = multi, FREQ_UNITS.get(base, base)
-    except KeyError as err:
-        raise ValueError(f"Sampling frequency {freq} has no corresponding units.") from err
-    if out == (7, "d"):
+    if base in FREQ_UNITS:
+        u = FREQ_UNITS[base]
+    else:
+        raise ValueError(f"Sampling frequency {freq} has no corresponding pint or CF units.")
+    if u == 'd' and multi == 7
         # Special case for weekly frequency. xarray's CFTimeOffsets do not have "W".
-        return 1, "week"
-    return out
+        u = "week"
+    return multi, u
 
 
 DELTA_ABSOLUTE_TEMP = {

--- a/src/xclim/core/units.py
+++ b/src/xclim/core/units.py
@@ -468,14 +468,15 @@ def cf_conversion(standard_name: str, conversion: str, direction: Literal["to", 
 
 
 FREQ_UNITS = {
+    "Y": "year",
+    "M": "month",
     "D": "d",
     "W": "week",
 }
 """
 Resampling frequency units for :py:func:`xclim.core.units.infer_sampling_units`.
 
-Mapping from offset base to CF-compliant unit. Only constant-length frequencies that are
-not also pint units are included.
+Mapping from offset base to CF-compliant unit.
 """
 
 
@@ -506,7 +507,7 @@ def infer_sampling_units(
     Raises
     ------
     ValueError
-        If the frequency has no exact corresponding units.
+        If the frequency has no corresponding units.
     """
     dimmed = getattr(da, dim)
     freq = xr.infer_freq(dimmed)
@@ -514,6 +515,9 @@ def infer_sampling_units(
         freq = deffreq
 
     multi, base, _, _ = parse_offset(freq)
+    if base == 'Q':
+        multi = multi * 3
+        base = 'M'
     try:
         out = multi, FREQ_UNITS.get(base, base)
     except KeyError as err:

--- a/src/xclim/core/units.py
+++ b/src/xclim/core/units.py
@@ -515,8 +515,8 @@ def infer_sampling_units(
     ValueError
         If the frequency has no corresponding units.
     """
-    dimmed = getattr(da, dim)
-    freq = xr.infer_freq(dimmed)
+    da = da[dim]
+    freq = xr.infer_freq(da)
     if freq is None:
         if deffreq is None:
             raise ValueError("Unable to find the sampling frequency of the data.")
@@ -533,6 +533,7 @@ def infer_sampling_units(
     if u == "d" and multi == 7:
         # Special case for weekly frequency. xarray's CFTimeOffsets do not have "W".
         u = "week"
+        multi = 1
     return multi, u
 
 

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -58,8 +58,8 @@ def test_time_bnds(freq, datetime_index, cftime_index):
     cftime_bounds = time_bnds(da_cftime, freq=freq)
     cftime_starts = cftime_bounds.isel(bnds=0)
     cftime_ends = cftime_bounds.isel(bnds=1)
-    cftime_starts = CFTimeIndex(cftime_starts.values).to_datetimeindex()
-    cftime_ends = CFTimeIndex(cftime_ends.values).to_datetimeindex()
+    cftime_starts = CFTimeIndex(cftime_starts.values).to_datetimeindex(time_unit="ns")
+    cftime_ends = CFTimeIndex(cftime_ends.values).to_datetimeindex(time_unit="ns")
 
     # cftime resolution goes down to microsecond only, code below corrects
     # that to allow for comparison with pandas datetime
@@ -454,21 +454,32 @@ def test_convert_doy():
     np.testing.assert_allclose(out.isel(lat=0), [31.0, 200.48, 190.0, 59.83607, 299.71885])
 
 
-@pytest.mark.parametrize("calendar", ["standard", None])
+@pytest.mark.parametrize("use_cftime", [True, False])
 @pytest.mark.parametrize(
-    "w,s,m,f,ss",
-    [(30, 10, None, "YS", 0), (3, 1, None, "QS-DEC", 60), (6, None, None, "MS", 0)],
+    "sf,w,s,m,f,ss",
+    [
+        ("D", 30, 10, None, "YS", 0),
+        ("D", 3, 1, None, "QS-DEC", 60),
+        ("D", 6, None, None, "MS", 0),
+        ("MS", 3, None, None, "YS", 0),
+        ("YS", 30, 10, None, "YS", 0),
+    ],
 )
-def test_stack_periods(tas_series, calendar, w, s, m, f, ss):
-    da = tas_series(np.arange(365 * 50), start="2000-01-01", calendar=calendar)
+def test_stack_periods(tas_series, use_cftime, sf, w, s, m, f, ss):
+    da = tas_series(np.arange((365 * 50) if sf == "D" else 50), start="2000-01-01", cftime=use_cftime, freq=sf)
 
     da_stck = stack_periods(da, window=w, stride=s, min_length=m, freq=f, align_days=False)
 
     assert "period_length" in da_stck.coords
+    assert da_stck.period.dtype == da.time.dtype
 
-    da2 = unstack_periods(da_stck)
-
-    xr.testing.assert_identical(da2, da.isel(time=slice(ss, da2.time.size + ss)))
+    if compare_offsets(sf, "<=", "W"):
+        da2 = unstack_periods(da_stck)
+        xr.testing.assert_identical(da2, da.isel(time=slice(ss, da2.time.size + ss)))
+    else:
+        with pytest.warns(UserWarning, match="xclim is not able to unstack"):
+            unstack_periods(da_stck)
+            # not checking, as it is not identical
 
 
 def test_stack_periods_special(tas_series):

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -398,16 +398,18 @@ def test_temp_difference_rountrip():
     assert attrs == {"units": "degC", "units_metadata": "temperature: difference"}
 
 
-@pytest.mark.parametrize("freq,expm,expu", [('3D', 3, 'd'), ('MS', 1, 'month'), ('QS-DEC', 3, 'month'), ('W', 1, 'week'), ('min', 1, 'min')])
+@pytest.mark.parametrize(
+    "freq,expm,expu", [("3D", 3, "d"), ("MS", 1, "month"), ("QS-DEC", 3, "month"), ("W", 1, "week"), ("min", 1, "min")]
+)
 def test_infer_sampling_units(freq, expm, expu):
-    time = xr.date_range('14-04-2025', periods=10, freq=freq)
+    time = xr.date_range("14-04-2025", periods=10, freq=freq)
     m, u = infer_sampling_units(time)
     assert expm == m
     assert expu == u
 
 
 def test_infer_sampling_units_errors():
-    time = xr.date_range('14-04-2025', periods=10, freq='D')
+    time = xr.date_range("14-04-2025", periods=10, freq="D")
     time = time[[0, 1, 5, 6]]
-    with pytest.raises(ValueError, match='Unable to find'):
+    with pytest.raises(ValueError, match="Unable to find"):
         infer_sampling_units(time)

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -403,13 +403,15 @@ def test_temp_difference_rountrip():
 )
 def test_infer_sampling_units(freq, expm, expu):
     time = xr.date_range("14-04-2025", periods=10, freq=freq)
-    m, u = infer_sampling_units(time)
+    da = xr.DataArray(list(range(10)), dims=("time",), coords={"time": time})
+    m, u = infer_sampling_units(da)
     assert expm == m
     assert expu == u
 
 
 def test_infer_sampling_units_errors():
     time = xr.date_range("14-04-2025", periods=10, freq="D")
-    time = time[[0, 1, 5, 6]]
+    da = xr.DataArray(list(range(10)), dims=("time",), coords={"time": time})
+    da = da[[0, 1, 5, 6]]
     with pytest.raises(ValueError, match="Unable to find"):
-        infer_sampling_units(time)
+        infer_sampling_units(da)


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #2148
- [x] Tests for the changes have been added (for bug fixes / features)
  - [x] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGELOG.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Allows the units "month" and "year" in the output of `infer_sampling_units`.
* Rewrite `infer_sampling_units` to be more explicit in the errors and safer with the defaults.

### Does this PR introduce a breaking change?
Yes, but minimal : `infer_sampling_units` would _assume_ `freq='D'` before, which I now think is a bit weird and dangerous. It will now fail on non-inferrable freqs instead, unless a default is passed.


### Other information:
Previously, the idea was that we would never use `pint` units that represented unequal periods (months, years), but seeing the source issue and thinking about it, maybe we can switch the usage responsibility to the user instead? "month" and "year" are valid CF units, so why not support them.
