### PR TITLE
Fix spell mask for 2D thresholds

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,7 +31,6 @@ Bug fixes
 * In ``xclim.indices._conversion.humidex`` and ``xclim.indices._conversion.vapor_pressure_deficit``, add a converter to ensure `hurs` has '%' units. (:pull:`2209`).
 * Indices relying on ``units.to_agg_units(src, out, 'count')`` will not raise on a non-inferrable frequency and instead use the common default of "D", as their docstring implies. (:issue:`2215`, :pull:`2217`).
 * Fix ``spell_length_statistics`` and related functions for cases where ``thresh`` is a DataArray. (:issue:`2216`, :pull:`2218`).
-* Indices relying on ``units.to_agg_units(src, out, 'count')`` will not raise on a non-inferrable frequency and instead use the common default of "D", as their docstring implies. (:issue:`2215`, :pull:`2217`).
 
 v0.57.0 (2025-05-22)
 --------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,7 @@ Bug fixes
 ^^^^^^^^^
 * Increase the tolerance in the tests of ``xclim.indices.standardized_groundwater_index`` (the standardized indices are sensitive to package versions because of the parameter optimization in `scipy`).  (:issue:`2183`, :pull:`2193`).
 * In ``xclim.indices._conversion.humidex`` and ``xclim.indices._conversion.vapor_pressure_deficit``, add a converter to ensure `hurs` has '%' units. (:pull:`2209`).
+* Fix ``spell_length_statistics`` and related functions for cases where ``thresh`` is a DataArray. (:issue:`2216`, :pull:`2218`).
 
 v0.57.0 (2025-05-22)
 --------------------

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -728,6 +728,21 @@ class TestSpellMask:
             generic.spell_mask(data, 3, "mean", "<=", 2, weights=[1, 2])
 
 
+def test_spell_length_statistics_quantified(tasmin_series):
+    tn = tasmin_series(np.arange(365) + K2C, start="2001-01-01").expand_dims(site=[0, 1])
+    thresh = xr.DataArray([330, 360], dims=("site",), coords={"site": tn.site}, attrs={"units": "°C"})
+    out = generic.spell_length_statistics(
+        tn,
+        thresh,
+        window=1,
+        win_reducer="min",
+        op=">",
+        spell_reducer="sum",
+        freq="YS",
+    )
+    np.testing.assert_allclose(out, [[34], [4]])
+
+
 def test_spell_length_statistics_multi(tasmin_series, tasmax_series):
     tn = tasmin_series(
         np.zeros(


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #2216
- [x] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGELOG.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* The way `spell_mask` tests to differentiate the single vs multiple variables has been rewritten so that it doesn't fail when `thresh` is  DataArray.

### Does this PR introduce a breaking change?
No.