### PR TITLE
Add indexing to rolling indicators missing it

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,11 +4,13 @@ Changelog
 
 v0.58.0 (unreleased)
 --------------------
-Contributors to this version: Sebastian Lehner (:user:`seblehner`), Trevor James Smith (:user:`Zeitsperre`).
+Contributors to this version: Sebastian Lehner (:user:`seblehner`), Trevor James Smith (:user:`Zeitsperre`) and Pascal Bourgault (:user:`aulemahal`).
 
-New indicators
-^^^^^^^^^^^^^^
+New indicators and features
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 * New indicator ``xclim.atmos.antecedent_precipitation_index`` computes the `antecedent_precipitation_index` (weighted summation of daily precipitation amounts for a given window). (:issue:`2166`, :pull:`2184`).
+* Argument ``indexer`` added to indicators ``max_n_day_precipitation_amount``, ``max_pr_intensity``, and ``blowing_snow``. (:issue:`2187`, :pull:`2190`).
+* Argument ``window`` added to indicator ``rain_on_frozen_ground_days``. (:pull:`2190`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/src/xclim/indicators/atmos/_temperature.py
+++ b/src/xclim/indicators/atmos/_temperature.py
@@ -907,7 +907,7 @@ freshet_start = Temp(
     parameters={"thresh": {"default": "0 degC"}, "window": {"default": 5}},
 )
 
-frost_days = Temp(
+frost_days = TempWithIndexing(
     title="Frost days",
     identifier="frost_days",
     units="days",

--- a/src/xclim/indices/_simple.py
+++ b/src/xclim/indices/_simple.py
@@ -331,7 +331,9 @@ def tx_min(tasmax: xarray.DataArray, freq: str = "YS") -> xarray.DataArray:
 
 @declare_units(tasmin="[temperature]", thresh="[temperature]")
 def frost_days(
-    tasmin: xarray.DataArray, thresh: Quantified = "0 degC", freq: str = "YS", **indexer
+    tasmin: xarray.DataArray,
+    thresh: Quantified = "0 degC",
+    freq: str = "YS",
 ) -> xarray.DataArray:
     r"""
     Frost days index.
@@ -346,9 +348,6 @@ def frost_days(
         Freezing temperature.
     freq : str
         Resampling frequency.
-    **indexer : {dim: indexer}, optional
-        Indexing parameters to compute the frost days on a temporal subset of the data.
-        It accepts the same arguments as :py:func:`xclim.indices.generic.select_time`.
 
     Returns
     -------
@@ -365,8 +364,7 @@ def frost_days(
        TN_{ij} < TT
     """
     frz = convert_units_to(thresh, tasmin)
-    sel = select_time(tasmin, **indexer)
-    out = threshold_count(sel, "<", frz, freq)
+    out = threshold_count(tasmin, "<", frz, freq)
     return to_agg_units(out, tasmin, "count")
 
 
@@ -444,7 +442,9 @@ def max_1day_precipitation_amount(pr: xarray.DataArray, freq: str = "YS") -> xar
 
 
 @declare_units(pr="[precipitation]")
-def max_n_day_precipitation_amount(pr: xarray.DataArray, window: int = 1, freq: str = "YS") -> xarray.DataArray:
+def max_n_day_precipitation_amount(
+    pr: xarray.DataArray, window: int = 1, freq: str = "YS", **indexer
+) -> xarray.DataArray:
     r"""
     Highest precipitation amount cumulated over a n-day moving window.
 
@@ -459,6 +459,11 @@ def max_n_day_precipitation_amount(pr: xarray.DataArray, window: int = 1, freq: 
         Window size in days.
     freq : str
         Resampling frequency.
+    **indexer : {dim: indexer}, optional
+        Indexing parameters to compute the indicator on a temporal subset of the data.
+        The subset is taken after the N-day sum, thus including data from up to ``window // 2``
+        days before and after the selected period.
+        It accepts the same arguments as :py:func:`xclim.indices.generic.select_time`.
 
     Returns
     -------
@@ -476,11 +481,12 @@ def max_n_day_precipitation_amount(pr: xarray.DataArray, window: int = 1, freq: 
     # Rolling sum of the values
     pram = rate2amount(pr)
     arr = pram.rolling(time=window).sum(skipna=False)
+    arr = select_time(arr, **indexer)
     return arr.resample(time=freq).max(dim="time").assign_attrs(units=pram.units)
 
 
 @declare_units(pr="[precipitation]")
-def max_pr_intensity(pr: xarray.DataArray, window: int = 1, freq: str = "YS") -> xarray.DataArray:
+def max_pr_intensity(pr: xarray.DataArray, window: int = 1, freq: str = "YS", **indexer) -> xarray.DataArray:
     r"""
     Highest precipitation intensity over a n-hour moving window.
 
@@ -495,6 +501,11 @@ def max_pr_intensity(pr: xarray.DataArray, window: int = 1, freq: str = "YS") ->
         Window size in hours.
     freq : str
         Resampling frequency.
+    **indexer : {dim: indexer}, optional
+        Indexing parameters to compute the indicator on a temporal subset of the data.
+        The subset is taken after the N-hour average, thus including data from up to ``window // 2``
+        hours before and after the selected period.
+        It accepts the same arguments as :py:func:`xclim.indices.generic.select_time`.
 
     Returns
     -------
@@ -511,6 +522,7 @@ def max_pr_intensity(pr: xarray.DataArray, window: int = 1, freq: str = "YS") ->
     """
     # Rolling sum of the values
     arr = pr.rolling(time=window).mean(skipna=False)
+    arr = select_time(arr, **indexer)
     out = arr.resample(time=freq).max(dim="time")
 
     out.attrs["units"] = pr.units

--- a/tests/test_precip.py
+++ b/tests/test_precip.py
@@ -320,6 +320,15 @@ class TestMaxPrIntensity:
         out = atmos.max_pr_intensity(pr, window=2, freq="YS")
         np.testing.assert_array_almost_equal(out.isel(time=0), [8.5 * 3600, 3600])
 
+    def test_indexing(self, pr_hr_series):
+        pr = pr_hr_series(np.zeros(366 * 24))
+        pr[20:30] += np.arange(10)
+
+        out1 = atmos.max_pr_intensity(pr, window=2, freq="YS")
+        out2 = atmos.max_pr_intensity(pr, window=2, freq="YS", doy_bounds=[200, 1])
+        np.testing.assert_array_almost_equal(out1.isel(time=0), [8.5 * 3600])
+        np.testing.assert_array_almost_equal(out2.isel(time=0), [2.5 * 3600])
+
 
 class TestMax1Day:
     # testing of wet_day and daily_pr_intensity, both are related
@@ -389,6 +398,14 @@ class TestMaxNDay:
         assert np.allclose(rx3, out1.values[0, 0, 0])
         assert np.isnan(out1.values[0, 1, 0])
         assert np.isnan(out1.values[0, -1, -1])
+
+    def test_indexing(self, open_dataset):
+        pr = open_dataset(self.nc_file).pr
+        out1 = atmos.max_n_day_precipitation_amount(pr, window=7, freq="YS")
+        out2 = atmos.max_n_day_precipitation_amount(pr, window=7, freq="YS", month=[6, 7, 8])
+
+        assert out1.values[0, 0, 0] == 55.48
+        assert out2.values[0, 0, 0] == 50.57
 
 
 class TestMaxConsecWetDays:

--- a/tests/test_temperature.py
+++ b/tests/test_temperature.py
@@ -436,6 +436,14 @@ class TestFrostDays:
         assert np.isnan(fd.values[0, -1, -1])
         # assert (np.isnan(fds.values[0, -1, -1]))
 
+    def test_indexing(self, open_dataset):
+        tasmin = open_dataset("ERA5/daily_surface_cancities_1990-1993.nc").tasmin
+        fd1 = atmos.frost_days(tasmin, freq="YS")
+        fd2 = atmos.frost_days(tasmin, freq="YS", date_bounds=["09-01", "12-31"])
+
+        assert np.testing.assert_array_equal(fd1.isel(location=0), [90, 99, 114, 100])
+        assert np.testing.assert_array_equal(fd2.isel(location=0), [18, 23, 24, 17])
+
 
 class TestIceDays:
     nc_file = "NRCANdaily/nrcan_canada_daily_tasmax_1990.nc"


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #2187 
- [x] Tests for the changes have been added (for bug fixes / features)
  - [x] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGELOG.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Adds the  `**indexer` argument to a few indicators:  `max_n_day_precipitation_amount`, `max_pr_intensity` , `blowing_snow`. These were the only  "rolling" indicators missing it. 
* Modifies `frost_days` to use the Indexing class instead of explicitly handling indexing.
* At first I thought I add to add indexing to `rain_on_frozen_grounds_days` only to realize it was already inheriting it from its class. I generalized the `window` arg along the way.

These are "rolling" indicator as in the indice function does a `rolling` operation and after which the indexing should happen. The indexing feature is still missing the indicators that use `run_length` constructs.


### Does this PR introduce a breaking change?
No.

### Other information:
