### PR TITLE
Ensure Python3.13 max is used for key CI workflows

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -36,6 +36,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: read
+    strategy:
+      matrix:
+        python-version: [ "3.13" ]
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
@@ -61,7 +64,7 @@ jobs:
       - name: Set up Python3
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
-          python-version: "3.x"
+          python-version: ${{ matrix.python-version }}
       - name: Import GPG Key
         uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6.3.0
         with:

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -16,6 +16,9 @@ jobs:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ "3.13" ]
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
@@ -35,7 +38,7 @@ jobs:
       - name: Set up Python3
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
-          python-version: "3.x"
+          python-version: ${{ matrix.python-version }}
       - name: Install CI libraries
         run: |
           python -m pip install --require-hashes -r CI/requirements_ci.txt

--- a/.github/workflows/tag-testpypi.yml
+++ b/.github/workflows/tag-testpypi.yml
@@ -16,6 +16,9 @@ jobs:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ "3.13" ]
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
@@ -35,7 +38,7 @@ jobs:
       - name: Set up Python3
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
-          python-version: "3.x"
+          python-version: ${{ matrix.python-version }}
       - name: Install CI libraries
         run: |
           python -m pip install --require-hashes -r CI/requirements_ci.txt


### PR DESCRIPTION
### What kind of change does this PR introduce?

* Sets the maximum Python for CI workflows to v3.13

### Does this PR introduce a breaking change?

No.

### Other information:

With the release of Python3.14, there are still several key packages required to adapt to it. In our CI pipelines, one project relies on Rust bindings that are not yet available for Python3.14.