### PR TITLE
Refactoring wine climatology indices

### DIFF
--- a/.github/workflows/cache-cleaner.yml
+++ b/.github/workflows/cache-cleaner.yml
@@ -23,6 +23,7 @@ jobs:
             api.github.com:443
             github.com:443
             objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
 
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
     hooks:
       - id: ruff-format
         exclude: '(src/xclim/indices/__init__.py|docs/installation.rst)'
-      - id: ruff
+      - id: ruff-check
         args: [ '--fix', '--show-fixes' ]
   - repo: https://github.com/pylint-dev/pylint
     rev: v3.3.7

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,18 +12,34 @@ New indicators and features
 * Argument ``indexer`` added to indicators ``max_n_day_precipitation_amount``, ``max_pr_intensity``, and ``blowing_snow``. (:issue:`2187`, :pull:`2190`).
 * Argument ``window`` added to indicator ``rain_on_frozen_ground_days``. (:pull:`2190`).
 * New helper ``xclim.indices.generic.season_length_from_boundaries`` takes `season_start` and `season_end` as input and gives `season_length`. This is used when starts and ends are computed with different resampling frequencies: `days_since` are used to compute temporal lengths in this case. (:pull:`2189`).
-* Allow `invalid_values` as argument for `relative_humidity_from_dewpoint`. (:pull:`2203`, :issue:`2202`)
+* Allow `invalid_values` as argument for ``relative_humidity_from_dewpoint``. (:pull:`2203`, :issue:`2202`)
 * New thermodynamic conversion indicators:
     + ``xclim.atmos.vapor_pressure`` to compute the partial pressure of water vapor from specific humidity and total pressure.
     + ``xclim.atmos.dewpoint_from_specific_humidity`` to compute the dewpoint temperature from specific humidity and total pressure.
-* All functions using saturation vapour pressure can now compute it with a smooth transition between saturation over ice and saturation over water. The transition is controlled by the ``interp_power`` , ``ice_thresh`` and ``water_thresh`` parameters. (:issue:`2165`, :pull:`2206`).
-    + New methods "buck81" and "aerk96" and new method "ECMWF" which is "buck81" on water and "aerk96" on ice.
+* All functions using saturation vapour pressure can now compute it with a smooth transition between saturation over ice and saturation over water. The transition is controlled by the `interp_power` , `ice_thresh` and `water_thresh` parameters. (:issue:`2165`, :pull:`2206`).
+    + New methods `"buck81"` and `"aerk96"` and new method `"ECMWF"` which is `"buck81"` on water and `"aerk96"` on ice.
     + Saturation vapor pressure calculations were reorganized. ``xclim.indices._conversion.ESAT_FORMULAS_COEFFICIENTS`` now stores the August-Roche-Magnus formula's coefficients.
 * New indicator ``xclim.atmos.hot_days`` as counterpart to ``xclim.atmos.frost_days``. (:issue:`2194`, :pull:`2213`).
+* New helper indices for computing the day-length coefficient for viticulture growing seasons based on several approaches:
+    * ``xclim.indices.helpers.gladstones_day_length_coefficient``: Based on the Gladstones (1992, 2011) method.
+    * ``xclim.indices.helpers.huglin_day_length_coefficient``: Based on the Huglin (1978, 1998) method.
+    * ``xclim.indices.helpers.jones_day_length_coefficient``: Based on the approach outlined in Hall and Jones (2010).
+* The ``xclim.indices.helpers.day_length`` function now accepts an `infill_polar_days` argument to control whether polar days or polar nights are filled with NaNs (`infill_polar_days=False`; default behaviour) or with a day length of 0 or 24 hours, depending on the date (`infill_polar_days=True`). (:issue:`2201`, :pull:`2207`).
+
+Breaking changes
+^^^^^^^^^^^^^^^^
+* The ``"jones"`` method for calculating `'k'` in ``xclim.indices.huglin_index`` and ``xclim.indices.biologically_effective_degree_days`` now require daily data computed at annual frequencies (`freq="YS"|"YS-JAN"|"YS-JUL"`). The previous behaviour for non-annual frequencies was undefined. (:issue:`2201`, :pull:`2207`).
+    * The ``"jones"`` method now sets a floor value for `'k'` where it is not allowed to be less than `'1.0'`. This is to avoid values below `'1.0'` for `'k'` which were previously allowed in `xclim` but not supported by the source literature.
+    * Incomplete growing seasons (where the values of `'k'` for all latitudes during the growing season are all below `'1.0'`) will now raise `ValueError`. This is to ensure that the expected output is consistent with the literature.
+* The ``"gladstones"`` method for calculating `'k'` in ``xclim.indices.biologically_effective_degree_days`` now uses a dedicated function based on a dynamic day_length compared to a reference latitude (40 degrees). The previous implementation of the `'gladstones'` method was based off an approximation found in Hall and Jones (2010). (:issue:`2201`, :pull:`2207`).
+    * The ``"gladstones"`` approximation is now available as a separate helper function: ``xclim.indices.helpers.jones_day_length_coefficient`` with `method="gladstones"`.
+* The ``"icclim"`` method for calculating `'k'` in ``xclim.indices.huglin_index`` has been renamed the ``"huglin"`` method. The ``"icclim"`` method was identical to the implementation proposed in Huglin (1978). (:issue:`2201`, :pull:`2207`).
 
 Internal changes
 ^^^^^^^^^^^^^^^^
 * Modified internal logic for ``xclim.testing.utils.default_testdata_cache`` to support mocking of `pooch`. (:pull:`2188`).
+* The `xclim.indices.helpers` module now uses an `__all__` variable to explicitly define the public API of the module. (:pull:`2207`).
+* Viticulture indices are more heavily tested and employ type guarding to ensure that parameters passed are those of the expected types. (:pull:`2207`).
 
 Bug fixes
 ^^^^^^^^^

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -25,9 +25,23 @@
   title = {Nouveau mode d'évaluation des possibilités héliothermiques d'un milieu viticole},
   booktitle = {Symposium {International} sur l'Écologie de la {Vigne}},
   publisher = {Ministère de l'Agriculture et de l'Industrie Alimentaire},
-  author = {Huglin, P.},
+  author = {Huglin, Pierre},
+  language = {fr},
   year = {1978},
   pages = {89--98}
+}
+
+
+@book{huglin_biologie_1998,
+  address = {Paris, France},
+  title = {Biologie et {Écologie} de la {Vigne}},
+  isbn = {978-2743002602},
+  author = {Huglin, Pierre and Schneider, Christophe},
+  publisher = {Tec et Doc},
+  language = {fr},
+  year = {1998},
+  month = {aug},
+  pages = {1--370}
 }
 
 

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -19,6 +19,16 @@
 }
 
 
