### PR TITLE
Allow pooch to be mocked

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,11 +4,15 @@ Changelog
 
 v0.58.0 (unreleased)
 --------------------
-Contributors to this version: Sebastian Lehner (:user:`seblehner`).
+Contributors to this version: Sebastian Lehner (:user:`seblehner`), Trevor James Smith (:user:`Zeitsperre`).
 
 New indicators
 ^^^^^^^^^^^^^^
 * New indicator ``xclim.atmos.antecedent_precipitation_index`` computes the `antecedent_precipitation_index` (weighted summation of daily precipitation amounts for a given window). (:issue:`2166`, :pull:`2184`).
+
+Internal changes
+^^^^^^^^^^^^^^^^
+* Modified internal logic for ``xclim.testing.utils.default_testdata_cache`` to support mocking of `pooch`.
 
 v0.57.0 (2025-05-22)
 --------------------

--- a/src/xclim/testing/utils.py
+++ b/src/xclim/testing/utils.py
@@ -78,7 +78,7 @@ default_testdata_repo_url = "https://raw.githubusercontent.com/Ouranosinc/xclim-
 try:
     default_testdata_cache = Path(pooch.os_cache("xclim-testdata"))
     """Default location for the testing data cache."""
-except AttributeError:
+except (AttributeError, TypeError):
     default_testdata_cache = None
 
 TESTDATA_REPO_URL = str(os.getenv("XCLIM_TESTDATA_REPO_URL", default_testdata_repo_url))


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGELOG.rst has been updated (with summary of main changes)
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Catches a really specific corner case that can affect downstream projects that rely on mocking of `pooch`.

### Does this PR introduce a breaking change?

No.

### Other information:

OK, this is wild. Let's say we want to install a very minimal amount of dependencies in order to reduce the memory load on ReadTheDocs; We can very safely mock most libraries and not need to worry unless one of the libraries expects to raise a specific error in the normal operation. 

If we mock `pooch` here, then the `pooch` call resolves but doesn't provide the expected data structure needed for `pathlib.Path` and instead of raising an Attribute error (`None` has no attributes), it raises instead a `TypeError` (the mocked `pooch.os_cache._type` is not a parsable string or Path).

Relevant Pull Request (`miranda`): https://github.com/Ouranosinc/miranda/pull/241