### PR TITLE
Use Literals in operator `op` arguments

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,10 +41,10 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.8
     hooks:
-      - id: ruff
-        args: [ '--fix', '--show-fixes' ]
       - id: ruff-format
         exclude: '(src/xclim/indices/__init__.py|docs/installation.rst)'
+      - id: ruff
+        args: [ '--fix', '--show-fixes' ]
   - repo: https://github.com/pylint-dev/pylint
     rev: v3.3.7
     hooks:

--- a/src/xclim/core/bootstrapping.py
+++ b/src/xclim/core/bootstrapping.py
@@ -154,7 +154,7 @@ def bootstrap_func(compute_index_func: Callable, **kwargs) -> xarray.DataArray:
         chunking = {d: "auto" for d in da.dims}
         chunking["time"] = -1  # no chunking on time to use map_block
         da = da.chunk(chunking)
-    # overlap of studied `da` and reference period used to compute percentile
+    # overlap of studied `da` and the reference period used to compute percentile
     overlap_da = da.sel(time=slice(*clim))
     if len(overlap_da.time) == len(da.time):
         raise KeyError(
@@ -234,18 +234,18 @@ def _get_year_label(year_dt) -> str:
 # TODO: Return a generator instead and assess performance
 def build_bootstrap_year_da(da: DataArray, groups: dict[Any, slice], label: Any, dim: str = "time") -> DataArray:
     """
-    Return an array where a group in the original is replaced by every other groups along a new dimension.
+    Return an array where every other group replaces a group in the original along a new dimension.
 
     Parameters
     ----------
     da : DataArray
-      Original input array over reference period.
+      Original input array over the reference period.
     groups : dict
       Output of grouping functions, such as `DataArrayResample.groups`.
     label : Any
       Key identifying the group item to replace.
     dim : str
-      Dimension recognized as time. Default: `time`.
+      Dimension recognised as time. Default: `time`.
 
     Returns
     -------

--- a/src/xclim/core/cfchecks.py
+++ b/src/xclim/core/cfchecks.py
@@ -62,7 +62,7 @@ def cfcheck_from_name(varname: str, vardata: xr.DataArray, attrs: list[str] | No
     vardata : xr.DataArray
         The variable to check.
     attrs : list of str, optional
-        The attributes to check. Default is ["cell_methods", "standard_name"].
+        Attributes to check. Default is ["cell_methods", "standard_name"].
 
     Raises
     ------

--- a/src/xclim/core/dataflags.py
+++ b/src/xclim/core/dataflags.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from collections.abc import Callable, Sequence
 from functools import reduce
 from inspect import signature
+from typing import Literal
 
 import numpy as np
 import xarray
@@ -24,6 +25,8 @@ from xclim.indices.generic import binary_ops
 from xclim.indices.run_length import suspicious_run
 
 _REGISTRY = {}
+
+ALL_OPERATORS = Literal[">", "gt", "<", "lt", ">=", "ge", "<=", "le", "==", "eq", "!=", "ne"]
 
 
 class DataQualityException(Exception):
@@ -230,7 +233,7 @@ def tas_below_tasmin(tas: xarray.DataArray, tasmin: xarray.DataArray) -> xarray.
 @declare_units(da="[temperature]", thresh="[temperature]")
 def temperature_extremely_low(da: xarray.DataArray, *, thresh: Quantified = "-90 degC") -> xarray.DataArray:
     """
-    Check if temperatures values are below -90 degrees Celsius for any given day.
+    Check if temperature values are below -90 degrees Celsius for any given day.
 
     Parameters
     ----------
@@ -267,7 +270,7 @@ def temperature_extremely_low(da: xarray.DataArray, *, thresh: Quantified = "-90
 @declare_units(da="[temperature]", thresh="[temperature]")
 def temperature_extremely_high(da: xarray.DataArray, *, thresh: Quantified = "60 degC") -> xarray.DataArray:
     """
-    Check if temperatures values exceed 60 degrees Celsius for any given day.
+    Check if temperature values exceed 60 degrees Celsius for any given day.
 
     Parameters
     ----------
@@ -344,7 +347,7 @@ def very_large_precipitation_events(da: xarray.DataArray, *, thresh: Quantified 
     da : xarray.DataArray
         Precipitation.
     thresh : str
-        Threshold to search array for that will trigger flag if any day exceeds value.
+        Threshold to search an array for that will trigger flag if any day exceeds value.
 
     Returns
     -------
@@ -371,7 +374,7 @@ def very_large_precipitation_events(da: xarray.DataArray, *, thresh: Quantified 
 @register_methods("values_{op}_{thresh}_repeating_for_{n}_or_more_days")
 @update_xclim_history
 def values_op_thresh_repeating_for_n_or_more_days(
-    da: xarray.DataArray, *, n: int, thresh: Quantified, op: str = "=="
+    da: xarray.DataArray, *, n: int, thresh: Quantified, op: ALL_OPERATORS = "=="
 ) -> xarray.DataArray:
     """
     Check if array values repeat at a given threshold for `N` or more days.
@@ -381,9 +384,9 @@ def values_op_thresh_repeating_for_n_or_more_days(
     da : xarray.DataArray
         Variable array.
     n : int
-        Number of repeating days needed to trigger flag.
+        Number of repeating days needed to trigger data flag.
     thresh : str
-        Repeating values to search for that will trigger flag.
+        Repeating values to search for that will trigger data flag.
     op : {">", "gt", "<", "lt", ">=", "ge", "<=", "le", "==", "eq", "!=", "ne"}
         Operator used for comparison with thresh.
 
@@ -751,7 +754,7 @@ def ecad_compliant(
     """
     Run ECAD compliance tests.
 
-    Assert file adheres to ECAD-based quality assurance checks.
+    Assert that file adheres to ECAD-based quality assurance checks.
 
     Parameters
     ----------
@@ -762,8 +765,8 @@ def ecad_compliant(
     raise_flags : bool
         Raise exception if any of the quality assessment flags are raised, otherwise returns None. Default: ``False``.
     append : bool
-        If `True`, returns the Dataset with the `ecad_qc_flag` array appended to data_vars.
-        If `False`, returns the DataArray of the `ecad_qc_flag` variable.
+        If `True`, return the Dataset with the `ecad_qc_flag` array appended to data_vars.
+        If `False`, return the DataArray of the `ecad_qc_flag` variable.
 
     Returns
     -------

--- a/src/xclim/core/locales.py
+++ b/src/xclim/core/locales.py
@@ -256,11 +256,11 @@ def read_locale_file(filename, module: str | None = None, encoding: str = "UTF8"
     filename : PathLike
         The file to read.
     module : str, optional
-        If module is a string, this module name is added to all identifiers translated in this file.
+        If the module is a string, this module name is added to all identifiers translated in this file.
         Defaults to None, and no module name is added (as if the indicator was an official xclim indicator).
     encoding : str
         The encoding to use when reading the file.
-        Defaults to `UTF-8`, overriding Python's default mechanism which is machine dependent.
+        Defaults to `UTF-8`, overriding Python's default mechanism which is machine-dependent.
 
     Returns
     -------

--- a/src/xclim/core/missing.py
+++ b/src/xclim/core/missing.py
@@ -323,7 +323,7 @@ class MissingAny(MissingBase):
 # TODO: Make coarser method controllable.
 class MissingTwoSteps(MissingBase):
     r"""
-    Base class used to determined where Indicator outputs should be masked in a two-step process.
+    Base class used to determine where Indicator outputs should be masked in a two-step process.
 
     In addition to what :py:class:`MissingBase` does, subclasses first perform the mask
     determination at some frequency and then resample at the (coarser) target frequency.
@@ -450,8 +450,8 @@ class MissingPct(MissingTwoSteps):
             The maximum tolerated proportion of missing values,
             given as a number between 0 and 1.
         subfreq : str, optional
-            If given, compute a mask at this frequency using this method and
-            then resample at the target frequency using the "any" method on sub-groups.
+            If given, computes a mask at this frequency using this method and
+            then resample at the target frequency using the "any" method on subgroups.
         """
         super().__init__(tolerance=tolerance, subfreq=subfreq)
 
@@ -478,15 +478,15 @@ class AtLeastNValid(MissingTwoSteps):
 
     def __init__(self, n: int = 20, subfreq: str | None = None):
         """
-        Create a AtLeastNValid object.
+        Create an AtLeastNValid object.
 
         Parameters
         ----------
         n: float
             The minimum number of valid values needed.
         subfreq : str, optional
-            If given, compute a mask at this frequency using this method and
-            then resample at the target frequency using the "any" method on sub-groups.
+            If given, computes a mask at this frequency using this method and
+            then resample at the target frequency using the "any" method on subgroups.
         """
         super().__init__(n=n, subfreq=subfreq)
 

--- a/src/xclim/core/units.py
+++ b/src/xclim/core/units.py
@@ -602,7 +602,12 @@ def ensure_delta(unit: xr.DataArray | str | units.Quantity) -> str:
     return delta_unit
 
 
-def to_agg_units(out: xr.DataArray, orig: xr.DataArray, op: str, dim: str = "time") -> xr.DataArray:
+def to_agg_units(
+    out: xr.DataArray,
+    orig: xr.DataArray,
+    op: Literal["min", "max", "mean", "std", "var", "doymin", "doymax", "count", "integral", "sum"],
+    dim: str = "time",
+) -> xr.DataArray:
     """
     Set and convert units of an array after an aggregation operation along the sampling dimension (time).
 
@@ -613,7 +618,7 @@ def to_agg_units(out: xr.DataArray, orig: xr.DataArray, op: str, dim: str = "tim
     orig : xr.DataArray
         The original array before the aggregation operation,
         used to infer the sampling units and get the variable units.
-    op : {'min', 'max', 'mean', 'std', 'var', 'doymin', 'doymax',  'count', 'integral', 'sum'}
+    op : {'min', 'max', 'mean', 'std', 'var', 'doymin', 'doymax', 'count', 'integral', 'sum'}
         The type of aggregation operation performed. "integral" is mathematically equivalent to "sum",
         but the units are multiplied by the timestep of the data (requires an inferrable frequency).
     dim : str

--- a/src/xclim/core/utils.py
+++ b/src/xclim/core/utils.py
@@ -622,7 +622,11 @@ def infer_kind_from_parameter(param) -> InputKind:
     if annot.issubset({"int", "float", "Sequence[int]", "Sequence[float]"}):
         return InputKind.NUMBER_SEQUENCE
 
-    if annot.issuperset({"str"}):
+    if (
+        annot.issuperset({"str"})
+        or any(a.startswith("Literal['") for a in annot)
+        or annot.issuperset({"REDUCTION_OPERATORS"})
+    ):
         return InputKind.STRING
 
     if annot == {"DateStr"}:

--- a/src/xclim/indices/_anuclim.py
+++ b/src/xclim/indices/_anuclim.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import cast
+from typing import Literal, cast
 
 import numpy as np
 import xarray
@@ -214,7 +214,7 @@ def precip_seasonality(pr: xarray.DataArray, freq: str = "YS") -> xarray.DataArr
 @declare_units(tas="[temperature]")
 def tg_mean_warmcold_quarter(
     tas: xarray.DataArray,
-    op: str,
+    op: Literal["warmest", "coldest"],
     freq: str = "YS",
 ) -> xarray.DataArray:
     r"""
@@ -228,8 +228,10 @@ def tg_mean_warmcold_quarter(
     ----------
     tas : xarray.DataArray
         Mean temperature at daily, weekly, or monthly frequency.
-    op : str {'warmest', 'coldest'}
-        Operation to perform: 'warmest' calculate the warmest quarter; 'coldest' calculate the coldest quarter.
+    op : {'warmest', 'coldest'}
+        Operation to perform:
+        'wettest' calculates the wettest quarter.
+        'driest' calculates the driest quarter.
     freq : str
         Resampling frequency.
 
@@ -273,7 +275,7 @@ def tg_mean_warmcold_quarter(
 def tg_mean_wetdry_quarter(
     tas: xarray.DataArray,
     pr: xarray.DataArray,
-    op: str,
+    op: Literal["wettest", "driest", "dryest"],
     freq: str = "YS",
 ) -> xarray.DataArray:
     r"""
@@ -289,8 +291,10 @@ def tg_mean_wetdry_quarter(
         Mean temperature at daily, weekly, or monthly frequency.
     pr : xarray.DataArray
         Total precipitation rate at daily, weekly, or monthly frequency.
-    op : {'wettest', 'driest'}
-        Operation to perform: 'wettest' calculate for the wettest quarter; 'driest' calculate for the driest quarter.
+    op : {"wettest", "driest"}
+        Operation to perform:
+        'wettest' calculates the wettest quarter.
+        'driest' calculates the driest quarter.
     freq : str
         Resampling frequency.
 
@@ -303,7 +307,7 @@ def tg_mean_wetdry_quarter(
     -----
     According to the ANUCLIM user-guide (:cite:t:`xu_anuclim_2010`, ch. 6), input values should be at a weekly
     (or monthly) frequency. However, the xclim.indices implementation here will calculate the result with input data
-    with daily frequency as well. As such weekly or monthly input values, if desired, should be calculated prior to
+    with daily frequency as well. As such, weekly or monthly input values, if desired, should be calculated before
     calling the function.
 
     References
@@ -324,7 +328,9 @@ def tg_mean_wetdry_quarter(
 
 
 @declare_units(pr="[precipitation]")
-def prcptot_wetdry_quarter(pr: xarray.DataArray, op: str, freq: str = "YS") -> xarray.DataArray:
+def prcptot_wetdry_quarter(
+    pr: xarray.DataArray, op: Literal["wettest", "driest", "dryest"], freq: str = "YS"
+) -> xarray.DataArray:
     r"""
     Total precipitation of wettest/driest quarter.
 
@@ -336,8 +342,10 @@ def prcptot_wetdry_quarter(pr: xarray.DataArray, op: str, freq: str = "YS") -> x
     ----------
     pr : xarray.DataArray
         Total precipitation rate at daily, weekly, or monthly frequency.
-    op : {'wettest', 'driest'}
-        Operation to perform :  'wettest' calculate the wettest quarter ; 'driest' calculate the driest quarter.
+    op : {"wettest", "driest"}
+        Operation to perform:
+        'wettest' calculates the wettest quarter.
+        'driest' calculates the driest quarter.
     freq : str
         Resampling frequency.
 
@@ -350,7 +358,7 @@ def prcptot_wetdry_quarter(pr: xarray.DataArray, op: str, freq: str = "YS") -> x
     -----
     According to the ANUCLIM user-guide (:cite:t:`xu_anuclim_2010`, ch. 6), input values should be at a weekly
     (or monthly) frequency. However, the xclim.indices implementation here will calculate the result with input data
-    with daily frequency as well. As such weekly or monthly input values, if desired, should be calculated prior to
+    with daily frequency as well. As such, weekly or monthly input values, if desired, should be calculated before
     calling the function.
 
     References
@@ -381,7 +389,7 @@ def prcptot_wetdry_quarter(pr: xarray.DataArray, op: str, freq: str = "YS") -> x
 def prcptot_warmcold_quarter(
     pr: xarray.DataArray,
     tas: xarray.DataArray,
-    op: str,
+    op: Literal["warmest", "coldest"],
     freq: str = "YS",
 ) -> xarray.DataArray:
     r"""
@@ -397,8 +405,10 @@ def prcptot_warmcold_quarter(
         Total precipitation rate at daily, weekly, or monthly frequency.
     tas : xarray.DataArray
         Mean temperature at daily, weekly, or monthly frequency.
-    op : {'warmest', 'coldest'}
-        Operation to perform: 'warmest' calculate for the warmest quarter; 'coldest' calculate for the coldest quarter.
+    op : {"warmest", "coldest"}
+        Operation to perform:
+        "warmest" calculates for the warmest quarter;
+        "coldest" calculates for the coldest quarter.
     freq : str
         Resampling frequency.
 
@@ -411,7 +421,7 @@ def prcptot_warmcold_quarter(
     -----
     According to the ANUCLIM user-guide (:cite:t:`xu_anuclim_2010`, ch. 6), input values should be at a weekly
     (or monthly) frequency. However, the xclim.indices implementation here will calculate the result with input data
-    with daily frequency as well. As such weekly or monthly input values, if desired, should be calculated prior to
+    with daily frequency as well. As such, weekly or monthly input values, if desired, should be calculated prior to
     calling the function.
 
     References
@@ -437,8 +447,8 @@ def prcptot(pr: xarray.DataArray, thresh: Quantified = "0 mm/d", freq: str = "YS
     r"""
     Accumulated total precipitation.
 
-    The total accumulated precipitation from days where precipitation exceeds a given amount. A threshold is provided in
-    order to allow the option of reducing the impact of days with trace precipitation amounts on period totals.
+    The total accumulated precipitation from days where precipitation exceeds a given amount. A threshold is provided
+    to allow the option of reducing the impact of days with trace precipitation amounts on period totals.
 
     Parameters
     ----------
@@ -461,7 +471,9 @@ def prcptot(pr: xarray.DataArray, thresh: Quantified = "0 mm/d", freq: str = "YS
 
 
 @declare_units(pr="[precipitation]")
-def prcptot_wetdry_period(pr: xarray.DataArray, *, op: str, freq: str = "YS") -> xarray.DataArray:
+def prcptot_wetdry_period(
+    pr: xarray.DataArray, *, op: Literal["wettest", "driest", "dryest"], freq: str = "YS"
+) -> xarray.DataArray:
     r"""
     Precipitation of the wettest/driest day, week, or month, depending on the time step.
 
@@ -471,8 +483,10 @@ def prcptot_wetdry_period(pr: xarray.DataArray, *, op: str, freq: str = "YS") ->
     ----------
     pr : xarray.DataArray
         Total precipitation flux [mm d-1], [mm week-1], [mm month-1] or similar.
-    op : {'wettest', 'driest'}
-        Operation to perform :  'wettest' calculate the wettest period ; 'driest' calculate the driest period.
+    op : {"wettest", "driest"}
+        Operation to perform:
+        "wettest" calculates the wettest quarter.
+        "driest" calculates the driest quarter.
     freq : str
         Resampling frequency.
 
@@ -485,7 +499,7 @@ def prcptot_wetdry_period(pr: xarray.DataArray, *, op: str, freq: str = "YS") ->
     -----
     According to the ANUCLIM user-guide (:cite:t:`xu_anuclim_2010`, ch. 6), input values should be at a weekly
     (or monthly) frequency. However, the xclim.indices implementation here will calculate the result with input data
-    with daily frequency as well. As such weekly or monthly input values, if desired, should be calculated prior to
+    with daily frequency as well. As such, weekly or monthly input values, if desired, should be calculated prior to
     calling the function.
 
     References
@@ -521,7 +535,7 @@ def _from_other_arg(criteria: xarray.DataArray, output: xarray.DataArray, op: Ca
     output : xarray.DataArray
         Series to be indexed.
     op : Callable
-        Function returning an index, for example: `np.argmin`, `np.argmax`, `np.nanargmin`, `np.nanargmax`.
+        Function returning an index, for example, `np.argmin`, `np.argmax`, `np.nanargmin`, `np.nanargmax`.
     freq : str
         Temporal grouping.
 

--- a/src/xclim/indices/_multivariate.py
+++ b/src/xclim/indices/_multivariate.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import cast
+from typing import Literal, cast
 
 import numpy as np
 import xarray
@@ -73,7 +73,7 @@ def cold_spell_duration_index(
     freq: str = "YS",
     resample_before_rl: bool = True,
     bootstrap: bool = False,  # noqa  # noqa
-    op: str = "<",
+    op: Literal["<", "<=", "lt", "le"] = "<",
 ) -> xarray.DataArray:
     r"""
     Cold spell duration index.
@@ -429,9 +429,9 @@ def multiday_temperature_swing(
     thresh_tasmin: Quantified = "0 degC",
     thresh_tasmax: Quantified = "0 degC",
     window: int = 1,
-    op: str = "mean",
-    op_tasmin: str = "<=",
-    op_tasmax: str = ">",
+    op: Literal["mean", "sum", "max", "min", "std", "count"] = "mean",
+    op_tasmin: Literal["<", "<=", "lt", "le"] = "<=",
+    op_tasmax: Literal[">", ">=", "gt", "ge"] = ">",
     freq: str = "YS",
     resample_before_rl: bool = True,
 ) -> xarray.DataArray:
@@ -453,7 +453,7 @@ def multiday_temperature_swing(
         The temperature threshold needed to trigger a thaw event.
     window : int
         The minimal length of spells to be included in the statistics.
-    op : {'mean', 'sum', 'max', 'min', 'std', 'count'}
+    op : {"mean", "sum", "max", "min", "std", "count"}
         The statistical operation to use when reducing the list of spell lengths.
     op_tasmin : {"<", "<=", "lt", "le"}
         Comparison operation for tasmin. Default: "<=".
@@ -515,7 +515,7 @@ def daily_temperature_range(
     tasmin: xarray.DataArray,
     tasmax: xarray.DataArray,
     freq: str = "YS",
-    op: str | Callable = "mean",
+    op: Literal["min", "max", "mean", "std"] | Callable = "mean",
 ) -> xarray.DataArray:
     r"""
     Statistics of daily temperature range.
@@ -530,7 +530,7 @@ def daily_temperature_range(
         Maximum daily temperature.
     freq : str
         Resampling frequency.
-    op : {'min', 'max', 'mean', 'std'} or func
+    op : {"min", "max", "mean", "std"} or Callable
         Reduce operation. Can either be a DataArray method or a function that can be applied to a DataArray.
 
     Returns
@@ -650,7 +650,7 @@ def heat_wave_frequency(
     thresh_tasmax: Quantified = "30 degC",
     window: int = 3,
     freq: str = "YS",
-    op: str = ">",
+    op: Literal[">", ">=", "gt", "ge"] = ">",
     resample_before_rl: bool = True,
 ) -> xarray.DataArray:
     r"""
@@ -728,16 +728,16 @@ def heat_wave_max_length(
     thresh_tasmax: Quantified = "30 degC",
     window: int = 3,
     freq: str = "YS",
-    op: str = ">",
+    op: Literal[">", ">=", "gt", "ge"] = ">",
     resample_before_rl: bool = True,
 ) -> xarray.DataArray:
     r"""
     Heat wave max length.
 
     Maximum length of heat waves over a given period. A heat wave is defined as an event where the minimum and maximum
-    daily temperature both exceeds specific thresholds over a minimum number of days.
+    daily temperature both exceed specific thresholds over a minimum number of days.
 
-    By definition heat_wave_max_length must be >= window.
+    By definition, heat_wave_max_length must be >= window.
 
     Parameters
     ----------
@@ -807,15 +807,15 @@ def heat_wave_total_length(
     thresh_tasmax: Quantified = "30 degC",
     window: int = 3,
     freq: str = "YS",
-    op: str = ">",
+    op: Literal[">", ">=", "gt", "ge"] = ">",
     resample_before_rl: bool = True,
 ) -> xarray.DataArray:
     r"""
     Heat wave total length.
 
     Total length of heat waves over a given period. A heat wave is defined as an event where the minimum and maximum
-    daily temperature both exceeds specific thresholds over a minimum number of days.
-    This the sum of all days in such events.
+    daily temperature both exceed specific thresholds over a minimum number of days.
+    This is the sum of all days in such events.
 
     Parameters
     ----------
@@ -1176,12 +1176,12 @@ def days_over_precip_thresh(
     thresh: Quantified = "1 mm/day",
     freq: str = "YS",
     bootstrap: bool = False,  # noqa
-    op: str = ">",
+    op: Literal[">", ">=", "gt", "ge"] = ">",
 ) -> xarray.DataArray:
     r"""
     Number of wet days with daily precipitation over a given percentile.
 
-    Number of days over period where the precipitation is above a threshold defining wet days and above a given
+    Number of days over a period where the precipitation is above a threshold defining wet days and above a given
     percentile for that day.
 
     Parameters
@@ -1200,8 +1200,8 @@ def days_over_precip_thresh(
         Bootstrapping is only useful when the percentiles are computed on a part of the studied sample.
         This period, common to percentiles and the sample must be bootstrapped to avoid inhomogeneities with
         the rest of the time series.
-        Keep bootstrap to False when there is no common period, it would give wrong results
-        plus, bootstrapping is computationally expensive.
+        Do not enable bootstrap when there is no common period, otherwise it will provide the wrong results.
+        Note that bootstrapping is computationally expensive.
     op : {">", ">=", "gt", "ge"}
         Comparison operation. Default: ">".
 
@@ -1238,13 +1238,13 @@ def fraction_over_precip_thresh(
     thresh: Quantified = "1 mm/day",
     freq: str = "YS",
     bootstrap: bool = False,  # noqa
-    op: str = ">",
+    op: Literal[">", ">=", "gt", "ge"] = ">",
 ) -> xarray.DataArray:
     r"""
     Fraction of precipitation due to wet days with daily precipitation over a given percentile.
 
-    Percentage of the total precipitation over period occurring in days when the precipitation is above a threshold
-    defining wet days and above a given percentile for that day.
+    The percentage of the total precipitation over a period occurring for days when the precipitation is above
+    a threshold defining wet days and above a given percentile for that day.
 
     Parameters
     ----------
@@ -1262,8 +1262,8 @@ def fraction_over_precip_thresh(
         Bootstrapping is only useful when the percentiles are computed on a part of the studied sample.
         This period, common to percentiles and the sample must be bootstrapped to avoid inhomogeneities with
         the rest of the time series.
-        Keep bootstrap to False when there is no common period, it would give wrong results
-        plus, bootstrapping is computationally expensive.
+        Do not enable bootstrap when there is no common period, otherwise it will provide the wrong results.
+        Note that bootstrapping is computationally expensive.
     op : {">", ">=", "gt", "ge"}
         Comparison operation. Default: ">".
 
@@ -1299,7 +1299,7 @@ def tg90p(
     tas_per: xarray.DataArray,
     freq: str = "YS",
     bootstrap: bool = False,  # noqa
-    op: str = ">",
+    op: Literal[">", ">=", "gt", "ge"] = ">",
 ) -> xarray.DataArray:
     r"""
     Number of days with daily mean temperature over the 90th percentile.
@@ -1319,8 +1319,8 @@ def tg90p(
         Bootstrapping is only useful when the percentiles are computed on a part of the studied sample.
         This period, common to percentiles and the sample must be bootstrapped to avoid inhomogeneities with
         the rest of the time series.
-        Keep bootstrap to False when there is no common period, it would give wrong results
-        plus, bootstrapping is computationally expensive.
+        Do not enable bootstrap when there is no common period, otherwise it will provide the wrong results.
+        Note that bootstrapping is computationally expensive.
     op : {">", ">=", "gt", "ge"}
         Comparison operation. Default: ">".
 
@@ -1358,7 +1358,7 @@ def tg10p(
     tas_per: xarray.DataArray,
     freq: str = "YS",
     bootstrap: bool = False,  # noqa
-    op: str = "<",
+    op: Literal[">", ">=", "gt", "ge"] = "<",
 ) -> xarray.DataArray:
     r"""
     Number of days with daily mean temperature below the 10th percentile.
@@ -1378,8 +1378,8 @@ def tg10p(
         Bootstrapping is only useful when the percentiles are computed on a part of the studied sample.
         This period, common to percentiles and the sample must be bootstrapped to avoid inhomogeneities with
         the rest of the time series.
-        Keep bootstrap to False when there is no common period, it would give wrong results
-        plus, bootstrapping is computationally expensive.
+        Do not enable bootstrap when there is no common period, otherwise it will provide the wrong results.
+        Note that bootstrapping is computationally expensive.
     op : {"<", "<=", "lt", "le"}
         Comparison operation. Default: "<".
 
@@ -1417,7 +1417,7 @@ def tn90p(
     tasmin_per: xarray.DataArray,
     freq: str = "YS",
     bootstrap: bool = False,  # noqa
-    op: str = ">",
+    op: Literal[">", ">=", "gt", "ge"] = ">",
 ) -> xarray.DataArray:
     r"""
     Number of days with daily minimum temperature over the 90th percentile.
@@ -1437,8 +1437,8 @@ def tn90p(
         Bootstrapping is only useful when the percentiles are computed on a part of the studied sample.
         This period, common to percentiles and the sample must be bootstrapped to avoid inhomogeneities with
         the rest of the time series.
-        Keep bootstrap to False when there is no common period, it would give wrong results
-        plus, bootstrapping is computationally expensive.
+        Do not enable bootstrap when there is no common period, otherwise it will provide the wrong results.
+        Note that bootstrapping is computationally expensive.
     op : {">", ">=", "gt", "ge"}
         Comparison operation. Default: ">".
 
@@ -1476,7 +1476,7 @@ def tn10p(
     tasmin_per: xarray.DataArray,
     freq: str = "YS",
     bootstrap: bool = False,  # noqa
-    op: str = "<",
+    op: Literal["<", "<=", "lt", "le"] = "<",
 ) -> xarray.DataArray:
     r"""
     Number of days with daily minimum temperature below the 10th percentile.
@@ -1496,8 +1496,8 @@ def tn10p(
         Bootstrapping is only useful when the percentiles are computed on a part of the studied sample.
         This period, common to percentiles and the sample must be bootstrapped to avoid inhomogeneities with
         the rest of the time series.
-        Keep bootstrap to False when there is no common period, it would give wrong results
-        plus, bootstrapping is computationally expensive.
+        Do not enable bootstrap when there is no common period, otherwise it will provide the wrong results.
+        Note that bootstrapping is computationally expensive.
     op : {"<", "<=", "lt", "le"}
         Comparison operation. Default: "<".
 
@@ -1535,7 +1535,7 @@ def tx90p(
     tasmax_per: xarray.DataArray,
     freq: str = "YS",
     bootstrap: bool = False,  # noqa
-    op: str = ">",
+    op: Literal["<", "<=", "lt", "le"] = ">",
 ) -> xarray.DataArray:
     r"""
     Number of days with daily maximum temperature over the 90th percentile.
@@ -1555,8 +1555,8 @@ def tx90p(
         Bootstrapping is only useful when the percentiles are computed on a part of the studied sample.
         This period, common to percentiles and the sample must be bootstrapped to avoid inhomogeneities with
         the rest of the time series.
-        Keep bootstrap to False when there is no common period, it would give wrong results
-        plus, bootstrapping is computationally expensive.
+        Do not enable bootstrap when there is no common period, otherwise it will provide the wrong results.
+        Note that bootstrapping is computationally expensive.
     op : {">", ">=", "gt", "ge"}
         Comparison operation. Default: ">".
 
@@ -1594,7 +1594,7 @@ def tx10p(
     tasmax_per: xarray.DataArray,
     freq: str = "YS",
     bootstrap: bool = False,  # noqa
-    op: str = "<",
+    op: Literal["<", "<=", "lt", "le"] = "<",
 ) -> xarray.DataArray:
     r"""
     Number of days with daily maximum temperature below the 10th percentile.
@@ -1614,8 +1614,8 @@ def tx10p(
         Bootstrapping is only useful when the percentiles are computed on a part of the studied sample.
         This period, common to percentiles and the sample must be bootstrapped to avoid inhomogeneities with
         the rest of the time series.
-        Keep bootstrap to False when there is no common period, it would give wrong results
-        plus, bootstrapping is computationally expensive.
+        Do not enable bootstrap when there is no common period, otherwise it will provide the wrong results.
+        Note that bootstrapping is computationally expensive.
     op : {"<", "<=", "lt", "le"}
         Comparison operation. Default: "<".
 
@@ -1658,7 +1658,7 @@ def tx_tn_days_above(
     thresh_tasmin: Quantified = "22 degC",
     thresh_tasmax: Quantified = "30 degC",
     freq: str = "YS",
-    op: str = ">",
+    op: Literal[">", ">=", "gt", "ge"] = ">",
 ) -> xarray.DataArray:
     r"""
     Number of days with both hot maximum and minimum daily temperatures.
@@ -1720,7 +1720,7 @@ def warm_spell_duration_index(
     freq: str = "YS",
     resample_before_rl: bool = True,
     bootstrap: bool = False,  # noqa
-    op: str = ">",
+    op: Literal[">", ">=", "gt", "ge"] = ">",
 ) -> xarray.DataArray:
     r"""
     Warm spell duration index.
@@ -1747,8 +1747,8 @@ def warm_spell_duration_index(
         Bootstrapping is only useful when the percentiles are computed on a part of the studied sample.
         This period, common to percentiles and the sample must be bootstrapped to avoid inhomogeneities with
         the rest of the time series.
-        Keep bootstrap to False when there is no common period, it would give wrong results
-        plus, bootstrapping is computationally expensive.
+        Do not enable bootstrap when there is no common period, otherwise it will provide the wrong results.
+        Note that bootstrapping is computationally expensive.
     op : {">", ">=", "gt", "ge"}
         Comparison operation. Default: ">".
 

--- a/src/xclim/indices/_threshold.py
+++ b/src/xclim/indices/_threshold.py
@@ -136,11 +136,12 @@ def calm_days(sfcWind: xarray.DataArray, thresh: Quantified = "2 m s-1", freq: s
     Returns
     -------
     xarray.DataArray, [time]
-        Number of days with average near-surface wind speed below threshold.
+        Number of days with average near-surface wind speed below the threshold.
 
     Notes
     -----
-    Let :math:`WS_{ij}` be the windspeed at day :math:`i` of period :math:`j`. Then counted is the number of days where:
+    Let :math:`WS_{ij}` be the windspeed at day :math:`i` of period :math:`j`.
+    Then counted is the number of days where:
 
     .. math::
 
@@ -158,7 +159,7 @@ def cold_spell_days(
     thresh: Quantified = "-10 degC",
     window: int = 5,
     freq: str = "YS-JUL",
-    op: str = "<",
+    op: Literal["<", "lt", "<=", "le"] = "<",
     resample_before_rl: bool = True,
 ) -> xarray.DataArray:
     r"""
@@ -174,10 +175,10 @@ def cold_spell_days(
     thresh : Quantified
         Threshold temperature below which a cold spell begins.
     window : int
-        Minimum number of days with temperature below threshold to qualify as a cold spell.
+        Minimum number of days with temperature below the threshold to qualify as a cold spell.
     freq : str
         Resampling frequency.
-    op : {"<", "<=", "lt", "le"}
+    op : {"<", "lt", "<=", "le"}
         Comparison operation. Default: "<".
     resample_before_rl : bool
         Determines if the resampling should take place before or after the run
@@ -218,7 +219,7 @@ def cold_spell_frequency(
     thresh: Quantified = "-10 degC",
     window: int = 5,
     freq: str = "YS-JUL",
-    op: str = "<",
+    op: Literal["<", "lt", "<=", "le"] = "<",
     resample_before_rl: bool = True,
 ) -> xarray.DataArray:
     r"""
@@ -234,10 +235,10 @@ def cold_spell_frequency(
     thresh : Quantified
         Threshold temperature below which a cold spell begins.
     window : int
-        Minimum number of days with temperature below threshold to qualify as a cold spell.
+        Minimum number of days with temperature below the threshold to qualify as a cold spell.
     freq : str
         Resampling frequency.
-    op : {"<", "<=", "lt", "le"}
+    op : {"<", "lt", "<=", "le"}
         Comparison operation. Default: "<".
     resample_before_rl : bool
         Determines if the resampling should take place before or after the run.
@@ -267,7 +268,7 @@ def cold_spell_max_length(
     thresh: Quantified = "-10 degC",
     window: int = 1,
     freq: str = "YS-JUL",
-    op: str = "<",
+    op: Literal["<", "lt", "<=", "le"] = "<",
     resample_before_rl: bool = True,
 ) -> xarray.DataArray:
     r"""
@@ -283,10 +284,10 @@ def cold_spell_max_length(
     thresh : Quantified
         The temperature threshold needed to trigger a cold spell.
     window : int
-        Minimum number of days with temperatures below thresholds to qualify as a cold spell.
+        Minimum number of days with temperatures below the threshold to qualify as a cold spell.
     freq : str
         Resampling frequency.
-    op : {"<", "<=", "lt", "le"}
+    op : {"<", "lt", "<=", "le"}
         Comparison operation. Default: "<".
     resample_before_rl : bool
         Determines if the resampling should take place before or after the run
@@ -317,7 +318,7 @@ def cold_spell_total_length(
     thresh: Quantified = "-10 degC",
     window: int = 3,
     freq: str = "YS-JUL",
-    op: str = "<",
+    op: Literal["<", "lt", "<=", "le"] = "<",
     resample_before_rl: bool = True,
 ) -> xarray.DataArray:
     r"""
@@ -333,10 +334,10 @@ def cold_spell_total_length(
     thresh : Quantified
         The temperature threshold needed to trigger a cold spell.
     window : int
-        Minimum number of days with temperatures below thresholds to qualify as a cold spell.
+        Minimum number of days with temperatures below the threshold to qualify as a cold spell.
     freq : str
         Resampling frequency.
-    op : {"<", "<=", "lt", "le"}
+    op : {"<", "lt", "<=", "le"}
         Comparison operation. Default: "<".
     resample_before_rl : bool
         Determines if the resampling should take place before or after the run
@@ -380,7 +381,7 @@ def snd_season_end(
     thresh : Quantified
         Threshold snow thickness.
     window : int
-        Minimum number of days with snow depth below threshold.
+        Minimum number of days with snow depth below the threshold.
     freq : str
         Resampling frequency. Default: "YS-JUL".
         The default value is chosen for the northern hemisphere.
@@ -420,9 +421,9 @@ def snw_season_end(
     thresh : str
         Threshold snow amount.
     window : int
-        Minimum number of days with snow water below threshold.
+        Minimum number of days with snow water below the threshold.
     freq : str
-        Resampling frequency. The default value is chosen for the northern hemisphere.
+        Resampling frequency. The default value is chosen for the Northern Hemisphere.
 
     Returns
     -------
@@ -459,9 +460,9 @@ def snd_season_start(
     thresh : Quantified
         Threshold snow thickness.
     window : int
-        Minimum number of days with snow depth above or equal to threshold.
+        Minimum number of days with snow depth above or equal to the threshold.
     freq : str
-        Resampling frequency. The default value is chosen for the northern hemisphere.
+        Resampling frequency. The default value is chosen for the Northern Hemisphere.
 
     Returns
     -------
@@ -497,7 +498,7 @@ def snw_season_start(
     thresh : str
         Threshold snow amount.
     window : int
-        Minimum number of days with snow amount above or equal to threshold.
+        Minimum number of days with snow amount above or equal to the threshold.
     freq : str
         Resampling frequency.
 
@@ -679,7 +680,7 @@ def daily_pr_intensity(
     pr: xarray.DataArray,
     thresh: Quantified = "1 mm/day",
     freq: str = "YS",
-    op: str = ">=",
+    op: Literal[">", "gt", ">=", "ge"] = ">=",
 ) -> xarray.DataArray:
     r"""
     Average daily precipitation intensity.
@@ -695,7 +696,7 @@ def daily_pr_intensity(
         Precipitation value over which a day is considered wet.
     freq : str
         Resampling frequency.
-    op : {">", ">=", "gt", "ge"}
+    op : {">", "gt", ">=", "ge"}
         Comparison operation. Default: ">=".
 
     Returns
@@ -755,7 +756,7 @@ def dry_days(
     pr: xarray.DataArray,
     thresh: Quantified = "0.2 mm/d",
     freq: str = "YS",
-    op: str = "<",
+    op: Literal["<", "lt", "<=", "le"] = "<",
 ) -> xarray.DataArray:
     r"""
     Dry days.
@@ -770,7 +771,7 @@ def dry_days(
         Threshold precipitation on which to base evaluation.
     freq : str
         Resampling frequency.
-    op : {"<", "<=", "lt", "le"}
+    op : {"<", "lt", "<=", "le"}
         Comparison operation. Default: "<".
 
     Returns
@@ -986,7 +987,7 @@ def growing_season_start(
     mid_date: DayOfYearStr | None = "07-01",
     window: int = 5,
     freq: str = "YS",
-    op: Literal[">", ">=", "gt", "ge"] = ">=",
+    op: Literal[">", "gt", ">=", "ge"] = ">=",
 ) -> xarray.DataArray:
     r"""
     Start of the growing season.
@@ -1009,7 +1010,7 @@ def growing_season_start(
         Minimum number of days with temperature above threshold needed for evaluation.
     freq : str
         Resampling frequency.
-    op : {">", ">=", "gt", "ge"}
+    op : {">", "gt", ">=", "ge"}
         Comparison operation. Default: ">=".
 
     Returns
@@ -1063,7 +1064,7 @@ def growing_season_end(
         Minimum number of days with temperature below threshold needed for evaluation.
     freq : str
         Resampling frequency.
-    op : {">", ">=", "gt", "ge"}
+    op : {">", "gt", ">=", "ge"}
         Comparison operation. Default: ">". Note that this comparison is what defines the season.
         The end of the season happens when the condition is NOT met for `window` consecutive days.
 
@@ -1107,7 +1108,7 @@ def growing_season_length(
     window: int = 6,
     mid_date: DayOfYearStr | None = "07-01",
     freq: str = "YS",
-    op: str = ">=",
+    op: Literal[">", "gt", ">=", "ge"] = ">=",
 ) -> xarray.DataArray:
     r"""
     Growing season length.
@@ -1126,13 +1127,13 @@ def growing_season_length(
     thresh : Quantified
         Threshold temperature on which to base evaluation.
     window : int
-        Minimum number of days with temperature above threshold to mark the beginning and end of growing season.
+        Minimum number of days with temperature above the threshold to mark the beginning and end of growing season.
     mid_date : str, optional
         Date of the year before which the season must start and after which it can end. Should have the format '%m-%d'.
         Setting `None` removes that constraint.
     freq : str
         Resampling frequency.
-    op : {">", ">=", "gt", "ge"}
+    op : {">", "gt", ">=", "ge"}
         Comparison operation. Default: ">=".
 
     Returns
@@ -1142,7 +1143,7 @@ def growing_season_length(
 
     Warnings
     --------
-    The default `freq` and `mid_date` parameters are valid for the northern hemisphere.
+    The default `freq` and `mid_date` parameters are valid for the Northern Hemisphere.
 
     Notes
     -----
@@ -1195,7 +1196,7 @@ def frost_season_length(
     mid_date: DayOfYearStr | None = "01-01",
     thresh: Quantified = "0.0 degC",
     freq: str = "YS-JUL",
-    op: str = "<",
+    op: Literal["<", "lt", "<=", "le"] = "<",
 ) -> xarray.DataArray:
     r"""
     Frost season length.
@@ -1212,13 +1213,13 @@ def frost_season_length(
     window : int
         Minimum number of days with temperature below threshold to mark the beginning and end of frost season.
     mid_date : str, optional
-        Date the must be included in the season. It is the earliest the end of the season can be.
+        The date must be included in the season. It is the earliest the end of the season can be.
         ``None`` removes that constraint.
     thresh : Quantified
         Threshold temperature on which to base evaluation.
     freq : str
         Resampling frequency.
-    op : {"<", "<=", "lt", "le"}
+    op : {"<", "lt", "<=", "le"}
         Comparison operation. Default: "<".
 
     Returns
@@ -1228,7 +1229,7 @@ def frost_season_length(
 
     Warnings
     --------
-    The default `freq` and `mid_date` parameters are valid for the northern hemisphere.
+    The default `freq` and `mid_date` parameters are valid for the Northern Hemisphere.
 
     Notes
     -----
@@ -1276,15 +1277,15 @@ def frost_free_season_start(
     thresh: Quantified = "0.0 degC",
     window: int = 5,
     mid_date: DayOfYearStr | None = "07-01",
-    op: str = ">=",
+    op: Literal[">", "gt", ">=", "ge"] = ">=",
     freq: str = "YS",
 ) -> xarray.DataArray:
     r"""
-    Start of the frost free season.
+    Start of the frost-free season.
 
-    The frost free season starts when a sequence of `window` consecutive days are above the threshold
+    The frost-free season starts when a sequence of `window` consecutive days are above the threshold
     and ends when a sequence of consecutive days of the same length are under the threshold. Sequences
-    of consecutive days under the threshold shorter then `window` are allowed within the season.
+    of consecutive days under the threshold shorter than `window` are allowed within the season.
     A middle date can be given, the start must occur before and the end after for the season to be valid.
 
     Parameters
@@ -1294,11 +1295,10 @@ def frost_free_season_start(
     thresh : Quantified
         Threshold temperature on which to base evaluation.
     window : int
-        Minimum number of days with temperature above/under threshold to start/end the season.
+        Minimum number of days with temperature above/under the threshold to start/end the season.
     mid_date : DayOfYearStr, optional
-        A date that must be included in the season.
-        ``None`` removes that constraint.
-    op : {'>', '>=', 'ge', 'gt'}
+        A date that must be included in the season. `None` removes that constraint.
+    op : {">", "gt", ">=", "ge"}
         How to compare tasmin and the threshold.
     freq : str
         Resampling frequency.
@@ -1306,7 +1306,7 @@ def frost_free_season_start(
     Returns
     -------
     xarray.DataArray, [dimensionless]
-        Day of the year when the frost free season starts.
+        Day of the year when the frost-free season starts.
 
     Notes
     -----
@@ -1338,15 +1338,15 @@ def frost_free_season_end(
     thresh: Quantified = "0.0 degC",
     window: int = 5,
     mid_date: DayOfYearStr | None = "07-01",
-    op: str = ">=",
+    op: Literal[">", "gt", ">=", "ge"] = ">=",
     freq: str = "YS",
 ) -> xarray.DataArray:
     r"""
-    End of the frost free season.
+    End of the frost-free season.
 
-    The frost free season starts when a sequence of `window` consecutive days are above the threshold
+    The frost-free season starts when a sequence of `window` consecutive days are above the threshold
     and ends when a sequence of consecutive days of the same length are under the threshold. Sequences
-    of consecutive days under the threshold shorter then `window` are allowed within the season.
+    of consecutive days under the threshold shorter than `window` are allowed within the season.
     A middle date can be given, the start must occur before and the end after for the season to be valid.
 
     Parameters
@@ -1356,10 +1356,10 @@ def frost_free_season_end(
     thresh : Quantified
         Threshold temperature on which to base evaluation.
     window : int
-        Minimum number of days with temperature above/under threshold to start/end the season.
+        Minimum number of days with temperature above/under the threshold to start/end the season.
     mid_date : DayOfYearStr, optional
-        A date what must be included in the season. ``None`` removes that constraint.
-    op : {'>', '>=', 'ge', 'gt'}
+        A date what must be included in the season. `None` removes that constraint.
+    op : {">", "gt", ">=", "ge"}
         How to compare tasmin and the threshold.
     freq : str
         Resampling frequency.
@@ -1367,7 +1367,7 @@ def frost_free_season_end(
     Returns
     -------
     xarray.DataArray, [dimensionless]
-        Day of the year when the frost free season starts.
+        Day of the year when the frost-free season starts.
 
     Notes
     -----
@@ -1406,15 +1406,15 @@ def frost_free_season_length(
     thresh: Quantified = "0.0 degC",
     window: int = 5,
     mid_date: DayOfYearStr | None = "07-01",
-    op: str = ">=",
+    op: Literal[">", "gt", ">=", "ge"] = ">=",
     freq: str = "YS",
 ) -> xarray.DataArray:
     r"""
-    Length of the frost free season.
+    Length of the frost-free season.
 
-    The frost free season starts when a sequence of `window` consecutive days are above the threshold
+    The frost-free season starts when a sequence of `window` consecutive days are above the threshold
     and ends when a sequence of consecutive days of the same length are under the threshold. Sequences
-    of consecutive days under the threshold shorter then `window` are allowed within the season.
+    of consecutive days under the threshold shorter than `window` are allowed within the season.
     A middle date can be given, the start must occur before and the end after for the season to be valid.
 
     Parameters
@@ -1424,10 +1424,10 @@ def frost_free_season_length(
     thresh : Quantified
         Threshold temperature on which to base evaluation.
     window : int
-        Minimum number of days with temperature above/under threshold to start/end the season.
+        Minimum number of days with temperature above/under the threshold to start/end the season.
     mid_date : DayOfYearStr, optional
-        A date what must be included in the season. ``None`` removes that constraint.
-    op : {'>', '>=', 'ge', 'gt'}
+        A date what must be included in the season. `None` removes that constraint.
+    op : {">", "gt", ">=", "ge"}
         How to compare tasmin and the threshold.
     freq : str
         Resampling frequency.
@@ -1487,11 +1487,11 @@ def frost_free_spell_max_length(
     thresh: Quantified = "0.0 degC",
     window: int = 1,
     freq: str = "YS-JUL",
-    op: str = ">=",
+    op: Literal[">", "gt", ">=", "ge"] = ">=",
     resample_before_rl: bool = True,
 ) -> xarray.DataArray:
     r"""
-    Longest frost free spell.
+    Longest frost-free spell.
 
     Longest spell of warm temperatures over a given period.
     Longest series of at least {window} consecutive days with temperature at or above the threshold.
@@ -1501,12 +1501,12 @@ def frost_free_spell_max_length(
     tasmin : xarray.DataArray
         Minimum daily temperature.
     thresh : Quantified
-        The temperature threshold needed to trigger a frost free spell.
+        The temperature threshold needed to trigger a frost-free spell.
     window : int
-        Minimum number of days with temperatures above thresholds to qualify as a frost free day.
+        Minimum number of days with temperatures above thresholds to qualify as a frost-free day.
     freq : str
         Resampling frequency.
-    op : {">", ">=", "gt", "ge"}
+    op : {">", "gt", ">=", "ge"}
         Comparison operation. Default: ">=".
     resample_before_rl : bool
         Determines if the resampling should take place before or after the run
@@ -1515,7 +1515,7 @@ def frost_free_spell_max_length(
     Returns
     -------
     xarray.DataArray, [days]
-        The {freq} longest spell in frost free periods of minimum {window} days.
+        The {freq} longest spell in frost-free periods of minimum {window} days.
     """
     thresh = convert_units_to(thresh, tasmin)
 
@@ -1535,7 +1535,7 @@ def frost_free_spell_max_length(
 def last_spring_frost(
     tasmin: xarray.DataArray,
     thresh: Quantified = "0 degC",
-    op: str = "<",
+    op: Literal["<", "lt", "<=", "le"] = "<",
     before_date: DayOfYearStr = "07-01",
     window: int = 1,
     freq: str = "YS",
@@ -1552,12 +1552,12 @@ def last_spring_frost(
         Mean daily temperature.
     thresh : Quantified
         Threshold temperature on which to base evaluation.
-    op : {"<", "<=", "lt", "le"}
+    op : {"<", "lt", "<=", "le"}
         Comparison operation. Default: "<".
     before_date : str,
         Date of the year before which to look for the final frost event. Should have the format '%m-%d'.
     window : int
-        Minimum number of days with temperature below threshold needed for evaluation.
+        Minimum number of days with temperature below the threshold needed for evaluation.
     freq : str
         Resampling frequency.
 
@@ -1569,7 +1569,7 @@ def last_spring_frost(
 
     Warnings
     --------
-    The default `freq` and `before_date` parameters are valid for the northern hemisphere.
+    The default `freq` and `before_date` parameters are valid for the Northern Hemisphere.
     """
     thresh = convert_units_to(thresh, tasmin)
     cond = compare(tasmin, op, thresh, constrain=("<", "<="))
@@ -1594,7 +1594,7 @@ def last_spring_frost(
 def first_day_temperature_below(
     tas: xarray.DataArray,
     thresh: Quantified = "0 degC",
-    op: str = "<",
+    op: Literal["<", "lt", "<=", "le"] = "<",
     after_date: DayOfYearStr = "07-01",
     window: int = 1,
     freq: str = "YS",
@@ -1611,12 +1611,12 @@ def first_day_temperature_below(
         Daily temperature.
     thresh : Quantified
         Threshold temperature on which to base evaluation.
-    op : {"<", "<=", "lt", "le"}
+    op : {"<", "lt", "<=", "le"}
         Comparison operation. Default: ">".
     after_date : str
         Date of the year after which to look for the first event. Should have the format '%m-%d'.
     window : int
-        Minimum number of days with temperature below threshold needed for evaluation.
+        Minimum number of days with temperature below the threshold needed for evaluation.
     freq : str
         Resampling frequency.
 
@@ -1628,7 +1628,7 @@ def first_day_temperature_below(
 
     Warnings
     --------
-    The default `freq` and `after_date` parameters are valid for the northern hemisphere.
+    The default `freq` and `after_date` parameters are valid for the Northern Hemisphere.
     """
     # noqa
 
@@ -1648,7 +1648,7 @@ def first_day_temperature_below(
 def first_day_temperature_above(
     tas: xarray.DataArray,
     thresh: Quantified = "0 degC",
-    op: str = ">",
+    op: Literal[">", "gt", ">=", "ge"] = ">",
     after_date: DayOfYearStr = "01-01",
     window: int = 1,
     freq: str = "YS",
@@ -1665,12 +1665,12 @@ def first_day_temperature_above(
         Daily temperature.
     thresh : Quantified
         Threshold temperature on which to base evaluation.
-    op : {">", ">=", "gt", "ge"}
+    op : {">", "gt", ">=", "ge"}
         Comparison operation. Default: ">".
     after_date : str
         Date of the year after which to look for the first event. Should have the format '%m-%d'.
     window : int
-        Minimum number of days with temperature above threshold needed for evaluation.
+        Minimum number of days with temperature above the threshold needed for evaluation.
     freq : str
         Resampling frequency.
 
@@ -1715,7 +1715,7 @@ def first_snowfall(
     freq: str = "YS-JUL",
 ) -> xarray.DataArray:
     r"""
-    First day with snowfall rate above a threshold.
+    First day with snowfall rate above a given threshold.
 
     Returns the first day of a period where snowfall exceeds a threshold (default: 1 mm/day).
 
@@ -1743,8 +1743,8 @@ def first_snowfall(
     The 1 mm/day liquid water equivalent snowfall rate threshold in :cite:cts:`frei_snowfall_2018` corresponds
     to the 1 cm/day snowfall rate threshold  in :cite:cts:`cbcl_climate_2020` using a snow density of 100 kg/m**3.
 
-    If threshold and prsn differ by a density (i.e. [length/time] vs. [mass/area/time]), a liquid water equivalent
-    snowfall rate is assumed and the threshold is converted using a 1000 kg m-3 density.
+    If the threshold and prsn differ by a density (i.e. [length/time] vs. [mass/area/time]), a liquid water equivalent
+    snowfall rate is assumed, and the threshold is converted using a 1000 kg m-3 density.
 
     References
     ----------
@@ -1771,7 +1771,7 @@ def last_snowfall(
     freq: str = "YS-JUL",
 ) -> xarray.DataArray:
     r"""
-    Last day with snowfall above a threshold.
+    Last day with snowfall above a given threshold.
 
     Returns the last day of a period where snowfall exceeds a threshold (default: 1 mm/day)
 
@@ -1792,15 +1792,15 @@ def last_snowfall(
 
     Warnings
     --------
-    The default `freq` is valid for the northern hemisphere.
+    The default `freq` is valid for the Northern Hemisphere.
 
     Notes
     -----
     The 1 mm/day liquid water equivalent snowfall rate threshold in :cite:cts:`frei_snowfall_2018` corresponds
-    to the 1 cm/day snowfall rate threshold  in :cite:cts:`cbcl_climate_2020` using a snow density of 100 kg/m**3.
+    to the 1 cm/day snowfall rate threshold in :cite:cts:`cbcl_climate_2020` using a snow density of 100 kg/m**3.
 
-    If threshold and prsn differ by a density (i.e. [length/time] vs. [mass/area/time]), a liquid water equivalent
-    snowfall rate is assumed and the threshold is converted using a 1000 kg m-3 density.
+    If the threshold and prsn differ by a density (i.e. [length/time] vs. [mass/area/time]), a liquid water equivalent
+    snowfall rate is assumed, and the threshold is converted using a 1000 kg m-3 density.
 
     References
     ----------
@@ -1894,19 +1894,19 @@ def snowfall_frequency(
     Returns
     -------
     xarray.DataArray, [%]
-        Percentage of days where snowfall exceeds a threshold.
+        Percentage of days where snowfall exceeds a given threshold.
 
     Warnings
     --------
-    The default `freq` is valid for the northern hemisphere.
+    The default `freq` is valid for the Northern Hemisphere.
 
     Notes
     -----
     The 1 mm/day liquid water equivalent snowfall rate threshold in :cite:cts:`frei_snowfall_2018` corresponds
-    to the 1 cm/day snowfall rate threshold  in :cite:cts:`cbcl_climate_2020` using a snow density of 100 kg/m**3.
+    to the 1 cm/day snowfall rate threshold in :cite:cts:`cbcl_climate_2020` using a snow density of 100 kg/m**3.
 
-    If threshold and prsn differ by a density (i.e. [length/time] vs. [mass/area/time]), a liquid water equivalent
-    snowfall rate is assumed and the threshold is converted using a 1000 kg m-3 density.
+    If the threshold and prsn differ by a density (i.e. [length/time] vs. [mass/area/time]), a liquid water equivalent
+    snowfall rate is assumed, and the threshold is converted using a 1000 kg m-3 density.
 
     References
     ----------
@@ -1936,7 +1936,7 @@ def snowfall_intensity(
     r"""
     Mean daily snowfall rate during snow days.
 
-    Return mean daily snowfall rate during days where snowfall exceeds a threshold (default: 1 mm/day).
+    Return the mean daily snowfall rate during days where snowfall exceeds a threshold (default: 1 mm/day).
 
     Parameters
     ----------
@@ -1954,7 +1954,7 @@ def snowfall_intensity(
 
     Warnings
     --------
-    The default `freq` is valid for the northern hemisphere.
+    The default `freq` is valid for the Northern Hemisphere.
 
     Notes
     -----
@@ -1985,7 +1985,7 @@ def heat_wave_index(
     thresh: Quantified = "25.0 degC",
     window: int = 5,
     freq: str = "YS",
-    op: str = ">",
+    op: Literal[">", "gt", ">=", "ge"] = ">",
     resample_before_rl: bool = True,
 ) -> xarray.DataArray:
     """
@@ -2000,10 +2000,10 @@ def heat_wave_index(
     thresh : Quantified
         Threshold temperature on which to designate a heatwave.
     window : int
-        Minimum number of days with temperature above threshold to qualify as a heatwave.
+        Minimum number of days with temperature above the threshold to qualify as a heatwave.
     freq : str
         Resampling frequency.
-    op : {">", ">=", "gt", "ge"}
+    op : {">", "gt", ">=", "ge"}
         Comparison operation. Default: ">".
     resample_before_rl : bool
         Determines if the resampling should take place before or after the run
@@ -2037,7 +2037,7 @@ def hot_spell_max_magnitude(
     """
     Hot spell maximum magnitude.
 
-    Magnitude of the most intensive heat wave event as sum of differences between tasmax
+    Magnitude of the most intensive heat wave event as the sum of differences between tasmax
     and the given threshold for Heat Wave days, defined as three or more consecutive days
     over the threshold.
 
@@ -2048,7 +2048,7 @@ def hot_spell_max_magnitude(
     thresh : xarray.DataArray
         Threshold temperature on which to designate a heatwave.
     window : int
-        Minimum number of days with temperature above threshold to qualify as a heatwave.
+        Minimum number of days with temperature above the threshold to qualify as a heatwave.
     freq : str
         Resampling frequency.
     resample_before_rl : bool
@@ -2182,7 +2182,7 @@ def hot_spell_max_length(
     thresh: Quantified = "30 degC",
     window: int = 1,
     freq: str = "YS",
-    op: str = ">",
+    op: Literal[">", "gt", ">=", "ge"] = ">",
     resample_before_rl: bool = True,
 ) -> xarray.DataArray:
     r"""
@@ -2201,7 +2201,7 @@ def hot_spell_max_length(
         Minimum number of days with temperatures below thresholds to qualify as a hot spell.
     freq : str
         Resampling frequency.
-    op : {">", ">=", "gt", "ge"}
+    op : {">", "gt", ">=", "ge"}
         Comparison operation. Default: ">".
     resample_before_rl : bool
         Determines if the resampling should take place before or after the run
@@ -2216,7 +2216,7 @@ def hot_spell_max_length(
     -----
     The threshold on `tasmax` follows the one used in heat waves. A day temperature threshold between 30° and 35°C
     was selected by Health Canada professionals, following a temperature–mortality analysis. This absolute temperature
-    threshold characterize the occurrence of hot weather events that can result in adverse health outcomes for Canadian
+    threshold characterizes the occurrence of hot weather events that can result in adverse health outcomes for Canadian
     communities :cite:p:`casati_regional_2013`.
 
     In :cite:t:`robinson_definition_2001` where heat waves are also considered, the corresponding parameters would
@@ -2245,7 +2245,7 @@ def hot_spell_total_length(
     thresh: Quantified = "30 degC",
     window: int = 3,
     freq: str = "YS",
-    op: str = ">",
+    op: Literal[">", "gt", ">=", "ge"] = ">",
     resample_before_rl: bool = True,
 ) -> xarray.DataArray:
     r"""
@@ -2261,10 +2261,10 @@ def hot_spell_total_length(
     thresh : Quantified
         The temperature threshold needed to trigger a hot spell.
     window : int
-        Minimum number of days with temperatures below thresholds to qualify as a hot spell.
+        Minimum number of days with temperatures below the threshold to qualify as a hot spell.
     freq : str
         Resampling frequency.
-    op : {">", ">=", "gt", "ge"}
+    op : {">", "gt", ">=", "ge"}
         Comparison operation. Default: ">".
     resample_before_rl : bool
         Determines if the resampling should take place before or after the run
@@ -2304,7 +2304,7 @@ def hot_spell_frequency(
     thresh: Quantified = "30 degC",
     window: int = 3,
     freq: str = "YS",
-    op: str = ">",
+    op: Literal[">", "gt", ">=", "ge"] = ">",
     resample_before_rl: bool = True,
 ) -> xarray.DataArray:
     """
@@ -2320,10 +2320,10 @@ def hot_spell_frequency(
     thresh : Quantified
         Threshold temperature below which a hot spell begins.
     window : int
-        Minimum number of days with temperature above threshold to qualify as a hot spell.
+        Minimum number of days with temperature above the threshold to qualify as a hot spell.
     freq : str
         Resampling frequency.
-    op : {">", ">=", "gt", "ge"}
+    op : {">", "gt", ">=", "ge"}
         Comparison operation. Default: ">".
     resample_before_rl : bool
         Determines if the resampling should take place before or after the run.
@@ -2366,12 +2366,12 @@ def snd_days_above(
     snd: xarray.DataArray,
     thresh: Quantified = "2 cm",
     freq: str = "YS-JUL",
-    op: str = ">=",
+    op: Literal[">", "gt", ">=", "ge"] = ">=",
 ) -> xarray.DataArray:
     """
     The number of days with snow depth above a threshold.
 
-    Number of days where surface snow depth is greater or equal to given threshold (default: 2 cm).
+    Number of days where surface snow depth is greater or equal to a given threshold (default: 2 cm).
 
     Parameters
     ----------
@@ -2380,8 +2380,8 @@ def snd_days_above(
     thresh : Quantified
         Threshold snow thickness.
     freq : str
-        Resampling frequency. The default value is chosen for the northern hemisphere.
-    op : {">", ">=", "gt", "ge"}
+        Resampling frequency. The default value is chosen for the Northern Hemisphere.
+    op : {">", "gt", ">=", "ge"}
         Comparison operation. Default: ">=".
 
     Returns
@@ -2400,12 +2400,12 @@ def snw_days_above(
     snw: xarray.DataArray,
     thresh: Quantified = "4 kg m-2",
     freq: str = "YS-JUL",
-    op: str = ">=",
+    op: Literal[">", "gt", ">=", "ge"] = ">=",
 ) -> xarray.DataArray:
     """
-    The number of days with snow amount above a threshold.
+    The number of days with snow amount above a given threshold.
 
-    Number of days where surface snow amount is greater or equal to given threshold.
+    Number of days where surface snow amount is greater or equal to a given threshold.
 
     Parameters
     ----------
@@ -2414,8 +2414,8 @@ def snw_days_above(
     thresh : str
         Threshold snow amount.
     freq : str
-        Resampling frequency. The default value is chosen for the northern hemisphere.
-    op : {">", ">=", "gt", "ge"}
+        Resampling frequency. The default value is chosen for the Northern hemisphere.
+    op : {">", "gt", ">=", "ge"}
         Comparison operation. Default: ">=".
 
     Returns
@@ -2434,7 +2434,7 @@ def tn_days_above(
     tasmin: xarray.DataArray,
     thresh: Quantified = "20.0 degC",
     freq: str = "YS",
-    op: str = ">",
+    op: Literal[">", "gt", ">=", "ge"] = ">",
 ):
     """
     The number of days with tasmin above a threshold (number of tropical nights).
@@ -2449,7 +2449,7 @@ def tn_days_above(
         Threshold temperature on which to base evaluation.
     freq : str
         Resampling frequency.
-    op : {">", ">=", "gt", "ge"}
+    op : {">", "gt", ">=", "ge"}
         Comparison operation. Default: ">".
 
     Returns
@@ -2476,12 +2476,12 @@ def tn_days_below(
     tasmin: xarray.DataArray,
     thresh: Quantified = "-10.0 degC",
     freq: str = "YS",
-    op: str = "<",
+    op: Literal["<", "lt", "<=", "le"] = "<",
 ) -> xarray.DataArray:
     """
-    Number of days with tasmin below a threshold.
+    Number of days with tasmin below a given threshold.
 
-    Number of days where minimum daily temperature is below a threshold (default: -10℃).
+    Number of days where minimum daily temperature is below a given threshold (default: -10℃).
 
     Parameters
     ----------
@@ -2491,7 +2491,7 @@ def tn_days_below(
         Threshold temperature on which to base evaluation.
     freq : str
         Resampling frequency.
-    op : {"<", "<=", "lt", "le"}
+    op : {"<", "lt", "<=", "le"}
         Comparison operation. Default: "<".
 
     Returns
@@ -2518,10 +2518,10 @@ def tg_days_above(
     tas: xarray.DataArray,
     thresh: Quantified = "10.0 degC",
     freq: str = "YS",
-    op: str = ">",
+    op: Literal["<", "lt", "<=", "le"] = ">",
 ):
     """
-    The number of days with tas above a threshold.
+    The number of days with tas above a given threshold.
 
     Number of days where mean daily temperature exceeds a threshold (default: 10℃).
 
@@ -2533,7 +2533,7 @@ def tg_days_above(
         Threshold temperature on which to base evaluation.
     freq : str
         Resampling frequency.
-    op : {">", ">=", "gt", "ge"}
+    op : {">", "gt", ">=", "ge"}
         Comparison operation. Default: ">".
 
     Returns
@@ -2560,12 +2560,12 @@ def tg_days_below(
     tas: xarray.DataArray,
     thresh: Quantified = "10.0 degC",
     freq: str = "YS",
-    op: str = "<",
+    op: Literal["<", "lt", "<=", "le"] = "<",
 ):
     """
-    The number of days with tas below a threshold.
+    The number of days with tas below a given threshold.
 
-    Number of days where mean daily temperature is below a threshold (default: 10℃).
+    Number of days where mean daily temperature is below a given threshold (default: 10℃).
 
     Parameters
     ----------
@@ -2575,7 +2575,7 @@ def tg_days_below(
         Threshold temperature on which to base evaluation.
     freq : str
         Resampling frequency.
-    op : {"<", "<=", "lt", "le"}
+    op : {"<", "lt", "<=", "le"}
         Comparison operation. Default: "<".
 
     Returns
@@ -2602,12 +2602,12 @@ def tx_days_above(
     tasmax: xarray.DataArray,
     thresh: Quantified = "25.0 degC",
     freq: str = "YS",
-    op: str = ">",
+    op: Literal[">", "gt", ">=", "ge"] = ">",
 ) -> xarray.DataArray:
     """
-    The number of days with tasmax above a threshold (number of summer days).
+    The number of days with tasmax above a given threshold (number of summer days).
 
-    Number of days where maximum daily temperature exceeds a threshold (default: 25℃).
+    Number of days where maximum daily temperature exceeds a given threshold (default: 25℃).
 
     Parameters
     ----------
@@ -2617,7 +2617,7 @@ def tx_days_above(
         Threshold temperature on which to base evaluation.
     freq : str
         Resampling frequency.
-    op : {">", ">=", "gt", "ge"}
+    op : {">", "gt", ">=", "ge"}
         Comparison operation. Default: ">".
 
     Returns
@@ -2644,12 +2644,12 @@ def tx_days_below(
     tasmax: xarray.DataArray,
     thresh: Quantified = "25.0 degC",
     freq: str = "YS",
-    op: str = "<",
+    op: Literal["<", "lt", "<=", "le"] = "<",
 ):
     """
-    The number of days with tmax below a threshold.
+    The number of days with tasmax below a given threshold.
 
-    Number of days where maximum daily temperature is below a threshold (default: 25℃).
+    Number of days where maximum daily temperature is below a given threshold (default: 25℃).
 
     Parameters
     ----------
@@ -2659,7 +2659,7 @@ def tx_days_below(
         Threshold temperature on which to base evaluation.
     freq : str
         Resampling frequency.
-    op : {"<", "<=", "lt", "le"}
+    op : {"<", "lt", "<=", "le"}
         Comparison operation. Default: "<".
 
     Returns
@@ -2686,12 +2686,12 @@ def warm_day_frequency(
     tasmax: xarray.DataArray,
     thresh: Quantified = "30 degC",
     freq: str = "YS",
-    op: str = ">",
+    op: Literal[">", "gt", ">=", "ge"] = ">",
 ) -> xarray.DataArray:
     """
     Frequency of extreme warm days.
 
-    Return the number of days with maximum daily temperature exceeding threshold (default: 30℃) per period.
+    Return the number of days with maximum daily temperature exceeding a given threshold (default: 30℃) per period.
 
     Parameters
     ----------
@@ -2701,7 +2701,7 @@ def warm_day_frequency(
         Threshold temperature on which to base evaluation.
     freq : str
         Resampling frequency.
-    op : {">", ">=", "gt", "ge"}
+    op : {">", "gt", ">=", "ge"}
         Comparison operation. Default: ">".
 
     Returns
@@ -2728,12 +2728,12 @@ def warm_night_frequency(
     tasmin: xarray.DataArray,
     thresh: Quantified = "22 degC",
     freq: str = "YS",
-    op: str = ">",
+    op: Literal[">", "gt", ">=", "ge"] = ">",
 ) -> xarray.DataArray:
     """
     Frequency of extreme warm nights.
 
-    Return the number of days with minimum daily temperature exceeding threshold (default: 22℃) per period.
+    Return the number of days with minimum daily temperatures exceeding a given threshold (default: 22℃) per period.
 
     Parameters
     ----------
@@ -2743,7 +2743,7 @@ def warm_night_frequency(
         Threshold temperature on which to base evaluation.
     freq : str
         Resampling frequency.
-    op : {">", ">=", "gt", "ge"}
+    op : {">", "gt", ">=", "ge"}
         Comparison operation. Default: ">".
 
     Returns
@@ -2761,12 +2761,12 @@ def wetdays(
     pr: xarray.DataArray,
     thresh: Quantified = "1.0 mm/day",
     freq: str = "YS",
-    op: str = ">=",
+    op: Literal[">", "gt", ">=", "ge"] = ">=",
 ) -> xarray.DataArray:
     """
     Wet days.
 
-    Return the total number of days during period with precipitation over threshold (default: 1.0 mm/day).
+    Return the total number of days during period with precipitations over a given threshold (default: 1.0 mm/day).
 
     Parameters
     ----------
@@ -2776,7 +2776,7 @@ def wetdays(
         Precipitation value over which a day is considered wet.
     freq : str
         Resampling frequency.
-    op : {">", ">=", "gt", "ge"}
+    op : {">", "gt", ">=", "ge"}
         Comparison operation. Default: ">=".
 
     Returns
@@ -2804,12 +2804,12 @@ def wetdays_prop(
     pr: xarray.DataArray,
     thresh: Quantified = "1.0 mm/day",
     freq: str = "YS",
-    op: str = ">=",
+    op: Literal[">", "gt", ">=", "ge"] = ">=",
 ) -> xarray.DataArray:
     """
     Proportion of wet days.
 
-    Return the proportion of days during period with precipitation over threshold (default: 1.0 mm/day).
+    Return the proportion of days during period with precipitations over a given threshold (default: 1.0 mm/day).
 
     Parameters
     ----------
@@ -2819,7 +2819,7 @@ def wetdays_prop(
         Precipitation value over which a day is considered wet.
     freq : str
         Resampling frequency.
-    op : {">", ">=", "gt", "ge"}
+    op : {">", "gt", ">=", "ge"}
         Comparison operation. Default: ">=".
 
     Returns
@@ -2875,7 +2875,7 @@ def maximum_consecutive_frost_days(
 
     Warnings
     --------
-    The default `freq` is valid for the northern hemisphere.
+    The default `freq` is valid for the Northern Hemisphere.
 
     Notes
     -----
@@ -2966,10 +2966,10 @@ def maximum_consecutive_frost_free_days(
     resample_before_rl: bool = True,
 ) -> xarray.DataArray:
     r"""
-    Maximum number of consecutive frost free days (Tn >= 0℃).
+    Maximum number of consecutive frost-free days (Tn >= 0℃).
 
     Return the maximum number of consecutive days within the period where the minimum daily temperature is
-    above or equal to a certain threshold (default: 0℃).
+    above or equal to a given threshold (default: 0℃).
 
     Parameters
     ----------
@@ -2990,7 +2990,7 @@ def maximum_consecutive_frost_free_days(
 
     Warnings
     --------
-    The default `freq` is valid for the northern hemisphere.
+    The default `freq` is valid for the Northern Hemisphere.
 
     Notes
     -----
@@ -3026,7 +3026,7 @@ def maximum_consecutive_tx_days(
     resample_before_rl: bool = True,
 ) -> xarray.DataArray:
     r"""
-    Maximum number of consecutive days with tasmax above a threshold (summer days).
+    Maximum number of consecutive days with tasmax above a given threshold (summer days).
 
     Return the maximum number of consecutive days within the period where the maximum daily temperature is
     above a certain threshold (default: 25℃).
@@ -3080,7 +3080,7 @@ def sea_ice_area(
     """
     Total sea ice area.
 
-    Sea ice area measures the total sea ice covered area where sea ice concentration is above a threshold,
+    Sea ice area measures the total sea ice covered area where sea ice concentration is above a given threshold,
     usually set to 15%.
 
     Parameters
@@ -3120,7 +3120,7 @@ def sea_ice_extent(
     Total sea ice extent.
 
     Sea ice extent measures the *ice-covered* area, where a region is considered ice-covered if its sea ice
-    concentration is above a threshold, usually set to 15%.
+    concentration is above a given threshold, usually set to 15%.
 
     Parameters
     ----------
@@ -3155,7 +3155,7 @@ def windy_days(sfcWind: xarray.DataArray, thresh: Quantified = "10.8 m s-1", fre
     r"""
     Windy days.
 
-    The number of days with average near-surface wind speed above threshold (default: 10.8 m/s).
+    The number of days with average near-surface wind speed above a given threshold (default: 10.8 m/s).
 
     Parameters
     ----------
@@ -3191,7 +3191,7 @@ def rprctot(
     prc: xarray.DataArray,
     thresh: Quantified = "1.0 mm/day",
     freq: str = "YS",
-    op: str = ">=",
+    op: Literal[">", "gt", ">=", "ge"] = ">=",
 ) -> xarray.DataArray:
     """
     Proportion of accumulated precipitation arising from convective processes.
@@ -3209,7 +3209,7 @@ def rprctot(
         Precipitation value over which a day is considered wet.
     freq : str
         Resampling frequency.
-    op : {">", ">=", "gt", "ge"}
+    op : {">", "gt", ">=", "ge"}
         Comparison operation. Default: ">=".
 
     Returns
@@ -3235,7 +3235,7 @@ def degree_days_exceedance_date(
     tas: xarray.DataArray,
     thresh: Quantified = "0 degC",
     sum_thresh: Quantified = "25 K days",
-    op: str = ">",
+    op: Literal[">", "gt", "<", "lt", ">=", "ge", "<=", "le"] = ">",
     after_date: DayOfYearStr | None = None,
     never_reached: DayOfYearStr | int | None = None,
     freq: str = "YS",
@@ -3297,9 +3297,9 @@ def degree_days_exceedance_date(
     tas = convert_units_to(tas, "K")
     sum_thresh = convert_units_to(sum_thresh, "K days")
 
-    if op in ["<", "<=", "lt", "le"]:
+    if op in ["<", "lt", "<=", "le"]:
         c = thresh - tas
-    elif op in [">", ">=", "gt", "ge"]:
+    elif op in [">", "gt", ">=", "ge"]:
         c = tas - thresh
     else:
         raise NotImplementedError(f"op: '{op}'.")
@@ -3336,13 +3336,14 @@ def dry_spell_frequency(
     window: int = 3,
     freq: str = "YS",
     resample_before_rl: bool = True,
-    op: str = "sum",
+    op: Literal["sum", "max", "min", "mean"] = "sum",
     **indexer,
 ) -> xarray.DataArray:
     r"""
     Return the number of dry periods of n days and more.
 
-    Periods during which the accumulated or maximal daily precipitation amount on a window of n days is under threshold.
+    Periods during which the accumulated or maximal daily precipitation amount
+    within a window of n days is under a given threshold.
 
     Parameters
     ----------
@@ -3350,7 +3351,7 @@ def dry_spell_frequency(
         Daily precipitation.
     thresh : Quantified
         Precipitation amount under which a period is considered dry.
-        The value against which the threshold is compared depends on  `op` .
+        The value against which the threshold is compared depends on `op`.
     window : int
         Minimum length of the spells.
     freq : str
@@ -3404,7 +3405,7 @@ def dry_spell_total_length(
     pr: xarray.DataArray,
     thresh: Quantified = "1.0 mm",
     window: int = 3,
-    op: str = "sum",
+    op: Literal["sum", "max", "min", "mean"] = "sum",
     freq: str = "YS",
     resample_before_rl: bool = True,
     **indexer,
@@ -3412,8 +3413,8 @@ def dry_spell_total_length(
     r"""
     Total length of dry spells.
 
-    Total number of days in dry periods of a minimum length, during which the maximum or
-    accumulated precipitation within a window of the same length is under a threshold.
+    The total number of days in dry periods of a minimum length, during which the maximum or
+    accumulated precipitation within a window of the same length is under a given threshold.
 
     Parameters
     ----------
@@ -3422,7 +3423,7 @@ def dry_spell_total_length(
     thresh : Quantified
         Accumulated precipitation value under which a period is considered dry.
     window : int
-        Number of days when the maximum or accumulated precipitation is under threshold.
+        Number of days when the maximum or accumulated precipitation is under the threshold.
     op : {"sum", "max", "min", "mean"}
         Operation to perform on the window.
         Default is "sum", which checks that the sum of accumulated precipitation over the whole window
@@ -3476,7 +3477,7 @@ def dry_spell_max_length(
     pr: xarray.DataArray,
     thresh: Quantified = "1.0 mm",
     window: int = 1,
-    op: str = "sum",
+    op: Literal["max", "sum"] = "sum",
     freq: str = "YS",
     resample_before_rl: bool = True,
     **indexer,
@@ -3484,7 +3485,7 @@ def dry_spell_max_length(
     r"""
     Longest dry spell.
 
-    Maximum number of consecutive days in a dry period of minimum length, during which the maximum or
+    The maximum number of consecutive days in a dry period of minimum length, during which the maximum or
     accumulated precipitation within a window of the same length is under a threshold.
 
     Parameters
@@ -3494,7 +3495,7 @@ def dry_spell_max_length(
     thresh : Quantified
         Accumulated precipitation value under which a period is considered dry.
     window : int
-        Number of days when the maximum or accumulated precipitation is under threshold.
+        Number of days when the maximum or accumulated precipitation is under the threshold.
     op : {"max", "sum"}
         Reduce operation.
     freq : str
@@ -3546,14 +3547,14 @@ def wet_spell_frequency(
     window: int = 3,
     freq: str = "YS",
     resample_before_rl: bool = True,
-    op: str = "sum",
+    op: Literal["sum", "min", "max", "mean"] = "sum",
     **indexer,
 ) -> xarray.DataArray:
     r"""
     Return the number of wet periods of n days and more.
 
-    Periods during which the accumulated, minimal, or maximal daily precipitation amount on a window
-    of n days is over threshold.
+    Periods during which the accumulated, minimal, or maximal daily precipitation amount within a window
+    of n days is over a given threshold.
 
     Parameters
     ----------
@@ -3615,7 +3616,7 @@ def wet_spell_total_length(
     pr: xarray.DataArray,
     thresh: Quantified = "1.0 mm",
     window: int = 3,
-    op: str = "sum",
+    op: Literal["min", "sum", "max", "mean"] = "sum",
     freq: str = "YS",
     resample_before_rl: bool = True,
     **indexer,
@@ -3633,7 +3634,7 @@ def wet_spell_total_length(
     thresh : Quantified
         Accumulated precipitation value over which a period is considered wet.
     window : int
-        Number of days when the maximum or accumulated precipitation is over threshold.
+        Number of days when the maximum or accumulated precipitation is over the threshold.
     op : {"min", "sum", "max", "mean"}
         Reduce operation.
         `min` means that all days within the minimum window must exceed the threshold.
@@ -3686,7 +3687,7 @@ def wet_spell_max_length(
     pr: xarray.DataArray,
     thresh: Quantified = "1.0 mm",
     window: int = 1,
-    op: str = "sum",
+    op: Literal["min", "sum", "max", "mean"] = "sum",
     freq: str = "YS",
     resample_before_rl: bool = True,
     **indexer,
@@ -3694,7 +3695,7 @@ def wet_spell_max_length(
     r"""
     Longest wet spell.
 
-    Maximum number of consecutive days in a wet period of minimum length, during which the minimum or
+    The maximum number of consecutive days in a wet period of minimum length, during which the minimum or
     accumulated precipitation within a window of the same length is over a threshold.
 
     Parameters
@@ -3761,7 +3762,7 @@ def wet_spell_max_length(
 def holiday_snow_days(
     snd: xarray.DataArray,
     snd_thresh: Quantified = "20 mm",
-    op: str = ">=",
+    op: Literal[">", "gt", ">=", "ge"] = ">=",
     date_start: str = "12-25",
     date_end: str | None = None,
     freq: str = "YS",
@@ -3780,7 +3781,7 @@ def holiday_snow_days(
     op : {">", "gt", ">=", "ge"}
         Comparison operation. Default: ">=".
     date_start : str
-        Beginning of analysis period. Default: "12-25" (December 25th).
+        Beginning of the analysis period. Default: "12-25" (December 25th).
     date_end : str, optional
         End of analysis period. If not provided, `date_start` is used.
         Default: None.
@@ -3819,8 +3820,8 @@ def holiday_snow_and_snowfall_days(
     prsn: xarray.DataArray | None = None,
     snd_thresh: Quantified = "20 mm",
     prsn_thresh: Quantified = "1 mm",
-    snd_op: str = ">=",
-    prsn_op: str = ">=",
+    snd_op: Literal[">", "gt", ">=", "ge"] = ">=",
+    prsn_op: Literal[">", "gt", ">=", "ge"] = ">=",
     date_start: str = "12-25",
     date_end: str | None = None,
     freq: str = "YS-JUL",

--- a/src/xclim/indices/generic.py
+++ b/src/xclim/indices/generic.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import operator
 import warnings
 from collections.abc import Callable, Sequence
+from typing import Literal
 
 import cftime
 import numpy as np
@@ -67,10 +68,14 @@ __all__ = [
 ]
 
 binary_ops = {">": "gt", "<": "lt", ">=": "ge", "<=": "le", "==": "eq", "!=": "ne"}
+DIFFERENCE_OPERATORS = Literal[">", "gt", "<", "lt", ">=", "ge", "<=", "le"]
+ALL_OPERATORS = Literal[">", "gt", "<", "lt", ">=", "ge", "<=", "le", "==", "eq", "!=", "ne"]
+
+REDUCTION_OPERATORS = Literal["min", "max", "mean", "std", "var", "count", "sum", "integral", "argmax", "argmin"]
 
 
 def select_resample_op(
-    da: xr.DataArray, op: str | Callable, freq: str = "YS", out_units=None, **indexer
+    da: xr.DataArray, op: REDUCTION_OPERATORS | Callable, freq: str = "YS", out_units=None, **indexer
 ) -> xr.DataArray:
     r"""
     Apply operation over each period that is part of the index selection.
@@ -79,8 +84,8 @@ def select_resample_op(
     ----------
     da : xr.DataArray
         Input data.
-    op : str {'min', 'max', 'mean', 'std', 'var', 'count', 'sum', 'integral', 'argmax', 'argmin'} or func
-        Reduce operation. Can either be a DataArray method or a function that can be applied to a DataArray.
+    op : {"min", "max", "mean", "std", "var", 'count', 'sum', 'integral', 'argmax', 'argmin'} or Callable
+        Reduce operation. It can either be a DataArray method or a function that can be applied to a DataArray.
     freq : str
         Resampling frequency defining the periods as defined in :ref:`timeseries.resampling`.
     out_units : str, optional
@@ -116,10 +121,10 @@ def select_resample_op(
 
 def select_rolling_resample_op(
     da: xr.DataArray,
-    op: str,
+    op: REDUCTION_OPERATORS | Callable,
     window: int,
     window_center: bool = True,
-    window_op: str = "mean",
+    window_op: Literal["min", "max", "mean", "std", "var", "count", "sum", "integral"] = "mean",
     freq: str = "YS",
     out_units=None,
     **indexer,
@@ -131,20 +136,20 @@ def select_rolling_resample_op(
     ----------
     da : xr.DataArray
         Input data.
-    op : str {'min', 'max', 'mean', 'std', 'var', 'count', 'sum', 'integral', 'argmax', 'argmin'} or func
+    op : {"min", "max", "mean", "std", "var", "count", "sum", "integral", "argmax", "argmin"} or Callable
         Reduce operation. Can either be a DataArray method or a function that can be applied to a DataArray.
     window : int
         Size of the rolling window (centered).
     window_center : bool
         If True, the window is centered on the date. If False, the window is right-aligned.
-    window_op : str {'min', 'max', 'mean', 'std', 'var', 'count', 'sum', 'integral'}
+    window_op : {"min", "max", "mean", "std", "var", "count", "sum", "integral"}
         Operation to apply to the rolling window. Default: 'mean'.
     freq : str
         Resampling frequency defining the periods as defined in :ref:`timeseries.resampling`.
         Applied after the rolling window.
     out_units : str, optional
         Output units to assign.
-        Only necessary if `op` is function not supported by :py:func:`xclim.core.units.to_agg_units`.
+        Only necessary if `op` is a function not supported by :py:func:`xclim.core.units.to_agg_units`.
     **indexer : {dim: indexer, }, optional
         Time attribute and values over which to subset the array. For example, use season='DJF' to select winter values,
         month=1 to select January, or month=[6,7,8] to select summer months. If not indexer is given, all values are
@@ -235,7 +240,7 @@ def default_freq(**indexer) -> str:
     return freq
 
 
-def get_op(op: str, constrain: Sequence[str] | None = None) -> Callable:
+def get_op(op: ALL_OPERATORS, constrain: Sequence[ALL_OPERATORS] | None = None) -> Callable:
     """
     Get python's comparing function according to its name of representation and validate allowed usage.
 
@@ -243,9 +248,9 @@ def get_op(op: str, constrain: Sequence[str] | None = None) -> Callable:
 
     Parameters
     ----------
-    op : str
+    op : Sequence of {">", "gt", "<", "lt", ">=", "ge", "<=", "le", "==", "eq", "!=", "ne"}
         Operator.
-    constrain : sequence of str, optional
+    constrain : sequence of {">", "gt", "<", "lt", ">=", "ge", "<=", "le", "==", "eq", "!=", "ne"}, optional
         A tuple of allowed operators.
 
     Returns
@@ -283,7 +288,7 @@ def get_op(op: str, constrain: Sequence[str] | None = None) -> Callable:
 
 def compare(
     left: xr.DataArray,
-    op: str,
+    op: ALL_OPERATORS,
     right: float | int | np.ndarray | xr.DataArray,
     constrain: Sequence[str] | None = None,
 ) -> xr.DataArray:
@@ -311,13 +316,13 @@ def compare(
 
 def threshold_count(
     da: xr.DataArray,
-    op: str,
+    op: DIFFERENCE_OPERATORS,
     threshold: float | int | xr.DataArray,
     freq: str,
     constrain: Sequence[str] | None = None,
 ) -> xr.DataArray:
     """
-    Count number of days where value is above or below threshold.
+    Count number of days where value is above or below a given threshold.
 
     Parameters
     ----------
@@ -378,7 +383,7 @@ def domain_count(
 def get_daily_events(
     da: xr.DataArray,
     threshold: float | int | xr.DataArray,
-    op: str,
+    op: ALL_OPERATORS,
     constrain: Sequence[str] | None = None,
 ) -> xr.DataArray:
     """
@@ -418,7 +423,7 @@ def spell_mask(
     data: xr.DataArray | Sequence[xr.DataArray],
     window: int,
     win_reducer: str,
-    op: str,
+    op: ALL_OPERATORS,
     thresh: float | Sequence[float],
     min_gap: int = 1,
     weights: Sequence[float] = None,
@@ -500,7 +505,7 @@ def spell_mask(
     else:
         data_pad = data.pad(time=(0, window))
         # The spell-wise value to test
-        # For example "window_reducer='sum'",
+        # For example, "window_reducer='sum'",
         # we want the sum over the minimum spell length (window) to be above the thresh
         if weights is not None:
             spell_value = data_pad.rolling(time=window).construct("window").dot(weights)
@@ -526,7 +531,7 @@ def _spell_length_statistics(
     thresh: float | xr.DataArray | Sequence[xr.DataArray] | Sequence[float],
     window: int,
     win_reducer: str,
-    op: str,
+    op: ALL_OPERATORS,
     spell_reducer: str | Sequence[str],
     freq: str,
     min_gap: int = 1,
@@ -571,9 +576,9 @@ def spell_length_statistics(
     data: xr.DataArray,
     threshold: Quantified,
     window: int,
-    win_reducer: str,
-    op: str,
-    spell_reducer: str,
+    win_reducer: Literal["min", "max", "sum", "mean"],
+    op: ALL_OPERATORS,
+    spell_reducer: Literal["max", "sum", "count"] | Sequence[str],
     freq: str,
     min_gap: int = 1,
     resample_before_rl: bool = True,
@@ -598,7 +603,7 @@ def spell_length_statistics(
         Note that this does not matter when `window` is 1.
     op : {">", "gt", "<", "lt", ">=", "ge", "<=", "le", "==", "eq", "!=", "ne"}
         Logical operator. Ex: spell_value > thresh.
-    spell_reducer : {'max', 'sum', 'count'} or sequence thereof
+    spell_reducer : {'max', 'sum', 'count'} or sequence of str
         Statistic on the spell lengths. If a list, multiple statistics are computed.
     freq : str
         Resampling frequency.
@@ -674,9 +679,9 @@ def bivariate_spell_length_statistics(
     data2: xr.DataArray,
     threshold2: Quantified,
     window: int,
-    win_reducer: str,
-    op: str,
-    spell_reducer: str,
+    win_reducer: Literal["min", "max", "sum", "mean"],
+    op: ALL_OPERATORS,
+    spell_reducer: Literal["max", "sum", "count"] | Sequence[str],
     freq: str,
     min_gap: int = 1,
     resample_before_rl: bool = True,
@@ -706,7 +711,7 @@ def bivariate_spell_length_statistics(
         Note that this does not matter when `window` is 1.
     op : {">", "gt", "<", "lt", ">=", "ge", "<=", "le", "==", "eq", "!=", "ne"}
         Logical operator. Ex: spell_value > thresh.
-    spell_reducer : {'max', 'sum', 'count'} or sequence thereof
+    spell_reducer : {'max', 'sum', 'count'} or sequence of str
         Statistic on the spell lengths. If a list, multiple statistics are computed.
     freq : str
         Resampling frequency.
@@ -752,8 +757,8 @@ def season(
     data: xr.DataArray,
     thresh: Quantified,
     window: int,
-    op: str,
-    stat: str,
+    op: ALL_OPERATORS,
+    stat: Literal["start", "end", "length"],
     freq: str,
     mid_date: DayOfYearStr | None = None,
     constrain: Sequence[str] | None = None,
@@ -773,7 +778,7 @@ def season(
         Threshold on which to base evaluation.
     window : int
         Minimum number of days that the condition must be met / not met for the start / end of the season.
-    op : str
+    op : {">", "gt", "<", "lt", ">=", "ge", "<=", "le", "==", "eq", "!=", "ne"}
         Comparison operation.
     stat : {'start', 'end', 'length'}
         Which season facet to return.
@@ -844,8 +849,8 @@ def count_level_crossings(
     threshold: Quantified,
     freq: str,
     *,
-    op_low: str = "<",
-    op_high: str = ">=",
+    op_low: Literal["<", "<=", "lt", "le"] = "<",
+    op_high: Literal[">", ">=", "gt", "ge"] = ">=",
 ) -> xr.DataArray:
     """
     Calculate the number of times low_data is below threshold while high_data is above threshold.
@@ -889,7 +894,7 @@ def count_occurrences(
     data: xr.DataArray,
     threshold: Quantified,
     freq: str,
-    op: str,
+    op: ALL_OPERATORS,
     constrain: Sequence[str] | None = None,
 ) -> xr.DataArray:
     """
@@ -934,9 +939,9 @@ def bivariate_count_occurrences(
     threshold_var1: Quantified,
     threshold_var2: Quantified,
     freq: str,
-    op_var1: str,
-    op_var2: str,
-    var_reducer: str,
+    op_var1: ALL_OPERATORS,
+    op_var2: ALL_OPERATORS,
+    var_reducer: Literal["all", "any"],
     constrain_var1: Sequence[str] | None = None,
     constrain_var2: Sequence[str] | None = None,
 ) -> xr.DataArray:
@@ -1000,7 +1005,9 @@ def bivariate_count_occurrences(
     return to_agg_units(out, data_var1, "count", dim="time")
 
 
-def diurnal_temperature_range(low_data: xr.DataArray, high_data: xr.DataArray, reducer: str, freq: str) -> xr.DataArray:
+def diurnal_temperature_range(
+    low_data: xr.DataArray, high_data: xr.DataArray, reducer: Literal["max", "min", "mean", "sum"], freq: str
+) -> xr.DataArray:
     """
     Calculate the diurnal temperature range and reduce according to a statistic.
 
@@ -1035,7 +1042,7 @@ def first_occurrence(
     data: xr.DataArray,
     threshold: Quantified,
     freq: str,
-    op: str,
+    op: ALL_OPERATORS,
     constrain: Sequence[str] | None = None,
 ) -> xr.DataArray:
     """
@@ -1083,7 +1090,7 @@ def last_occurrence(
     data: xr.DataArray,
     threshold: Quantified,
     freq: str,
-    op: str,
+    op: ALL_OPERATORS,
     constrain: Sequence[str] | None = None,
 ) -> xr.DataArray:
     """
@@ -1127,7 +1134,13 @@ def last_occurrence(
 
 
 @declare_relative_units(threshold="<data>")
-def spell_length(data: xr.DataArray, threshold: Quantified, reducer: str, freq: str, op: str) -> xr.DataArray:
+def spell_length(
+    data: xr.DataArray,
+    threshold: Quantified,
+    reducer: Literal["max", "min", "mean", "sum"],
+    freq: str,
+    op: ALL_OPERATORS,
+) -> xr.DataArray:
     """
     Calculate statistics on lengths of spells.
 
@@ -1171,7 +1184,7 @@ def spell_length(data: xr.DataArray, threshold: Quantified, reducer: str, freq: 
     return to_agg_units(out, data, "count")
 
 
-def statistics(data: xr.DataArray, reducer: str, freq: str) -> xr.DataArray:
+def statistics(data: xr.DataArray, reducer: Literal["max", "min", "mean", "sum"], freq: str) -> xr.DataArray:
     """
     Calculate a simple statistic of the data.
 
@@ -1197,9 +1210,9 @@ def statistics(data: xr.DataArray, reducer: str, freq: str) -> xr.DataArray:
 @declare_relative_units(threshold="<data>")
 def thresholded_statistics(
     data: xr.DataArray,
-    op: str,
+    op: ALL_OPERATORS,
     threshold: Quantified,
-    reducer: str,
+    reducer: Literal["max", "min", "mean", "sum"],
     freq: str,
     constrain: Sequence[str] | None = None,
 ) -> xr.DataArray:
@@ -1240,7 +1253,7 @@ def thresholded_statistics(
 
 
 @declare_relative_units(threshold="<data>")
-def temperature_sum(data: xr.DataArray, op: str, threshold: Quantified, freq: str) -> xr.DataArray:
+def temperature_sum(data: xr.DataArray, op: DIFFERENCE_OPERATORS, threshold: Quantified, freq: str) -> xr.DataArray:
     """
     Calculate the temperature sum above/below a threshold.
 
@@ -1337,7 +1350,7 @@ def aggregate_between_dates(
     data: xr.DataArray,
     start: xr.DataArray | DayOfYearStr,
     end: xr.DataArray | DayOfYearStr,
-    op: str = "sum",
+    op: Literal["min", "max", "sum", "mean", "std"] = "sum",
     freq: str | None = None,
 ) -> xr.DataArray:
     """
@@ -1431,7 +1444,9 @@ def aggregate_between_dates(
 
 
 @declare_relative_units(threshold="<data>")
-def cumulative_difference(data: xr.DataArray, threshold: Quantified, op: str, freq: str | None = None) -> xr.DataArray:
+def cumulative_difference(
+    data: xr.DataArray, threshold: Quantified, op: DIFFERENCE_OPERATORS, freq: str | None = None
+) -> xr.DataArray:
     """
     Calculate the cumulative difference below/above a given value threshold.
 
@@ -1474,7 +1489,7 @@ def first_day_threshold_reached(
     data: xr.DataArray,
     *,
     threshold: Quantified,
-    op: str,
+    op: ALL_OPERATORS,
     after_date: DayOfYearStr,
     window: int = 1,
     freq: str = "YS",
@@ -1657,10 +1672,10 @@ def detrend(ds: xr.DataArray | xr.Dataset, dim="time", deg=1) -> xr.DataArray | 
 def thresholded_events(
     data: xr.DataArray,
     thresh: Quantified,
-    op: str,
+    op: ALL_OPERATORS,
     window: int,
     thresh_stop: Quantified | None = None,
-    op_stop: str | None = None,
+    op_stop: ALL_OPERATORS | None = None,
     window_stop: int = 1,
     freq: str | None = None,
 ) -> xr.Dataset:

--- a/src/xclim/indices/run_length.py
+++ b/src/xclim/indices/run_length.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Sequence
 from datetime import datetime
+from typing import Literal
 from warnings import warn
 
 import numpy as np
@@ -1677,7 +1678,7 @@ def index_of_date(
 def suspicious_run_1d(
     arr: np.ndarray,
     window: int = 10,
-    op: str = ">",
+    op: Literal[">", "gt", "<", "lt", ">=", "ge", "<=", "le", "==", "eq", "!=", "ne"] = ">",
     thresh: float | None = None,
 ) -> np.ndarray:
     """
@@ -1689,7 +1690,7 @@ def suspicious_run_1d(
         Array of values to be parsed.
     window : int
         Minimum run length.
-    op : {">", ">=", "==", "<", "<=", "eq", "gt", "lt", "gteq", "lteq", "ge", "le"}
+    op : {">", "gt", "<", "lt", ">=", "ge", "<=", "le", "==", "eq", "!=", "ne"}
         Operator for threshold comparison. Defaults to ">".
     thresh : float, optional
         Threshold compared against which values are checked for identical values.
@@ -1727,7 +1728,7 @@ def suspicious_run(
     arr: xr.DataArray,
     dim: str = "time",
     window: int = 10,
-    op: str = ">",
+    op: Literal[">", "gt", "<", "lt", ">=", "ge", "<=", "le", "==", "eq", "!=", "ne"] = ">",
     thresh: float | None = None,
 ) -> xr.DataArray:
     """
@@ -1743,7 +1744,7 @@ def suspicious_run(
         Dimension along which to check for runs (default: "time").
     window : int
         Minimum run length.
-    op : {">", ">=", "==", "<", "<=", "eq", "gt", "lt", "gteq", "lteq"}
+    op : {">", "gt", "<", "lt", ">=", "ge", "<=", "le", "==", "eq", "!=", "ne"}
         Operator for threshold comparison, defaults to ">".
     thresh : float, optional
         Threshold above which values are checked for identical values.
@@ -1873,7 +1874,7 @@ def find_events(
         The number of consecutive True values for an event to start.
     condition_stop : DataArray of bool, optional
         The stopping boolean mask, true where the end condition of the event is fulfilled.
-        Defaults to the opposite of ``condition``.
+        Defaults to the opposite of `condition`.
     window_stop : int
         The number of consecutive True values in ``condition_stop`` for an event to end.
         Defaults to 1.

--- a/src/xclim/indices/stats.py
+++ b/src/xclim/indices/stats.py
@@ -603,7 +603,9 @@ def _fit_start(x, dist: str, **fitkwargs: Any) -> tuple[tuple, dict]:
         # MLE estimation
         log_x_pos = np.log(x_pos)
         shape0 = log_x_pos.std()
-        scale0 = np.exp(log_x_pos.mean())
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message="Mean of empty slice.", category=RuntimeWarning)
+            scale0 = np.exp(log_x_pos.mean())
         kwargs = {"scale": scale0, "loc": loc0}
         return (shape0,), kwargs
 

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -479,13 +479,10 @@ def test_all_parameters_understood(official_indicators):
         for name, param in indinst.parameters.items():
             if param.kind == InputKind.OTHER_PARAMETER:
                 problems.add((identifier, name))
-    # this one we are ok with.
+    # We can deal with 'lat\ for the moment.
     if problems - {
         ("COOL_NIGHT_INDEX", "lat"),
         ("DRYNESS_INDEX", "lat"),
-        # TODO: How should we handle the case of Literal[str]?
-        ("GROWING_SEASON_END", "op"),
-        ("GROWING_SEASON_START", "op"),
     }:
         raise ValueError(f"The following indicator/parameter couple {problems} use types not listed in InputKind.")
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1810 
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] CHANGELOG.rst has been updated (with summary of main changes)
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Changes the call signatures for `op` arguments to use the `Literal` type when providing a limited set of acceptable strings.
* Updates the `infer_kind_from_input_parameter` to accept a `Literal` sequence of string options.

### Does this PR introduce a breaking change?

No.

### Other information:

This change will make it so that coding behaviour in IDEs will show warnings if a string being supplied as an argument is not within the list of acceptable options. This is not just an aesthetic/behavioural change but can also help with `mypy` type checking.