### PR TITLE
Assume daily frequency when inferring units of a count or integral index

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,7 @@ Internal changes
 
 Bug fixes
 ^^^^^^^^^
+* Indices relying on ``units.to_agg_units(src, out, 'count')`` will not raise on a non-inferrable frequency and instead use the common default of "D", as their docstring implies. (:issue:`2215`, :pull:`2217`).
 * Increase the tolerance in the tests of ``xclim.indices.standardized_groundwater_index`` (the standardized indices are sensitive to package versions because of the parameter optimization in `scipy`).  (:issue:`2183`, :pull:`2193`).
 * In ``xclim.indices._conversion.humidex`` and ``xclim.indices._conversion.vapor_pressure_deficit``, add a converter to ensure `hurs` has '%' units. (:pull:`2209`).
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,9 +27,9 @@ Internal changes
 
 Bug fixes
 ^^^^^^^^^
-* Indices relying on ``units.to_agg_units(src, out, 'count')`` will not raise on a non-inferrable frequency and instead use the common default of "D", as their docstring implies. (:issue:`2215`, :pull:`2217`).
 * Increase the tolerance in the tests of ``xclim.indices.standardized_groundwater_index`` (the standardized indices are sensitive to package versions because of the parameter optimization in `scipy`).  (:issue:`2183`, :pull:`2193`).
 * In ``xclim.indices._conversion.humidex`` and ``xclim.indices._conversion.vapor_pressure_deficit``, add a converter to ensure `hurs` has '%' units. (:pull:`2209`).
+* Indices relying on ``units.to_agg_units(src, out, 'count')`` will not raise on a non-inferrable frequency and instead use the common default of "D", as their docstring implies. (:issue:`2215`, :pull:`2217`).
 
 v0.57.0 (2025-05-22)
 --------------------

