### PR TITLE
Remove `blackdoc` and `black`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,12 +82,6 @@ repos:
     hooks:
       - id: mdformat
         exclude: '.github/\w+.md|.github/publish-mastodon-template.md|docs/paper/paper.md'
-  - repo: https://github.com/keewis/blackdoc
-    rev: v0.4.1
-    hooks:
-      - id: blackdoc
-        additional_dependencies: [ 'black==25.1.0' ]
-        exclude: '(.py|docs/installation.rst)'
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1
     hooks:
@@ -126,6 +120,6 @@ ci:
   autofix_prs: true
   autoupdate_branch: ''
   autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
-  autoupdate_schedule: monthly
+  autoupdate_schedule: quarterly
   skip: [ nbstripout ]
   submodules: false

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ New indicators and features
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 * ``xclim.ensembles.robustness_fractions`` now accepts instances of ``xclim.core.missing`` classes as a new ``invalid`` argument to control how data points are flagged as invalid. (:pull:`2245`).
 
+Breaking changes
+^^^^^^^^^^^^^^^^
+* `black` and `blackdoc` are no longer required for development. `ruff` is now exclusively used for code and code-block formatting.
+
 Bug fixes
 ^^^^^^^^^
 * Fix dimensions of "prsn" in the variable dictionary. (:pull:`2242`).

--- a/Makefile
+++ b/Makefile
@@ -53,10 +53,9 @@ clean-test: ## remove test and coverage artifacts
 	rm -fr .pytest_cache
 
 lint: ## check style with flake8 and black
-	python -m ruff check src/xclim tests
+	python -m ruff check .
 	python -m flake8 --config=.flake8 src/xclim tests
 	python -m vulture src/xclim tests
-	python -m blackdoc --check README.rst CHANGELOG.rst CONTRIBUTING.rst docs --exclude=".py"
 	codespell src/xclim tests docs
 	python -m numpydoc lint src/xclim/*.py src/xclim/ensembles/*.py src/xclim/indices/*.py src/xclim/indicators/*.py src/xclim/testing/*.py
 	python -m deptry src

--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,7 @@ However, `xclim` will *always* assume the temporal coordinate is named "time". I
 
     ds = ds.rename(T="time")
 
-`xclim` employs `black`_-like code formatting style, a modified `ruff`_ linting configuration, and (mostly) adheres to the `NumPy docstring`_ style. For more information on coding and development conventions, see the `Contributing Guidelines`_.
+`xclim` employs a `black`_-compatible code formatting style (via a modified `ruff`_ configuration) and (mostly) adheres to the `NumPy docstring`_ style. For more information on coding and development conventions, see the `Contributing Guidelines`_.
 
 .. _black: https://black.readthedocs.io/en/stable/
 .. _ruff: https://docs.astral.sh/ruff/

--- a/environment.yml
+++ b/environment.yml
@@ -28,9 +28,7 @@ dependencies:
   # lmoments3 - Not an official dependency but required for some Jupyter notebooks
   - lmoments3 >=1.0.7
   # Testing and development dependencies
-  - black <25.9.0
-  - blackdoc <0.4.2
-  - bump-my-version >=1.1.1
+  - bump-my-version >=1.2.3
   - cairosvg >=2.6.0
   - codespell >=2.4.1
   - coverage >=7.5.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,9 +57,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
   # Dev tools and testing
-  "black <25.9.0",
-  "blackdoc <0.4.2",
-  "bump-my-version >=1.1.1",
+  "bump-my-version >=1.2.3",
   "codespell >=2.4.1",
   "coverage[toml] >=7.5.0",
   "deptry >=0.23.0",

--- a/tox.ini
+++ b/tox.ini
@@ -30,10 +30,8 @@ description = Run code quality compliance tests under {basepython}
 skip_install = True
 extras =
 deps =
-    black <25.9.0
-    blackdoc <0.4.2
     codespell >=2.4.1
-    deptry >=0.23.0
+    deptry >=0.23.1
     flake8 >=7.2.0
     flake8-rst-docstrings ==0.3.1
     numpydoc >=1.9.0


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGELOG.rst has been updated (with summary of main changes)
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* `black` and `blackdoc` have been removed from the code base in favour of `ruff`
* `pre-commit` is now configured to only update hooks every three (3) months.

### Does this PR introduce a breaking change?

No. Recent versions of `ruff` were already checking code blocks in text, and `black` was only listed as a runtime dependency for `blackdoc`.
