### PR TITLE
Use importlib.metadata to get more accurate dependency and version strings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -46,6 +46,7 @@ Internal changes
 * The ``xclim.indices.helpers`` module now uses an ``__all__`` variable to explicitly define the public API of the module. (:pull:`2207`).
 * Viticulture indices are more heavily tested and employ type guarding to ensure that parameters passed are those of the expected types. (:pull:`2207`).
 * Conversion indicators have been split from ``tests/test_atmos.py`` into new ``tests/test_converters.py``. This is to ensure that conversion indicators are tested separately from other atmospheric indicators. (:issue:`1289`, :pull:`2224`).
+* ``xclim.testing.utils.show_versions`` now uses the `importlib.metadata` library to more accurately gather dependency information. (:pull:`2229`).
 
 Bug fixes
 ^^^^^^^^^

--- a/src/xclim/testing/utils.py
+++ b/src/xclim/testing/utils.py
@@ -5,6 +5,7 @@ Testing and Tutorial Utilities' Module
 
 from __future__ import annotations
 
+import importlib.metadata as ilm
 import importlib.resources as ilr
 import logging
 import os
@@ -13,10 +14,10 @@ import re
 import sys
 import time
 import warnings
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from datetime import datetime as dt
 from functools import wraps
-from importlib import import_module
+from importlib.metadata import PackageNotFoundError
 from io import StringIO
 from pathlib import Path
 from shutil import copytree
@@ -286,7 +287,7 @@ _xclim_deps = [
     "xclim",
     "xarray",
     "statsmodels",
-    "sklearn",
+    "scikit-learn",
     "scipy",
     "pint",
     "pandas",
@@ -307,7 +308,7 @@ _xclim_deps = [
 
 def show_versions(
     file: os.PathLike | StringIO | TextIO | None = None,
-    deps: list[str] | None = None,
+    deps: Iterable[str] | None = None,
 ) -> str | None:
     """
     Print the versions of xclim and its dependencies.
@@ -316,8 +317,8 @@ def show_versions(
     ----------
     file : {os.PathLike, StringIO, TextIO}, optional
         If provided, prints to the given file-like object. Otherwise, returns a string.
-    deps : list of str, optional
-        A list of dependencies to gather and print version information from.
+    deps : iterable of str, optional
+        An iterable of dependencies to gather and print version information from.
         Otherwise, prints `xclim` dependencies.
 
     Returns
@@ -331,25 +332,15 @@ def show_versions(
     else:
         dependencies = deps
 
-    dependency_versions = [(d, lambda mod: mod.__version__) for d in dependencies]
-
-    deps_blob: list[tuple[str, str | None]] = []
-    for modname, ver_f in dependency_versions:
+    dependency_versions = {}
+    for d in dependencies:
         try:
-            if modname in sys.modules:
-                mod = sys.modules[modname]
-            else:
-                mod = import_module(modname)
-        except (KeyError, ModuleNotFoundError):
-            deps_blob.append((modname, None))
-        else:
-            try:
-                ver = ver_f(mod)
-                deps_blob.append((modname, ver))
-            except AttributeError:
-                deps_blob.append((modname, "installed"))
+            _version = ilm.version(d)
+        except PackageNotFoundError:
+            _version = None
+        dependency_versions[d] = _version
 
-    modules_versions = "\n".join([f"{k}: {stat}" for k, stat in sorted(deps_blob)])
+    modules_versions = "\n".join([f"{k}: {stat}" for k, stat in sorted(dependency_versions.items())])
 
     installed_versions = [
         "INSTALLED VERSIONS",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,12 +2,16 @@
 # Tests for `xclim` package, command line interface
 from __future__ import annotations
 
+import platform
+
 import numpy as np
 import pytest
 import xarray as xr
 from click.testing import CliRunner
+from packaging import version
 
 import xclim
+from xclim import __version__ as __xclim_version__
 from xclim.cli import cli
 
 try:
@@ -377,6 +381,7 @@ def test_release_notes_failure(method, error):
 def test_show_version_info():
     runner = CliRunner()
     results = runner.invoke(cli, ["show_version_info"])
-    assert "INSTALLED VERSIONS" in results.output
-    assert "python" in results.output
-    assert "boltons: installed" in results.output
+    assert "INSTALLED VERSIONS\n" in results.output
+    assert "------------------\n" in results.output
+    assert f"python: {platform.python_version()}\n" in results.output
+    assert f"xclim: {version.Version(__xclim_version__)}\n" in results.output

--- a/tests/test_testing_utils.py
+++ b/tests/test_testing_utils.py
@@ -73,8 +73,7 @@ class TestReleaseSupportFuncs:
             assert "INSTALLED VERSIONS\n" in contents
             assert "------------------\n" in contents
             assert f"python: {platform.python_version()}\n" in contents
-            assert f"xclim: {__xclim_version__}\n" in contents
-            assert "boltons: installed\n" in contents
+            assert f"xclim: {__xclim_version__.replace('-dev.', '.dev')}\n" in contents
 
     @pytest.mark.requires_docs
     def test_release_notes_file(self, tmp_path):

--- a/tests/test_testing_utils.py
+++ b/tests/test_testing_utils.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+from packaging.version import Version
 from xarray import Dataset
 
 from xclim import __version__ as __xclim_version__
@@ -73,7 +74,7 @@ class TestReleaseSupportFuncs:
             assert "INSTALLED VERSIONS\n" in contents
             assert "------------------\n" in contents
             assert f"python: {platform.python_version()}\n" in contents
-            assert f"xclim: {__xclim_version__.replace('-dev.', '.dev')}\n" in contents
+            assert f"xclim: {Version(__xclim_version__)}\n" in contents
 
     @pytest.mark.requires_docs
     def test_release_notes_file(self, tmp_path):


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGELOG.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Simplifies the collection of version strings in `show_versions` by using `importlib.metadata.version()`

### Does this PR introduce a breaking change?

No.

### Other information:

This should technically be faster, but it is also more accurate as it depends on the package name while not requiring the `__version__` variable (which is not present in some packages).