+@book{gladstones_wine_2011,
+  address = {Adelaide},
+  title = {{Wine}, {Terroir} and {Climate Change}},
+  isbn = {978-1-74305-032-3},
+  publisher = {Wakefield Press},
+  author = {Gladstones, John},
+  year = {2011}
+}
+
+
 @incollection{huglin_nouveau_1978,
   address = {Constança, Roumanie},
   series = {1},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,7 +154,7 @@ values = [
 ]
 
 [tool.codespell]
-skip = '*xclim/data/*.json,*docs/_build,*docs/notebooks/xclim_training/*.ipynb,*docs/references.bib,*.gz,*.nc,*.png,*.svg,*.whl'
+skip = '*xclim/data/*.json,*docs/_build,*docs/notebooks/xclim_training/*.ipynb,*docs/*.bib,*.gz,*.nc,*.png,*.svg,*.whl'
 ignore-words-list = "absolue,astroid,bloc,bui,callendar,degreee,environnement,hanel,indx,inferrable,lond,nam,nd,ot,ressources,socio-economic,sie,vas"
 
 [tool.coverage.run]

--- a/src/xclim/indices/_agro.py
+++ b/src/xclim/indices/_agro.py
@@ -254,6 +254,8 @@ def huglin_index(
                 date_bounds=(start_date, end_date),
                 include_bounds=(True, False),
             )
+            .dropna(dim="time", how="all")
+            .dropna(dim="lat", how="any")
             .resample(time=freq)
             .sum()
         )

--- a/src/xclim/indices/_agro.py
+++ b/src/xclim/indices/_agro.py
@@ -242,7 +242,7 @@ def huglin_index(
 
     k: int | xarray.DataArray = 1
     k_aggregated: xarray.DataArray | None = None
-    if method.lower() in ["huglin", "icclim", "interpolated"]:
+    if (method:=method.lower()) in ["huglin", "icclim", "interpolated"]:
         if method == "icclim":
             warnings.warn("Method 'icclim' is deprecated. Use 'stepwise' instead.", DeprecationWarning)
             method = "huglin"

--- a/src/xclim/indices/_agro.py
+++ b/src/xclim/indices/_agro.py
@@ -519,7 +519,7 @@ def cool_night_index(
         elif lat.lower() == "south":
             month = 3
         else:
-            raise ValueError(f"Latitude value not implemented: {lat}.")
+            raise NotImplementedError(f"Latitude value not implemented: {lat}.")
     else:
         raise ValueError("Latitude must be a DataArray or str ('north' or 'south').")
 

--- a/src/xclim/indices/_agro.py
+++ b/src/xclim/indices/_agro.py
@@ -242,7 +242,7 @@ def huglin_index(
 
     k: int | xarray.DataArray = 1
     k_aggregated: xarray.DataArray | None = None
-    if (method:=method.lower()) in ["huglin", "icclim", "interpolated"]:
+    if (method := method.lower()) in ["huglin", "icclim", "interpolated"]:
         if method == "icclim":
             warnings.warn("Method 'icclim' is deprecated. Use 'stepwise' instead.", DeprecationWarning)
             method = "huglin"

--- a/src/xclim/indices/_agro.py
+++ b/src/xclim/indices/_agro.py
@@ -143,6 +143,7 @@ def corn_heat_units(
     tasmax="[temperature]",
     lat="[]",
     thresh="[temperature]",
+    cap_latitude="[]",
 )
 def huglin_index(
     tas: xarray.DataArray,
@@ -150,7 +151,7 @@ def huglin_index(
     lat: xarray.DataArray | None = None,
     thresh: Quantified = "10 degC",
     method: str = "smoothed",
-    cap_latitude: bool | int | float = True,
+    cap_latitude: bool | str = True,
     start_date: DayOfYearStr = "04-01",
     end_date: DayOfYearStr = "10-01",
     freq: Literal["YS", "YS-JAN", "YS-JUL"] = "YS",
@@ -176,10 +177,10 @@ def huglin_index(
     method : {"icclim", "jones", "smoothed", "stepwise"}
         The formula to use for the latitude coefficient calculation.
         The "icclim" method is identical to the "stepwise" method.
-    cap_latitude : bool or int or float
+    cap_latitude : bool or str
         Whether to cap the latitude at 50°N or 50°S.
         If true, values above 50°N or below 50°S will be set to NaN.
-        If an int or float, it will be used as the cap value.
+        If str (e.g. "45 degree_north"), it will be used as the cap value.
         if False, values above 50°N or below 50°S will be set to 1.0.
         Default: True.
     start_date : DayOfYearStr
@@ -277,6 +278,7 @@ def huglin_index(
     low_dtr="[temperature]",
     high_dtr="[temperature]",
     max_daily_degree_days="[temperature]",
+    cap_latitude="[]",
 )
 def biologically_effective_degree_days(
     tasmin: xarray.DataArray,
@@ -287,7 +289,7 @@ def biologically_effective_degree_days(
     low_dtr: Quantified = "10 degC",
     high_dtr: Quantified = "13 degC",
     max_daily_degree_days: Quantified = "9 degC",
-    cap_latitude: bool | int | float = True,
+    cap_latitude: bool | str = True,
     start_date: DayOfYearStr = "04-01",
     end_date: DayOfYearStr = "11-01",
     freq: Literal["YS", "YS-JAN", "YS-JUL"] = "YS",

--- a/src/xclim/indices/_agro.py
+++ b/src/xclim/indices/_agro.py
@@ -218,13 +218,13 @@ def huglin_index(
     - For the `"huglin"/"icclim"` and `"interpolated"` methods, values for k increase from `1.0` at 40°N or 40°S to `1.06` at 50°N or 50°S,
       where the `interpolated` method uses a smoothed curve and the `huglin/icclim` method uses a stepwise function.
       Values above 50°N or below 50°S are set via the `cap_value` variable, with `1.0` set as default.
-      See: :py:func:`xclim.indices.helpers.day_length_latitude_coefficient` for more information.
+      See: :py:func:`xclim.indices.helpers.huglin_day_length_latitude_coefficient` for more information.
     - For the `"jones"` method, A more robust day-length calculation based on latitude, calendar, day-of-year,
       and obliquity is used. The current implementation requires an annual frequency for consistent results.
       See: :py:func:`xclim.indices.generic.jones_day_length_coefficient` or :cite:t:`hall_spatial_2010` for more information.
 
     For compatibility with the original ICCLIM implementation :cite:p:`project_team_eca&d_algorithm_2013`,
-    `end_date` should be set to `11-01` with `method="huglin"` or `method="icclim"` (deprecated).
+    `end_date` should be set to `11-01` with `method="huglin"`.
 
     References
     ----------

--- a/src/xclim/indices/helpers.py
+++ b/src/xclim/indices/helpers.py
@@ -586,7 +586,7 @@ def aggregated_day_length_latitude_coefficient(
     method: Literal["gladstones", "jones"],
     start_date: DayOfYearStr = "04-01",
     end_date: DayOfYearStr = "11-01",
-    freq: str = "YS",
+    freq: Literal["YS", "YS-JAN", "YS-JUL"] = "YS",
 ) -> xr.DataArray:
     """
     Complex day length latitude coefficient.
@@ -605,9 +605,8 @@ def aggregated_day_length_latitude_coefficient(
         The start date of the growing season.
     end_date : DayOfYearStr
         The end date of the growing season. Date is not included in the aggregation.
-    freq : str
+    freq : {"YS", "YS-JAN", "YS-JUL"}
         The frequency at which to aggregate the day lengths.
-        Must be an annual frequency, such as "YS" or "YS-*" for methods "gladstones" and "jones".
 
     Returns
     -------

--- a/src/xclim/indices/helpers.py
+++ b/src/xclim/indices/helpers.py
@@ -599,7 +599,7 @@ def gladstones_day_length_latitude_coefficient(
     dates: xr.DataArray,
     lat: xr.DataArray | int | float,
     neutral_latitude: str = "40.0 deg",
-    constrain: bool | str = False,
+    constrain: str | None = None,
     day_length_method: Literal["simple", "spencer"] = "spencer",
 ) -> xr.DataArray:
     """
@@ -620,11 +620,9 @@ def gladstones_day_length_latitude_coefficient(
         Latitudes between this value and 0 degrees North will have a coefficient below 1.0 during the growing season,
         while latitudes above this value will have a coefficient greater than 1.0.
         This negative absolute value of this latitude is used for the Southern Hemisphere.
-    constrain : bool or str
-        The lower latitude limit for the coefficient.
-        If True, latitudes below 25 degrees North and above 25 degrees South will have a coefficient of 1.0.
-        If False, the coefficient is calculated for all near-equatorial latitudes.
-        If a str is given, it is used as the lower latitude limit for the coefficient.
+    constrain : str, optional
+        The lower latitude limit for applying the latitude coefficient.
+        If a str is given (e.g. '25 degree_north`), values below this threshold will be set to '1.0'.
     day_length_method : {'simple', 'spencer'}
         The method to use for the day length calculation.
         The "simple" method uses a simple approximation of the day length based on latitude and time of year.
@@ -640,14 +638,12 @@ def gladstones_day_length_latitude_coefficient(
     if day_length_method not in ["simple", "spencer"]:
         raise NotImplementedError("day_length_method must be one of 'simple' or 'spencer'.")
 
-    if not constrain:
-        constrain_value = False
-    elif isinstance(constrain, bool):
-        constrain_value = 25.0
-    elif isinstance(constrain, str):
+    if isinstance(constrain, str):
         constrain_value = convert_units_to(constrain, "deg")
+    elif constrain is None:
+        constrain_value = False
     else:
-        raise ValueError("Argument 'constrain' must be a bool or str (e.g. '25 degree_north').")
+        raise ValueError("Argument 'constrain' must be a str (e.g. '25 degree_north') or 'None'.")
 
     _neutral_latitude = convert_units_to(neutral_latitude, "deg")
 

--- a/src/xclim/indices/helpers.py
+++ b/src/xclim/indices/helpers.py
@@ -602,12 +602,12 @@ def huglin_day_length_latitude_coefficient(
     lat_abs = abs(lat)
     if method == "huglin":
         k_f = [0, 0.02, 0.03, 0.04, 0.05, 0.06]
-        k_f_bounds = [(0,0,40), (0.02,40,42), (0.03,42,44), (0.04,44,46), (0.05,46,48), (0.06,48,50)]
-        k = xr.fill_like(lat_abs, _cap_value+1)
-        
-        for k_f_b in  k_f_bounds:
-            cond = (k_f_b[1] < lat_abs)&(lat_abs <= k_f_b[2])
-            k = k.where(~cond, 1+k_f_b[0])
+        k_f_bounds = [(0, 0, 40), (0.02, 40, 42), (0.03, 42, 44), (0.04, 44, 46), (0.05, 46, 48), (0.06, 48, 50)]
+        k = xr.fill_like(lat_abs, _cap_value + 1)
+
+        for k_f_b in k_f_bounds:
+            cond = (k_f_b[1] < lat_abs) & (lat_abs <= k_f_b[2])
+            k = k.where(~cond, 1 + k_f_b[0])
     elif method == "interpolated":
         lat_mask = lat_abs <= 50
         lat_coefficient = 1 + ((lat_abs - 40) / 10).clip(min=0) * 0.06

--- a/src/xclim/indices/helpers.py
+++ b/src/xclim/indices/helpers.py
@@ -497,7 +497,7 @@ def day_lengths(
     ----------
     :cite:cts:`kalogirou_chapter_2014`
     """
-    if xr.infer_freq(dates) != "D":
+    if len(dates) >= 3 and xr.infer_freq(dates) != "D":
         raise NotImplementedError("day_lengths only supports daily data.")
 
     declination = solar_declination(dates.time, method=method)

--- a/src/xclim/indices/helpers.py
+++ b/src/xclim/indices/helpers.py
@@ -602,27 +602,12 @@ def huglin_day_length_latitude_coefficient(
     lat_abs = abs(lat)
     if method == "huglin":
         k_f = [0, 0.02, 0.03, 0.04, 0.05, 0.06]
-        k = 1 + xr.where(
-            lat_abs <= 40,
-            k_f[0],
-            xr.where(
-                (40 < lat_abs) & (lat_abs <= 42),
-                k_f[1],
-                xr.where(
-                    (42 < lat_abs) & (lat_abs <= 44),
-                    k_f[2],
-                    xr.where(
-                        (44 < lat_abs) & (lat_abs <= 46),
-                        k_f[3],
-                        xr.where(
-                            (46 < lat_abs) & (lat_abs <= 48),
-                            k_f[4],
-                            xr.where((48 < lat_abs) & (lat_abs <= 50), k_f[5], _cap_value),
-                        ),
-                    ),
-                ),
-            ),
-        )
+        k_f_bounds = [(0,0,40), (0.02,40,42), (0.03,42,44), (0.04,44,46), (0.05,46,48), (0.06,48,50)]
+        k = xr.fill_like(lat_abs, _cap_value+1)
+        
+        for k_f_b in  k_f_bounds:
+            cond = (k_f_b[1] < lat_abs)&(lat_abs <= k_f_b[2])
+            k = k.where(~cond, 1+k_f_b[0])
     elif method == "interpolated":
         lat_mask = lat_abs <= 50
         lat_coefficient = 1 + ((lat_abs - 40) / 10).clip(min=0) * 0.06

--- a/src/xclim/indices/helpers.py
+++ b/src/xclim/indices/helpers.py
@@ -242,7 +242,7 @@ def eccentricity_correction_factor(
 def cosine_of_solar_zenith_angle(
     time: xr.DataArray,
     declination: xr.DataArray,
-    lat: Quantified | xr.DataArray | xr.DataTree,
+    lat: Quantified | xr.DataTree,
     lon: Quantified = "0 °",
     time_correction: xr.DataArray | None = None,
     stat: Literal["average", "integral", "instant"] = "average",
@@ -515,7 +515,8 @@ def day_lengths(
         polar_night = ((lat_broadcast > 66.5) & (decl_broadcast < 0)) | ((lat_broadcast < -66.5) & (decl_broadcast > 0))
         # Infill polar days with 24 hours and polar nights with 0 hours.
         valid = ~xr.ufuncs.isnan(day_length_hours)
-        day_length_hours = xr.where(polar_day & ~valid, 24.0, xr.where(polar_night & ~valid, 0.0, day_length_hours))
+        day_length_hours = day_length_hours.where(~(polar_day & ~valid), 24.0)
+        day_length_hours = day_length_hours.where(~(polar_night & ~valid), 0)
 
     # Drop nonessential coordinates
     for coord in day_length_hours.coords:

--- a/src/xclim/indices/helpers.py
+++ b/src/xclim/indices/helpers.py
@@ -727,7 +727,8 @@ def jones_day_length_latitude_coefficient(
         The "jones" method .
         The "gladstones" method uses an approximation of the Gladstones methodology for day length latitude coefficient.
     floor : bool, optional
-        For latitudes below 50° N and above 50° S, the value for the coefficient is floored to '1.0'.
+        If True, latitudes where the day length latitude coefficient would be below '1.0', the value is set to '1.0'.
+        if False, coefficient can be below '1.0' for latitudes where the day length is less than the reference latitude.
     start_date : str or DayOfYearStr
         The start date of the growing season.
     end_date : str or DayOfYearStr
@@ -789,7 +790,6 @@ def jones_day_length_latitude_coefficient(
             .sum()
         )
         k_jones: xr.DataArray = (2.8311e-4 * day_length) + 0.30834
-
         if method == "jones":
             k_aggregated = k_jones
         else:

--- a/src/xclim/indices/helpers.py
+++ b/src/xclim/indices/helpers.py
@@ -493,7 +493,7 @@ def day_lengths(
 def huglin_day_length_latitude_coefficient(
     lat: xr.DataArray | str,
     method: Literal["huglin", "interpolated"],
-    cap_value: float = 1.0,
+    cap_value: float = np.nan,
 ):
     r"""
     Simple coefficient for the day-length and high latitudes.
@@ -510,7 +510,7 @@ def huglin_day_length_latitude_coefficient(
         The method to use for the coefficient calculation.
     cap_value : float
         For latitudes north of 50° N and south of 50° S, the value for the coefficient.
-        Default: 1.0.
+        Default: np.nan.
 
     Returns
     -------
@@ -546,7 +546,7 @@ def huglin_day_length_latitude_coefficient(
                      m, & \text{if } | lat | > 50 \\
                      \end{cases}
 
-    Where :math:`m` is the cap value, which is set to a float value of 1.0, or other if provided.
+    Where :math:`m` is the cap value, which is set to np.nan, or other if provided.
 
     References
     ----------
@@ -554,12 +554,14 @@ def huglin_day_length_latitude_coefficient(
     """
     if isinstance(lat, str):
         _lat_value = convert_units_to(lat, "deg")
-        lat = xr.DataArray(lat, attrs={"units": "degree_north"})
+        _lat = xr.DataArray(lat, attrs={"units": "degree_north"})
+    else:
+        _lat = lat
 
     if isinstance(cap_value, float):
         _cap_value = cap_value
     else:
-        raise TypeError("Argument 'cap_value' must be a bool, int or float.")
+        raise TypeError("Argument 'cap_value' must be a float (or numpy.nan).")
 
     lat_abs = abs(lat)
     if method == "interpolated":

--- a/src/xclim/indices/helpers.py
+++ b/src/xclim/indices/helpers.py
@@ -601,10 +601,8 @@ def huglin_day_length_latitude_coefficient(
 
     lat_abs = abs(lat)
     if method == "huglin":
-        k_f = [0, 0.02, 0.03, 0.04, 0.05, 0.06]
-        k_f_bounds = [(0, 0, 40), (0.02, 40, 42), (0.03, 42, 44), (0.04, 44, 46), (0.05, 46, 48), (0.06, 48, 50)]
-        k = xr.fill_like(lat_abs, _cap_value + 1)
-
+        k_f_bounds = [(0, -np.inf, 40), (0.02, 40, 42), (0.03, 42, 44), (0.04, 44, 46), (0.05, 46, 48), (0.06, 48, 50)]
+        k = xr.full_like(lat_abs, _cap_value + 1)
         for k_f_b in k_f_bounds:
             cond = (k_f_b[1] < lat_abs) & (lat_abs <= k_f_b[2])
             k = k.where(~cond, 1 + k_f_b[0])

--- a/src/xclim/indices/helpers.py
+++ b/src/xclim/indices/helpers.py
@@ -267,7 +267,7 @@ def cosine_of_solar_zenith_angle(
     declination : xr.DataArray
         Solar declination. See :py:func:`solar_declination`.
     lat : Quantified
-        Latitude.
+        Latitude coordinate. Expects units of "degree_north".
     lon : Quantified
         Longitude. Needed if the input timeseries is subdaily.
     time_correction : xr.DataArray, optional
@@ -417,7 +417,7 @@ def extraterrestrial_solar_radiation(
     times : xr.DataArray
         Daily datetime data. This function makes no sense with data of other frequency.
     lat : xr.DataArray
-        Latitude.
+        Latitude coordinate. Expects units of "degree_north".
     solar_constant : str
         The solar constant, the energy received on earth from the sun per surface per time.
     method : {'spencer', 'simple'}
@@ -443,7 +443,7 @@ def extraterrestrial_solar_radiation(
     return (
         gsc
         * rad_to_day
-        * cosine_of_solar_zenith_angle(times, ds, lat, stat="integral", sunlit=True, chunks=chunks)
+        * cosine_of_solar_zenith_angle(times, ds, lat=lat, stat="integral", sunlit=True, chunks=chunks)
         * dr
     ).assign_attrs(units="J m-2 d-1")
 
@@ -466,7 +466,7 @@ def day_lengths(
         Daily datetime data.
         This function makes no sense with data of other time frequencies.
     lat : Quantified or xarray.Dataset or xarray.DataTree
-        Latitude coordinate.
+        Latitude coordinate. Expects units of "degree_north".
     method : {'spencer', 'simple'}
         Which approximation to use when computing the solar declination angle.
         See :py:func:`xclim.indices.helpers.solar_declination`.
@@ -541,7 +541,7 @@ def huglin_day_length_latitude_coefficient(
     Parameters
     ----------
     lat : xarray.DataArray, str
-        Latitude coordinate.
+        Latitude coordinate. Expects units of "degree_north".
         If provided a string (e.g. "45 degree_north"), it is converted to an xarray.DataArray.
     method : {"huglin", "interpolated"}
         The method to use for the coefficient calculation.
@@ -652,7 +652,8 @@ def gladstones_day_length_latitude_coefficient(
     dates : xarray.DataArray
         The dates for which the day length latitude coefficient is computed.
     lat : xarray.DataArray or int or float
-        Latitude coordinate. If a single value is given, it is converted to an xarray.DataArray.
+        Latitude coordinate. Expects units of "degree_north".
+        If a single value is given, it is converted to an xarray.DataArray.
     neutral_latitude : str
         The latitude at which the day length coefficient is 1.0.
         Latitudes between this value and 0 degrees North will have a coefficient below 1.0 during the growing season,
@@ -722,7 +723,8 @@ def jones_day_length_latitude_coefficient(
     dates : xarray.DataArray
         The dates for which the day length latitude coefficient is computed.
     lat : xr.DataArray or xr.Dataset or xr.DataTree
-        Latitude coordinate. If a single value is given, it is converted to an xarray.DataArray.
+        Latitude coordinate. Expects units of "degree_north".
+        If a single value is given, it is converted to an xarray.DataArray.
     method : {"gladstones", "jones"}
         The method to use for the coefficient calculation.
         The "jones" method .

--- a/src/xclim/indices/helpers.py
+++ b/src/xclim/indices/helpers.py
@@ -448,7 +448,7 @@ def day_lengths(
     dates : xr.DataArray
         Daily datetime data.
         This function makes no sense with data of other frequency.
-    lat : xarray.DataArray
+    lat : Quantified or xarray.Dataset or xarray.DataTree
         Latitude coordinate.
     method : {'spencer', 'simple'}
         Which approximation to use when computing the solar declination angle.

--- a/src/xclim/indices/helpers.py
+++ b/src/xclim/indices/helpers.py
@@ -748,7 +748,7 @@ def jones_day_length_latitude_coefficient(
 
     .. math::
 
-        totalSeasonDayLength_{Lat} = \\sum_{Jday=\text{103}}^{\text{284}}{dayLength_{Lat_{JDay}}}
+        totalSeasonDayLength_{Lat} = \sum_{Jday=\text{103}}^{\text{284}}{dayLength_{Lat_{JDay}}}
 
     The day length latitude coefficient (:math:`k`) using the "jones" method is calculated as follows:
 

--- a/src/xclim/indices/helpers.py
+++ b/src/xclim/indices/helpers.py
@@ -464,12 +464,12 @@ def day_lengths(
     ----------
     dates : xr.DataArray
         Daily datetime data.
-        This function makes no sense with data of other frequency.
+        This function makes no sense with data of other time frequencies.
     lat : Quantified or xarray.Dataset or xarray.DataTree
         Latitude coordinate.
     method : {'spencer', 'simple'}
         Which approximation to use when computing the solar declination angle.
-        See :py:func:`solar_declination`.
+        See :py:func:`xclim.indices.helpers.solar_declination`.
     infill_polar_days : bool
         Whether to use a mask of 24 hours for polar days and 0 hours for polar nights.
         If False, polar days and nights will be NaN.
@@ -480,6 +480,11 @@ def day_lengths(
     -------
     xarray.DataArray, [hours]
         Day-lengths in hours per individual day.
+
+    Raises
+    ------
+    NotImplementedError
+        If dates provided are not inferrable at a daily time frequency.
 
     Notes
     -----
@@ -492,6 +497,9 @@ def day_lengths(
     ----------
     :cite:cts:`kalogirou_chapter_2014`
     """
+    if xr.infer_freq(dates) != "D":
+        raise NotImplementedError("day_lengths only supports daily data.")
+
     declination = solar_declination(dates.time, method=method)
     radians = convert_units_to(lat, "rad")
     lat_deg = convert_units_to(lat, "deg")
@@ -537,7 +545,6 @@ def huglin_day_length_latitude_coefficient(
         The method to use for the coefficient calculation.
     cap_value : float
         For latitudes north of 50° N and south of 50° S, the value for the coefficient.
-        Default: np.nan.
 
     Returns
     -------
@@ -697,8 +704,8 @@ def jones_day_length_latitude_coefficient(
     dates: xr.DataArray,
     lat: xr.DataArray | xr.Dataset | xr.DataTree,
     method: Literal["gladstones", "jones"],
-    start_date: DayOfYearStr = "04-01",
-    end_date: DayOfYearStr = "11-01",
+    start_date: str | DayOfYearStr = "04-01",
+    end_date: str | DayOfYearStr = "11-01",
     freq: Literal["YS", "YS-JAN", "YS-JUL"] = "YS",
 ) -> xr.DataArray:
     """
@@ -717,13 +724,14 @@ def jones_day_length_latitude_coefficient(
         The method to use for the coefficient calculation.
         The "jones" method .
         The "gladstones" method uses an approximation of the Gladstones methodology for day length latitude coefficient.
-    start_date : DayOfYearStr
+    start_date : str or DayOfYearStr
         The start date of the growing season.
-    end_date : DayOfYearStr
+    end_date : str or DayOfYearStr
         The end date of the growing season. Date is not included in the aggregation.
     freq : {"YS", "YS-JAN", "YS-JUL"}
         The frequency at which to aggregate the day lengths.
-        Must be an annual frequency, such as "YS" or "YS-JAN" (yearly start), "YS-JUL" (yearly start in July),
+        Must be an annual frequency, such as "YS" or "YS-JAN" (yearly start in January)
+        or "YS-JUL" (yearly start in July).
 
     Returns
     -------

--- a/src/xclim/indices/helpers.py
+++ b/src/xclim/indices/helpers.py
@@ -473,7 +473,7 @@ def day_lengths(
 
 
 def day_length_latitude_coefficient(
-    lat: xr.DataArray | int | float,
+    lat: xr.DataArray | str,
     method: Literal["stepwise", "smoothed"],
     cap_value: bool | float | int,
 ):
@@ -485,8 +485,8 @@ def day_length_latitude_coefficient(
 
     Parameters
     ----------
-    lat : xarray.DataArray, int or float
-        Latitude coordinate. If a single value is given, it is converted to an xarray.DataArray.
+    lat : xarray.DataArray, str
+        Latitude coordinate. If provided a string (e.g. "45 degree_north"), it is converted to an xarray.DataArray.
     method : {"smoothed", "stepwise"}
         The method to use for the coefficient calculation.
     cap_value : bool or float
@@ -532,8 +532,9 @@ def day_length_latitude_coefficient(
     ----------
     :cite:cts:`huglin_nouveau_1978,project_team_eca&d_algorithm_2013`
     """
-    if isinstance(lat, int | float):
-        lat = xr.DataArray(lat)
+    if isinstance(lat, str):
+        _lat_value = convert_units_to(lat, "deg")
+        lat = xr.DataArray(lat, attrs={"units": "degree_north"})
 
     if cap_value:
         if isinstance(cap_value, bool):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -150,6 +150,15 @@ class TestDayLength:
                 False,
                 [1.18, 1.07, 1.02, 0.99, 0.97, 0.95, 0.93, 0.91, 0.89, 0.86, 0.83, 0.78, 0.67],
             ),
+            # Incomplete growing season; Raise a ValueError
+            (
+                "jones",
+                "04-01",
+                "11-01",
+                "YS-JUL",
+                False,
+                None,
+            ),
         ],
     )
     def test_jones_day_length_latitude_coefficient(self, method, start_date, end_date, freq, floor, results):
@@ -159,17 +168,28 @@ class TestDayLength:
             setup_dates = {}
 
         data = self.data_setup(lats=np.linspace(-65, 65, 13, endpoint=True), **setup_dates)
-        k = helpers.jones_day_length_latitude_coefficient(
-            dates=data.time,
-            lat=data.lat,
-            start_date=start_date,
-            end_date=end_date,
-            freq=freq,
-            method=method,
-            floor=floor,
-        )
-
-        np.testing.assert_array_almost_equal(k.transpose()[0], results, 2)
+        if results is None:
+            with pytest.raises(ValueError):
+                helpers.jones_day_length_latitude_coefficient(
+                    dates=data.time,
+                    lat=data.lat,
+                    start_date=start_date,
+                    end_date=end_date,
+                    freq=freq,
+                    method=method,
+                    floor=floor,
+                )
+        else:
+            k = helpers.jones_day_length_latitude_coefficient(
+                dates=data.time,
+                lat=data.lat,
+                start_date=start_date,
+                end_date=end_date,
+                freq=freq,
+                method=method,
+                floor=floor,
+            )
+            np.testing.assert_array_almost_equal(k.transpose()[0], results, 2)
 
     @pytest.mark.parametrize("constrain", [None, "20 degree_north"])
     def test_gladstones_day_length(self, constrain):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -50,26 +50,26 @@ def test_extraterrestrial_radiation(method):
     )
 
 
-@pytest.mark.parametrize("method", ["spencer", "simple"])
-def test_day_lengths(method):
+@pytest.mark.parametrize("method, infill", [("spencer", False), ("spencer", True), ("simple", False)])
+def test_day_lengths(method, infill):
     time_data = xr.date_range("1992-12-01", "1994-01-01", freq="D", calendar="standard")
     data = xr.DataArray(
-        np.ones((time_data.size, 7)),
+        np.ones((time_data.size, 8)),
         dims=("time", "lat"),
-        coords={"time": time_data, "lat": [-60, -45, -30, 0, 30, 45, 60]},
+        coords={"time": time_data, "lat": [-60, -45, -30, 0, 30, 45, 60, 80]},
     )
     data.lat.attrs["units"] = "degree_north"
 
-    dl = helpers.day_lengths(dates=data.time, lat=data.lat, method=method)
+    dl = helpers.day_lengths(dates=data.time, lat=data.lat, method=method, infill_polar_days=infill)
 
     events = dict(
         solstice=[
-            ["1992-12-21", [18.49, 15.43, 13.93, 12.0, 10.07, 8.57, 5.51]],
-            ["1993-06-21", [5.51, 8.57, 10.07, 12.0, 13.93, 15.43, 18.49]],
-            ["1993-12-21", [18.49, 15.43, 13.93, 12.0, 10.07, 8.57, 5.51]],
+            ["1992-12-21", [18.49, 15.43, 13.93, 12.0, 10.07, 8.57, 5.51, 0.0 if infill else np.nan]],
+            ["1993-06-21", [5.51, 8.57, 10.07, 12.0, 13.93, 15.43, 18.49, 24.0 if infill else np.nan]],
+            ["1993-12-21", [18.49, 15.43, 13.93, 12.0, 10.07, 8.57, 5.51, 0.0 if infill else np.nan]],
         ],
         equinox=[
-            ["1993-03-20", [12] * 7]
+            ["1993-03-20", [12] * 8]
         ],  # True equinox on 1993-03-20 at 14:41 GMT. Some relative tolerance is needed.
     )
 
@@ -81,7 +81,7 @@ def test_day_lengths(method):
                 np.testing.assert_allclose(dl.sel(time=e[0]).transpose(), np.array(e[1]), rtol=2e-1)
 
 
-@pytest.mark.parametrize("constrain", [False, True, "20 degree_north"])
+@pytest.mark.parametrize("constrain", [None, "20 degree_north"])
 def test_gladstones_day_length(constrain):
     time_data = xr.date_range("1992-12-01", "1994-01-01", freq="D", calendar="standard")
     data = xr.DataArray(
@@ -103,13 +103,9 @@ def test_gladstones_day_length(constrain):
         ],  # True equinox on 1993-03-20 at 14:41 GMT. Some relative tolerance is needed.
     )
 
-    if constrain:
-        if constrain == "20 degree_north":
-            for entry in events["solstice"]:
-                entry[1][5:8] = [1.0] * 3
-        else:
-            for entry in events["solstice"]:
-                entry[1][4:9] = [1.0] * 5
+    if constrain == "20 degree_north":
+        for entry in events["solstice"]:
+            entry[1][5:8] = [1.0] * 3
 
     for event, evaluations in events.items():
         for e in evaluations:
@@ -162,10 +158,6 @@ def test_cosine_of_solar_zenith_angle(calendar):
         ]
     )
     np.testing.assert_allclose(cza[:4, :], exp_cza, rtol=1e-3)
-
-
-def _test_function(da, op, dim):
-    return getattr(da, op)(dim)
 
 
 @pytest.mark.parametrize(["in_chunks", "exp_chunks"], [(60, 6 * (2,)), (30, 12 * (1,)), (-1, (12,))])

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -516,12 +516,9 @@ def test_all_parameters_understood(official_indicators):
         for name, param in indinst.parameters.items():
             if param.kind == InputKind.OTHER_PARAMETER:
                 problems.add((identifier, name))
-    # We can deal with 'lat' for the moment.
-    if problems - {
-        ("COOL_NIGHT_INDEX", "lat"),
-        ("DRYNESS_INDEX", "lat"),
-    }:
-        raise ValueError(f"The following indicator/parameter couple {problems} use types not listed in InputKind.")
+    # lat is present in many indicators, but is exceptionally allowed.
+    if problems - {("INDICE", "test_param")}:
+        raise ValueError(f"The following indicator/parameter couple(s) {problems} use types not listed in InputKind.")
 
 
 def test_signature():

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -343,9 +343,9 @@ class TestAgroclimaticIndices:
                     # Leap year has no influence on 'huglin' or 'interpolated' method
                     np.testing.assert_array_equal(bedd.isel(lat=0)[0], bedd.isel(lat=0)[1])
                 else:
-                    # Leap-year has slightly higher values for higher latitudes
-                    np.testing.assert_array_less(bedd[0], bedd[1])
-                    np.testing.assert_array_less(bedd[1], bedd[2])
+                    # Higher latitudes have higher values
+                    np.testing.assert_array_less(bedd.isel(lat=0), bedd.isel(lat=1))
+                    np.testing.assert_array_less(bedd.isel(lat=1), bedd.isel(lat=2))
 
             elif freq == "MS":
                 np.testing.assert_allclose(

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -271,9 +271,9 @@ class TestAgroclimaticIndices:
         "method, end_date, deg_days, max_deg_days",
         [
             ("gladstones", "11-01", 1090.1, 1926.0),
-            ("stepwise", "11-01", 1112.8, 1926.0),
-            ("smoothed", "11-01", 1102.1, 1926.0),
+            ("huglin", "11-01", 1112.8, 1926.0),
             ("icclim", "10-01", 915.0, 1647.0),
+            ("interpolated", "11-01", 1102.1, 1926.0),
             ("jones", "11-01", 1211.1, 2122.72),
         ],
     )
@@ -385,7 +385,7 @@ class TestAgroclimaticIndices:
         np.testing.assert_array_equal(cni_nh, tn_nh)
         np.testing.assert_array_equal(cni_sh, tn_sh)
 
-        # Treat all areas as northern hemisphere
+        # Treat all areas as Northern Hemisphere
         cni_all_nh = xci.cool_night_index(tasmin=ds.tasmin, lat="north")
         tn_all_nh = tasmin.where(tasmin.time.dt.month == 9, drop=True)
 

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -419,8 +419,8 @@ class TestAgroclimaticIndices:
             ("huglin", "11-01", "MS", 283.88, np.nan),
             ("huglin", "11-01", "MS", 334.02, 1.0),
             ("icclim", "11-01", "YS", 2247.25, 1.0),
-            ("jones", "10-01", "YS", 1739.81, np.nan),
-            ("jones", "11-01", "YS", 2219.51, np.nan),
+            ("jones", "10-01", "YS", 2299.30, np.nan),
+            ("jones", "11-01", "YS", 2931.21, np.nan),
             ("jones", "10-01", "MS", None, np.nan),  # not implemented
         ],
     )

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -270,37 +270,40 @@ class TestAgroclimaticIndices:
     @pytest.mark.parametrize(
         "method, end_date, deg_days, max_deg_days",
         [
-            ("gladstones", "11-01", 1203.9, 2167.15),
-            ("huglin", "11-01", 1203.9, 2167.15),
+            ("gladstones", "11-01", 1090.1, 1926.0),
+            ("stepwise", "11-01", 1112.8, 1926.0),
+            ("smoothed", "11-01", 1102.1, 1926.0),
             ("icclim", "10-01", 915.0, 1647.0),
-            ("jones", "11-01", 1211.1, 2180.14),
+            ("jones", "11-01", 1211.1, 2122.72),
         ],
     )
     def test_bedd(self, method, end_date, deg_days, max_deg_days):
         time_data = xr.date_range("1992-01-01", "1995-06-01", freq="D", calendar="standard")
+
+        lat = xr.DataArray([35, 45], dims=("lat",), name="lat", attrs={"units": "degrees_north"})
+        high_lat = xr.DataArray(48, name="lat", attrs={"units": "degrees_north"})
+
         tn = xr.DataArray(
             np.zeros(time_data.size) + 10 + K2C,
             dims="time",
             coords={"time": time_data},
             attrs={"units": "K"},
         )
-
+        tn = tn.expand_dims(lat=lat)
         tx = xr.DataArray(
             np.zeros(time_data.size) + 20 + K2C,
             dims="time",
             coords={"time": time_data},
             attrs={"units": "K"},
         )
-
+        tx = tx.expand_dims(lat=lat)
         tx_hot = xr.DataArray(
             np.zeros(time_data.size) + 50 + K2C,
             dims="time",
             coords={"time": time_data},
             attrs={"units": "K"},
         )
-
-        lat = xr.DataArray([35, 45], dims=("lat",), name="lat", attrs={"units": "degrees_north"})
-        high_lat = xr.DataArray(48, name="lat", attrs={"units": "degrees_north"})
+        tx_hot = tx_hot.expand_dims(lat=lat)
 
         bedd = xci.biologically_effective_degree_days(
             tasmin=tn,
@@ -318,28 +321,27 @@ class TestAgroclimaticIndices:
             end_date=end_date,  # noqa
             freq="YS",
         )
-        if method != "icclim":
-            bedd = bedd.isel(lat=1)
-            bedd_hot = bedd_hot.isel(lat=1)
         bedd_high_lat = xci.biologically_effective_degree_days(
-            tasmin=tn,
-            tasmax=tx,
-            lat=high_lat,
+            tasmin=tn.isel(lat=0),
+            tasmax=tx.isel(lat=0),
+            lat=high_lat,  # Replace with a higher latitude
             method=method,
             end_date=end_date,  # noqa
             freq="YS",
         )
 
-        np.testing.assert_allclose(bedd[:3], np.array([deg_days, deg_days, deg_days]), atol=0.125)
-        np.testing.assert_allclose(bedd_hot[:3], [max_deg_days, max_deg_days, max_deg_days], atol=0.1)
+        np.testing.assert_allclose(np.array([deg_days, deg_days, deg_days]), bedd.isel(lat=1)[:3], atol=0.125)
+        np.testing.assert_allclose([max_deg_days, max_deg_days, max_deg_days], bedd_hot.isel(lat=0)[:3], atol=0.1)
         if method == "icclim":
-            # Lat has no influence on 'icclim' method
-            np.testing.assert_array_equal(bedd[1], bedd[0])
-            np.testing.assert_array_equal(bedd, bedd_high_lat)
+            # Latitude has no influence on 'icclim' method
+            np.testing.assert_array_equal(bedd.isel(lat=0), bedd_high_lat)
+        elif method in ["stepwise", "smoothed"]:
+            # Leap year has no influence on 'stepwise' or 'smoothed' method
+            np.testing.assert_array_equal(bedd.isel(lat=0)[0], bedd.isel(lat=0)[1])
         else:
             # Leap-year has slightly higher values for higher latitudes
-            np.testing.assert_array_less(bedd[1], bedd[0])
-            np.testing.assert_array_less(bedd, bedd_high_lat)
+            np.testing.assert_array_less(bedd[0], bedd[1])
+            np.testing.assert_array_less(bedd[1], bedd_high_lat[0])
 
     def test_chill_portions(self, tas_series):
         tas = tas_series(np.linspace(0, 15, 120 * 24) + K2C, freq="h")


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #2201 
- [x] Tests for the changes have been added (for bug fixes / features)
  - [x] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGELOG.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Refactors the latitude correction algorithms into `xc.indices.helpers`
* Adjusts existing wine-climatology call signatures to be more restrictive about allowed time frequencies
* Adjusted the `"jones"`, method for the `huglin_index` to drop latitudes falling within the polar extremes:
  * For cases where all latitude values for a growing season fall below `1.0`, that season is dropped from the array.
    * If no season has values above `1.0`, a `ValueError` is raised.
* Added a `cap_value` for simple latitude coefficient functions to allow users to set an arbitrary value for extreme latitudes (e.g. `np.nan`, `1.0`, `1.08`, etc.).
* Added the option of setting values for polar days and polar nights in `day_lengths`
* `day_lengths` no longer modifies the `lat` DataArray passed to it
* latitude-day-length-coefficient algorithms are now found in `xclim.indices.helpers`:
  * gladstones_day_length_latitude_coefficient
  * huglin_day_length_latitude_coefficient
  * jones_day_length_latitude_coefficient

### Does this PR introduce a breaking change?

Yes. The `icclim` method for calculating Heliothermal Index of Huglin (HI) has been renamed the `huglin` method. This algorithm is directly based on the original [Huglin (1978)](https://www-iuem.univ-brest.fr/wapps/letg/adviclim/BDX/PDF/CR_Acad%C3%A9mie_agriculture_1978_64_Huglin.pdf) paper. The `icclim` option is still accepted (reverts to `huglin`) but should be deprecated.

The seasonally-aggregated method for calculating the latitude adjustment factors in HI and BEDD based on [Hall and Jones (2010)](https://onlinelibrary.wiley.com/doi/10.1111/j.1755-0238.2010.00100.x) are now restricted to `YS-JAN` or `YS-JUL` time frequencies. Additionally, the previous version of the `jones` day-length calculation were providing erroneous values for extreme latitudes where day-lengths can extend to either 0 or 24 hours; The new behaviour is to drop these latitudes from the calculation.

The `gladstones` method for calculating `k` in `biologically_effective_degree_days` now uses a dedicated function based on a dynamic `day_length` compared to a reference latitude (40 degrees). The previous implementation of the `"gladstones"` method was based off an approximation based on `Hall and Jones (2010)`; This new version is based directly off of [Gladstones (1992) and (2011)](https://www.wakefieldpress.com.au/product/wine-terroir-and-climate-change/)

### Other information:

The `day_length` function has been modified to accept an `infill_polar_days` argument (default: False) that adds the zero- or 24-hour latitudes as needed (instead of `np.nan`), e.g. `infill_polar_days=False`:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/76f60404-d09a-407a-9fe7-10e1c3060267" />

and `infill_polar_days=True`:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/9b836d9f-7925-41ff-8e9f-89de460e85a5" />

For the `"jones"` methods in HI and BEDD, this is hard-coded to `False`, but is available for other indices to make use of.