### PR TITLE
Add pytest-timeout, fix test engine bug

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,7 @@ Breaking changes
     * The other global variable `SDBA_ENCODE_CF` was removed as it has been rendered obsolete.
 * The previously deprecated functions ``sfcwind_2_uas_vas`` and ``uas_vas_2_sfcwind`` have been removed. (:pull:`2139`).
 * ``xclim.testing.open_dataset`` has been deprecated and will be removed in a future version. Contributors are encouraged to consult the documentation pertaining to ``xclim.testing.nimbus`` for the new approach to fetching testing data. (:pull:`2139`).
+* The `dev` installation recipe now requires `pytest-timeout` for ending stalled tests. (:pull:`2176`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^
@@ -42,6 +43,7 @@ Internal changes
 * Updated a deprecated `pathlib` usage in the `xclim` documentation that was causing failures under Python 3.13. (:pull:`2141`).
 * Call signatures for most `op` arguments in `xclim` have been updated to use `Literal` types instead of `str`. This change is intended to improve type checking and code clarity. (:issue:`1810`, :pull:`2168`).
 * Changes to `pylint` configuration and to address low-hanging `pylint` issues. (:pull:`2170`).
+* The ``pyproject.toml`` file has been adjusted to leverage `pytest-timeout` with a maximum session time of 15 minutes and a maximum test duration of 5 mins. (:pull:`2176`).
 
 v0.56.0 (2025-03-27)
 --------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,6 +44,7 @@ Internal changes
 * Call signatures for most `op` arguments in `xclim` have been updated to use `Literal` types instead of `str`. This change is intended to improve type checking and code clarity. (:issue:`1810`, :pull:`2168`).
 * Changes to `pylint` configuration and to address low-hanging `pylint` issues. (:pull:`2170`).
 * The ``pyproject.toml`` file has been adjusted to leverage `pytest-timeout` with a maximum session time of 15 minutes and a maximum test duration of 5 mins. (:pull:`2176`).
+* Fixed a bug present in tests found in ``test_wind.py`` that was causing failures when run in parallel. (:issue:`2179`, :pull:`2176`).
 
 v0.56.0 (2025-03-27)
 --------------------

--- a/environment.yml
+++ b/environment.yml
@@ -59,6 +59,7 @@ dependencies:
   - pytest >=8.0.0
   - pytest-cov >=5.0.0
   - pytest-socket >=0.6.0
+  - pytest-timeout >=2.4.0
   - pytest-xdist >=3.2
   - ruff >=0.9.6
   - sphinx >=8.2.0

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - cf_xarray >=0.9.3
   - cftime >=1.4.1
   - click >=8.1
-  - dask >=2024.8.1
+  - dask >=2024.8.1,!=2025.5.1
   - filelock >=3.14.0
   - numba >=0.57.0
   - numpy >=1.24.0

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - cf_xarray >=0.9.3
   - cftime >=1.4.1
   - click >=8.1
-  - dask >=2024.8.1,!=2025.5.1
+  - dask >=2024.8.1
   - filelock >=3.14.0
   - numba >=0.57.0
   - numpy >=1.24.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ dev = [
   "pytest >=8.0.0",
   "pytest-cov >=5.0.0",
   "pytest-socket >=0.6.0",
+  "pytest-timeout >=2.4.0",
   "pytest-xdist[psutil] >=3.2",
   "ruff >=0.9.6",
   "tokenize-rt >=5.2.0",
@@ -289,6 +290,9 @@ markers = [
   "requires_docs: mark tests that can only be run with documentation present (deselect with '-m \"not requires_docs\"')",
   "requires_internet: mark tests that require internet access (deselect with '-m \"not requires_internet\"')"
 ]
+session_timeout = 900
+timeout = 300
+timeout_method = "thread"
 xfail_strict = true
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
   "cf-xarray >=0.9.3", # cf-xarray is differently named on conda-forge
   "cftime >=1.4.1",
   "click >=8.1",
-  "dask[array] >=2024.8.1,!=2025.5.1",
+  "dask[array] >=2024.8.1",
   "filelock >=3.14.0",
   "numba >=0.57.0",
   "numpy >=1.24.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
   "cf-xarray >=0.9.3", # cf-xarray is differently named on conda-forge
   "cftime >=1.4.1",
   "click >=8.1",
-  "dask[array] >=2024.8.1",
+  "dask[array] >=2024.8.1,!=2025.5.1",
   "filelock >=3.14.0",
   "numba >=0.57.0",
   "numpy >=1.24.0",

--- a/tests/test_analog.py
+++ b/tests/test_analog.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 import pytest
-import xarray as xr
 from numpy.testing import assert_almost_equal
 from scipy import integrate, stats
 from sklearn import datasets
@@ -58,9 +57,9 @@ def test_exact_randn(exact_randn):
 
 @pytest.mark.slow
 @pytest.mark.parametrize("method", xca.metrics.keys())
-def test_spatial_analogs(method, nimbus):
-    diss = xr.open_dataset(nimbus.fetch("SpatialAnalogs/dissimilarity.nc"))
-    data = xr.open_dataset(nimbus.fetch("SpatialAnalogs/indicators.nc"))
+def test_spatial_analogs(method, open_dataset):
+    diss = open_dataset("SpatialAnalogs/dissimilarity.nc")
+    data = open_dataset("SpatialAnalogs/indicators.nc")
 
     target = data.sel(lat=46.1875, lon=-72.1875, time=slice("1970", "1990"))
     candidates = data.sel(time=slice("1970", "1990"))
@@ -73,10 +72,10 @@ def test_spatial_analogs(method, nimbus):
     np.testing.assert_allclose(diss[method], out, rtol=1e-3, atol=1e-3)
 
 
-def test_unsupported_spatial_analog_method(nimbus):
+def test_unsupported_spatial_analog_method(open_dataset):
     method = "KonMari"
 
-    data = xr.open_dataset(nimbus.fetch("SpatialAnalogs/indicators.nc"))
+    data = open_dataset("SpatialAnalogs/indicators.nc")
     target = data.sel(lat=46.1875, lon=-72.1875, time=slice("1970", "1990"))
     candidates = data.sel(time=slice("1970", "1990"))
 
@@ -86,10 +85,10 @@ def test_unsupported_spatial_analog_method(nimbus):
         xca.spatial_analogs(target, candidates, method=method)
 
 
-def test_spatial_analogs_multi_index(nimbus):
+def test_spatial_analogs_multi_index(open_dataset):
     # Test multi-indexes
-    diss = xr.open_dataset(nimbus.fetch("SpatialAnalogs/dissimilarity.nc"))
-    data = xr.open_dataset(nimbus.fetch("SpatialAnalogs/indicators.nc"))
+    diss = open_dataset("SpatialAnalogs/dissimilarity.nc")
+    data = open_dataset("SpatialAnalogs/indicators.nc")
 
     target = data.sel(lat=46.1875, lon=-72.1875, time=slice("1970", "1990"))
     candidates = data.sel(time=slice("1970", "1990"))

--- a/tests/test_bootstrapping.py
+++ b/tests/test_bootstrapping.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
-import xarray as xr
 
 from xclim.core.calendar import percentile_doy
 from xclim.indices import (
@@ -114,16 +113,16 @@ class Test_bootstrap:
             tg10p(tas_out_base, per, freq="MS", bootstrap=True)
 
     @pytest.mark.slow
-    def test_multi_per(self, nimbus):
-        tas = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc")).tas
+    def test_multi_per(self, open_dataset):
+        tas = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc").tas
         t90 = percentile_doy(tas.sel(time=slice("1990-01-01", "1991-12-31")), window=5, per=[90, 91])
         res = tg90p(tas=tas, tas_per=t90, freq="YS", bootstrap=True)
         np.testing.assert_array_equal([90, 91], res.percentiles)
 
     @pytest.mark.slow
-    def test_doctest_ndims(self, nimbus):
+    def test_doctest_ndims(self, open_dataset):
         """Replicates doctest to facilitate debugging."""
-        tas = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc")).tas
+        tas = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc").tas
         t90 = percentile_doy(tas.sel(time=slice("1990-01-01", "1991-12-31")), window=5, per=90)
         tg90p(tas=tas, tas_per=t90.isel(percentiles=0), freq="YS", bootstrap=True)
         tg90p(tas=tas, tas_per=t90, freq="YS", bootstrap=True)

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -216,8 +216,8 @@ def test_adjust_doy_366_to_360():
         ("NRCANdaily/nrcan_canada_daily_pr_1990.nc", "proleptic_gregorian", 366),
     ],
 )
-def test_get_calendar(file, cal, maxdoy, nimbus):
-    with xr.open_dataset(nimbus.fetch(file)) as ds:
+def test_get_calendar(file, cal, maxdoy, open_dataset):
+    with open_dataset(file) as ds:
         out_cal = get_calendar(ds)
         assert cal == out_cal
         assert max_doy[cal] == maxdoy

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -97,9 +97,9 @@ def test_normal_computation(tasmin_series, tasmax_series, pr_series, tmp_path, i
     assert "Processing :" in results.output
     assert "100% Completed" in results.output
 
-    out = xr.open_dataset(output_file)
-    outvar = list(out.data_vars.values())[0]
-    np.testing.assert_allclose(outvar[0], expected)
+    with xr.open_dataset(output_file) as out:
+        outvar = list(out.data_vars.values())[0]
+        np.testing.assert_allclose(outvar[0], expected)
 
 
 def test_multi_input(tas_series, pr_series, tmp_path):
@@ -126,12 +126,12 @@ def test_multi_input(tas_series, pr_series, tmp_path):
     )
     assert "Processing : solidprcptot" in results.output
 
-    out = xr.open_dataset(output_file)
-    assert out.solidprcptot.sum() == 0
+    with xr.open_dataset(output_file) as out:
+        assert out.solidprcptot.sum() == 0
 
 
-def test_multi_output(tmp_path, nimbus):
-    ds = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc"))
+def test_multi_output(tmp_path, open_dataset):
+    ds = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc")
     input_file = tmp_path / "ws_in.nc"
     output_file = tmp_path / "out.nc"
     ds.to_netcdf(input_file, engine="h5netcdf")
@@ -175,8 +175,8 @@ def test_renaming_variable(tas_series, tmp_path):
         assert "Processing : tn_mean" in results.output
         assert "100% Completed" in results.output
 
-    out = xr.open_dataset(output_file)
-    assert out.tn_mean[0] == 1.0
+    with xr.open_dataset(output_file) as out:
+        assert out.tn_mean[0] == 1.0
 
 
 def test_indicator_chain(tas_series, tmp_path):
@@ -204,9 +204,9 @@ def test_indicator_chain(tas_series, tmp_path):
     assert "Processing : growing_degree_days" in results.output
     assert "100% Completed" in results.output
 
-    out = xr.open_dataset(output_file)
-    assert out.tg_mean[0] == 1.0
-    assert out.growing_degree_days[0] == 0
+    with xr.open_dataset(output_file) as out:
+        assert out.tg_mean[0] == 1.0
+        assert out.growing_degree_days[0] == 0
 
 
 def test_missing_variable(tas_series, tmp_path):

--- a/tests/test_ensembles.py
+++ b/tests/test_ensembles.py
@@ -34,10 +34,10 @@ def random_state():
 
 
 class TestEnsembleStats:
-    def test_create_ensemble(self, ensemble_dataset_objects, nimbus):
+    def test_create_ensemble(self, ensemble_dataset_objects, open_dataset, nimbus):
         ds_all = []
         for n in ensemble_dataset_objects["nc_files_simple"]:
-            ds = xr.open_dataset(nimbus.fetch(n), decode_times=False)
+            ds = open_dataset(n, decode_times=False)
             ds["time"] = xr.decode_cf(ds).time
             ds_all.append(ds)
         ens = ensembles.create_ensemble(ds_all)
@@ -55,13 +55,13 @@ class TestEnsembleStats:
         ens2 = ensembles.create_ensemble(dict(zip(reals, files, strict=False)))
         xr.testing.assert_identical(ens1, ens2)
 
-    def test_no_time(self, tmp_path, ensemble_dataset_objects, nimbus):
+    def test_no_time(self, tmp_path, ensemble_dataset_objects, open_dataset):
         # create again using xr.Dataset objects
         f1 = Path(tmp_path / "notime")
         f1.mkdir()
         ds_all = []
         for n in ensemble_dataset_objects["nc_files"]:
-            ds = xr.open_dataset(nimbus.fetch(n), decode_times=False)
+            ds = open_dataset(n, decode_times=False)
             ds["time"] = xr.decode_cf(ds).time
             ds_all.append(ds.groupby(ds.time.dt.month).mean("time", keep_attrs=True))
             ds.groupby(ds.time.dt.month).mean("time", keep_attrs=True).to_netcdf(
@@ -75,10 +75,10 @@ class TestEnsembleStats:
         ens = ensembles.create_ensemble(in_ncs)
         assert len(ens.realization) == len(ensemble_dataset_objects["nc_files"])
 
-    def test_create_unequal_times(self, ensemble_dataset_objects, nimbus):
+    def test_create_unequal_times(self, ensemble_dataset_objects, open_dataset):
         ds_all = []
         for n in ensemble_dataset_objects["nc_files"]:
-            ds = xr.open_dataset(nimbus.fetch(n))
+            ds = open_dataset(n)
             ds_all.append(ds)
         ens = ensembles.create_ensemble(ds_all)
 
@@ -117,10 +117,10 @@ class TestEnsembleStats:
         np.testing.assert_equal(ens.isel(time=0), [0, 0])
 
     @pytest.mark.parametrize("transpose", [False, True])
-    def test_calc_perc(self, transpose, ensemble_dataset_objects, nimbus):
+    def test_calc_perc(self, transpose, ensemble_dataset_objects, open_dataset):
         ds_all = []
         for n in ensemble_dataset_objects["nc_files_simple"]:
-            ds = xr.open_dataset(nimbus.fetch(n))
+            ds = open_dataset(n)
             ds_all.append(ds)
         ens = ensembles.create_ensemble(ds_all)
 
@@ -179,10 +179,10 @@ class TestEnsembleStats:
         assert np.all(out4["tg_mean_p90"] > out4["tg_mean_p10"])
 
     @pytest.mark.parametrize("keep_chunk_size", [False, True, None])
-    def test_calc_perc_dask(self, keep_chunk_size, ensemble_dataset_objects, nimbus):
+    def test_calc_perc_dask(self, keep_chunk_size, ensemble_dataset_objects, open_dataset):
         ds_all = []
         for n in ensemble_dataset_objects["nc_files_simple"]:
-            ds = xr.open_dataset(nimbus.fetch(n))
+            ds = open_dataset(n)
             ds_all.append(ds)
         ens = ensembles.create_ensemble(ds_all)
 
@@ -190,10 +190,10 @@ class TestEnsembleStats:
         out1 = ensembles.ensemble_percentiles(ens.load(), split=False)
         np.testing.assert_array_equal(out1["tg_mean"], out2["tg_mean"])
 
-    def test_calc_perc_nans(self, ensemble_dataset_objects, nimbus):
+    def test_calc_perc_nans(self, ensemble_dataset_objects, open_dataset):
         ds_all = []
         for n in ensemble_dataset_objects["nc_files_simple"]:
-            ds = xr.open_dataset(nimbus.fetch(n))
+            ds = open_dataset(n)
             ds_all.append(ds)
         ens = ensembles.create_ensemble(ds_all).load()
 
@@ -213,10 +213,10 @@ class TestEnsembleStats:
         assert np.all(out1["tg_mean_p90"] > out1["tg_mean_p50"])
         assert np.all(out1["tg_mean_p50"] > out1["tg_mean_p10"])
 
-    def test_calc_mean_std_min_max(self, ensemble_dataset_objects, nimbus):
+    def test_calc_mean_std_min_max(self, ensemble_dataset_objects, open_dataset):
         ds_all = []
         for n in ensemble_dataset_objects["nc_files_simple"]:
-            ds = xr.open_dataset(nimbus.fetch(n))
+            ds = open_dataset(n)
             ds_all.append(ds)
         ens = ensembles.create_ensemble(ds_all, multifile=False)
 
@@ -255,8 +255,8 @@ class TestEnsembleStats:
         np.testing.assert_array_equal(out1.tg_mean_min[0, 5, 5], out2.tg_mean_min[0, 5, 5])
 
     @pytest.mark.parametrize("aggfunc", [ensembles.ensemble_percentiles, ensembles.ensemble_mean_std_max_min])
-    def test_stats_min_members(self, ensemble_dataset_objects, aggfunc, nimbus):
-        ds_all = [xr.open_dataset(nimbus.fetch(n)) for n in ensemble_dataset_objects["nc_files_simple"]]
+    def test_stats_min_members(self, ensemble_dataset_objects, aggfunc, open_dataset):
+        ds_all = [open_dataset(n) for n in ensemble_dataset_objects["nc_files_simple"]]
         ens = ensembles.create_ensemble(ds_all).isel(lat=0, lon=0)
         ens = ens.where(ens.realization > 0)
         ens = xr.where((ens.realization == 1) & (ens.time.dt.year == 1950), np.nan, ens)

--- a/tests/test_ffdi.py
+++ b/tests/test_ffdi.py
@@ -129,7 +129,7 @@ class TestFFDI:
     @pytest.mark.slow
     @pytest.mark.parametrize("init_kbdi", [True, False])
     @pytest.mark.parametrize("limiting_func", ["xlim", "discrete"])
-    def test_ffdi_indicators(self, nimbus, init_kbdi, limiting_func):
+    def test_ffdi_indicators(self, init_kbdi, limiting_func, open_dataset):
         """Test the FFDI indicators using real data"""
         # I couldn't find any high quality data or code to test against. I considered
         # the CEMS GEFF dataset, and the R packages ClimInd and ecbtools but all use
@@ -137,7 +137,7 @@ class TestFFDI:
         # think reflect the modern literature.
         # For now, we just test that the indicators run using real data and that the
         # outputs look sensible
-        test_data = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc"))
+        test_data = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc")
 
         pr_annual = test_data["pr"].resample(time="YS").mean().mean("time")
         pr_annual.attrs["units"] = test_data["pr"].attrs["units"]

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -121,8 +121,8 @@ class TestDataFlags:
         ):
             df.data_flags(bad_ds.tasmax, bad_ds, raise_flags=True)
 
-    def test_era5_ecad_qc_flag(self, nimbus):
-        bad_ds = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc"))
+    def test_era5_ecad_qc_flag(self, open_dataset):
+        bad_ds = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc")
 
         # Add some suspicious run values
         bad_ds["tas"].values[0][100:300] = 17 + K2C

--- a/tests/test_hydrology.py
+++ b/tests/test_hydrology.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
-import xarray as xr
 
 from xclim import indices as xci
 from xclim import land
@@ -29,9 +28,9 @@ class TestRBIndex:
 
 class TestStandardizedStreamflow:
     @pytest.mark.slow
-    def test_3d_data_with_nans(self, nimbus):
+    def test_3d_data_with_nans(self, open_dataset):
         # test with data
-        ds = xr.open_dataset(nimbus.fetch("Raven/q_sim.nc"))
+        ds = open_dataset("Raven/q_sim.nc")
         q = ds.q_obs.sel(time=slice("2008")).rename("q")
         qMM = convert_units_to(q, "mm**3/s", context="hydro")  # noqa
         # put a nan somewhere
@@ -57,9 +56,9 @@ class TestStandardizedStreamflow:
         np.testing.assert_array_almost_equal(out1, out2, 3)
 
     @pytest.mark.slow
-    def test_3d_data_with_nans_value(self, nimbus):
+    def test_3d_data_with_nans_value(self, open_dataset):
         # test with data
-        ds = xr.open_dataset(nimbus.fetch("Raven/q_sim.nc"))
+        ds = open_dataset("Raven/q_sim.nc")
         q = ds.q_obs.sel(time=slice("2008", "2018")).rename("q")
         q[{"time": 10}] = np.nan
 

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -666,8 +666,8 @@ def test_update_history():
     assert merged.startswith("a: Text1")
 
 
-def test_input_dataset(nimbus):
-    ds = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc"))
+def test_input_dataset(open_dataset):
+    ds = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc")
 
     # Use defaults
     _ = xclim.atmos.daily_temperature_range(freq="YS", ds=ds)
@@ -684,7 +684,7 @@ def test_input_dataset(nimbus):
     with pytest.raises(MissingVariableError):
         out = xclim.atmos.daily_temperature_range(freq="YS", ds=dsx)  # noqa
 
-    # dataset not given
+    # dataset is not given
     with pytest.raises(ValueError):
         xclim.atmos.daily_temperature_range(tasmax="tmax")
 

--- a/tests/test_missing.py
+++ b/tests/test_missing.py
@@ -142,8 +142,8 @@ class TestMissingAnyFills:
         miss = missing.missing_any(ts2, freq=None, month=[7], src_timestep="h")
         np.testing.assert_array_equal(miss, True)
 
-    def test_hydro(self, nimbus):
-        ds = xr.open_dataset(nimbus.fetch("Raven/q_sim.nc"))
+    def test_hydro(self, open_dataset):
+        ds = open_dataset("Raven/q_sim.nc")
         miss = missing.missing_any(ds.q_sim, freq="YS")
         np.testing.assert_array_equal(miss[:-1], False)
         np.testing.assert_array_equal(miss[-1], True)

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -60,11 +60,11 @@ def test_virtual_modules(virtual_indicator, atmosds):
 
 
 @pytest.mark.requires_docs
-def test_custom_indices(nimbus):
+def test_custom_indices(open_dataset):
     # Use the example data used in the Extending Xclim notebook for testing.
     example_path = Path(__file__).parent.parent / "docs" / "notebooks" / "example"
 
-    pr = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc")).pr
+    pr = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc").pr
 
     # This tests load_module with a python file that is _not_ on the PATH
     example = load_module(example_path / "example.py")

--- a/tests/test_partitioning.py
+++ b/tests/test_partitioning.py
@@ -12,14 +12,10 @@ from xclim.ensembles import (
 from xclim.ensembles._filters import _concat_hist, _model_in_all_scens, _single_member
 
 
-def test_hawkins_sutton_smoke(nimbus):
+def test_hawkins_sutton_smoke(open_dataset):
     """Just a smoke test."""
     dims = {"run": "member", "scen": "scenario"}
-    da = (
-        xr.open_dataset(nimbus.fetch("uncertainty_partitioning/cmip5_pr_global_mon.nc"))
-        .pr.sel(time=slice("1950", None))
-        .rename(dims)
-    )
+    da = open_dataset("uncertainty_partitioning/cmip5_pr_global_mon.nc").pr.sel(time=slice("1950", None)).rename(dims)
     da1 = _model_in_all_scens(da)
     dac = _concat_hist(da1, scenario="historical")
     das = _single_member(dac)

--- a/tests/test_precip.py
+++ b/tests/test_precip.py
@@ -15,8 +15,8 @@ K2C = 273.15
 
 class TestRainOnFrozenGround:
     @pytest.mark.parametrize("chunks", [{"time": 366}, None])
-    def test_3d_data_with_nans(self, nimbus, chunks):
-        ds = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc"))
+    def test_3d_data_with_nans(self, open_dataset, chunks):
+        ds = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc")
 
         pr = ds.pr.copy()
         pr.values[1, 10] = np.nan
@@ -30,8 +30,8 @@ class TestRainOnFrozenGround:
 
 class TestRainSeason:
     # @pytest.mark.parametrize("chunks", [{"time": 366}, None])
-    def test_3d_data_with_nans(self, nimbus):
-        ds = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc"))
+    def test_3d_data_with_nans(self, open_dataset):
+        ds = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc")
 
         pr = ds.pr.isel(location=0).copy()
         pr[{"time": [0, 10, 100]}] = np.nan
@@ -58,10 +58,10 @@ class TestPrecipAccumulation:
     nc_pr = "NRCANdaily/nrcan_canada_daily_pr_1990.nc"
     nc_tasmin = "NRCANdaily/nrcan_canada_daily_tasmin_1990.nc"
 
-    def test_3d_data_with_nans(self, nimbus):
+    def test_3d_data_with_nans(self, open_dataset):
         # test with 3d data
-        pr = xr.open_dataset(nimbus.fetch(self.nc_pr)).pr  # mm/s
-        prMM = xr.open_dataset(nimbus.fetch(self.nc_pr)).pr
+        pr = open_dataset(self.nc_pr).pr  # mm/s
+        prMM = open_dataset(self.nc_pr).pr
         prMM *= 86400
         prMM.attrs["units"] = "mm/day"
         # put a nan somewhere
@@ -88,10 +88,10 @@ class TestPrecipAccumulation:
         assert np.isnan(out1.values[0, 1, 0])
         assert np.isnan(out1.values[0, -1, -1])
 
-    def test_with_different_phases(self, nimbus):
+    def test_with_different_phases(self, open_dataset):
         # test with different phases
-        pr = xr.open_dataset(nimbus.fetch(self.nc_pr)).pr  # mm/s
-        tasmin = xr.open_dataset(nimbus.fetch(self.nc_tasmin)).tasmin  # K
+        pr = open_dataset(self.nc_pr).pr  # mm/s
+        tasmin = open_dataset(self.nc_tasmin).tasmin  # K
 
         out_tot = atmos.precip_accumulation(pr, freq="MS")
         out_sol = atmos.solid_precip_accumulation(pr, tas=tasmin, freq="MS")
@@ -114,10 +114,10 @@ class TestPrecipAverage:
     nc_pr = "NRCANdaily/nrcan_canada_daily_pr_1990.nc"
     nc_tasmin = "NRCANdaily/nrcan_canada_daily_tasmin_1990.nc"
 
-    def test_3d_data_with_nans(self, nimbus):
+    def test_3d_data_with_nans(self, open_dataset):
         # test with 3d data
-        pr = xr.open_dataset(nimbus.fetch(self.nc_pr)).pr  # mm/s
-        prMM = xr.open_dataset(nimbus.fetch(self.nc_pr)).pr
+        pr = open_dataset(self.nc_pr).pr  # mm/s
+        prMM = open_dataset(self.nc_pr).pr
         prMM *= 86400
         prMM.attrs["units"] = "mm/day"
         # put a nan somewhere
@@ -145,10 +145,10 @@ class TestPrecipAverage:
 
         assert np.isnan(out1.values[0, -1, -1])
 
-    def test_with_different_phases(self, nimbus):
+    def test_with_different_phases(self, open_dataset):
         # test with different phases
-        pr = xr.open_dataset(nimbus.fetch(self.nc_pr)).pr  # mm/s
-        tasmin = xr.open_dataset(nimbus.fetch(self.nc_tasmin)).tasmin  # K
+        pr = open_dataset(self.nc_pr).pr  # mm/s
+        tasmin = open_dataset(self.nc_tasmin).tasmin  # K
 
         out_tot = atmos.precip_average(pr, freq="MS")
         out_sol = atmos.solid_precip_average(pr, tas=tasmin, freq="MS")
@@ -171,9 +171,9 @@ class TestStandardizedPrecip:
     nc_ds = "sdba/CanESM2_1950-2100.nc"
 
     @pytest.mark.slow
-    def test_3d_data_with_nans(self, nimbus):
+    def test_3d_data_with_nans(self, open_dataset):
         # test with data
-        ds = xr.open_dataset(nimbus.fetch(self.nc_ds))
+        ds = open_dataset(self.nc_ds)
         pr = ds.pr.sel(time=slice("2000"))  # kg m-2 s-1
         prMM = convert_units_to(pr, "mm/day", context="hydro")  # noqa
         # put a nan somewhere
@@ -219,10 +219,10 @@ class TestStandardizedPrecip:
 class TestWetDays:
     nc_file = "NRCANdaily/nrcan_canada_daily_pr_1990.nc"
 
-    def test_3d_data_with_nans(self, nimbus):
+    def test_3d_data_with_nans(self, open_dataset):
         # test with 3d data
-        pr = xr.open_dataset(nimbus.fetch(self.nc_file)).pr
-        prMM = xr.open_dataset(nimbus.fetch(self.nc_file)).pr
+        pr = open_dataset(self.nc_file).pr
+        prMM = open_dataset(self.nc_file).pr
         prMM.values *= 86400.0
         prMM.attrs["units"] = "mm/day"
         # put a nan somewhere
@@ -272,10 +272,10 @@ class TestDailyIntensity:
     # testing of wet_day and daily_pr_intensity, both are related
     nc_file = "NRCANdaily/nrcan_canada_daily_pr_1990.nc"
 
-    def test_3d_data_with_nans(self, nimbus):
+    def test_3d_data_with_nans(self, open_dataset):
         # test with 3d data
-        pr = xr.open_dataset(nimbus.fetch(self.nc_file)).pr
-        prMM = xr.open_dataset(nimbus.fetch(self.nc_file)).pr
+        pr = open_dataset(self.nc_file).pr
+        prMM = open_dataset(self.nc_file).pr
         prMM.values *= 86400.0
         prMM.attrs["units"] = "mm/day"
         # put a nan somewhere
@@ -326,10 +326,10 @@ class TestMax1Day:
 
     nc_file = "NRCANdaily/nrcan_canada_daily_pr_1990.nc"
 
-    def test_3d_data_with_nans(self, nimbus):
+    def test_3d_data_with_nans(self, open_dataset):
         # test with 3d data
-        pr = xr.open_dataset(nimbus.fetch(self.nc_file)).pr
-        prMM = xr.open_dataset(nimbus.fetch(self.nc_file)).pr
+        pr = open_dataset(self.nc_file).pr
+        prMM = open_dataset(self.nc_file).pr
         prMM.values *= 86400.0
         prMM.attrs["units"] = "mm/day"
         # put a nan somewhere
@@ -367,10 +367,10 @@ class TestMaxNDay:
             ("mm/s", 1, {"time": 73.0}),
         ],
     )
-    def test_3d_data_with_nans(self, nimbus, units, factor, chunks):
+    def test_3d_data_with_nans(self, open_dataset, units, factor, chunks):
         # test with 3d data
-        pr1 = xr.open_dataset(nimbus.fetch(self.nc_file)).pr
-        pr2 = xr.open_dataset(nimbus.fetch(self.nc_file), chunks=chunks).pr
+        pr1 = open_dataset(self.nc_file).pr
+        pr2 = open_dataset(self.nc_file, chunks=chunks).pr
         pr2.values *= factor
         pr2.attrs["units"] = units
         # put a nan somewhere
@@ -394,10 +394,10 @@ class TestMaxNDay:
 class TestMaxConsecWetDays:
     nc_file = "NRCANdaily/nrcan_canada_daily_pr_1990.nc"
 
-    def test_3d_data_with_nans(self, nimbus):
+    def test_3d_data_with_nans(self, open_dataset):
         # test with 3d data
-        pr = xr.open_dataset(nimbus.fetch(self.nc_file)).pr
-        prMM = xr.open_dataset(nimbus.fetch(self.nc_file)).pr
+        pr = open_dataset(self.nc_file).pr
+        prMM = open_dataset(self.nc_file).pr
         prMM.values *= 86400.0
         prMM.attrs["units"] = "mm/day"
         # put a nan somewhere
@@ -431,10 +431,10 @@ class TestMaxConsecWetDays:
 class TestMaxConsecDryDays:
     nc_file = "NRCANdaily/nrcan_canada_daily_pr_1990.nc"
 
-    def test_3d_data_with_nans(self, nimbus):
+    def test_3d_data_with_nans(self, open_dataset):
         # test with 3d data
-        pr = xr.open_dataset(nimbus.fetch(self.nc_file)).pr
-        prMM = xr.open_dataset(nimbus.fetch(self.nc_file)).pr
+        pr = open_dataset(self.nc_file).pr
+        prMM = open_dataset(self.nc_file).pr
         prMM.values *= 86400.0
         prMM.attrs["units"] = "mm/day"
         # put a nan somewhere
@@ -471,7 +471,12 @@ class TestSnowfallDate:
 
     @classmethod
     def get_snowfall(cls, nimbus):
-        dnr = xr.merge((xr.open_dataset(nimbus.fetch(cls.pr_file)), xr.open_dataset(nimbus.fetch(cls.tasmin_file))))
+        dnr = xr.merge(
+            (
+                xr.open_dataset(nimbus.fetch(cls.pr_file), engine="h5netcdf"),
+                xr.open_dataset(nimbus.fetch(cls.tasmin_file), engine="h5netcdf"),
+            )
+        )
         return atmos.snowfall_approximation(dnr.pr, tas=dnr.tasmin, thresh="-0.5 degC", method="binary")
 
     def test_first_snowfall(self, nimbus):
