### PR TITLE
Address click deprecation - use h5netcdf in cli tests

### DIFF
--- a/src/xclim/cli.py
+++ b/src/xclim/cli.py
@@ -355,10 +355,10 @@ def _format_dict(data, formatter, key_fg="blue", spaces=2):
             formatter.write_text(click.style(" " * spaces + attr + " :", fg=key_fg) + " " + str(val))
 
 
-class XclimCli(click.MultiCommand):
+class XclimCli(click.Group):
     """Main cli class."""
 
-    def list_commands(self, ctx) -> tuple[str, str, str, str, str, str]:  # numpydoc ignore=PR01,RT01
+    def list_commands(self, ctx) -> list[str, str, str, str, str, str]:  # numpydoc ignore=PR01,RT01
         """Return the available commands (other than the indicators)."""
         return (
             "indices",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -94,7 +94,7 @@ def test_normal_computation(tasmin_series, tasmax_series, pr_series, tmp_path, i
 
     ds.to_netcdf(input_file, engine="h5netcdf")
 
-    args = ["-i", str(input_file), "-o", str(output_file), "-v", indicator]
+    args = ["-i", str(input_file), "-o", str(output_file), "-v", "--engine", "h5netcdf", indicator]
     runner = CliRunner()
     results = runner.invoke(cli, args)
     for var_name in var_names:
@@ -126,6 +126,8 @@ def test_multi_input(tas_series, pr_series, tmp_path):
             "-o",
             str(output_file),
             "-v",
+            "--engine",
+            "h5netcdf",
             "solidprcptot",
         ],
     )
@@ -150,6 +152,8 @@ def test_multi_output(tmp_path, open_dataset):
             "-o",
             str(output_file),
             "-v",
+            "--engine",
+            "h5netcdf",
             "wind_speed_from_vector",
         ],
     )
@@ -172,6 +176,8 @@ def test_renaming_variable(tas_series, tmp_path):
                 "-o",
                 str(output_file),
                 "-v",
+                "--engine",
+                "h5netcdf",
                 "tn_mean",
                 "--tasmin",
                 "tas",
@@ -200,6 +206,8 @@ def test_indicator_chain(tas_series, tmp_path):
             "-o",
             str(output_file),
             "-v",
+            "--engine",
+            "h5netcdf",
             "tg_mean",
             "growing_degree_days",
         ],
@@ -268,7 +276,7 @@ def test_suspicious_precipitation_flags(pr_series, tmp_path):
     bad_pr.to_netcdf(input_file)
 
     runner = CliRunner()
-    runner.invoke(cli, ["-i", str(input_file), "-o", str(output_file), "dataflags", "pr"])
+    runner.invoke(cli, ["-i", str(input_file), "-o", str(output_file), "--engine", "h5netcdf", "dataflags", "pr"])
     with xr.open_dataset(output_file) as ds:
         for var in ds.data_vars:
             assert var


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #2212
- [x] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] CHANGELOG.rst has been updated (with summary of main changes)
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Address a Click warning about using `Group` instead of `MultiCommand`. I tested and the change is retrocompatible with 8.1 (our lowest click allowed)
* Use `h5netcdf` in the cli tests, hopefully that fixes the worker crashes ?

### Does this PR introduce a breaking change?
No

### Other information:
