### PR TITLE
Fix rate2amount error of 1000 when sampling inferred from cftime coord

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog
 =========
 
+v0.61.1 (unreleased)
+--------------------
+Contributors to this version: Pascal Bourgault (:user:`aulemahal`).
+
+Bug fixes
+^^^^^^^^^
+* Fix conversion error with ``xc.units.rate2amount`` and ``xc.units.amount2rate`` when ``sampling_rate_from_coord=True`` or sampling frequency is monthly or coarser and time coordinate is cftime-backed. Previous results were 1000x to small. (:pull:`2357`).
+
 v0.61.0 (2026-05-07)
 --------------------
 Contributors to this version: Pascal Bourgault (:user:`aulemahal`), Trevor James Smith (:user:`Zeitsperre`), Hui-Min Wang (:user:`Hem-W`), Éric Dupuis (:user:`coxipi`).

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ Contributors to this version: Pascal Bourgault (:user:`aulemahal`).
 
 Bug fixes
 ^^^^^^^^^
-* Fix conversion error with ``xc.units.rate2amount`` and ``xc.units.amount2rate`` when ``sampling_rate_from_coord=True`` or sampling frequency is monthly or coarser and time coordinate is cftime-backed. Previous results were 1000x to small. (:pull:`2357`).
+* Fix conversion error with ``xc.units.rate2amount`` and ``xc.units.amount2rate`` when ``sampling_rate_from_coord=True`` or sampling frequency is monthly or coarser and time coordinate is `cftime`-based. Previous results were 1000x too small. (:pull:`2357`).
 
 v0.61.0 (2026-05-07)
 --------------------

--- a/src/xclim/core/units.py
+++ b/src/xclim/core/units.py
@@ -815,8 +815,8 @@ def _rate_and_amount_converter(
         # In the case with no freq, last period as the same length as the one before.
         # In the case with freq in M, Q, A, this has been dealt with above in `time`
         # and `label` has been updated accordingly.
-        dt = time.diff(dim, label=label).reindex({dim: time}, method="ffill").astype(float)
-        dt = dt / 1e9  # Convert to seconds
+        dt = time.diff(dim, label=label).reindex({dim: time}, method="ffill")
+        dt = dt.astype("timedelta64[s]").astype(float)  # Convert to seconds
 
         if to == "amount":
             tu = (str2pint(da.units) * str2pint("s")).to_reduced_units()

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -229,9 +229,11 @@ class TestCheckUnits:
             check_units("deg C", "[temperature]")
 
 
-def test_rate2amount(pr_series):
-    pr = pr_series(np.ones(365 + 366 + 365), start="2019-01-01")
+@pytest.mark.parametrize("use_cftime", [True, False])
+def test_rate2amount(pr_series, use_cftime):
+    pr = pr_series(np.ones(365 + 366 + 365), start="2019-01-01", cftime=use_cftime)
 
+    # this uses the inferred freq to get a timedelta
     am_d = rate2amount(pr)
     np.testing.assert_array_equal(am_d, 86400)
 
@@ -239,6 +241,7 @@ def test_rate2amount(pr_series):
         pr_ms = pr.resample(time="MS").mean()
         pr_m = pr.resample(time="ME").mean()
 
+        # MS is not a constant-length period, this uses the sampling coord diff to get timedeltas
         am_ms = rate2amount(pr_ms)
         np.testing.assert_array_equal(am_ms[:4], 86400 * np.array([31, 28, 31, 30]))
         am_m = rate2amount(pr_m)


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGELOG.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?
In `rate2amount` and `amount2rate`,  when `sampling_rate_from_coord` is True, which is implicit when the sampling freq is monthly or coarser, we compute the length of the sampling period by taking the diff of the time coordinate, we then convert the `timedelta` objects in seconds.

Previously, both time types (`numpy.datetime64` and  `cftime`) yielded a `timedelta64[ns]`  dtype when subtracted. But, when pandas introduced support for other units, xarray followed and now it will often return `timedelta64[us]` in the cftime case. 

This PR changes the conversion to be explicit, not simply assuming nanoseconds.

### Does this PR introduce a breaking change?
No, it was broken before.

### Other information:
I'm afraid the changes in pandas and xarray are not so recent, so this bug has been there for a while!!

@Zeitsperre I think this is a patch-release level seriousness (but perhaps not urgent enough for releasing on a friday).