--- a/src/xclim/core/units.py
+++ b/src/xclim/core/units.py
@@ -533,10 +533,8 @@ def infer_sampling_units(
     if freq is None:
         if deffreq is None:
             raise ValueError(f"Unable to find the sampling frequency of the data along dimension {dim}.")
-        warnings.warn(
-            f"Unable to find the sampling frequency of the data along dimension {dim}. Assuming '{deffreq}' instead.",
-            stacklevel=2,
-        )
+        msg = f"Unable to find the sampling frequency of the data along dimension {dim}. Assuming '{deffreq}' instead."
+        warnings.warn(msg, stacklevel=2)
         freq = deffreq
 
     multi, base, _, _ = parse_offset(freq)
@@ -642,7 +640,7 @@ def to_agg_units(
     dim : str
         The time dimension along which the aggregation was performed.
     deffreq : str, optional
-        For ``op`` `count` and `integral`, this gives the default source frequency to assume,
+        For operations `count` and `integral`, this gives the default source frequency to assume,
         if it can't be inferred from ``out[dim]``.
 
     Returns

--- a/src/xclim/indices/_agro.py
+++ b/src/xclim/indices/_agro.py
@@ -1459,7 +1459,7 @@ def effective_growing_degree_days(
 
     deg_days = (tas - thresh).clip(min=0)
     egdd: xarray.DataArray = aggregate_between_dates(deg_days, start=start, end=end, freq=freq)
-    egdd = to_agg_units(egdd, tas, op="integral")
+    egdd = to_agg_units(egdd, tas, op="integral", deffreq="D")
     return egdd
 
 

--- a/src/xclim/indices/_hydrology.py
+++ b/src/xclim/indices/_hydrology.py
@@ -614,7 +614,7 @@ def high_flow_frequency(q: xarray.DataArray, threshold_factor: int = 9, freq: st
     median_flow = q.median(dim="time")
     threshold = threshold_factor * median_flow
     out = threshold_count(q, ">", threshold, freq=freq)
-    return to_agg_units(out, q, "count")
+    return to_agg_units(out, q, "count", deffreq="D")
 
 
 @declare_units(q="[discharge]")
@@ -647,7 +647,7 @@ def low_flow_frequency(q: xarray.DataArray, threshold_factor: float = 0.2, freq:
     mean_flow = q.mean(dim="time")
     threshold = threshold_factor * mean_flow
     out = threshold_count(q, "<", threshold, freq=freq)
-    return to_agg_units(out, q, "count")
+    return to_agg_units(out, q, "count", deffreq="D")
 
 
 @declare_units(pr="[precipitation]")

--- a/src/xclim/indices/_multivariate.py
+++ b/src/xclim/indices/_multivariate.py
@@ -150,7 +150,7 @@ def cold_spell_duration_index(
         freq=freq,
     )
 
-    return to_agg_units(out, tasmin, "count")
+    return to_agg_units(out, tasmin, "count", deffreq="D")
 
 
 @declare_units(
@@ -215,7 +215,7 @@ def cold_and_dry_days(
 
     cold_and_dry = cast(xarray.DataArray, np.logical_and(tg25, pr25))
     resampled = cold_and_dry.resample(time=freq).sum(dim="time")
-    out = to_agg_units(resampled, tas, "count")
+    out = to_agg_units(resampled, tas, "count", deffreq="D")
     return out
 
 
@@ -281,7 +281,7 @@ def warm_and_dry_days(
 
     warm_and_dry = cast(xarray.DataArray, np.logical_and(tg75, pr25))
     resampled = warm_and_dry.resample(time=freq).sum(dim="time")
-    out = to_agg_units(resampled, tas, "count")
+    out = to_agg_units(resampled, tas, "count", deffreq="D")
     return out
 
 
@@ -347,7 +347,7 @@ def warm_and_wet_days(
 
     warm_and_wet = cast(xarray.DataArray, np.logical_and(tg75, pr75))
     resampled = warm_and_wet.resample(time=freq).sum(dim="time")
-    out = to_agg_units(resampled, tas, "count")
+    out = to_agg_units(resampled, tas, "count", deffreq="D")
     return out
 
 
@@ -413,7 +413,7 @@ def cold_and_wet_days(
 
     cold_and_wet = cast(xarray.DataArray, np.logical_and(tg25, pr75))
     resampled = cold_and_wet.resample(time=freq).sum(dim="time")
-    out = to_agg_units(resampled, tas, "count")
+    out = to_agg_units(resampled, tas, "count", deffreq="D")
     return out
 
 
@@ -507,7 +507,7 @@ def multiday_temperature_swing(
             freq=freq,
         )
 
-    return to_agg_units(out, tasmin, "count")
+    return to_agg_units(out, tasmin, "count", deffreq="D")
 
 
 @declare_units(tasmax="[temperature]", tasmin="[temperature]")
@@ -791,7 +791,7 @@ def heat_wave_max_length(
         window=window,
         freq=freq,
     )
-    return to_agg_units(out, tasmax, "count")
+    return to_agg_units(out, tasmax, "count", deffreq="D")
 
 
 @declare_units(
@@ -859,7 +859,7 @@ def heat_wave_total_length(
         freq=freq,
     )
 
-    return to_agg_units(out, tasmin, "count")
+    return to_agg_units(out, tasmin, "count", deffreq="D")
 
 
 @declare_units(
@@ -1116,7 +1116,7 @@ def rain_on_frozen_ground_days(
     pcond = pr > t
 
     out = (tcond * pcond * 1).resample(time=freq).sum(dim="time")
-    return to_agg_units(out, tas, "count")
+    return to_agg_units(out, tas, "count", deffreq="D")
 
 
 @declare_units(
@@ -1168,7 +1168,7 @@ def high_precip_low_temp(
 
     cond = (pr >= pr_thresh) * (tas < tas_thresh) * 1
     out = cond.resample(time=freq).sum(dim="time")
-    return to_agg_units(out, pr, "count")
+    return to_agg_units(out, pr, "count", deffreq="D")
 
 
 @declare_units(pr="[precipitation]", pr_per="[precipitation]", thresh="[precipitation]")
@@ -1230,7 +1230,7 @@ def days_over_precip_thresh(
 
     # Compute the days when precip is both over the wet day threshold and the percentile threshold.
     out = threshold_count(pr, op, tp, freq, constrain=(">", ">="))
-    return to_agg_units(out, pr, "count")
+    return to_agg_units(out, pr, "count", deffreq="D")
 
 
 @declare_units(pr="[precipitation]", pr_per="[precipitation]", thresh="[precipitation]")
@@ -1351,7 +1351,7 @@ def tg90p(
 
     # Identify the days over the 90th percentile
     out = threshold_count(tas, op, thresh, freq, constrain=(">", ">="))
-    return to_agg_units(out, tas, "count")
+    return to_agg_units(out, tas, "count", deffreq="D")
 
 
 @declare_units(tas="[temperature]", tas_per="[temperature]")
@@ -1410,7 +1410,7 @@ def tg10p(
 
     # Identify the days below the 10th percentile
     out = threshold_count(tas, op, thresh, freq, constrain=("<", "<="))
-    return to_agg_units(out, tas, "count")
+    return to_agg_units(out, tas, "count", deffreq="D")
 
 
 @declare_units(tasmin="[temperature]", tasmin_per="[temperature]")
@@ -1469,7 +1469,7 @@ def tn90p(
 
     # Identify the days with min temp above 90th percentile.
     out = threshold_count(tasmin, op, thresh, freq, constrain=(">", ">="))
-    return to_agg_units(out, tasmin, "count")
+    return to_agg_units(out, tasmin, "count", deffreq="D")
 
 
 @declare_units(tasmin="[temperature]", tasmin_per="[temperature]")
@@ -1528,7 +1528,7 @@ def tn10p(
 
     # Identify the days below the 10th percentile
     out = threshold_count(tasmin, op, thresh, freq, constrain=("<", "<="))
-    return to_agg_units(out, tasmin, "count")
+    return to_agg_units(out, tasmin, "count", deffreq="D")
 
 
 @declare_units(tasmax="[temperature]", tasmax_per="[temperature]")
@@ -1587,7 +1587,7 @@ def tx90p(
 
     # Identify the days with max temp above 90th percentile.
     out = threshold_count(tasmax, op, thresh, freq, constrain=(">", ">="))
-    return to_agg_units(out, tasmax, "count")
+    return to_agg_units(out, tasmax, "count", deffreq="D")
 
 
 @declare_units(tasmax="[temperature]", tasmax_per="[temperature]")
@@ -1646,7 +1646,7 @@ def tx10p(
 
     # Identify the days below the 10th percentile
     out = threshold_count(tasmax, op, thresh, freq, constrain=("<", "<="))
-    return to_agg_units(out, tasmax, "count")
+    return to_agg_units(out, tasmax, "count", deffreq="D")
 
 
 @declare_units(
@@ -1711,7 +1711,7 @@ def tx_tn_days_above(
     constrain = (">", ">=")
     events = (compare(tasmin, op, thresh_tasmin, constrain) & compare(tasmax, op, thresh_tasmax, constrain)) * 1
     out = events.resample(time=freq).sum(dim="time")
-    return to_agg_units(out, tasmin, "count")
+    return to_agg_units(out, tasmin, "count", deffreq="D")
 
 
 @declare_units(tasmax="[temperature]", tasmax_per="[temperature]")
@@ -1790,7 +1790,7 @@ def warm_spell_duration_index(
         freq=freq,
     )
 
-    return to_agg_units(out, tasmax, "count")
+    return to_agg_units(out, tasmax, "count", deffreq="D")
 
 
 @declare_units(pr="[precipitation]", prsn="[precipitation]", tas="[temperature]")
@@ -1880,7 +1880,7 @@ def blowing_snow(
     cond = (snow >= snd_thresh) * (sfcWind >= sfcWind_thresh) * 1
 
     out = cond.resample(time=freq).sum(dim="time")
-    out = out.assign_attrs(units=to_agg_units(out, snd, "count"))
+    out = out.assign_attrs(units=to_agg_units(out, snd, "count", deffreq="D"))
     return out
 
 

--- a/src/xclim/indices/_simple.py
+++ b/src/xclim/indices/_simple.py
@@ -366,7 +366,7 @@ def hot_days(
     """
     thresh = convert_units_to(thresh, tasmax)
     out = threshold_count(tasmax, ">", thresh, freq)
-    return to_agg_units(out, tasmax, "count")
+    return to_agg_units(out, tasmax, "count", deffreq="D")
 
 
 @declare_units(tasmin="[temperature]", thresh="[temperature]")
@@ -405,7 +405,7 @@ def frost_days(
     """
     frz = convert_units_to(thresh, tasmin)
     out = threshold_count(tasmin, "<", frz, freq)
-    return to_agg_units(out, tasmin, "count")
+    return to_agg_units(out, tasmin, "count", deffreq="D")
 
 
 @declare_units(tasmax="[temperature]", thresh="[temperature]")
@@ -440,7 +440,7 @@ def ice_days(tasmax: xarray.DataArray, thresh: Quantified = "0 degC", freq: str 
     """
     frz = convert_units_to(thresh, tasmax)
     out = threshold_count(tasmax, "<", frz, freq)
-    return to_agg_units(out, tasmax, "count")
+    return to_agg_units(out, tasmax, "count", deffreq="D")
 
 
 @declare_units(pr="[precipitation]")

--- a/src/xclim/indices/_threshold.py
+++ b/src/xclim/indices/_threshold.py
@@ -149,7 +149,7 @@ def calm_days(sfcWind: xarray.DataArray, thresh: Quantified = "2 m s-1", freq: s
     """
     thresh = convert_units_to(thresh, sfcWind)
     out = threshold_count(sfcWind, "<", thresh, freq)
-    out = to_agg_units(out, sfcWind, "count")
+    out = to_agg_units(out, sfcWind, "count", deffreq="D")
     return out
 
 
@@ -210,7 +210,7 @@ def cold_spell_days(
         window=window,
         freq=freq,
     )
-    return to_agg_units(out, tas, "count")
+    return to_agg_units(out, tas, "count", deffreq="D")
 
 
 @declare_units(tas="[temperature]", thresh="[temperature]")
@@ -308,7 +308,7 @@ def cold_spell_max_length(
         freq=freq,
     )
     max_window = max_l.where(max_l >= window, 0)
-    out = to_agg_units(max_window, tas, "count")
+    out = to_agg_units(max_window, tas, "count", deffreq="D")
     return out
 
 
@@ -358,7 +358,7 @@ def cold_spell_total_length(
         window=window,
         freq=freq,
     )
-    return to_agg_units(out, tas, "count")
+    return to_agg_units(out, tas, "count", deffreq="D")
 
 
 @declare_units(snd="[length]", thresh="[length]")
@@ -631,7 +631,7 @@ def snd_storm_days(snd: xarray.DataArray, thresh: Quantified = "25 cm", freq: st
 
     # Winter storm condition
     snd_sd = threshold_count(acc, ">=", thresh, freq)
-    snd_sd = snd_sd.assign_attrs(units=to_agg_units(snd_sd, snd, "count"))
+    snd_sd = snd_sd.assign_attrs(units=to_agg_units(snd_sd, snd, "count", deffreq="D"))
     return snd_sd
 
 
@@ -671,7 +671,7 @@ def snw_storm_days(snw: xarray.DataArray, thresh: Quantified = "10 kg m-2", freq
 
     # Winter storm condition
     snw_sd = threshold_count(acc, ">=", thresh, freq)
-    snw_sd = snw_sd.assign_attrs(units=to_agg_units(snw_sd, snw, "count"))
+    snw_sd = snw_sd.assign_attrs(units=to_agg_units(snw_sd, snw, "count", deffreq="D"))
     return snw_sd
 
 
@@ -790,7 +790,7 @@ def dry_days(
     """
     thresh = convert_units_to(thresh, pr, context="hydro")
     count = threshold_count(pr, op, thresh, freq, constrain=("<", "<="))
-    dd = to_agg_units(count, pr, "count")
+    dd = to_agg_units(count, pr, "count", deffreq="D")
     return dd
 
 
@@ -845,7 +845,7 @@ def maximum_consecutive_wet_days(
         rl.longest_run,
         freq=freq,
     )
-    mcwd = to_agg_units(mcwd, pr, "count")
+    mcwd = to_agg_units(mcwd, pr, "count", deffreq="D")
     return mcwd
 
 
@@ -906,7 +906,7 @@ def cooling_degree_days_approximation(
         ),
     )
     cdd = cdd.resample(time=freq).sum(dim="time")
-    cdd = to_agg_units(cdd, tas, "integral")
+    cdd = to_agg_units(cdd, tas, "integral", deffreq="D")
     return cdd
 
 
@@ -1527,7 +1527,7 @@ def frost_free_spell_max_length(
         freq=freq,
     )
     out = max_l.where(max_l >= window, 0)
-    return to_agg_units(out, tasmin, "count")
+    return to_agg_units(out, tasmin, "count", deffreq="D")
 
 
 # FIXME: `tas` should instead be `tasmin` if we want to follow expected definitions.
@@ -1868,7 +1868,7 @@ def days_with_snow(
     low = convert_units_to(low, prsn, context="hydro")
     high = convert_units_to(high, prsn, context="hydro")
     out = domain_count(prsn, low, high, freq)
-    return to_agg_units(out, prsn, "count")
+    return to_agg_units(out, prsn, "count", deffreq="D")
 
 
 @declare_units(prsn="[precipitation]", thresh="[precipitation]")
@@ -2023,7 +2023,7 @@ def heat_wave_index(
         window=window,
         freq=freq,
     )
-    return to_agg_units(out, tasmax, "count")
+    return to_agg_units(out, tasmax, "count", deffreq="D")
 
 
 @declare_units(tasmax="[temperature]", thresh="[temperature]")
@@ -2074,7 +2074,7 @@ def hot_spell_max_magnitude(
         window=window,
         freq=freq,
     )
-    return to_agg_units(out, tasmax, op="integral")
+    return to_agg_units(out, tasmax, op="integral", deffreq="D")
 
 
 @declare_units(tasmax="[temperature]", tasmin="[temperature]", tas="[temperature]", thresh="[temperature]")
@@ -2130,7 +2130,7 @@ def heating_degree_days_approximation(
         ),
     )
     hdd = hdd.resample(time=freq).sum(dim="time")
-    hdd = to_agg_units(hdd, tas, "integral")
+    hdd = to_agg_units(hdd, tas, "integral", deffreq="D")
     return hdd
 
 
@@ -2236,7 +2236,7 @@ def hot_spell_max_length(
         freq=freq,
     )
     out = max_l.where(max_l >= window, 0)
-    return to_agg_units(out, tasmax, "count")
+    return to_agg_units(out, tasmax, "count", deffreq="D")
 
 
 @declare_units(tasmax="[temperature]", thresh="[temperature]")
@@ -2295,7 +2295,7 @@ def hot_spell_total_length(
         window=window,
         freq=freq,
     )
-    return to_agg_units(out, tasmax, "count")
+    return to_agg_units(out, tasmax, "count", deffreq="D")
 
 
 @declare_units(tasmax="[temperature]", thresh="[temperature]")
@@ -2392,7 +2392,7 @@ def snd_days_above(
     valid = at_least_n_valid(snd, n=1, freq=freq)
     thresh = convert_units_to(thresh, snd)
     out = threshold_count(snd, op, thresh, freq)
-    return to_agg_units(out, snd, "count").where(~valid)
+    return to_agg_units(out, snd, "count", deffreq="D").where(~valid)
 
 
 @declare_units(snw="[mass]/[area]", thresh="[mass]/[area]")
@@ -2426,7 +2426,7 @@ def snw_days_above(
     valid = at_least_n_valid(snw, n=1, freq=freq)
     thresh = convert_units_to(thresh, snw)
     out = threshold_count(snw, op, thresh, freq)
-    return to_agg_units(out, snw, "count").where(~valid)
+    return to_agg_units(out, snw, "count", deffreq="D").where(~valid)
 
 
 @declare_units(tasmin="[temperature]", thresh="[temperature]")
@@ -2468,7 +2468,7 @@ def tn_days_above(
     """
     thresh = convert_units_to(thresh, tasmin)
     f = threshold_count(tasmin, op, thresh, freq, constrain=(">", ">="))
-    return to_agg_units(f, tasmin, "count")
+    return to_agg_units(f, tasmin, "count", deffreq="D")
 
 
 @declare_units(tasmin="[temperature]", thresh="[temperature]")
@@ -2510,7 +2510,7 @@ def tn_days_below(
     """
     thresh = convert_units_to(thresh, tasmin)
     f1 = threshold_count(tasmin, op, thresh, freq, constrain=("<", "<="))
-    return to_agg_units(f1, tasmin, "count")
+    return to_agg_units(f1, tasmin, "count", deffreq="D")
 
 
 @declare_units(tas="[temperature]", thresh="[temperature]")
@@ -2552,7 +2552,7 @@ def tg_days_above(
     """
     thresh = convert_units_to(thresh, tas)
     f = threshold_count(tas, op, thresh, freq, constrain=(">", ">="))
-    return to_agg_units(f, tas, "count")
+    return to_agg_units(f, tas, "count", deffreq="D")
 
 
 @declare_units(tas="[temperature]", thresh="[temperature]")
@@ -2594,7 +2594,7 @@ def tg_days_below(
     """
     thresh = convert_units_to(thresh, tas)
     f1 = threshold_count(tas, op, thresh, freq, constrain=("<", "<="))
-    return to_agg_units(f1, tas, "count")
+    return to_agg_units(f1, tas, "count", deffreq="D")
 
 
 @declare_units(tasmax="[temperature]", thresh="[temperature]")
@@ -2636,7 +2636,7 @@ def tx_days_above(
     """
     thresh = convert_units_to(thresh, tasmax)
     f = threshold_count(tasmax, op, thresh, freq, constrain=(">", ">="))
-    return to_agg_units(f, tasmax, "count")
+    return to_agg_units(f, tasmax, "count", deffreq="D")
 
 
 @declare_units(tasmax="[temperature]", thresh="[temperature]")
@@ -2678,7 +2678,7 @@ def tx_days_below(
     """
     thresh = convert_units_to(thresh, tasmax)
     f1 = threshold_count(tasmax, op, thresh, freq, constrain=("<", "<="))
-    return to_agg_units(f1, tasmax, "count")
+    return to_agg_units(f1, tasmax, "count", deffreq="D")
 
 
 @declare_units(tasmax="[temperature]", thresh="[temperature]")
@@ -2720,7 +2720,7 @@ def warm_day_frequency(
     """
     thresh = convert_units_to(thresh, tasmax)
     events = threshold_count(tasmax, op, thresh, freq, constrain=(">", ">="))
-    return to_agg_units(events, tasmax, "count")
+    return to_agg_units(events, tasmax, "count", deffreq="D")
 
 
 @declare_units(tasmin="[temperature]", thresh="[temperature]")
@@ -2753,7 +2753,7 @@ def warm_night_frequency(
     """
     thresh = convert_units_to(thresh, tasmin)
     events = threshold_count(tasmin, op, thresh, freq, constrain=(">", ">="))
-    return to_agg_units(events, tasmin, "count")
+    return to_agg_units(events, tasmin, "count", deffreq="D")
 
 
 @declare_units(pr="[precipitation]", thresh="[precipitation]")
@@ -2796,7 +2796,7 @@ def wetdays(
     thresh = convert_units_to(thresh, pr, context="hydro")
 
     wd = threshold_count(pr, op, thresh, freq, constrain=(">", ">="))
-    return to_agg_units(wd, pr, "count")
+    return to_agg_units(wd, pr, "count", deffreq="D")
 
 
 @declare_units(pr="[precipitation]", thresh="[precipitation]")
@@ -2954,7 +2954,7 @@ def maximum_consecutive_dry_days(
         rl.longest_run,
         freq=freq,
     )
-    mcdd = to_agg_units(resampled, pr, "count")
+    mcdd = to_agg_units(resampled, pr, "count", deffreq="D")
     return mcdd
 
 
@@ -3181,7 +3181,7 @@ def windy_days(sfcWind: xarray.DataArray, thresh: Quantified = "10.8 m s-1", fre
     """
     thresh = convert_units_to(thresh, sfcWind)
     out = threshold_count(sfcWind, ">=", thresh, freq)
-    out = to_agg_units(out, sfcWind, "count")
+    out = to_agg_units(out, sfcWind, "count", deffreq="D")
     return out
 
 
@@ -3805,7 +3805,7 @@ def holiday_snow_days(
 
     xmas_days = count_occurrences(snd_constrained, snd_thresh, freq, op, constrain=[">=", ">"])
 
-    xmas_days = to_agg_units(xmas_days, snd, "count")
+    xmas_days = to_agg_units(xmas_days, snd, "count", deffreq="D")
     return xmas_days
 
 
@@ -3887,5 +3887,5 @@ def holiday_snow_and_snowfall_days(
         constrain_var2=[">=", ">"],
     )
 
-    perfect_xmas_days = to_agg_units(perfect_xmas_days, snd, "count")
+    perfect_xmas_days = to_agg_units(perfect_xmas_days, snd, "count", deffreq="D")
     return perfect_xmas_days


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #2215
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [x] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGELOG.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?
 `deffreq` is passed from the index function to `infer_sampling_units` via `to_agg_units` when it matters.

This allows an index to define a default frequency to assume if the data has missing steps, useful when the units depends on it, when `op='count'` or `op='integral'`. 

This way, indices that are clearly written with daily inputs in mind or that do not make sense for other frequencies anyway can avoid failing on data with a few missing days. 

Indicators still have the data check that will fail on non-inferrable time coordinates, and that can also be disabled.

### Does this PR introduce a breaking change?
No, what worked before still works the same. Some cases that failed before don't fail anymore.