@@ -504,14 +509,14 @@ class TestSnowfallDate:
 
 
 class TestDaysWithSnow:
-    def test_simple(self, nimbus, prsn_series):
-        prsn = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc")).prsn
+    def test_simple(self, open_dataset, prsn_series):
+        prsn = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc").prsn
         out = atmos.days_with_snow(prsn, low="0 kg m-2 s-1", high="1e6 kg m-2 s-1")
         np.testing.assert_array_equal(out[1], [np.nan, 162, 159, 126, np.nan])
 
 
-def test_days_over_precip_doy_thresh(nimbus):
-    pr = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc")).pr
+def test_days_over_precip_doy_thresh(open_dataset):
+    pr = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc").pr
     per = percentile_doy(pr, window=5, per=80)
 
     out1 = atmos.days_over_precip_doy_thresh(pr, per)
@@ -526,8 +531,8 @@ def test_days_over_precip_doy_thresh(nimbus):
     assert "5 day(s)" in out2.attrs["description"]
 
 
-def test_days_over_precip_thresh(nimbus):
-    pr = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc")).pr
+def test_days_over_precip_thresh(open_dataset):
+    pr = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc").pr
     per = pr.quantile(0.8, "time", keep_attrs=True)
     per.attrs["climatology_bounds"] = build_climatology_bounds(pr)
 
@@ -538,9 +543,9 @@ def test_days_over_precip_thresh(nimbus):
     assert "['1990-01-01', '1993-12-31'] period" in out.attrs["description"]
 
 
-def test_days_over_precip_thresh__seasonal_indexer(nimbus):
+def test_days_over_precip_thresh__seasonal_indexer(open_dataset):
     # GIVEN
-    pr = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc")).pr
+    pr = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc").pr
     per = pr.quantile(0.8, "time", keep_attrs=True)
     # WHEN
     out = atmos.days_over_precip_thresh(pr, per, freq="YS", date_bounds=("01-10", "12-31"))
@@ -548,8 +553,8 @@ def test_days_over_precip_thresh__seasonal_indexer(nimbus):
     np.testing.assert_almost_equal(out[0], np.array([81.0, 66.0, 66.0, 75.0]))
 
 
-def test_fraction_over_precip_doy_thresh(nimbus):
-    pr = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc")).pr
+def test_fraction_over_precip_doy_thresh(open_dataset):
+    pr = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc").pr
     per = percentile_doy(pr, window=5, per=80)
 
     out = atmos.fraction_over_precip_doy_thresh(pr, per)
@@ -564,8 +569,8 @@ def test_fraction_over_precip_doy_thresh(nimbus):
     assert "5 day(s)" in out.attrs["description"]
 
 
-def test_fraction_over_precip_thresh(nimbus):
-    pr = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc")).pr
+def test_fraction_over_precip_thresh(open_dataset):
+    pr = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc").pr
     per = pr.quantile(0.8, "time", keep_attrs=True)
     per.attrs["climatology_bounds"] = build_climatology_bounds(pr)
 
@@ -577,8 +582,8 @@ def test_fraction_over_precip_thresh(nimbus):
     assert "['1990-01-01', '1993-12-31'] period" in out.attrs["description"]
 
 
-def test_liquid_precip_ratio(nimbus):
-    ds = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc"))
+def test_liquid_precip_ratio(open_dataset):
+    ds = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc")
 
     out = atmos.liquid_precip_ratio(pr=ds.pr, tas=ds.tas, thresh="0 degC", freq="YS")
     np.testing.assert_allclose(out[:, 0], np.array([0.919, 0.805, 0.525, 0.740, 0.993]), atol=1e3)
@@ -649,8 +654,8 @@ def test_dry_spell_max_length_indexer(pr_series):
     np.testing.assert_allclose(out, [9] + [0] * 11)
 
 
-def test_dry_spell_frequency_op(nimbus):
-    pr = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc")).pr
+def test_dry_spell_frequency_op(open_dataset):
+    pr = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc").pr
     test_sum = atmos.dry_spell_frequency(pr, thresh="3 mm", window=7, freq="MS", op="sum")
     test_max = atmos.dry_spell_frequency(pr, thresh="3 mm", window=7, freq="MS", op="max")
 
@@ -672,7 +677,12 @@ class TestSnowfallMeteoSwiss:
 
     @classmethod
     def get_snowfall(cls, nimbus):
-        dnr = xr.merge((xr.open_dataset(nimbus.fetch(cls.pr_file)), xr.open_dataset(nimbus.fetch(cls.tasmin_file))))
+        dnr = xr.merge(
+            (
+                xr.open_dataset(nimbus.fetch(cls.pr_file), engine="h5netcdf"),
+                xr.open_dataset(nimbus.fetch(cls.tasmin_file), engine="h5netcdf"),
+            )
+        )
         return atmos.snowfall_approximation(dnr.pr, tas=dnr.tasmin, thresh="-0.5 degC", method="binary")
 
     def test_snowfall_frequency(self, nimbus):

--- a/tests/test_run_length.py
+++ b/tests/test_run_length.py
@@ -283,10 +283,10 @@ class TestFirstRun:
         i = rl.first_run(a, 5, dim="x")
         assert 10 == i
 
-    def test_real_data(self, nimbus):
+    def test_real_data(self, open_dataset):
         # FIXME: No test here?!
         # n-dim version versus ufunc
-        da3d = xr.open_dataset(nimbus.fetch(self.nc_pr), engine="h5netcdf").pr[:, 40:50, 50:68] != 0
+        da3d = open_dataset(self.nc_pr, engine="h5netcdf").pr[:, 40:50, 50:68] != 0
         da3d.resample(time="ME").map(rl.first_run, window=5)
 
     @pytest.mark.parametrize(
@@ -411,8 +411,8 @@ def test_run_bounds_synthetic():
     np.testing.assert_array_equal(bounds, [[1, 6], [4, 9]])
 
 
-def test_run_bounds_data(nimbus):
-    era5 = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc"), engine="h5netcdf")
+def test_run_bounds_data(open_dataset):
+    era5 = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc")
     cond = era5.tas.rolling(time=7).mean() > 285
 
     bounds = rl.run_bounds(cond, "time")  # def coord = True
@@ -432,8 +432,8 @@ def test_keep_longest_run_synthetic():
     np.testing.assert_array_equal(lrun, np.array([0, 1, 1, 1, 0, 0, 0, 0, 0, 0], dtype=bool))
 
 
-def test_keep_longest_run_data(nimbus):
-    era5 = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc"), engine="h5netcdf")
+def test_keep_longest_run_data(open_dataset):
+    era5 = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc")
     cond = era5.swe > 0.002
     lrun = rl.keep_longest_run(cond, "time")
     np.testing.assert_array_equal(

--- a/tests/test_snow.py
+++ b/tests/test_snow.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
-import xarray as xr
 
 from xclim import land
 from xclim.core import ValidationError
@@ -122,8 +121,8 @@ class TestSnwMaxDoy:
 
 
 class TestHolidaySnowIndicators:
-    def test_xmas_days_simple(self, nimbus):
-        ds = xr.open_dataset(nimbus.fetch("cmip6/snw_day_CanESM5_historical_r1i1p1f1_gn_19910101-20101231.nc"))
+    def test_xmas_days_simple(self, open_dataset):
+        ds = open_dataset("cmip6/snw_day_CanESM5_historical_r1i1p1f1_gn_19910101-20101231.nc")
         snd = land.snw_to_snd(ds.snw)
 
         out = land.holiday_snow_days(snd)
@@ -142,9 +141,9 @@ class TestHolidaySnowIndicators:
             ],
         )
 
-    def test_perfect_xmas_days_simple(self, nimbus):
-        ds_snw = xr.open_dataset(nimbus.fetch("cmip6/snw_day_CanESM5_historical_r1i1p1f1_gn_19910101-20101231.nc"))
-        ds_prsn = xr.open_dataset(nimbus.fetch("cmip6/prsn_day_CanESM5_historical_r1i1p1f1_gn_19910101-20101231.nc"))
+    def test_perfect_xmas_days_simple(self, open_dataset):
+        ds_snw = open_dataset("cmip6/snw_day_CanESM5_historical_r1i1p1f1_gn_19910101-20101231.nc")
+        ds_prsn = open_dataset("cmip6/prsn_day_CanESM5_historical_r1i1p1f1_gn_19910101-20101231.nc")
 
         snd = land.snw_to_snd(ds_snw.snw)
         prsn = ds_prsn.prsn

--- a/tests/test_temperature.py
+++ b/tests/test_temperature.py
@@ -58,13 +58,13 @@ class TestDTR:
     nc_tasmax = "NRCANdaily/nrcan_canada_daily_tasmax_1990.nc"
     nc_tasmin = "NRCANdaily/nrcan_canada_daily_tasmin_1990.nc"
 
-    def test_DTR_3d_data_with_nans(self, nimbus):
-        tasmax = xr.open_dataset(nimbus.fetch(self.nc_tasmax)).tasmax
-        tasmax_C = xr.open_dataset(nimbus.fetch(self.nc_tasmax)).tasmax
+    def test_DTR_3d_data_with_nans(self, open_dataset):
+        tasmax = open_dataset(self.nc_tasmax).tasmax
+        tasmax_C = open_dataset(self.nc_tasmax).tasmax
         tasmax_C -= K2C
         tasmax_C.attrs["units"] = "C"
-        tasmin = xr.open_dataset(nimbus.fetch(self.nc_tasmin)).tasmin
-        tasmin_C = xr.open_dataset(nimbus.fetch(self.nc_tasmin)).tasmin
+        tasmin = open_dataset(self.nc_tasmin).tasmin
+        tasmin_C = open_dataset(self.nc_tasmin).tasmin
         tasmin_C -= K2C
         tasmin_C.attrs["units"] = "C"
         # put a nan somewhere
@@ -98,13 +98,13 @@ class TestDTRVar:
     nc_tasmax = "NRCANdaily/nrcan_canada_daily_tasmax_1990.nc"
     nc_tasmin = "NRCANdaily/nrcan_canada_daily_tasmin_1990.nc"
 
-    def test_dtr_var_3d_data_with_nans(self, nimbus):
-        tasmax = xr.open_dataset(nimbus.fetch(self.nc_tasmax)).tasmax
-        tasmax_C = xr.open_dataset(nimbus.fetch(self.nc_tasmax)).tasmax
+    def test_dtr_var_3d_data_with_nans(self, open_dataset):
+        tasmax = open_dataset(self.nc_tasmax).tasmax
+        tasmax_C = open_dataset(self.nc_tasmax).tasmax
         tasmax_C -= K2C
         tasmax_C.attrs["units"] = "C"
-        tasmin = xr.open_dataset(nimbus.fetch(self.nc_tasmin)).tasmin
-        tasmin_C = xr.open_dataset(nimbus.fetch(self.nc_tasmin)).tasmin
+        tasmin = open_dataset(self.nc_tasmin).tasmin
+        tasmin_C = open_dataset(self.nc_tasmin).tasmin
         tasmin_C -= K2C
         tasmin_C.attrs["units"] = "C"
         # put a nan somewhere
@@ -131,13 +131,13 @@ class TestETR:
     nc_tasmax = "NRCANdaily/nrcan_canada_daily_tasmax_1990.nc"
     nc_tasmin = "NRCANdaily/nrcan_canada_daily_tasmin_1990.nc"
 
-    def test_dtr_var_3d_data_with_nans(self, nimbus):
-        tasmax = xr.open_dataset(nimbus.fetch(self.nc_tasmax)).tasmax
-        tasmax_C = xr.open_dataset(nimbus.fetch(self.nc_tasmax)).tasmax
+    def test_dtr_var_3d_data_with_nans(self, open_dataset):
+        tasmax = open_dataset(self.nc_tasmax).tasmax
+        tasmax_C = open_dataset(self.nc_tasmax).tasmax
         tasmax_C -= K2C
         tasmax_C.attrs["units"] = "C"
-        tasmin = xr.open_dataset(nimbus.fetch(self.nc_tasmin)).tasmin
-        tasmin_C = xr.open_dataset(nimbus.fetch(self.nc_tasmin)).tasmin
+        tasmin = open_dataset(self.nc_tasmin).tasmin
+        tasmin_C = open_dataset(self.nc_tasmin).tasmin
         tasmin_C -= K2C
         tasmin_C.attrs["units"] = "C"
         # put a nan somewhere
@@ -165,9 +165,9 @@ class TestTmean:
         "NRCANdaily/nrcan_canada_daily_tasmin_1990.nc",
     )
 
-    def test_Tmean_3d_data(self, nimbus):
-        ds_tmax = xr.open_dataset(nimbus.fetch(self.nc_files[0]))
-        ds_tmin = xr.open_dataset(nimbus.fetch(self.nc_files[1]))
+    def test_Tmean_3d_data(self, open_dataset):
+        ds_tmax = open_dataset(self.nc_files[0])
+        ds_tmin = open_dataset(self.nc_files[1])
         tas = atmos.tg(ds_tmin.tasmin, ds_tmax.tasmax)
         tas_C = atmos.tg(ds_tmin.tasmin, ds_tmax.tasmax)
         tas_C.values -= K2C
@@ -194,9 +194,9 @@ class TestTmean:
 class TestTx:
     nc_file = "NRCANdaily/nrcan_canada_daily_tasmax_1990.nc"
 
-    def test_TX_3d_data(self, nimbus):
-        tasmax = xr.open_dataset(nimbus.fetch(self.nc_file)).tasmax
-        tasmax_C = xr.open_dataset(nimbus.fetch(self.nc_file)).tasmax
+    def test_TX_3d_data(self, open_dataset):
+        tasmax = open_dataset(self.nc_file).tasmax
+        tasmax_C = open_dataset(self.nc_file).tasmax
         tasmax_C.values -= K2C
         tasmax_C.attrs["units"] = "C"
         # put a nan somewhere
@@ -242,9 +242,9 @@ class TestTx:
 class TestTn:
     nc_file = "NRCANdaily/nrcan_canada_daily_tasmin_1990.nc"
 
-    def test_TN_3d_data(self, nimbus):
-        tasmin = xr.open_dataset(nimbus.fetch(self.nc_file)).tasmin
-        tasmin_C = xr.open_dataset(nimbus.fetch(self.nc_file)).tasmin
+    def test_TN_3d_data(self, open_dataset):
+        tasmin = open_dataset(self.nc_file).tasmin
+        tasmin_C = open_dataset(self.nc_file).tasmin
         tasmin_C.values -= K2C
         tasmin_C.attrs["units"] = "C"
         # put a nan somewhere
@@ -408,10 +408,10 @@ class TestColdSpellDays:
 class TestFrostDays:
     nc_file = "NRCANdaily/nrcan_canada_daily_tasmin_1990.nc"
 
-    def test_3d_data_with_nans(self, nimbus):
+    def test_3d_data_with_nans(self, open_dataset):
         # test with 3d data
-        tasmin = xr.open_dataset(nimbus.fetch(self.nc_file)).tasmin
-        tasminC = xr.open_dataset(nimbus.fetch(self.nc_file)).tasmin
+        tasmin = open_dataset(self.nc_file).tasmin
+        tasminC = open_dataset(self.nc_file).tasmin
         tasminC -= K2C
         tasminC.attrs["units"] = "C"
         # put a nan somewhere
@@ -440,10 +440,10 @@ class TestFrostDays:
 class TestIceDays:
     nc_file = "NRCANdaily/nrcan_canada_daily_tasmax_1990.nc"
 
-    def test_3d_data_with_nans(self, nimbus):
+    def test_3d_data_with_nans(self, open_dataset):
         # test with 3d data
-        tas = xr.open_dataset(nimbus.fetch(self.nc_file)).tasmax
-        tasC = xr.open_dataset(nimbus.fetch(self.nc_file)).tasmax
+        tas = open_dataset(self.nc_file).tasmax
+        tasC = open_dataset(self.nc_file).tasmax
         tasC -= K2C
         tasC.attrs["units"] = "C"
         # put a nan somewhere
@@ -461,18 +461,16 @@ class TestIceDays:
         np.testing.assert_array_equal(fd, fdC)
 
         assert np.allclose(fd1, fd.values[0, 0, 0])
-
         assert np.isnan(fd.values[0, 1, 0])
-
         assert np.isnan(fd.values[0, -1, -1])
 
 
 class TestCoolingDegreeDays:
     nc_file = "NRCANdaily/nrcan_canada_daily_tasmax_1990.nc"
 
-    def test_3d_data_with_nans(self, nimbus):
+    def test_3d_data_with_nans(self, open_dataset):
         # test with 3d data
-        tas = xr.open_dataset(nimbus.fetch(self.nc_file)).tasmax
+        tas = open_dataset(self.nc_file).tasmax
         tas.attrs["cell_methods"] = "time: mean within days"
         # put a nan somewhere
         tas.values[180, 1, 0] = np.nan
@@ -486,14 +484,12 @@ class TestCoolingDegreeDays:
         cdd1 = (x1[x1 > thresh] - thresh).sum()
 
         assert np.allclose(cdd1, cdd.values[0, 0, 0])
-
         assert np.isnan(cdd.values[0, 1, 0])
-
         assert np.isnan(cdd.values[0, -1, -1])
 
-    def test_convert_units(self, nimbus):
+    def test_convert_units(self, open_dataset):
         # test with 3d data
-        tas = xr.open_dataset(nimbus.fetch(self.nc_file)).tasmax
+        tas = open_dataset(self.nc_file).tasmax
         tas.values -= K2C
         tas.attrs["units"] = "C"
         tas.attrs["cell_methods"] = "time: mean within days"
@@ -521,9 +517,9 @@ class TestCoolingDegreeDays:
 class TestHeatingDegreeDays:
     nc_file = "NRCANdaily/nrcan_canada_daily_tasmax_1990.nc"
 
-    def test_3d_data_with_nans(self, nimbus):
+    def test_3d_data_with_nans(self, open_dataset):
         # test with 3d data
-        tas = xr.open_dataset(nimbus.fetch(self.nc_file)).tasmax
+        tas = open_dataset(self.nc_file).tasmax
         # put a nan somewhere
         tas.values[180, 1, 0] = np.nan
         tas.attrs["cell_methods"] = "time: mean within days"
@@ -536,14 +532,12 @@ class TestHeatingDegreeDays:
         hdd1 = (thresh - x1).clip(min=0).sum()
 
         assert np.allclose(hdd1, hdd.values[0, 0, 0])
-
         assert np.isnan(hdd.values[0, 1, 0])
-
         assert np.isnan(hdd.values[0, -1, -1])
 
-    def test_convert_units(self, nimbus):
+    def test_convert_units(self, open_dataset):
         # test with 3d data
-        tas = xr.open_dataset(nimbus.fetch(self.nc_file)).tasmax
+        tas = open_dataset(self.nc_file).tasmax
         # put a nan somewhere
         tas.values[180, 1, 0] = np.nan
         tas.values -= K2C
@@ -558,18 +552,17 @@ class TestHeatingDegreeDays:
         hdd1 = (thresh - x1).clip(min=0).sum()
 
         assert np.allclose(hdd1, hdd.values[0, 0, 0])
-
         assert np.isnan(hdd.values[0, 1, 0])
-
         assert np.isnan(hdd.values[0, -1, -1])
 
 
 class TestGrowingDegreeDays:
-    nc_file = "NRCANdaily/nrcan_canada_daily_tasmax_1990.nc"
+    tasmax_file = "NRCANdaily/nrcan_canada_daily_tasmax_1990.nc"
+    cancities_file = "ERA5/daily_surface_cancities_1990-1993.nc"
 
-    def test_3d_data_with_nans(self, nimbus):
+    def test_3d_data_with_nans(self, open_dataset):
         # test with 3d data
-        tas = xr.open_dataset(nimbus.fetch(self.nc_file)).tasmax
+        tas = open_dataset(self.tasmax_file).tasmax
         tas.attrs["cell_methods"] = "time: mean within days"
         # put a nan somewhere
         tas.values[180, 1, 0] = np.nan
@@ -591,8 +584,8 @@ class TestGrowingDegreeDays:
 
         assert np.isnan(gdd.values[0, -1, -1])
 
-    def test_conversion(self, nimbus):
-        ds = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc"))
+    def test_conversion(self, open_dataset):
+        ds = open_dataset(self.cancities_file)
 
         ds["tas_F"] = convert_units_to(ds.tas, "degF")
         ds_pt = ds.isel(location=1)
@@ -849,9 +842,9 @@ class TestDailyFreezeThaw:
     nc_tasmax = "NRCANdaily/nrcan_canada_daily_tasmax_1990.nc"
     nc_tasmin = "NRCANdaily/nrcan_canada_daily_tasmin_1990.nc"
 
-    def test_3d_data_with_nans(self, nimbus):
-        tasmax = xr.open_dataset(nimbus.fetch(self.nc_tasmax)).tasmax
-        tasmin = xr.open_dataset(nimbus.fetch(self.nc_tasmin)).tasmin
+    def test_3d_data_with_nans(self, open_dataset):
+        tasmax = open_dataset(self.nc_tasmax).tasmax
+        tasmin = open_dataset(self.nc_tasmin).tasmin
 
         # put a nan somewhere
         tasmin.values[180, 1, 0] = np.nan
@@ -869,9 +862,9 @@ class TestDailyFreezeThaw:
 
         assert np.isnan(frzthw.values[0, -1, -1])
 
-    def test_convert_units(self, nimbus):
-        tasmax = xr.open_dataset(nimbus.fetch(self.nc_tasmax)).tasmax
-        tasmin = xr.open_dataset(nimbus.fetch(self.nc_tasmin)).tasmin
+    def test_convert_units(self, open_dataset):
+        tasmax = open_dataset(self.nc_tasmax).tasmax
+        tasmin = open_dataset(self.nc_tasmin).tasmin
         tasmax.values -= K2C
         tasmax.attrs["units"] = "C"
         tasmin.values -= K2C
@@ -962,10 +955,10 @@ class TestGrowingSeasonLength:
 class TestTnDaysBelow:
     nc_file = "NRCANdaily/nrcan_canada_daily_tasmin_1990.nc"
 
-    def test_3d_data_with_nans(self, nimbus):
+    def test_3d_data_with_nans(self, open_dataset):
         # test with 3d data
-        tas = xr.open_dataset(nimbus.fetch(self.nc_file)).tasmin
-        tasC = xr.open_dataset(nimbus.fetch(self.nc_file)).tasmin
+        tas = open_dataset(self.nc_file).tasmin
+        tasC = open_dataset(self.nc_file).tasmin
         tasC -= K2C
         tasC.attrs["units"] = "C"
         # put a nan somewhere
@@ -992,10 +985,10 @@ class TestTnDaysBelow:
 class TestTxDaysAbove:
     nc_file = "NRCANdaily/nrcan_canada_daily_tasmax_1990.nc"
 
-    def test_3d_data_with_nans(self, nimbus):
+    def test_3d_data_with_nans(self, open_dataset):
         # test with 3d data
-        tas = xr.open_dataset(nimbus.fetch(self.nc_file)).tasmax
-        tasC = xr.open_dataset(nimbus.fetch(self.nc_file)).tasmax
+        tas = open_dataset(self.nc_file).tasmax
+        tasC = open_dataset(self.nc_file).tasmax
         tasC -= K2C
         tasC.attrs["units"] = "C"
         # put a nan somewhere
@@ -1026,10 +1019,10 @@ class TestTnDaysAbove:
         "tn_indice, kwargs",
         [("tn_days_above", dict(thresh="20 degC")), ("tropical_nights", dict())],
     )
-    def test_3d_data_with_nans(self, nimbus, tn_indice, kwargs):
+    def test_3d_data_with_nans(self, open_dataset, tn_indice, kwargs):
         # test with 3d data
-        tas = xr.open_dataset(nimbus.fetch(self.nc_file)).tasmin
-        tasC = xr.open_dataset(nimbus.fetch(self.nc_file)).tasmin
+        tas = open_dataset(self.nc_file).tasmin
+        tasC = open_dataset(self.nc_file).tasmin
         tasC -= K2C
         tasC.attrs["units"] = "C"
         # put a nan somewhere
@@ -1057,12 +1050,12 @@ class TestTxTnDaysAbove:
     nc_tasmax = "NRCANdaily/nrcan_canada_daily_tasmax_1990.nc"
     nc_tasmin = "NRCANdaily/nrcan_canada_daily_tasmin_1990.nc"
 
-    def test_3d_data_with_nans(self, nimbus):
-        tasmax = xr.open_dataset(nimbus.fetch(self.nc_tasmax)).tasmax
-        tasmin = xr.open_dataset(nimbus.fetch(self.nc_tasmin)).tasmin
+    def test_3d_data_with_nans(self, open_dataset):
+        tasmax = open_dataset(self.nc_tasmax).tasmax
+        tasmin = open_dataset(self.nc_tasmin).tasmin
 
-        tasmaxC = xr.open_dataset(nimbus.fetch(self.nc_tasmax)).tasmax
-        tasminC = xr.open_dataset(nimbus.fetch(self.nc_tasmin)).tasmin
+        tasmaxC = open_dataset(self.nc_tasmax).tasmax
+        tasminC = open_dataset(self.nc_tasmin).tasmin
         tasmaxC -= K2C
         tasmaxC.attrs["units"] = "C"
         tasminC -= K2C
@@ -1293,8 +1286,8 @@ def test_freshet_start(tas_series):
     assert out[0] == 51
 
 
-def test_degree_days_exceedance_date(nimbus):
-    tas = xr.open_dataset(nimbus.fetch("FWI/GFWED_sample_2017.nc")).tas
+def test_degree_days_exceedance_date(open_dataset):
+    tas = open_dataset("FWI/GFWED_sample_2017.nc").tas
     tas.attrs.update(cell_methods="time: mean within days", standard_name="air_temperature")
 
     out = atmos.degree_days_exceedance_date(
@@ -1331,8 +1324,8 @@ def test_degree_days_exceedance_date(nimbus):
 
 
 @pytest.mark.parametrize("never_reached,exp", [(None, np.nan), (300, 300), ("12-01", 335)])
-def test_degree_days_exceedance_date_never_reached(nimbus, never_reached, exp):
-    tas = xr.open_dataset(nimbus.fetch("FWI/GFWED_sample_2017.nc")).tas
+def test_degree_days_exceedance_date_never_reached(open_dataset, never_reached, exp):
+    tas = open_dataset("FWI/GFWED_sample_2017.nc").tas
     tas.attrs.update(cell_methods="time: mean within days", standard_name="air_temperature")
     # Default -> NaN
     out = atmos.degree_days_exceedance_date(
@@ -1348,17 +1341,17 @@ def test_degree_days_exceedance_date_never_reached(nimbus, never_reached, exp):
 
 
 class TestWarmSpellDurationIndex:
-    def test_warm_spell_duration_index(self, nimbus):
-        tasmax = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc")).tasmax
+    def test_warm_spell_duration_index(self, open_dataset):
+        tasmax = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc").tasmax
         tx90 = percentile_doy(tasmax, window=5, per=90)
 
         out = atmos.warm_spell_duration_index(tasmax=tasmax, tasmax_per=tx90, window=3, freq="YS-JUL")
         np.testing.assert_array_equal(out.isel(location=0, percentiles=0), np.array([np.nan, 4, 0, 0, np.nan]))
         assert "Annual number of days with at least 3 consecutive days" in out.description
 
-    def test_wsdi_custom_percentiles_parameters(self, nimbus):
+    def test_wsdi_custom_percentiles_parameters(self, open_dataset):
         # GIVEN
-        tasmax = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc")).tasmax
+        tasmax = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc").tasmax
         tasmax_per = tasmax.sel(time=slice("01-01-1990", "31-12-1991"))
         # WHEN
         tx90 = percentile_doy(tasmax_per, per=[42, 24], window=2)
@@ -1368,9 +1361,9 @@ class TestWarmSpellDurationIndex:
         assert "2 day(s) window" in out.attrs["description"]
         assert "['1990-01-01', '1991-12-31']" in out.attrs["description"]
 
-    def test_wsdi_default_percentiles_parameters(self, nimbus):
+    def test_wsdi_default_percentiles_parameters(self, open_dataset):
         # GIVEN
-        tasmax = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc")).tasmax
+        tasmax = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc").tasmax
         tasmax_per = tasmax.sel(time=slice("01-01-1990", "31-12-1991"))
         # WHEN
         tx90 = percentile_doy(tasmax_per, per=[42, 24], window=2)
@@ -1382,16 +1375,16 @@ class TestWarmSpellDurationIndex:
         assert "{unknown}th percentile(s)" in res.attrs["description"]
 
 
-def test_maximum_consecutive_warm_days(nimbus):
-    tasmax = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc")).tasmax
+def test_maximum_consecutive_warm_days(open_dataset):
+    tasmax = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc").tasmax
     out = atmos.maximum_consecutive_warm_days(tasmax)
     np.testing.assert_array_equal(out[1, :], np.array([13, 21, 6, 10]))
     assert "Annual longest spell of consecutive days with maximum daily temperature above 25 degc." in out.description
 
 
-def test_corn_heat_units(nimbus):
-    tn = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc")).tasmin
-    tx = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc")).tasmax
+def test_corn_heat_units(open_dataset):
+    tn = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc").tasmin
+    tx = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc").tasmax
 
     with xr.set_options(keep_attrs=True):
         tnC = tn - K2C
@@ -1408,8 +1401,8 @@ def test_corn_heat_units(nimbus):
 
 
 class TestFreezeThawSpell:
-    def test_freezethaw_spell_frequency(self, nimbus):
-        ds = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc"))
+    def test_freezethaw_spell_frequency(self, open_dataset):
+        ds = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc")
 
         out = atmos.freezethaw_spell_frequency(tasmin=ds.tasmin, tasmax=ds.tasmax, freq="YS")
         np.testing.assert_array_equal(out.isel(location=0), [34.0, 37.0, 36.0, 30.0])
@@ -1432,8 +1425,8 @@ class TestFreezeThawSpell:
             "and minimum daily temperatures are at or below 0 degc for at least 2 consecutive day(s)."
         ]
 
-    def test_freezethaw_spell_mean_length(self, nimbus):
-        ds = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc"))
+    def test_freezethaw_spell_mean_length(self, open_dataset):
+        ds = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc")
 
         out = atmos.freezethaw_spell_mean_length(tasmin=ds.tasmin, tasmax=ds.tasmax, freq="YS")
         np.testing.assert_allclose(out.isel(location=0), [1.911765, 2.027027, 1.888889, 1.733333], rtol=1e-06)
@@ -1456,8 +1449,8 @@ class TestFreezeThawSpell:
             "and minimum daily temperatures are at or below 0 degc for at least 2 consecutive day(s)."
         ]
 
-    def test_freezethaw_spell_max_length(self, nimbus):
-        ds = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc"))
+    def test_freezethaw_spell_max_length(self, open_dataset):
+        ds = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc")
 
         out = atmos.freezethaw_spell_max_length(tasmin=ds.tasmin, tasmax=ds.tasmax, freq="YS")
         np.testing.assert_array_equal(out.isel(location=0), [12, 7, 7, 4])

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -66,6 +66,8 @@ class TestUnits:
 
 
 class TestConvertUnitsTo:
+    test_data = "ERA5/daily_surface_cancities_1990-1993.nc"
+
     def test_deprecation(self, tas_series):
         with pytest.raises(TypeError):
             convert_units_to(0, units.K)
@@ -118,22 +120,22 @@ class TestConvertUnitsTo:
         assert out == 2
         assert out.attrs["units"] == "degC"
 
-    def test_dataset(self, nimbus):
-        ds = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc"))
+    def test_dataset(self, open_dataset):
+        ds = open_dataset(self.test_data)
 
         out = convert_units_to(ds, {"tas": "degC", "pr": "mm/d"})
         assert out.tas.attrs["units"] == "°C"
         assert out.pr.attrs["units"] == "mm d-1"
         assert out.snd.attrs["units"] == "m"
 
-    def test_dataset_missing(self, nimbus):
-        ds = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc"))
+    def test_dataset_missing(self, open_dataset):
+        ds = open_dataset(self.test_data)
 
         with pytest.raises(KeyError, match="No variable named"):
             convert_units_to(ds, {"nonexistingvariable": "Å / °R"})
 
-    def test_datatree(self, nimbus):
-        ds = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc"))
+    def test_datatree(self, open_dataset):
+        ds = open_dataset(self.test_data)
 
         dt = xr.DataTree.from_dict(
             {

--- a/tests/test_wind.py
+++ b/tests/test_wind.py
@@ -7,8 +7,10 @@ from xclim import atmos
 
 
 class TestWindSpeedIndicators:
+    test_data = "ERA5/daily_surface_cancities_1990-1993.nc"
+
     def test_calm_windy_days(self, nimbus):
-        ds = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc"), engine="h5netcdf")
+        ds = xr.open_dataset(nimbus.fetch(self.test_data), engine="h5netcdf")
         sfcwind, _ = atmos.wind_speed_from_vector(ds.uas, ds.vas, calm_wind_thresh="0 m/s")
 
         calm = atmos.calm_days(sfcwind, thresh="5 m/s")
@@ -17,29 +19,27 @@ class TestWindSpeedIndicators:
         np.testing.assert_array_equal(calm + windy, c)
 
 
-class TestSfcWindMax:
+class TestSfcWind:
+    test_data = "ERA5/daily_surface_cancities_1990-1993.nc"
+
     def test_sfcWind_max(self, nimbus):
-        ds = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc"), engine="h5netcdf")
+        ds = xr.open_dataset(nimbus.fetch(self.test_data), engine="h5netcdf")
         sfcWind, _ = atmos.wind_speed_from_vector(ds.uas, ds.vas)
 
         sfcWind_max = atmos.sfcWind_max(sfcWind)
         c = sfcWind.resample(time="YS").max()
         np.testing.assert_array_equal(sfcWind_max, c)
 
-
-class TestSfcWindMean:
     def test_sfcWind_mean(self, nimbus):
-        ds = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc"), engine="h5netcdf")
+        ds = xr.open_dataset(nimbus.fetch(self.test_data), engine="h5netcdf")
         sfcWind, _ = atmos.wind_speed_from_vector(ds.uas, ds.vas)
 
         sfcWind_mean = atmos.sfcWind_mean(sfcWind)
         c = sfcWind.resample(time="YS").mean()
         np.testing.assert_array_equal(sfcWind_mean, c)
 
-
-class TestSfcWindMin:
     def test_sfcWind_min(self, nimbus):
-        ds = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc"), engine="h5netcdf")
+        ds = xr.open_dataset(nimbus.fetch(self.test_data), engine="h5netcdf")
         sfcWind, _ = atmos.wind_speed_from_vector(ds.uas, ds.vas)
 
         sfcWind_min = atmos.sfcWind_min(sfcWind)
@@ -47,29 +47,27 @@ class TestSfcWindMin:
         np.testing.assert_array_equal(sfcWind_min, c)
 
 
-class TestSfcWindmaxMax:
+class TestSfcWindMax:
+    test_data = "ERA5/daily_surface_cancities_1990-1993.nc"
+
     def test_sfcWindmax_max(self, nimbus):
-        ds = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc"), engine="h5netcdf")
+        ds = xr.open_dataset(nimbus.fetch(self.test_data), engine="h5netcdf")
         sfcWindmax, _ = atmos.wind_speed_from_vector(ds.uas, ds.vas)
 
         sfcWindmax_max = atmos.sfcWindmax_max(sfcWindmax)
         c = sfcWindmax.resample(time="YS").max()
         np.testing.assert_array_equal(sfcWindmax_max, c)
 
-
-class TestSfcWindmaxMean:
     def test_sfcWindmax_mean(self, nimbus):
-        ds = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc"), engine="h5netcdf")
+        ds = xr.open_dataset(nimbus.fetch(self.test_data), engine="h5netcdf")
         sfcWindmax, _ = atmos.wind_speed_from_vector(ds.uas, ds.vas)
 
         sfcWindmax_mean = atmos.sfcWindmax_mean(sfcWindmax)
         c = sfcWindmax.resample(time="YS").mean()
         np.testing.assert_array_equal(sfcWindmax_mean, c)
 
-
-class TestSfcWindmaxMin:
-    def test_sfcWindmax_mean(self, nimbus):
-        ds = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc"), engine="h5netcdf")
+    def test_sfcWindmax_min(self, nimbus):
+        ds = xr.open_dataset(nimbus.fetch(self.test_data), engine="h5netcdf")
         sfcWindmax, _ = atmos.wind_speed_from_vector(ds.uas, ds.vas)
 
         sfcWindmax_min = atmos.sfcWindmax_min(sfcWindmax)

--- a/tests/test_wind.py
+++ b/tests/test_wind.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
-import xarray as xr
 
 from xclim import atmos
 
@@ -10,8 +9,8 @@ from xclim import atmos
 class TestWindSpeedIndicators:
     test_data = "ERA5/daily_surface_cancities_1990-1993.nc"
 
-    def test_calm_windy_days(self, nimbus):
-        with xr.open_dataset(nimbus.fetch(self.test_data), engine="h5netcdf") as ds:
+    def test_calm_windy_days(self, open_dataset):
+        with open_dataset(self.test_data) as ds:
             sfcwind, _ = atmos.wind_speed_from_vector(ds.uas, ds.vas, calm_wind_thresh="0 m/s")
             calm = atmos.calm_days(sfcwind, thresh="5 m/s")
             windy = atmos.windy_days(sfcwind, thresh="5 m/s")
@@ -26,8 +25,8 @@ class TestSfcWind:
         "metric",
         ["mean", "max", "min"],
     )
-    def test_sfcWind(self, nimbus, metric):
-        with xr.open_dataset(nimbus.fetch(self.test_data), engine="h5netcdf") as ds:
+    def test_sfcWind(self, open_dataset, metric):
+        with open_dataset(self.test_data) as ds:
             sfcWind, _ = atmos.wind_speed_from_vector(ds.uas, ds.vas)
             sfcWind_calculated = getattr(atmos, f"sfcWind_{metric}")(sfcWind)
 
@@ -43,8 +42,8 @@ class TestSfcWindMax:
         "metric",
         ["mean", "max", "min"],
     )
-    def test_sfcWindmax(self, nimbus, metric):
-        with xr.open_dataset(nimbus.fetch(self.test_data), engine="h5netcdf") as ds:
+    def test_sfcWindmax(self, open_dataset, metric):
+        with open_dataset(self.test_data) as ds:
             sfcWind, _ = atmos.wind_speed_from_vector(ds.uas, ds.vas)
             sfcWindmax_calculated = getattr(atmos, f"sfcWindmax_{metric}")(sfcWind)
 

--- a/tests/test_wind.py
+++ b/tests/test_wind.py
@@ -10,66 +10,59 @@ class TestWindSpeedIndicators:
     test_data = "ERA5/daily_surface_cancities_1990-1993.nc"
 
     def test_calm_windy_days(self, nimbus):
-        ds = xr.open_dataset(nimbus.fetch(self.test_data), engine="h5netcdf")
-        sfcwind, _ = atmos.wind_speed_from_vector(ds.uas, ds.vas, calm_wind_thresh="0 m/s")
-
-        calm = atmos.calm_days(sfcwind, thresh="5 m/s")
-        windy = atmos.windy_days(sfcwind, thresh="5 m/s")
-        c = sfcwind.resample(time="MS").count()
-        np.testing.assert_array_equal(calm + windy, c)
+        with xr.open_dataset(nimbus.fetch(self.test_data), engine="h5netcdf") as ds:
+            sfcwind, _ = atmos.wind_speed_from_vector(ds.uas, ds.vas, calm_wind_thresh="0 m/s")
+            calm = atmos.calm_days(sfcwind, thresh="5 m/s")
+            windy = atmos.windy_days(sfcwind, thresh="5 m/s")
+            c = sfcwind.resample(time="MS").count()
+            np.testing.assert_array_equal(calm + windy, c)
 
 
 class TestSfcWind:
     test_data = "ERA5/daily_surface_cancities_1990-1993.nc"
 
     def test_sfcWind_max(self, nimbus):
-        ds = xr.open_dataset(nimbus.fetch(self.test_data), engine="h5netcdf")
-        sfcWind, _ = atmos.wind_speed_from_vector(ds.uas, ds.vas)
-
-        sfcWind_max = atmos.sfcWind_max(sfcWind)
-        c = sfcWind.resample(time="YS").max()
-        np.testing.assert_array_equal(sfcWind_max, c)
+        with xr.open_dataset(nimbus.fetch(self.test_data), engine="h5netcdf") as ds:
+            sfcWind, _ = atmos.wind_speed_from_vector(ds.uas, ds.vas)
+            sfcWind_max = atmos.sfcWind_max(sfcWind)
+            c = sfcWind.resample(time="YS").max()
+            np.testing.assert_array_equal(sfcWind_max, c)
 
     def test_sfcWind_mean(self, nimbus):
-        ds = xr.open_dataset(nimbus.fetch(self.test_data), engine="h5netcdf")
-        sfcWind, _ = atmos.wind_speed_from_vector(ds.uas, ds.vas)
-
-        sfcWind_mean = atmos.sfcWind_mean(sfcWind)
-        c = sfcWind.resample(time="YS").mean()
-        np.testing.assert_array_equal(sfcWind_mean, c)
+        with xr.open_dataset(nimbus.fetch(self.test_data), engine="h5netcdf") as ds:
+            sfcWind, _ = atmos.wind_speed_from_vector(ds.uas, ds.vas)
+            sfcWind_mean = atmos.sfcWind_mean(sfcWind)
+            c = sfcWind.resample(time="YS").mean()
+            np.testing.assert_array_equal(sfcWind_mean, c)
 
     def test_sfcWind_min(self, nimbus):
-        ds = xr.open_dataset(nimbus.fetch(self.test_data), engine="h5netcdf")
-        sfcWind, _ = atmos.wind_speed_from_vector(ds.uas, ds.vas)
-
-        sfcWind_min = atmos.sfcWind_min(sfcWind)
-        c = sfcWind.resample(time="YS").min()
-        np.testing.assert_array_equal(sfcWind_min, c)
+        with xr.open_dataset(nimbus.fetch(self.test_data), engine="h5netcdf") as ds:
+            sfcWind, _ = atmos.wind_speed_from_vector(ds.uas, ds.vas)
+            sfcWind_min = atmos.sfcWind_min(sfcWind)
+            c = sfcWind.resample(time="YS").min()
+            np.testing.assert_array_equal(sfcWind_min, c)
 
 
 class TestSfcWindMax:
     test_data = "ERA5/daily_surface_cancities_1990-1993.nc"
 
     def test_sfcWindmax_max(self, nimbus):
-        ds = xr.open_dataset(nimbus.fetch(self.test_data), engine="h5netcdf")
-        sfcWindmax, _ = atmos.wind_speed_from_vector(ds.uas, ds.vas)
-
-        sfcWindmax_max = atmos.sfcWindmax_max(sfcWindmax)
-        c = sfcWindmax.resample(time="YS").max()
-        np.testing.assert_array_equal(sfcWindmax_max, c)
+        with xr.open_dataset(nimbus.fetch(self.test_data), engine="h5netcdf") as ds:
+            sfcWindmax, _ = atmos.wind_speed_from_vector(ds.uas, ds.vas)
+            sfcWindmax_max = atmos.sfcWindmax_max(sfcWindmax)
+            c = sfcWindmax.resample(time="YS").max()
+            np.testing.assert_array_equal(sfcWindmax_max, c)
 
     def test_sfcWindmax_mean(self, nimbus):
-        ds = xr.open_dataset(nimbus.fetch(self.test_data), engine="h5netcdf")
-        sfcWindmax, _ = atmos.wind_speed_from_vector(ds.uas, ds.vas)
-
-        sfcWindmax_mean = atmos.sfcWindmax_mean(sfcWindmax)
-        c = sfcWindmax.resample(time="YS").mean()
-        np.testing.assert_array_equal(sfcWindmax_mean, c)
+        with xr.open_dataset(nimbus.fetch(self.test_data), engine="h5netcdf") as ds:
+            sfcWindmax, _ = atmos.wind_speed_from_vector(ds.uas, ds.vas)
+            sfcWindmax_mean = atmos.sfcWindmax_mean(sfcWindmax)
+            c = sfcWindmax.resample(time="YS").mean()
+            np.testing.assert_array_equal(sfcWindmax_mean, c)
 
     def test_sfcWindmax_min(self, nimbus):
-        ds = xr.open_dataset(nimbus.fetch(self.test_data), engine="h5netcdf")
-        sfcWindmax, _ = atmos.wind_speed_from_vector(ds.uas, ds.vas)
-
-        sfcWindmax_min = atmos.sfcWindmax_min(sfcWindmax)
-        c = sfcWindmax.resample(time="YS").min()
-        np.testing.assert_array_equal(sfcWindmax_min, c)
+        with xr.open_dataset(nimbus.fetch(self.test_data), engine="h5netcdf") as ds:
+            sfcWindmax, _ = atmos.wind_speed_from_vector(ds.uas, ds.vas)
+            sfcWindmax_min = atmos.sfcWindmax_min(sfcWindmax)
+            c = sfcWindmax.resample(time="YS").min()
+            np.testing.assert_array_equal(sfcWindmax_min, c)

--- a/tests/test_wind.py
+++ b/tests/test_wind.py
@@ -8,7 +8,7 @@ from xclim import atmos
 
 class TestWindSpeedIndicators:
     def test_calm_windy_days(self, nimbus):
-        ds = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc"))
+        ds = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc"), engine="h5netcdf")
         sfcwind, _ = atmos.wind_speed_from_vector(ds.uas, ds.vas, calm_wind_thresh="0 m/s")
 
         calm = atmos.calm_days(sfcwind, thresh="5 m/s")
@@ -19,7 +19,7 @@ class TestWindSpeedIndicators:
 
 class TestSfcWindMax:
     def test_sfcWind_max(self, nimbus):
-        ds = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc"))
+        ds = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc"), engine="h5netcdf")
         sfcWind, _ = atmos.wind_speed_from_vector(ds.uas, ds.vas)
 
         sfcWind_max = atmos.sfcWind_max(sfcWind)
@@ -29,7 +29,7 @@ class TestSfcWindMax:
 
 class TestSfcWindMean:
     def test_sfcWind_mean(self, nimbus):
-        ds = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc"))
+        ds = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc"), engine="h5netcdf")
         sfcWind, _ = atmos.wind_speed_from_vector(ds.uas, ds.vas)
 
         sfcWind_mean = atmos.sfcWind_mean(sfcWind)
@@ -39,7 +39,7 @@ class TestSfcWindMean:
 
 class TestSfcWindMin:
     def test_sfcWind_min(self, nimbus):
-        ds = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc"))
+        ds = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc"), engine="h5netcdf")
         sfcWind, _ = atmos.wind_speed_from_vector(ds.uas, ds.vas)
 
         sfcWind_min = atmos.sfcWind_min(sfcWind)
@@ -49,7 +49,7 @@ class TestSfcWindMin:
 
 class TestSfcWindmaxMax:
     def test_sfcWindmax_max(self, nimbus):
-        ds = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc"))
+        ds = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc"), engine="h5netcdf")
         sfcWindmax, _ = atmos.wind_speed_from_vector(ds.uas, ds.vas)
 
         sfcWindmax_max = atmos.sfcWindmax_max(sfcWindmax)
@@ -59,7 +59,7 @@ class TestSfcWindmaxMax:
 
 class TestSfcWindmaxMean:
     def test_sfcWindmax_mean(self, nimbus):
-        ds = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc"))
+        ds = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc"), engine="h5netcdf")
         sfcWindmax, _ = atmos.wind_speed_from_vector(ds.uas, ds.vas)
 
         sfcWindmax_mean = atmos.sfcWindmax_mean(sfcWindmax)
@@ -69,7 +69,7 @@ class TestSfcWindmaxMean:
 
 class TestSfcWindmaxMin:
     def test_sfcWindmax_mean(self, nimbus):
-        ds = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc"))
+        ds = xr.open_dataset(nimbus.fetch("ERA5/daily_surface_cancities_1990-1993.nc"), engine="h5netcdf")
         sfcWindmax, _ = atmos.wind_speed_from_vector(ds.uas, ds.vas)
 
         sfcWindmax_min = atmos.sfcWindmax_min(sfcWindmax)

--- a/tests/test_wind.py
+++ b/tests/test_wind.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 import xarray as xr
 
 from xclim import atmos
@@ -21,48 +22,32 @@ class TestWindSpeedIndicators:
 class TestSfcWind:
     test_data = "ERA5/daily_surface_cancities_1990-1993.nc"
 
-    def test_sfcWind_max(self, nimbus):
+    @pytest.mark.parametrize(
+        "metric",
+        ["mean", "max", "min"],
+    )
+    def test_sfcWind(self, nimbus, metric):
         with xr.open_dataset(nimbus.fetch(self.test_data), engine="h5netcdf") as ds:
             sfcWind, _ = atmos.wind_speed_from_vector(ds.uas, ds.vas)
-            sfcWind_max = atmos.sfcWind_max(sfcWind)
-            c = sfcWind.resample(time="YS").max()
-            np.testing.assert_array_equal(sfcWind_max, c)
+            sfcWind_calculated = getattr(atmos, f"sfcWind_{metric}")(sfcWind)
 
-    def test_sfcWind_mean(self, nimbus):
-        with xr.open_dataset(nimbus.fetch(self.test_data), engine="h5netcdf") as ds:
-            sfcWind, _ = atmos.wind_speed_from_vector(ds.uas, ds.vas)
-            sfcWind_mean = atmos.sfcWind_mean(sfcWind)
-            c = sfcWind.resample(time="YS").mean()
-            np.testing.assert_array_equal(sfcWind_mean, c)
-
-    def test_sfcWind_min(self, nimbus):
-        with xr.open_dataset(nimbus.fetch(self.test_data), engine="h5netcdf") as ds:
-            sfcWind, _ = atmos.wind_speed_from_vector(ds.uas, ds.vas)
-            sfcWind_min = atmos.sfcWind_min(sfcWind)
-            c = sfcWind.resample(time="YS").min()
-            np.testing.assert_array_equal(sfcWind_min, c)
+            resample = sfcWind.resample(time="YS")
+            c = getattr(resample, metric)()
+            np.testing.assert_array_equal(sfcWind_calculated, c)
 
 
 class TestSfcWindMax:
     test_data = "ERA5/daily_surface_cancities_1990-1993.nc"
 
-    def test_sfcWindmax_max(self, nimbus):
+    @pytest.mark.parametrize(
+        "metric",
+        ["mean", "max", "min"],
+    )
+    def test_sfcWindmax(self, nimbus, metric):
         with xr.open_dataset(nimbus.fetch(self.test_data), engine="h5netcdf") as ds:
-            sfcWindmax, _ = atmos.wind_speed_from_vector(ds.uas, ds.vas)
-            sfcWindmax_max = atmos.sfcWindmax_max(sfcWindmax)
-            c = sfcWindmax.resample(time="YS").max()
-            np.testing.assert_array_equal(sfcWindmax_max, c)
+            sfcWind, _ = atmos.wind_speed_from_vector(ds.uas, ds.vas)
+            sfcWindmax_calculated = getattr(atmos, f"sfcWindmax_{metric}")(sfcWind)
 
-    def test_sfcWindmax_mean(self, nimbus):
-        with xr.open_dataset(nimbus.fetch(self.test_data), engine="h5netcdf") as ds:
-            sfcWindmax, _ = atmos.wind_speed_from_vector(ds.uas, ds.vas)
-            sfcWindmax_mean = atmos.sfcWindmax_mean(sfcWindmax)
-            c = sfcWindmax.resample(time="YS").mean()
-            np.testing.assert_array_equal(sfcWindmax_mean, c)
-
-    def test_sfcWindmax_min(self, nimbus):
-        with xr.open_dataset(nimbus.fetch(self.test_data), engine="h5netcdf") as ds:
-            sfcWindmax, _ = atmos.wind_speed_from_vector(ds.uas, ds.vas)
-            sfcWindmax_min = atmos.sfcWindmax_min(sfcWindmax)
-            c = sfcWindmax.resample(time="YS").min()
-            np.testing.assert_array_equal(sfcWindmax_min, c)
+            resample = sfcWind.resample(time="YS")
+            c = getattr(resample, metric)()
+            np.testing.assert_array_equal(sfcWindmax_calculated, c)


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #2179 
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGELOG.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Adds the `pytest-timeout` library for ending stalled tests.
* Configures the `pytest` options to use:
  * `session_timeout = 900` (15 mins for full test suite
  * `timeout = 300` (5 mins for an individual test; might be too high)
  * `timeout_method = "thread"` (Attempt to kill test thread rather than process)
* Fixes a bug caused by `netcdf4` engine when used with `pytest-xdist`

### Does this PR introduce a breaking change?

`pytest-timeout` is now a firm development dependency. Configured defaults might be too strict when running tests on very old/underpowered hardware.

### Other information:

https://github.com/pytest-dev/pytest-timeout