### PR TITLE
Control invalidity in robustness fractions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ v0.59 (unreleased)
 ------------------
 Contributors to this version: Pascal Bourgault (:user:`aulemahal`).
 
+New indicators and features
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+* ``xclim.ensembles.robustness_fractions`` now accepts instances of ``xclim.core.missing`` classes as a new ``invalid`` argument to control how data points are flagged as invalid. (:pull:`2245`).
+
 Bug fixes
 ^^^^^^^^^
 * Fix dimensions of "prsn" in the variable dictionary. (:pull:`2242`).

--- a/src/xclim/ensembles/_robustness.py
+++ b/src/xclim/ensembles/_robustness.py
@@ -20,6 +20,7 @@ import scipy.stats as spstats  # noqa
 import xarray as xr
 
 from xclim.core.formatting import gen_call_string, update_xclim_history
+from xclim.core.missing import MissingAny, MissingBase
 from xclim.indices.generic import compare, detrend
 
 __all__ = [
@@ -75,6 +76,7 @@ def robustness_fractions(  # noqa: C901
     ref: xr.DataArray | None = None,
     test: str | None = None,
     weights: xr.DataArray | None = None,
+    invalid: MissingBase = MissingAny(),
     **kwargs,
 ) -> xr.Dataset:
     r"""
@@ -97,6 +99,11 @@ def robustness_fractions(  # noqa: C901
         Name of the statistical test used to determine if there was significant change. See notes.
     weights : xr.DataArray
         Weights to apply along the 'realization' dimension. This array cannot contain missing values.
+    invalid : xc.core.missing.MissingBase instance
+        A Missing class from :py:mod:`xclim.core.missing` to use to flag points what are invalid.
+        Invalid points are not included in the fractions. Default is MissingAny, which means any
+        nan along the "time" dimension means the timeseries is invalid.
+        Not used if only deltas are passed as `fut`.
     **kwargs : dict
         Other arguments specific to the statistical test. See notes.
 
@@ -130,7 +137,7 @@ def robustness_fractions(  # noqa: C901
 
         - valid
             - The weighted fraction of valid members.
-              A member is valid if there are no NaNs along the time axes of `fut` and `ref`.
+              By default, a member is valid if there are no NaNs along the time axes of `fut` and `ref`.
 
         - pvals
             - The p-values estimated by the significance tests.
@@ -208,7 +215,7 @@ def robustness_fractions(  # noqa: C901
             raise ValueError("When deltas are given (ref=None), 'test' must be None or 'threshold'.")
     else:
         delta = fut.mean("time") - ref.mean("time")
-        valid = fut.notnull().all("time") & ref.notnull().all("time")
+        valid = ~invalid(fut) & ~invalid(ref)
 
     if test is None:
         test_params = {}

--- a/tests/test_ensembles.py
+++ b/tests/test_ensembles.py
@@ -22,6 +22,7 @@ import xarray as xr
 from scipy.stats.mstats import mquantiles
 
 from xclim import ensembles
+from xclim.core.missing import AtLeastNValid
 from xclim.indices.stats import get_dist
 
 
@@ -708,6 +709,13 @@ def test_robustness_fractions_empty():
     f = ensembles.robustness_fractions(fut, ref, test="ttest")
     np.testing.assert_array_equal(f.changed, 0)
     np.testing.assert_array_equal(f.valid, 0)
+
+
+def test_robustness_fractions_missing(robust_data):
+    ref, fut = robust_data
+    fut = fut.where(fut.time < fut.time[20], fut.ffill('lon'))
+    fracs = ensembles.robustness_fractions(fut, ref, test='ttest', invalid=AtLeastNValid(n=20))
+    np.testing.assert_array_almost_equal(fracs.valid, [1, 1, 1, 1])
 
 
 def test_robustness_categories():


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] Tests for the changes have been added (for bug fixes / features)
  - [x] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGELOG.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?
Add a `invalid` argument to `robustness_fractions`. This argument receives instances from `xclim.core.missing` classes (`MissingAny`, `AtLeastNValid`, etc). It is used to flag points as invalid and remove them from the fraction calculation.

### Does this PR introduce a breaking change?
Default is `MissingAny` which has the same behaviour as the previous code.


### Other information:
