### PR TITLE
Fix robustness fractions and categories for no data

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,12 +10,14 @@ Announcements
 ^^^^^^^^^^^^^
 * The ``xclim.sdba`` module has been split from `xclim` into the new package `xsdba <https://github.com/Ouranosinc/xsdba>`_. Users must install `xsdba` from `PyPI` or `conda-forge` in order to maintain the `xclim.sdba` functionality. Refer to the `xsdba Migration Guide <https://xsdba.readthedocs.io/en/latest/xclim_migration_guide.html>`_ for more information. (:issue:`2074`, :pull:`2099`).
 
-New indicators
-^^^^^^^^^^^^^^
+New indicators and features
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 * New indicator ``xclim.atmos.clearness_index`` computes the `clearness_index` (ratio of downwards solar radiation to extraterrestrial solar radiation). (:pull:`2140`).
 * Added ``cooling_degree_days_approximation`` and ``heating_degree_days_approximation`` indices to compute the number of cooling and heating degree days with consideration for daily temperature cycles. (:issue:`1941`, :pull:`2135`).
 * Added dtr in variables.yml. (:issue:`2146`, :pull:`2147`).
 * Added Mahalanobis distance. (:issue:`2151`, :pull:`2157`).
+* Support for ``DataTree`` objects in indicators. All non-empty nodes of the tree must contain all required variables, non-variable parameters are the same for all nodes. (:issue:`2127`, :pull:`2144`).
+* Support for ``Dataset`` and ``DataTree`` objects in ``xc.core.units.convert_units_to``. Target units are passed as a mapping from variable name to units. Unmentionned variables are left untouched. (:issue:`2127`, :pull:`2144`).
 
 Bug fixes
 ^^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,7 +23,7 @@ Bug fixes
 * ``xclim.core.calendar.stack_periods`` was fixed to work with larger-than-daily source timesteps. Users are still encouraged to use `da.resample(time=FREQ).construct('period')` when possible. (:issue:`2148`, :pull:`2150`).
 * Update ``create_ensemble`` docstring to avoid confusion about how the function aligns realizations with different calendars. (:issue:`2108`, :pull:`2164`).
 * Fix ``xc.indices.run_length.find_events`` for multidimensional input using a cftime calendar. (:pull:`2172`).
-* ``xc.ensembles.robustness_fractions`` will now return 0 when all members were invalid (had missing values), this avoids faulty flags in ``robustness_categories``. (:issue:`2167`, :pull:`2178`).
+* ``xc.ensembles.robustness_fractions`` will now return 0 when all members were invalid (had missing values), this avoids faulty flags in ``robustness_categories``. The latter was also modified to read the ``valid`` fraction and mask its output accordingly. (:issue:`2167`, :pull:`2178`).
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,7 @@ Bug fixes
 * ``xclim.core.calendar.stack_periods`` was fixed to work with larger-than-daily source timesteps. Users are still encouraged to use `da.resample(time=FREQ).construct('period')` when possible. (:issue:`2148`, :pull:`2150`).
 * Update ``create_ensemble`` docstring to avoid confusion about how the function aligns realizations with different calendars. (:issue:`2108`, :pull:`2164`).
 * Fix ``xc.indices.run_length.find_events`` for multidimensional input using a cftime calendar. (:pull:`2172`).
+* ``xc.ensembles.robustness_fractions`` will now return 0 when all members were invalid (had missing values), this avoids faulty flags in ``robustness_categories``. (:issue:`2167`, :pull:`2178`).
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/src/xclim/ensembles/_robustness.py
+++ b/src/xclim/ensembles/_robustness.py
@@ -254,7 +254,7 @@ def robustness_fractions(  # noqa: C901
     out = xr.Dataset(
         {
             "changed": change_frac.assign_attrs(
-                description="Fraction of valid members showing significant change. " + test_str,
+                description=f"Fraction of valid members showing significant change. {test_str}",
                 units="",
                 test=str(test),
             ),
@@ -263,7 +263,7 @@ def robustness_fractions(  # noqa: C901
                 units="",
             ),
             "changed_positive": change_pos_frac.assign_attrs(
-                description="Fraction of valid members showing significant and positive change. " + test_str,
+                description=f"Fraction of valid members showing significant and positive change. {test_str}",
                 units="",
                 test=str(test),
             ),
@@ -272,7 +272,7 @@ def robustness_fractions(  # noqa: C901
                 units="",
             ),
             "changed_negative": change_neg_frac.assign_attrs(
-                description="Fraction of valid members showing significant and negative change. " + test_str,
+                description=f"Fraction of valid members showing significant and negative change. {test_str}",
                 units="",
                 test=str(test),
             ),
@@ -294,7 +294,7 @@ def robustness_fractions(  # noqa: C901
 
     if pvals is not None:
         pvals.attrs.update(
-            description="P-values from change significance test. " + test_str,
+            description=f"P-values from change significance test. {test_str}",
             units="",
         )
         out = out.assign(pvals=pvals)

--- a/src/xclim/ensembles/_robustness.py
+++ b/src/xclim/ensembles/_robustness.py
@@ -103,7 +103,8 @@ def robustness_fractions(  # noqa: C901
     Returns
     -------
     xr.Dataset
-        Same coordinates as `fut` and  `ref`, but no `time` and no `realization`. Variables returned are:
+        Same coordinates as `fut` and  `ref`, but no `time` and no `realization`.
+        Values are zero if all members were invalid. Variables returned are:
 
         - changed
             - The weighted fraction of valid members showing significant change.
@@ -129,7 +130,7 @@ def robustness_fractions(  # noqa: C901
 
         - valid
             - The weighted fraction of valid members.
-              A member is valid is there are no NaNs along the time axes of `fut` and `ref`.
+              A member is valid if there are no NaNs along the time axes of `fut` and `ref`.
 
         - pvals
             - The p-values estimated by the significance tests.
@@ -253,7 +254,7 @@ def robustness_fractions(  # noqa: C901
     out = xr.Dataset(
         {
             "changed": change_frac.assign_attrs(
-                description="Fraction of members showing significant change. " + test_str,
+                description="Fraction of valid members showing significant change. " + test_str,
                 units="",
                 test=str(test),
             ),
@@ -289,6 +290,7 @@ def robustness_fractions(  # noqa: C901
         },
         attrs={"description": "Significant change and sign of change fractions."},
     )
+    out = out.fillna(0)
 
     if pvals is not None:
         pvals.attrs.update(

--- a/tests/test_ensembles.py
+++ b/tests/test_ensembles.py
@@ -698,7 +698,7 @@ def test_robustness_fractions_delta(robust_data):
 
 
 def test_robustness_fractions_empty():
-    """Test that NaN is returned if input arrays are full of NaNs."""
+    """Test that arrays full of NaNs return appropriate values"""
     r = np.full((20, 10), np.nan)
     f = np.full((20, 10), np.nan)
 
@@ -706,7 +706,8 @@ def test_robustness_fractions_empty():
     fut = xr.DataArray(f, dims=("realization", "time"), name="tas")
 
     f = ensembles.robustness_fractions(fut, ref, test="ttest")
-    assert np.all(np.isnan(f.changed))
+    np.testing.assert_array_equal(f.changed, 0)
+    np.testing.assert_array_equal(f.valid, 0)
 
 
 def test_robustness_categories():


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #2167
- [x] Tests for the changes have been added (for bug fixes / features)
  - [x] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGELOG.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Instead of `NaN`, fractions are returned as 0 when there are no valid members.
* The categories are masked if no valid members were found.

### Does this PR introduce a breaking change?
Yes as the previous NaN output might have been expected (at least a test expected it). But all the information used here was already there before. 

### Other information:
