### PR TITLE
Use pull_request trigger instead of pull_request_target

### DIFF
--- a/.github/workflows/auto-accept-ci-changes.yml
+++ b/.github/workflows/auto-accept-ci-changes.yml
@@ -1,7 +1,7 @@
 name: Accept Dependabot CI Updates
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     types:
@@ -17,7 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       github.event.pull_request.user.login == 'dependabot[bot]' &&
-      contains(github.event.pull_request.labels.*.name, 'dependencies')
+      contains(github.event.pull_request.labels.*.name, 'dependencies') &&
+      github.repository == 'Ouranosinc/xclim'
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
### What kind of change does this PR introduce?

* Sets the trigger to use `pull_request` instead of `pull_request_target`

### Other information:

Permissions are very much locked down for Dependabot (which is good), but it makes what I'm trying to do much more complicated.
