### PR TITLE
Fix dimensions of prsn

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog
 =========
 
+v0.59 (unreleased)
+------------------
+Contributors to this version: Pascal Bourgault (:user:`aulemahal`).
+
+Bug fixes
+^^^^^^^^^
+* Fix dimensions of "prsn" in the variable dictionary. (:pull:`2242`).
+
 v0.58.1 (2025-08-28)
 --------------------
 Contributors to this version: Pascal Bourgault (:user:`aulemahal`).

--- a/src/xclim/data/variables.yml
+++ b/src/xclim/data/variables.yml
@@ -94,7 +94,7 @@ variables:
     canonical_units: kg m-2 s-1
     cell_methods: "time: mean"
     description: Surface snowfall flux.
-    dimensions: "[mass]/([area][time])"  # Not precipitation because it's not referring to liquid water
+    dimensions: "[mass]/([area]*[time])"  # Not precipitation because it's not referring to liquid water
     standard_name: snowfall_flux
     data_flags:
       - negative_accumulation_values:


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGELOG.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* The dimensions of `prsn` in the variable dictionary were missing a * symbol and it makes pint fail.

### Does this PR introduce a breaking change?
* No


### Other information:
