### PR TITLE
Fix Indicator documentation for Sphinx 9

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,7 @@ Bug fixes
 * Fix conversion error with ``xc.units.rate2amount`` and ``xc.units.amount2rate`` when ``sampling_rate_from_coord=True`` or sampling frequency is monthly or coarser and time coordinate is `cftime`-based. Previous results were 1000x too small. (:pull:`2357`).
 
 Internal changes
-^^^^^^^^^^^^^^^^ 
+^^^^^^^^^^^^^^^^
 * Fixed documentation generation with Sphinx 9 by activating the legacy `autodoc` system. (:pull:`2358`).
 
 v0.61.0 (2026-05-07)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ Bug fixes
 ^^^^^^^^^
 * Fix conversion error with ``xc.units.rate2amount`` and ``xc.units.amount2rate`` when ``sampling_rate_from_coord=True`` or sampling frequency is monthly or coarser and time coordinate is `cftime`-based. Previous results were 1000x too small. (:pull:`2357`).
 
+Internal changes
+^^^^^^^^^^^^^^^^ 
+* Fixed documentation generation with Sphinx 9 by activating the legacy `autodoc` system. (:pull:`2358`).
+
 v0.61.0 (2026-05-07)
 --------------------
 Contributors to this version: Pascal Bourgault (:user:`aulemahal`), Trevor James Smith (:user:`Zeitsperre`), Hui-Min Wang (:user:`Hem-W`), Éric Dupuis (:user:`coxipi`).

--- a/docs/autodoc_indicator.py
+++ b/docs/autodoc_indicator.py
@@ -11,11 +11,13 @@ from __future__ import annotations
 from sphinx.domains.python import PyFunction, PyXRefRole
 from sphinx.ext import autodoc
 
+from xclim import __version__
 from xclim.core.indicator import Indicator
 
 
 class IndicatorDocumenter(autodoc.FunctionDocumenter):
     objtype = "indicator"
+    directivetype = "indicator"
 
     @classmethod
     def can_document_member(cls, member, membername, isattr, parent):
@@ -27,6 +29,8 @@ class IndicatorDirective(PyFunction):
 
 
 def setup(app):
+    app.setup_extension("sphinx.ext.autodoc")
     app.add_autodocumenter(IndicatorDocumenter)
     app.add_directive_to_domain("py", "indicator", IndicatorDirective)
     app.add_role_to_domain("py", "indicator", PyXRefRole())
+    return {"version": __version__, "parallel_read_safe": True}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -112,6 +112,7 @@ extensions = [
 autodoc_typehints = "description"
 autodoc_typehints_format = "fully-qualified"
 autodoc_typehints_description_target = "documented_params"
+autodoc_use_legacy_class_based = True
 
 autosectionlabel_prefix_document = True
 autosectionlabel_maxdepth = 2

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -112,7 +112,7 @@ extensions = [
 autodoc_typehints = "description"
 autodoc_typehints_format = "fully-qualified"
 autodoc_typehints_description_target = "documented_params"
-autodoc_use_legacy_class_based = True
+autodoc_use_legacy_class_based = True  # required for Indicators API with sphinx v9.0
 
 autosectionlabel_prefix_document = True
 autosectionlabel_maxdepth = 2


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGELOG.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?
Turns out sphinx 9 became the one installed in the RTD env somewhere between xclim 0.60 and 0.61. Sphinx 9 has completely rewritten the `autodoc` module and our custom indicator documenter is not supported in the new version. 

Recall that an indicator is an instance of the `Indicator` class, so not one of the objects `autodoc` knows how to document. We have a custom sphinx extension that registers an `IndicatorDocumenter` which inherits `FunctionDocumenter` and allows documenting indicators as if they were functions.

The "legacy" method is still usable with a new option, which this PR activates.

It looks like extending the new `autodoc` in a similar way is simply impossible for the moment.  There's an issue open on sphinx about this. For the record : sphinx's doc has an example for custom documenters and no where in it does it mentions that it's using a "legacy" mechanism and there's no explanation on how to do this with the new version yet.


The changes to `autodoc_indicator.py` are mainly esthetic, remnants from a few experiments trying to make it work before finding the solution.