### PR TITLE
Fix tests relying on inexact pint 0.24 and avoid numbagg-introduced noise in standardized index testing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,6 +40,7 @@ Internal changes
 * Modified internal logic for ``xclim.testing.utils.default_testdata_cache`` to support mocking of `pooch`. (:pull:`2188`).
 * The `xclim.indices.helpers` module now uses an `__all__` variable to explicitly define the public API of the module. (:pull:`2207`).
 * Viticulture indices are more heavily tested and employ type guarding to ensure that parameters passed are those of the expected types. (:pull:`2207`).
+* Fixed some tests relying on floating-point imprecision. Avoid numbagg on sensitive fitting tests. (:pull:`2228`).
 
 Bug fixes
 ^^^^^^^^^

--- a/environment.yml
+++ b/environment.yml
@@ -24,6 +24,7 @@ dependencies:
   # Extras
   - flox >=0.9
   - xsdba >=0.4.0
+  - numbagg >= 0.8
   # lmoments3 - Not an official dependency but required for some Jupyter notebooks
   - lmoments3 >=1.0.7
   # Testing and development dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -389,7 +389,8 @@ convention = "numpy"
 [tool.vulture]
 exclude = []
 ignore_decorators = ["@pytest.fixture"]
-ignore_names = []
+# no_numbagg is a simple fixture that activates a xr option, it has no value
+ignore_names = ['no_numbagg']
 min_confidence = 90
 paths = ["src/xclim", "tests"]
 sort_by_size = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,7 +170,7 @@ pep621_dev_dependency_groups = ["all", "dev", "docs"]
 "pyyaml" = "yaml"
 
 [tool.deptry.per_rule_ignores]
-DEP002 = ["bottleneck", "h5netcdf", "pyarrow"]
+DEP002 = ["bottleneck", "h5netcdf", "numbagg", "pyarrow"]
 DEP004 = ["matplotlib", "pooch", "pytest", "pytest_socket"]
 
 [tool.flit.sdist]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ docs = [
   "sphinxcontrib-bibtex",
   "sphinxcontrib-svg2pdfconverter[Cairosvg]"
 ]
-extras = ["flox >=0.9", "xsdba >=0.4.0"]
+extras = ["flox >=0.9", "xsdba >=0.4.0", "numbagg >= 0.8"]
 all = ["xclim[dev]", "xclim[docs]", "xclim[extras]"]
 
 [project.scripts]

