### PR TITLE
Fix `create_ensemble` calendar argument docstring

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 
 v0.57.0 (unreleased)
 --------------------
-Contributors to this version: Éric Dupuis (:user:`coxipi`), Trevor James Smith (:user:`Zeitsperre`), Juliette Lavoie (:user:`juliettelavoie`), Pascal Bourgault (:user:`aulemahal`), Armin Hofmann (:user:`HofmannGeo`).
+Contributors to this version: Éric Dupuis (:user:`coxipi`), Trevor James Smith (:user:`Zeitsperre`), Juliette Lavoie (:user:`juliettelavoie`), Pascal Bourgault (:user:`aulemahal`), Armin Hofmann (:user:`HofmannGeo`), Baptiste Hamon (:user:`baptistehamon`).
 
 New indicators
 ^^^^^^^^^^^^^^
@@ -17,7 +17,7 @@ Bug fixes
 ^^^^^^^^^
 * Adjustments were made to the `docs` install recipe to ensure that the `xclim` documentation builds correctly. The minimum required Python for rendering the documentation is now 3.11. (:pull:`2141`).
 * ``xclim.core.calendar.stack_periods`` was fixed to work with larger-than-daily source timesteps. Users are still encouraged to use `da.resample(time=FREQ).construct('period')` when possible. (:issue:`2148`, :pull:`2150`).
-* Update ``create_ensemble`` docstring to avoid confusion about how the function alignes realizations with different calendars. (:issue:`2108`, :pull:`2164`).
+* Update ``create_ensemble`` docstring to avoid confusion about how the function aligns realizations with different calendars. (:issue:`2108`, :pull:`2164`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Bug fixes
 ^^^^^^^^^
 * Adjustments were made to the `docs` install recipe to ensure that the `xclim` documentation builds correctly. The minimum required Python for rendering the documentation is now 3.11. (:pull:`2141`).
 * ``xclim.core.calendar.stack_periods`` was fixed to work with larger-than-daily source timesteps. Users are still encouraged to use `da.resample(time=FREQ).construct('period')` when possible. (:issue:`2148`, :pull:`2150`).
+* Update ``create_ensemble`` docstring to avoid confusion about how the function alignes realizations with different calendars. (:issue:`2108`, :pull:`2164`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/src/xclim/ensembles/_base.py
+++ b/src/xclim/ensembles/_base.py
@@ -65,7 +65,7 @@ def create_ensemble(
         If resample_freq is set, the time coordinate of each member will be modified to fit this frequency.
     calendar : str, optional
         The calendar of the time coordinate of the ensemble.
-        By default, the smallest common calendar is chosen.
+        By default, the biggest calendar (in number of days by year) is chosen.
         For example, a mixed input of "noleap" and "360_day" will default to "noleap".
         'default' is the standard calendar using np.datetime64 objects (xarray's "standard" with `use_cftime=False`).
     realizations : sequence, optional


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #2108
- [x] CHANGELOG.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* This PR modifies the docstring of `create_ensemble` to avoid confusion about how the function aligns realizations with different calendars.