### PR TITLE
Restrict token access

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           app-id: ${{ secrets.OURANOS_HELPER_BOT_ID }}
           private-key: ${{ secrets.OURANOS_HELPER_BOT_KEY }}
+          permission-repository-projects: write
 
       - name: Add Issue to xclim Project
         uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2

--- a/.github/workflows/auto-accept-ci-changes.yml
+++ b/.github/workflows/auto-accept-ci-changes.yml
@@ -34,6 +34,8 @@ jobs:
         with:
           app-id: ${{ secrets.OURANOS_HELPER_BOT_ID }}
           private-key: ${{ secrets.OURANOS_HELPER_BOT_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Fetch Dependabot metadata
         id: dependabot-metadata

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -56,6 +56,8 @@ jobs:
         with:
           app-id: ${{ secrets.OURANOS_HELPER_BOT_ID }}
           private-key: ${{ secrets.OURANOS_HELPER_BOT_KEY }}
+          permission-contents: write
+
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,4 +1,4 @@
-name: Bump Patch Version
+name: Bump Version
 
 on:
   push:
@@ -32,10 +32,10 @@ permissions:
 
 jobs:
   bump_patch_version:
-    name: Bumpversion Patch
+    name: Conditional Bump
     runs-on: ubuntu-latest
     permissions:
-      actions: read
+      contents: write
     strategy:
       matrix:
         python-version: [ "3.13" ]
@@ -50,6 +50,7 @@ jobs:
             files.pythonhosted.org:443
             github.com:443
             pypi.org:443
+
       - name: Generate App Token
         id: token_generator
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
@@ -63,10 +64,12 @@ jobs:
         with:
           token: ${{ steps.token_generator.outputs.token }}
           persist-credentials: false
-      - name: Set up Python3
+
+      - name: Set up Python${{ matrix.python-version }}
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
+
       - name: Import GPG Key
         uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
         with:
@@ -75,9 +78,11 @@ jobs:
           git_user_signingkey: true
           git_commit_gpgsign: true
           trust_level: 5
+
       - name: Install CI libraries
         run: |
           python -m pip install --require-hashes -r CI/requirements_ci.txt
+
       - name: Conditional Bump
         run: |
           CURRENT_VERSION=$(bump-my-version show current_version)
@@ -89,6 +94,7 @@ jobs:
             bump-my-version bump patch
           fi
           echo "new_version=$(bump-my-version show current_version)"
+
       - name: Push Changes
         uses: ad-m/github-push-action@77c5b412c50b723d2a4fbc6d71fb5723bcd439aa # v1.0.0
         with:

--- a/.github/workflows/label-on-approval.yml
+++ b/.github/workflows/label-on-approval.yml
@@ -57,6 +57,7 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
+
       - name: Find Warning Comment
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: fc_warning
@@ -64,6 +65,7 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
           body-includes: This Pull Request is coming from a fork and must be manually tagged `approved` in order to perform additional testing.
+
       - name: Update Warning Comment
         if: |
           (steps.fc_warning.outputs.comment-id == '') &&
@@ -77,6 +79,7 @@ jobs:
             > [!WARNING]
             > This Pull Request is coming from a fork and must be manually tagged `approved` in order to perform additional testing.
           edit-mode: replace
+
       - name: Find Note Comment
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: fc_note
@@ -84,6 +87,7 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
           body-includes: This Pull Request has been manually approved for additional testing!
+
       - name: Update Note Comment
         if: |
           (steps.fc_note.outputs.comment-id == '') &&

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -62,6 +62,7 @@ jobs:
             release-assets.githubusercontent.com:443
             repo.anaconda.com:443
             sum.golang.org:443
+
       - name: Start Measurement
         uses: green-coding-solutions/eco-ci-energy-estimation@0fd2200a8f02d7939066c535e3642c2ebee9db16 # v5.2
         with:
@@ -71,11 +72,13 @@ jobs:
           machine: ${{ matrix.os }}
           tags: "CI/CD, Upstream, Test-${{ matrix.python-version }}"
           gmt-api-token: ${{ secrets.GMT_API_TOKEN }}
+
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # Fetch all history for all branches and tags.
           persist-credentials: false
+
       - name: Setup Conda (Micromamba) with Python${{ matrix.python-version }}
         uses: mamba-org/setup-micromamba@add3a49764cedee8ee24e82dfde87f5bc2914462 # v2.0.7
         with:
@@ -87,39 +90,47 @@ jobs:
             pybind11
             pytest-reportlog
             python=${{ matrix.python-version }}
+
       - name: Micromamba version
         run: |
           echo "micromamba: $(micromamba --version)"
+
       - name: Install upstream versions and SBCK
         run: |
           # git-based dependencies cannot be installed from hashes
           python -m pip install -r CI/requirements_upstream.txt
           python -m pip install "sbck @ git+https://github.com/yrobink/SBCK-python.git@master"
+
       - name: Install xclim
         run: |
           python -m pip install --no-user --no-deps --editable .
+
       - name: Check versions
         run: |
           micromamba list
           xclim show_version_info
           python -m pip check || true
+
       - name: Setup Python Measurement
         uses: green-coding-solutions/eco-ci-energy-estimation@0fd2200a8f02d7939066c535e3642c2ebee9db16 # v5.2
         with:
           task: get-measurement
           label: 'Environment Setup (Upstream, Python${{ matrix.python-version }})'
         continue-on-error: true
+
       - name: Test Data Caching
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: |
             ${{ matrix.testdata-cache }}
           key: ${{ runner.os }}-xclim-testdata-upstream-${{ hashFiles('pyproject.toml', 'tox.ini') }}
+
       - name: Run Tests
         if: success()
         id: status
         run: |
           python -m pytest --numprocesses=logical --durations=10 --cov=xclim --cov-report=term-missing --report-log output-${{ matrix.python-version }}-log.jsonl
+
       - name: Generate and publish the report
         if: |
           failure()
@@ -130,12 +141,14 @@ jobs:
         with:
           issue-title: "⚠️ Nightly upstream-dev CI failed for Python${{ matrix.python-version }} ⚠️"
           log-path: output-${{ matrix.python-version }}-log.jsonl
+
       - name: Tests measurement
         uses: green-coding-solutions/eco-ci-energy-estimation@0fd2200a8f02d7939066c535e3642c2ebee9db16 # v5.2
         with:
           task: get-measurement
           label: 'Testing and Reporting (Upstream, Python${{ matrix.python-version }})'
         continue-on-error: true
+
       - name: Show Energy Results
         uses: green-coding-solutions/eco-ci-energy-estimation@0fd2200a8f02d7939066c535e3642c2ebee9db16 # v5.2
         with:

--- a/.github/workflows/workflow-warning.yml
+++ b/.github/workflows/workflow-warning.yml
@@ -22,55 +22,70 @@ jobs:
     if: |
       (github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name)
     permissions:
-      contents: read
       pull-requests: write
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
         with:
           disable-sudo: true
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
-      - name: Find Warning Comment
-        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
-        id: fc_warning
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: |
-            This Pull Request modifies GitHub workflows and is coming from a fork.
-      - name: Create Warning Comment
-        if: |
-          (steps.fc_warning.outputs.comment-id == '') &&
-          (!contains(github.event.pull_request.labels.*.name, 'approved')) &&
-          (github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name)
-        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
-        with:
-          comment-id: ${{ steps.fc_warning.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            > [!WARNING]
-            > This Pull Request modifies GitHub Workflows and is coming from a fork.
-            **It is very important for the reviewer to ensure that the workflow changes are appropriate.**
-          edit-mode: replace
-      - name: Find Note Comment
-        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
-        id: fc_note
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: Workflow changes in this Pull Request have been approved!
-      - name: Update Comment
-        if: |
-          contains(github.event.pull_request.labels.*.name, 'approved')
-        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
-        with:
-          comment-id: ${{ steps.fc_note.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            > [!NOTE]
-            > Workflow changes in this Pull Request have been approved!
-          reactions: |
-            hooray
-          edit-mode: replace
+
+      - name: Manage Warning / Note Comments
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APPROVED: ${{ contains(github.event.pull_request.labels.*.name, 'approved') }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          WARNING_TEXT="This Pull Request modifies GitHub workflows and is coming from a fork."
+          NOTE_TEXT="Workflow changes in this Pull Request have been approved!"
+
+          # Fetch existing comments
+          COMMENTS=$(gh api repos/$REPO/issues/$PR_NUMBER/comments)
+
+          # Find warning comment ID
+          WARNING_COMMENT_ID=$(echo "$COMMENTS" | jq -r \
+            '.[] | select(.user.login=="github-actions[bot]") | select(.body | contains("'"$WARNING_TEXT"'")) | .id' | head -n 1)
+
+          # Find note comment ID
+          NOTE_COMMENT_ID=$(echo "$COMMENTS" | jq -r \
+            '.[] | select(.user.login=="github-actions[bot]") | select(.body | contains("'"$NOTE_TEXT"'")) | .id' | head -n 1)
+
+          if [ "$APPROVED" = "true" ]; then
+            BODY="> [!NOTE]
+          > Workflow changes in this Pull Request have been approved!"
+
+            if [ -n "$NOTE_COMMENT_ID" ] && [ "$NOTE_COMMENT_ID" != "null" ]; then
+              # Append to existing note comment
+              EXISTING=$(gh api repos/$REPO/issues/comments/$NOTE_COMMENT_ID --jq .body)
+              gh api \
+                --method PATCH \
+                repos/$REPO/issues/comments/$NOTE_COMMENT_ID \
+                -f body="$EXISTING
+
+          $BODY"
+            else
+              # Create new note comment
+              gh pr comment "$PR_NUMBER" --body "$BODY"
+            fi
+
+            # Add reaction (hooray)
+            if [ -n "$NOTE_COMMENT_ID" ] && [ "$NOTE_COMMENT_ID" != "null" ]; then
+              gh api \
+                --method POST \
+                repos/$REPO/issues/comments/$NOTE_COMMENT_ID/reactions \
+                -f content='hooray' \
+                -H "Accept: application/vnd.github+json"
+            fi
+
+          else
+            BODY="> [!WARNING]
+          > This Pull Request modifies GitHub Workflows and is coming from a fork.
+          **It is very important for the reviewer to ensure that the workflow changes are appropriate.**"
+
+            if [ -z "$WARNING_COMMENT_ID" ] || [ "$WARNING_COMMENT_ID" = "null" ]; then
+              gh pr comment "$PR_NUMBER" --body "$BODY"
+            fi
+          fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -113,6 +113,11 @@ repos:
     hooks:
       - id: check-github-workflows
       - id: check-readthedocs
+  - repo: https://github.com/woodruffw/zizmor-pre-commit
+    rev: v1.24.1
+    hooks:
+      - id: zizmor
+        args: [ '--config=.zizmor.yml' ]
   - repo: meta
     hooks:
       - id: check-hooks-apply

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,7 @@ sphinx:
 #  - pdf
 
 build:
-  os: "ubuntu-24.04"
+  os: "ubuntu-26.04"
   tools:
     python: "miniforge3-25.11"
   jobs:

--- a/.zizmor.yml
+++ b/.zizmor.yml
@@ -1,0 +1,7 @@
+rules:
+  dangerous-triggers:
+    ignore:
+      - label.yml:9
+      - label-on-approval.yml:3
+      - first-pull-request.yml:3
+      - workflow-warning.yml:3

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,17 @@
 Changelog
 =========
 
+v0.61.2 (unreleased)
+--------------------
+Contributors to this version: Trevor James Smith (:user:`Zeitsperre`).
+
+Internal changes
+^^^^^^^^^^^^^^^^
+* `zizmor` added to `pre-commit` hooks. GitHub workflow permissions have been adapted for better security settings by default. (:pull:`2367`):
+    * Adjusted the token creation permissions to prevent creating tokens with unnecessary access privileges.
+    * ReadTheDocs OS version updated to ``ubuntu-26.04``.
+    * ``workflow-warning.yml`` now simply uses GitHub API calls.
+
 v0.61.1 (2026-05-25)
 --------------------
 Contributors to this version: Pascal Bourgault (:user:`aulemahal`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,10 +181,12 @@ include = [
   "CHANGELOG.rst",
   "CI/requirements_upstream.txt",
   "CITATION.cff",
+  "CODE_OF_CONDUCT.md",
   "CONTRIBUTING.rst",
   "LICENSE",
   "Makefile",
   "README.rst",
+  "SECURITY.md",
   "docs/**/*.gif",
   "docs/**/*.jpg",
   "docs/**/*.png",
@@ -199,12 +201,15 @@ include = [
   "src/xclim/**/*.yml",
   "tests/**/*.py",
   "tests/**/*.txt",
-  "tox.ini"
+  "tox.toml"
 ]
 exclude = [
   "**/*.py[co]",
   "**/__pycache__",
   ".*",
+  "AGENTS.md",
+  "AI_POLICY.md",
+  "CI/requirements_ci.in",
   "CI/requirements_ci.txt",
   "docs/_*",
   "docs/modules.rst",


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGELOG.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Adjust the token creation permissions to prevent creating tokens with too much access.
* Spacing fixes for better readability.
* ReadTheDocs OS version updated to ubuntu-26.04.
* `workflow-warning` workflow now just uses GH API calls.
* Adds the `zizmor` hook for evaluating CI workflow security. 

### Does this PR introduce a breaking change?

No.

### Other information:

Token permissions options for the `actions/create-github-app-token` took me entirely by surprise; This step should be inheriting from the workflow and job permissions, but **it does not**. How odd.