--- a/src/xclim/core/units.py
+++ b/src/xclim/core/units.py
@@ -891,6 +891,13 @@ def rate2amount(
     --------
     amount2rate : Convert an amount to a rate.
 
+    Notes
+    -----
+    Floating-point precision can have surprising results. For example, a daily series of 1 mm/d precipitation
+    rates might not convert to exactly 1 mm daily amounts. This is because a float multiplication is still
+    happening in the background and the time step duration might have been stored in [nano]seconds at one
+    point.
+
     Examples
     --------
     The following converts a daily array of precipitation in mm/h to the daily amounts in mm:

--- a/src/xclim/indices/_agro.py
+++ b/src/xclim/indices/_agro.py
@@ -1119,7 +1119,8 @@ def standardized_precipitation_index(
         Name of the univariate distribution, or a callable `rv_continuous` (see :py:mod:`scipy.stats`).
     method : {"APP", "ML", "PWM"}
         Name of the fitting method, such as `ML` (maximum likelihood), `APP` (approximate). The approximate method
-        uses a deterministic function that does not involve any optimization. `PWM` should be used with a `lmoments3` distribution.
+        uses a deterministic function that does not involve any optimization, which can be sensitive to noise.
+        `PWM` should be used with a `lmoments3` distribution.
     fitkwargs : dict, optional
         Kwargs passed to ``xclim.indices.stats.fit`` used to impose values of certains parameters (`floc`, `fscale`).
         If method is `PWM`, `fitkwargs` should be empty, except for `floc` with `dist`=`gamma` which is allowed.
@@ -1260,7 +1261,8 @@ def standardized_precipitation_evapotranspiration_index(
         Name of the univariate distribution, or a callable `rv_continuous` (see :py:mod:`scipy.stats`).
     method : {"APP", "ML", "PWM"}
         Name of the fitting method, such as `ML` (maximum likelihood), `APP` (approximate). The approximate method
-        uses a deterministic function that does not involve any optimization. `PWM` should be used with a `lmoments3` distribution.
+        uses a deterministic function that does not involve any optimization, which can be sensitive to noise.
+        `PWM` should be used with a `lmoments3` distribution.
     fitkwargs : dict, optional
         Kwargs passed to ``xclim.indices.stats.fit`` used to impose values of certains parameters (`floc`, `fscale`).
         If method is `PWM`, `fitkwargs` should be empty, except for `floc` with `dist`=`gamma` which is allowed.

--- a/src/xclim/indices/_hydrology.py
+++ b/src/xclim/indices/_hydrology.py
@@ -148,7 +148,7 @@ def standardized_streamflow_index(
         Name of the univariate distribution, or a callable `rv_continuous` (see :py:mod:`scipy.stats`).
     method : {"APP", "ML", "PWM"}
         Name of the fitting method, such as `ML` (maximum likelihood), `APP` (approximate). The approximate method
-        uses a deterministic function that does not involve any optimization.
+        uses a deterministic function that does not involve any optimization, which can be sensitive to noise.
         `PWM` should be used with a `lmoments3` distribution.
     fitkwargs : dict, optional
         Kwargs passed to ``xclim.indices.stats.fit`` used to impose values of certain parameters (`floc`, `fscale`).
@@ -455,8 +455,8 @@ def standardized_groundwater_index(
         Name of the univariate distribution, or a callable `rv_continuous` (see :py:mod:`scipy.stats`).
     method : {"APP", "ML", "PWM"}
         Name of the fitting method, such as `ML` (maximum likelihood), `APP` (approximate).
-        The approximate method uses a deterministic function that does not involve any optimization.
-        `PWM` should be used with a `lmoments3` distribution.
+        The approximate method uses a deterministic function that does not involve any optimization,
+        which can be sensitive to noise. `PWM` should be used with a `lmoments3` distribution.
     fitkwargs : dict, optional
         Kwargs passed to ``xclim.indices.stats.fit`` used to impose values of certain parameters (`floc`, `fscale`).
     cal_start : DateStr, optional

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -403,3 +403,9 @@ def gather_session_data(request, nimbus, worker_id):
                 pass
 
     request.addfinalizer(remove_data_written_flag)
+
+
+@pytest.fixture
+def no_numbagg():
+    with xr.set_options(use_numbagg=False):
+        yield

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -738,7 +738,9 @@ class TestStandardizedIndices:
             ),
         ],
     )
-    def test_standardized_precipitation_index(self, freq, window, dist, method, values, diff_tol, open_dataset):
+    def test_standardized_precipitation_index(
+        self, freq, window, dist, method, values, diff_tol, open_dataset, no_numbagg
+    ):
         if method == "ML" and freq == "D" and Version(__numpy_version__) < Version("2.0.0"):
             pytest.skip("Skipping SPI/ML/D on older numpy")
 
@@ -772,7 +774,6 @@ class TestStandardizedIndices:
         spi = xci.standardized_precipitation_index(pr, params=params)
         # Only a few moments before year 2000 are tested
         spi = spi.isel(time=slice(-11, -1, 2))
-
         # [Guttman, 1999]: The number of precipitation events (over a month/season or
         # other time period) is generally less than 100 in the US. This suggests that
         # bounds of ± 3.09 correspond to 0.999 and 0.001 probabilities. SPI indices outside
@@ -1008,18 +1009,13 @@ class TestStandardizedIndices:
                 ],
             ),
             ("MS", 1, "fisk", "APP", [0.4663, -1.9076, -0.5362, 0.8070, -0.8035], 2e-2),
-            pytest.param(
+            (
                 "MS",
                 12,
                 "genextreme",
                 "ML",
                 [-0.9795, -1.0398, -1.9019, -1.6970, -1.4761],
                 2e-2,
-                marks=[
-                    pytest.mark.xfail(
-                        reason="These values fail for unknown reason after an update, skipping.", strict=False
-                    )
-                ],
             ),
             (
                 "MS",
@@ -1047,7 +1043,9 @@ class TestStandardizedIndices:
             ),
         ],
     )
-    def test_standardized_streamflow_index(self, freq, window, dist, method, values, diff_tol, open_dataset):
+    def test_standardized_streamflow_index(
+        self, freq, window, dist, method, values, diff_tol, open_dataset, no_numbagg
+    ):
         ds = open_dataset("Raven/q_sim.nc")
         q = ds.q_obs.rename("q")
         q_cal = ds.q_sim.rename("q").fillna(ds.q_sim.mean())
@@ -1905,7 +1903,7 @@ class TestHolidayIndices:
         prsnd.loc["2000-12-25"] = 5
         prsnd.loc["2001-12-25"] = 2
         prsnd.loc["2001-12-26"] = 30  # too bad it's Boxing Day
-        prsnd.loc["2002-12-25"] = 1  # not quite enough
+        prsnd.loc["2002-12-25"] = 0.9  # not quite enough
         prsnd.loc["2003-12-25"] = 0  # no snow
         prsnd.loc["2004-12-25"] = 10
 
@@ -3976,13 +3974,13 @@ def test_dry_spell(pr_series, pr, thresh1, thresh2, window, outs):
 
 def test_dry_spell_total_length_indexer(pr_series):
     pr = pr_series([1] * 5 + [0] * 10 + [1] * 350, start="1900-01-01", units="mm/d")
-    out = xci.dry_spell_total_length(pr, window=7, op="sum", thresh="3 mm", freq="MS", date_bounds=("01-10", "12-31"))
+    out = xci.dry_spell_total_length(pr, window=7, op="sum", thresh="3.1 mm", freq="MS", date_bounds=("01-10", "12-31"))
     np.testing.assert_allclose(out, [9] + [0] * 11)
 
 
 def test_dry_spell_max_length_indexer(pr_series):
     pr = pr_series([1] * 5 + [0] * 10 + [1] * 350, start="1900-01-01", units="mm/d")
-    out = xci.dry_spell_max_length(pr, window=7, op="sum", thresh="3 mm", freq="MS", date_bounds=("01-10", "12-31"))
+    out = xci.dry_spell_max_length(pr, window=7, op="sum", thresh="3.1 mm", freq="MS", date_bounds=("01-10", "12-31"))
     np.testing.assert_allclose(out, [9] + [0] * 11)
 
 

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -1903,7 +1903,7 @@ class TestHolidayIndices:
         prsnd.loc["2000-12-25"] = 5
         prsnd.loc["2001-12-25"] = 2
         prsnd.loc["2001-12-26"] = 30  # too bad it's Boxing Day
-        prsnd.loc["2002-12-25"] = 0.9  # not quite enough
+        prsnd.loc["2002-12-25"] = 0.995  # not quite enough
         prsnd.loc["2003-12-25"] = 0  # no snow
         prsnd.loc["2004-12-25"] = 10
 

--- a/tests/test_precip.py
+++ b/tests/test_precip.py
@@ -647,12 +647,14 @@ def test_dry_spell_total_length_indexer(pr_series):
         pr,
         window=7,
         op="sum",
-        thresh="3 mm",
+        thresh="3.1 mm",
         freq="MS",
     )
     np.testing.assert_allclose(out, [np.nan] + [0] * 11)
 
-    out = atmos.dry_spell_total_length(pr, window=7, op="sum", thresh="3 mm", freq="MS", date_bounds=("01-10", "12-31"))
+    out = atmos.dry_spell_total_length(
+        pr, window=7, op="sum", thresh="3.1 mm", freq="MS", date_bounds=("01-10", "12-31")
+    )
     np.testing.assert_allclose(out, [9] + [0] * 11)
 
 
@@ -662,12 +664,14 @@ def test_dry_spell_max_length_indexer(pr_series):
         pr,
         window=7,
         op="sum",
-        thresh="3 mm",
+        thresh="3.1 mm",
         freq="MS",
     )
     np.testing.assert_allclose(out, [np.nan] + [0] * 11)
 
-    out = atmos.dry_spell_total_length(pr, window=7, op="sum", thresh="3 mm", freq="MS", date_bounds=("01-10", "12-31"))
+    out = atmos.dry_spell_total_length(
+        pr, window=7, op="sum", thresh="3.1 mm", freq="MS", date_bounds=("01-10", "12-31")
+    )
     np.testing.assert_allclose(out, [9] + [0] * 11)
 
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] Tests for the changes have been added (for bug fixes / features)
  - [x] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGELOG.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Fix tests that were relying on inexact conversions from pint 0.24.4
    + `pr` data flags where strangely inputting an array full of 1 mm/d and then asserting that the "eq_1_repeating_for_10_or_more_days" tests was _false_. Fixed to True, skipped with older pint.
    + Similarly, the other test had hardcoded inexact kg m-2 s-1 values that converted to 1 in pint 0.24.4, but not pint 0.25.
    + The dry spell tests had a day where the precip amount was just under 3 mm because of inexact conversion, but in theory it should have been 3 (which it is in new pint). The threshold was modified to be less sensitive.
* Avoid `numbagg` for standardized indices. It seems the use (or not) of numbagg changes only slightly the rolling mean values, but this change is enough to throw off the mle-fit-based result of the test. I create a simple fixture that simply deactivates the usage of `numbagg` in the tests where it is added as an arg.

### Does this PR introduce a breaking change?
No.


### Other information:
