### PR TITLE
Validating call signature types

### DIFF
--- a/src/xclim/core/validations.py
+++ b/src/xclim/core/validations.py
@@ -1,0 +1,406 @@
+"""Module containing base QC which call multiple QC functions and could be applied on a DataBundle."""
+
+from __future__ import annotations
+
+import collections.abc as abc
+import inspect
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from functools import wraps
+from types import UnionType
+from typing import (
+    Annotated,
+    Any,
+    Literal,
+    Union,
+    get_args,
+    get_origin,
+    get_type_hints,
+)
+
+import numpy as np
+import numpy.typing as npt
+import pandas as pd
+
+
+def validate_non_generic(value: Any, expected: Any) -> bool:
+    """
+    Validate a non-generic type (str, int, float, etc.).
+
+    Parameters
+    ----------
+    value : Any
+        The value to validate.
+    expected : Any
+        The expected type.
+
+    Returns
+    -------
+    bool
+        True if `value` matches `expected`, False otherwise.
+    """
+    if isinstance(expected, type):
+        return isinstance(value, expected)
+    return False
+
+
+def validate_mapping(value: Mapping[Any, Any], origin: type, args: tuple[Any, ...]) -> bool:
+    """
+    Validate a mapping type (dict, Mapping).
+
+    Parameters
+    ----------
+    value : Mapping[Any, Any]
+        The value to validate.
+    origin : type
+        The mapping type (e.g., dict).
+    args : tuple[Any, ...]
+        Expected key and value types.
+
+    Returns
+    -------
+    bool
+        True if `value` matches the mapping type and key/value types, False otherwise.
+    """
+    if not isinstance(value, origin):
+        return False
+    if not args:
+        return True
+    key_type, val_type = args
+    return all(validate_type(k, key_type) and validate_type(v, val_type) for k, v in value.items())
+
+
+def validate_iterable(value: Iterable[Any], origin: type, args: tuple[Any, ...]) -> bool:
+    """
+    Validate an iterable type (list, set, frozenset).
+
+    Parameters
+    ----------
+    value : Any
+        The value to validate.
+    origin : type
+        The iterable type.
+    args : tuple[Any, ...]
+        Expected element types.
+
+    Returns
+    -------
+    bool
+        True if all elements match the expected type, False otherwise.
+    """
+    if not isinstance(value, origin):
+        return False
+    if not args:
+        return True
+    elem_type = args[0]
+    return all(validate_type(v, elem_type) for v in value)
+
+
+def validate_sequence(value: Any, args: tuple[Any, ...]) -> bool:
+    """
+    Validate a generic sequence type (e.g., Sequence[int]).
+
+    Parameters
+    ----------
+    value : Any
+        The value to validate.
+    args : tuple[Any, ...]
+        Expected element types.
+
+    Returns
+    -------
+    bool
+        True if all elements match the expected type, False otherwise.
+    """
+    if not isinstance(value, abc.Sequence) or isinstance(value, (str, bytes)):
+        return False
+    if not args:
+        return True
+    elem_type = args[0]
+    return all(validate_type(v, elem_type) for v in value)
+
+
+def validate_tuple(value: Any, args: tuple[Any, ...]) -> bool:
+    """
+    Validate a tuple type (fixed-length or homogeneous).
+
+    Parameters
+    ----------
+    value : Any
+        The value to validate.
+    args : tuple[Any, ...]
+        Expected element types.
+
+    Returns
+    -------
+    bool
+        True if the tuple matches the expected types and length, False otherwise.
+    """
+    if not isinstance(value, abc.Sequence) or isinstance(value, (str, bytes)):
+        return False
+    if not args:
+        return True
+    if len(args) == 2 and args[1] is Ellipsis:
+        return all(validate_type(v, args[0]) for v in value)
+    if len(args) != len(value):
+        return False
+    return all(validate_type(v, t) for v, t in zip(value, args, strict=False))
+
+
+def validate_ndarray(value: Any, args: tuple[Any, ...]) -> bool:
+    """
+    Validate a numpy ndarray type, optionally checking dtype.
+
+    Parameters
+    ----------
+    value : Any
+        The value to validate.
+    args : tuple[Any, ...]
+        Expected dtype (first argument may be `Any` or unspecified).
+
+    Returns
+    -------
+    bool
+        True if `value` is an ndarray and matches expected dtype, False otherwise.
+    """
+    if not isinstance(value, np.ndarray):
+        return False
+
+    if not args:
+        return True
+
+    if len(args) < 2:
+        return True
+
+    expected_dtype = args[1]
+
+    inner = get_args(expected_dtype)
+    if inner:
+        expected_dtype = inner[0]
+
+    if expected_dtype in (Any, None):
+        return True
+
+    try:
+        return np.issubdtype(value.dtype, expected_dtype)
+    except TypeError:
+        return False
+
+
+def safe_isinstance(value: Any, origin: Any) -> bool:
+    """
+    Safely check if value is an instance of a type, avoiding TypeError for weird generics.
+
+    Parameters
+    ----------
+    value : Any
+        Value to check.
+    origin : Any
+        Type or generic to check against.
+
+    Returns
+    -------
+    bool
+        True if `value` is an instance of `origin`, False otherwise.
+    """
+    try:
+        return isinstance(value, origin)
+    except TypeError:
+        return False
+
+
+def validate_type(value: Any, expected: Any) -> bool:
+    """
+    Recursively validate that a value matches the expected type hint.
+
+    Parameters
+    ----------
+    value : Any
+        The value to validate.
+    expected : Any
+        The expected value type for validation.
+
+    Returns
+    -------
+    bool
+        - True if type of `value` does match `expected`.
+        - False if type of `value` does not match `expected`.
+    """
+    if expected is Any:
+        return True
+
+    origin = get_origin(expected)
+    args = get_args(expected)
+
+    if origin is Annotated:
+        return validate_type(value, args[0])
+
+    if origin is Literal:
+        return value in args
+
+    if origin in (Union, UnionType):
+        return any(validate_type(value, t) for t in args)
+
+    if origin is abc.Callable:
+        return callable(value)
+
+    if origin is tuple:
+        return validate_tuple(value, args)
+
+    if origin in (np.ndarray, npt.NDArray):
+        return validate_ndarray(value, args)
+
+    if isinstance(expected, type) and issubclass(expected, (pd.DataFrame, pd.Series)):
+        return isinstance(value, expected)
+
+    if isinstance(origin, type):
+        if issubclass(origin, abc.Mapping):
+            return validate_mapping(value, origin, args)
+        if issubclass(origin, (list, set, frozenset)):
+            return validate_iterable(value, origin, args)
+        if issubclass(origin, abc.Sequence):
+            return validate_sequence(value, args)
+
+    if origin is None:
+        return validate_non_generic(value, expected)
+
+    return safe_isinstance(value, origin)
+
+
+def validate_arg(
+    key: str,
+    value: Any,
+    func_name: str,
+    parameters: Mapping[str, inspect.Parameter],
+    type_hints: Mapping[str, Any],
+    has_arguments: bool,
+) -> None:
+    """
+    Validate argument against a function's signature, taking decorators into account.
+
+    Parameters
+    ----------
+    key : str
+        The name of the argument to validate.
+    value : Any
+        The value of the argument to validate.
+    func_name : str
+        The name of the function (used in error message).
+    parameters : Mapping[str, inspect.Parameter]
+        A mapping of parameter names to `inspect.Parameter` objects,
+        typically from `inspect.signature(func).parameters`.
+    type_hints : Mapping[str, type]
+        A mapping of parameter names to expected types,
+        typically from `typing.get_type_hints(func)`.
+    has_arguments : bool
+        Whether the function accepts arbitrary arguments.
+    """
+    if has_arguments:
+        return
+
+    if key not in parameters:
+        raise ValueError(f"Parameter '{key}' is not a valid parameter of function '{func_name}'.")
+
+    expected = type_hints.get(key)
+    if not expected or expected is inspect._empty:
+        return
+
+    if not validate_type(value, expected):
+        raise TypeError(
+            f"Parameter '{key}' does not match {expected!r}. Got value {value!r} of type {type(value).__name__}."
+        )
+
+
+def validate_args(
+    func: Callable[..., Any],
+    args: Sequence[Any] | None = None,
+    kwargs: Mapping[str, Any] | None = None,
+) -> None:
+    """
+    Validate positional and keyword arguments against a function's signature.
+
+    This function checks that:
+    - All provided keyword arguments correspond to valid parameters of the given function.
+    - All required parameters of the function are present in the provided keyword arguments.
+
+    Parameters
+    ----------
+    func : Callable[..., Any]
+        The function whose signature is used for validation.
+    args : Sequence[Any], optional
+        Sequence of arguments intended to be passed to `func`.
+    kwargs : Mapping[str, Any], optional
+        Dictionary of keyword arguments intended to be passed to `func`.
+
+    Raises
+    ------
+    ValueError
+        If `kwargs` contains a key that is not a parameter of `func`.
+    TypeError
+        If a required parameter of `func` is missing from `kwargs`.
+    """
+    args = args or ()
+    if not isinstance(args, (list, tuple)):
+        args = (args,)
+
+    kwargs = kwargs or {}
+
+    sig = inspect.signature(func)
+    params = list(sig.parameters.values())
+
+    positional_params = [
+        p for p in params if p.kind in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+    ]
+
+    has_args = any(p.kind == inspect.Parameter.VAR_POSITIONAL for p in params)
+
+    if len(args) > len(positional_params) and not has_args:
+        raise TypeError(f"Too many positional arguments for function '{func.__name__}'.")
+
+    bound_args = [positional_params[i].name for i in range(min(len(args), len(positional_params)))]
+
+    has_kwargs = any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params)
+
+    type_hints = get_type_hints(func)
+
+    for i, arg in enumerate(args):
+        validate_arg(bound_args[i], arg, func.__name__, sig.parameters, type_hints, has_args)
+
+    for key, value in kwargs.items():
+        validate_arg(key, value, func.__name__, sig.parameters, type_hints, has_kwargs)
+
+    for param in params:
+        if (
+            param.default is inspect.Parameter.empty
+            and param.kind
+            in (
+                inspect.Parameter.POSITIONAL_ONLY,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                inspect.Parameter.KEYWORD_ONLY,
+            )
+            and param.name not in kwargs
+            and param.name not in bound_args
+        ):
+            raise TypeError(f"Required parameter '{param.name}' is missing for function '{func.__name__}'.")
+
+
+def validate_parameters(func: Callable[..., Any]) -> Callable[..., Any]:
+    """
+    A decorator that validates function arguments against type hints before calling the function.
+
+    Parameters
+    ----------
+    func : Callable[..., Any]
+        The function to wrap.
+
+    Returns
+    -------
+    Callable[..., Any]
+        The wrapped function with argument validation.
+    """
+
+    @wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:  # numpydoc ignore=GL08
+        validate_args(func, args, kwargs)
+        return func(*args, **kwargs)
+
+    return wrapper

--- a/tests/test_validations.py
+++ b/tests/test_validations.py
@@ -1,0 +1,445 @@
+from __future__ import annotations
+
+import inspect
+from collections.abc import Callable, Mapping, Sequence
+from typing import Annotated, Any, Literal, get_type_hints
+
+import numpy as np
+import numpy.typing as npt
+import pandas as pd
+import pytest
+
+from xclim.core.validations import (
+    safe_isinstance,
+    validate_arg,
+    validate_args,
+    validate_iterable,
+    validate_mapping,
+    validate_ndarray,
+    validate_non_generic,
+    validate_parameters,
+    validate_sequence,
+    validate_tuple,
+    validate_type,
+)
+
+
+def sample_func_long(
+    a: int,
+    b: list[int],
+    c: dict[str, int],
+    d: tuple[int, str],
+    e: tuple[int, ...],
+    f: int | None,
+    g: Literal["x", "y"],
+    h: int | str,
+    i: list[int | str],
+    j: Annotated[int, "positive"],
+    k: Callable[[int], str],
+    m: set[float],
+    n: frozenset[int],
+    o: Sequence[int],
+    p: Mapping[str, list[int]],
+    q: dict[str, list[tuple[int, float | None]]],
+    r: pd.DataFrame,
+    s: pd.Series,
+    t: np.ndarray,
+    u: npt.NDArray[np.int64],
+    v,
+):
+    return a, b, c, d, e, f, g, h, i, j, k, m, n, o, p, q, r, s, t, u
+
+
+def sample_func_short(a: int):
+    return a
+
+
+def sample_func_kwargs(a: int, **kwargs):
+    return {"a": a, **kwargs}
+
+
+@pytest.fixture
+def series_ind():
+    return pd.Series([1, 2, 3, 4], name="value")
+
+
+@pytest.fixture
+def df_ind():
+    return pd.DataFrame({"value1": [1, 2, 3, 4], "value2": [1, 1, 2, 2]})
+
+
+@validate_parameters
+def add(x: int, y: int) -> int:
+    return x + y
+
+
+@validate_parameters
+def mulc(x: int, y: int = 2) -> int:
+    return x * y
+
+
+PARAMETERS = inspect.signature(sample_func_long).parameters
+TYPE_HINTS = get_type_hints(sample_func_long)
+
+
+def test_validate_non_generic():
+    assert validate_non_generic(5, int)
+    assert not validate_non_generic("5", int)
+    assert not validate_non_generic(5, 123)
+
+
+def test_validate_mapping():
+    assert not validate_mapping([], dict, (str, int))
+    assert validate_mapping({"a": 1}, dict, ())
+    assert validate_mapping({"a": 1}, dict, (str, int))
+    assert not validate_mapping({"a": "1"}, dict, (str, int))
+
+
+def test_validate_iterable():
+    assert not validate_iterable((1, 2), list, (int,))
+    assert validate_iterable([1, 2], list, ())
+    assert validate_iterable([1, 2], list, (int,))
+    assert not validate_iterable([1, "2"], list, (int,))
+
+
+def test_validate_sequence():
+    assert not validate_sequence("123", (int,))
+    assert validate_sequence([1, 2], ())
+    assert validate_sequence([1, 2], (int,))
+    assert not validate_sequence([1, "2"], (int,))
+
+
+def test_validate_tuple():
+    assert not validate_tuple("123", (int,))
+    assert validate_tuple((1, 2), ())
+    assert validate_tuple((1, 2), (int, Ellipsis))
+    assert not validate_tuple((1, "2"), (int, Ellipsis))
+    assert validate_tuple((1, "2"), (int, str))
+    assert not validate_tuple((1,), (int, str))
+    assert not validate_tuple((1, 2), (int, str))
+
+
+def test_validate_ndarray():
+    arr = np.array([1, 2, 3])
+
+    assert not validate_ndarray([1, 2, 3], (None, np.int64))
+    assert validate_ndarray(arr, ())
+    assert validate_ndarray(arr, (np.int64,))
+    assert validate_ndarray(arr, (None, Any))
+    assert validate_ndarray(arr, (None, None))
+    assert validate_ndarray(arr, (None, np.int64))
+    assert not validate_ndarray(arr, (None, np.float64))
+    assert not validate_ndarray(arr, (None, object()))
+
+
+def test_safe_isinstance():
+    assert safe_isinstance(5, int)
+    assert not safe_isinstance(5, list[int])
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        # Simple types
+        (123, Any),
+        ("abc", str),
+        (5, int),
+        (int, type[int]),
+        # Annotated / Literal
+        (10, Annotated[int, "meta"]),
+        ("x", Literal["x", "y"]),
+        # Union / Optional
+        (5, int | str),
+        ("hello", int | str),
+        (None, int | None),
+        # Callable
+        (lambda x: x, Callable[[int], int]),
+        # Mappings
+        ({"a": 1}, dict[str, int]),
+        ({"a": 1}, dict),
+        ({}, dict[str, int]),
+        # Iterables
+        ([1, 2, 3], list[int]),
+        ([1, 2, 3], list),
+        ([1, 2, 3], Sequence[int]),
+        ([1, 2, 3], Sequence),
+        ([1], tuple[int, ...]),
+        ((1, 2, 3), tuple[int, ...]),
+        ((1, 2, 3), tuple),
+        ((1, "x"), tuple[int, str]),
+        # Sets/ frozensets
+        ({1.0, 2.0}, set[float]),
+        (frozenset({1, 2}), frozenset[int]),
+        # NumPy arrays
+        (np.array([1, 2, 3]), np.ndarray),
+        (np.array([1, 2, 3], dtype=np.int64), npt.NDArray[np.int64]),
+        (np.array([1, 2, 3]), npt.NDArray[np.int64]),
+        (np.array([1.0, 2.0]), npt.NDArray[Any]),
+        (np.array([1, 2, 3]), npt.NDArray[Any]),
+        # pandas objects
+        (pd.DataFrame({"a": [1, 2]}), pd.DataFrame),
+        (pd.Series([1, 2]), pd.Series),
+    ],
+)
+def test_validate_type_valid(value, expected):
+    assert validate_type(value, expected)
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        # Simple types
+        ("5", int),
+        ("z", Literal["x", "y"]),
+        (5.5, int | str),
+        (5, str),
+        # Mappings
+        ({1: "a"}, dict[str, int]),
+        ({"a": "b"}, dict[str, int]),
+        ([("a", 1)], dict[str, int]),
+        # Sequence
+        ([1, "x"], list[int]),
+        ((1,), tuple[int, str]),
+        ((1, 2), tuple[int, str]),
+        ((1, "x"), tuple[int, int]),
+        ((1, 2), list[int]),
+        ([1, "x"], Sequence[int]),
+        ("abc", Sequence[str]),
+        # NumPy arrays
+        (np.array([1.0, 2.0]), npt.NDArray[np.int64]),
+        (np.array([1, 2, 3]), npt.NDArray[object]),
+        # pandas objects
+        (pd.Series([1, 2]), pd.DataFrame),
+        # Others
+        (5, list[int]),
+        (5, 123),
+        (123, Callable[[int], int]),
+        ("abc", Sequence[int]),
+    ],
+)
+def test_validate_type_invalid(value, expected):
+    assert not validate_type(value, expected)
+
+
+@pytest.mark.parametrize(
+    "key,value",
+    [
+        ("a", 5),
+        ("b", [1, 2, 3]),
+        ("c", {"x": 1, "y": 2}),
+        ("d", (1, "hello")),
+        ("e", (1, 2, 3)),
+        ("f", None),
+        ("f", 10),
+        ("g", "x"),
+        ("h", 42),
+        ("h", "hello"),
+        ("i", [1, "a", 3]),
+        ("j", 99),
+        ("k", lambda x: str(x)),
+        ("m", {1.0, 2.5}),
+        ("n", frozenset({1, 2, 3})),
+        ("o", [1, 2, 3]),
+        ("p", {"a": [1, 2], "b": [3]}),
+        ("q", {"a": [(1, 2.0), (3, None)]}),
+        ("r", pd.DataFrame({"a": [1, 2, 3]})),
+        ("s", pd.Series([1, 2, 3])),
+        ("t", np.array([1, 2, 3])),
+        ("u", np.array([1, 2, 3], dtype=np.int64)),
+        ("v", 1),
+    ],
+)
+def test_validate_arg_valid(key, value):
+    validate_arg(
+        key=key,
+        value=value,
+        func_name="sample_func_long",
+        parameters=PARAMETERS,
+        type_hints=TYPE_HINTS,
+        has_arguments=False,
+    )
+
+
+@pytest.mark.parametrize(
+    "key,value",
+    [
+        ("a", "not int"),
+        ("b", [1, "wrong"]),
+        ("c", {"x": "wrong"}),
+        ("d", (1, 2)),
+        ("e", ("wrong",)),
+        ("f", "not optional int"),
+        ("g", "z"),
+        ("h", 3.14),
+        ("i", [1, 2.0]),
+        ("g", "z"),
+        ("j", "not int"),
+        ("k", "not callable"),
+        ("m", {1, 2}),
+        ("n", {1, 2}),
+        ("o", ["x", "y"]),
+        ("p", {"a": ["wrong"]}),
+        ("q", {"a": [(1, "wrong")]}),
+        ("d", (1, 2)),
+        ("e", ("a",)),
+        ("r", {"a": [1, 2, 3]}),
+        ("s", [1, 2, 3]),
+        ("t", [1, 2, 3]),
+        ("u", np.array([1, 2, 3], dtype=float)),
+    ],
+)
+def test_validate_arg_invalid_type(key, value):
+    with pytest.raises(TypeError):
+        validate_arg(
+            key=key,
+            value=value,
+            func_name="sample_func_long",
+            parameters=PARAMETERS,
+            type_hints=TYPE_HINTS,
+            has_arguments=False,
+        )
+
+
+def test_validate_arg_invalid_parameter_name():
+    with pytest.raises(ValueError):
+        validate_arg(
+            key="unknown",
+            value=123,
+            func_name="sample_func_long",
+            parameters=PARAMETERS,
+            type_hints=TYPE_HINTS,
+            has_arguments=False,
+        )
+
+
+def test_has_arguments_skips_validation():
+    validate_arg(
+        key="unknown",
+        value="anything",
+        func_name="sample_func_long",
+        parameters=PARAMETERS,
+        type_hints=TYPE_HINTS,
+        has_arguments=True,
+    )
+
+
+def test_validate_args_passing_required_only():
+    validate_args(sample_func_short, kwargs={"a": 2})
+
+
+def test_validate_args_passing_with_extra_kwargs():
+    validate_args(sample_func_kwargs, kwargs={"a": 2, "extra": 123})
+
+
+def test_validate_args_passing_with_args_and_kwargs():
+    validate_args(sample_func_kwargs, args=2, kwargs={"extra": 123})
+
+
+def test_validate_args_invalid_param():
+    with pytest.raises(ValueError, match="is not a valid parameter of function"):
+        validate_args(sample_func_short, kwargs={"a": 2, "extra": 123})
+
+
+def test_validate_args_missing_required_param():
+    with pytest.raises(TypeError, match="is missing for function"):
+        validate_args(sample_func_kwargs, kwargs={"extra": 123})
+
+
+def test_validate_args_too_many_args():
+    with pytest.raises(TypeError, match="Too many positional arguments for function"):
+        validate_args(sample_func_short, args=(1, 2))
+
+
+def test_validate_args_passing_args_only():
+    validate_args(
+        sample_func_long,
+        args=(
+            5,
+            [1, 2, 3],
+            {"x": 1, "y": 2},
+            (1, "hello"),
+            (1, 2, 3),
+            10,
+            "x",
+            42,
+            [1, "a", 3],
+            99,
+            lambda x: str(x),
+            {1.0, 2.5},
+            frozenset({1, 2, 3}),
+            [1, 2, 3],
+            {"a": [1, 2], "b": [3]},
+            {"a": [(1, 2.0), (3, None)]},
+            pd.DataFrame({"a": [1, 2, 3]}),
+            pd.Series([1, 2, 3]),
+            np.array([1, 2, 3]),
+            np.array([1, 2, 3], dtype=np.int64),
+            1,
+        ),
+    )
+
+
+def test_validate_args_passing_kwargs_only():
+    validate_args(
+        sample_func_long,
+        kwargs={
+            "a": 5,
+            "b": [1, 2, 3],
+            "c": {"x": 1, "y": 2},
+            "d": (1, "hello"),
+            "e": (1, 2, 3),
+            "f": 10,
+            "g": "x",
+            "h": 42,
+            "i": [1, "a", 3],
+            "j": 99,
+            "k": lambda x: str(x),
+            "m": {1.0, 2.5},
+            "n": frozenset({1, 2, 3}),
+            "o": [1, 2, 3],
+            "p": {"a": [1, 2], "b": [3]},
+            "q": {"a": [(1, 2.0), (3, None)]},
+            "r": pd.DataFrame({"a": [1, 2, 3]}),
+            "s": pd.Series([1, 2, 3]),
+            "t": np.array([1, 2, 3]),
+            "u": np.array([1, 2, 3], dtype=np.int64),
+            "v": 1,
+        },
+    )
+
+
+def test_validate_parameters_pass_pos():
+    assert add(2, 3) == 5
+
+
+def test_validate_parameters_pass_kw():
+    assert add(x=2, y=3) == 5
+
+
+def test_validate_parameters_error_pos():
+    with pytest.raises(TypeError, match="does not match expected type"):
+        add(2, "3")
+
+
+def test_validate_parameters_error_kw():
+    with pytest.raises(TypeError, match="does not match expected type"):
+        add(x=2, y="3")
+
+
+def test_validate_parameters_error_few():
+    with pytest.raises(TypeError, match="Required parameter"):
+        add(2)  # pylint: disable=E1120
+
+
+def test_validate_parameters_error_many():
+    with pytest.raises(TypeError, match="Too many positional arguments"):
+        add(2, 3, 4)  # pylint: disable=E1121
+
+
+def test_validate_parameters_error_invalid_kw():
+    with pytest.raises(ValueError, match="not a valid parameter"):
+        add(x=2, z=3)  # pylint: disable=E1120
+
+
+def test_validate_parameters_pass_default():
+    assert mulc(2) == 4

--- a/tests/test_validations.py
+++ b/tests/test_validations.py
@@ -58,16 +58,6 @@ def sample_func_kwargs(a: int, **kwargs):
     return {"a": a, **kwargs}
 
 
-@pytest.fixture
-def series_ind():
-    return pd.Series([1, 2, 3, 4], name="value")
-
-
-@pytest.fixture
-def df_ind():
-    return pd.DataFrame({"value1": [1, 2, 3, 4], "value2": [1, 1, 2, 2]})
-
-
 @validate_parameters
 def add(x: int, y: int) -> int:
     return x + y


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #2328
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] CHANGELOG.rst has been updated (with summary of main changes)
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* [ ] add simple type validation functions in module `xclim.core.validations`
* [ ] add decorator that validates function arguments against type hints `xclim.core.validations.validate_parameters`

### Does this PR introduce a breaking change?

* new  decorator that validates function arguments against type hints

### Questions

- Do you want me to adjust the new decorator to some functions?
- How can we take other decorators into account? Do other decorators convert the type?