### PR TITLE
Add `infill_polar_days` option to `make_hourly_temperature`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ Contributors to this version: Trevor James Smith (:user:`Zeitsperre`), Pascal Bo
 
 New indicators and features
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-* ``xclim.indices.helpers.make_hourly_temperature`` now accepts `infill_polar_days`. If set to `True`, this means that polar days and nights are set to 24 and 0 hours duration, respectively. The default behaviour is unchanged (`infill_polar_days=False`) and fills these cases with NaNs.
+* ``xclim.indices.helpers.make_hourly_temperature`` now accepts `infill_polar_days`. If set to `True`, this means that polar days and nights are set to 24 and 0 hours duration, respectively. The default behaviour is unchanged (`infill_polar_days=False`) and fills these cases with NaNs. (:issue:`2381`, :pull:`2382`).
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,11 @@ Changelog
 
 v0.61.2 (unreleased)
 --------------------
-Contributors to this version: Trevor James Smith (:user:`Zeitsperre`), Pascal Bourgault (:user:`aulemahal`).
+Contributors to this version: Trevor James Smith (:user:`Zeitsperre`), Pascal Bourgault (:user:`aulemahal`), Éric Dupuis (:user:`coxipi`).
+
+New indicators and features
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+* ``xclim.indices.helpers.make_hourly_temperature`` now accepts `infill_polar_days`. If set to `True`, this means that polar days and nights are set to 24 and 0 hours duration, respectively. The default behaviour is unchanged (`infill_polar_days=False`) and fills these cases with NaNs.
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/src/xclim/indices/helpers.py
+++ b/src/xclim/indices/helpers.py
@@ -1056,7 +1056,9 @@ def _add_one_day(time: xr.DataArray) -> xr.DataArray:
     return time + np.timedelta64(1, "D")
 
 
-def make_hourly_temperature(tasmin: xr.DataArray, tasmax: xr.DataArray) -> xr.DataArray:
+def make_hourly_temperature(
+    tasmin: xr.DataArray, tasmax: xr.DataArray, infill_polar_days: bool = False
+) -> xr.DataArray:
     """
     Compute hourly temperatures from tasmin and tasmax.
 
@@ -1074,6 +1076,11 @@ def make_hourly_temperature(tasmin: xr.DataArray, tasmax: xr.DataArray) -> xr.Da
         Daily minimum temperature.
     tasmax : xarray.DataArray
         Daily maximum temperature.
+    infill_polar_days : bool
+        Whether to use a mask of 24 hours for polar days and 0 hours for polar nights.
+        If False, polar days and nights will be NaN.
+        If True, they will be filled with 24 and 0 hours, respectively,
+        dependent on latitude and solar declination at the given date.
 
     Returns
     -------
@@ -1091,7 +1098,7 @@ def make_hourly_temperature(tasmin: xr.DataArray, tasmax: xr.DataArray) -> xr.Da
         dim="time",
     )
 
-    daylength = day_lengths(data.time, data.lat)
+    daylength = day_lengths(data.time, data.lat, infill_polar_days)
     # Create daily chunks to avoid memory issues after the resampling
     data = data.assign(
         daylength=daylength,

--- a/src/xclim/indices/helpers.py
+++ b/src/xclim/indices/helpers.py
@@ -1098,7 +1098,7 @@ def make_hourly_temperature(
         dim="time",
     )
 
-    daylength = day_lengths(data.time, data.lat, infill_polar_days)
+    daylength = day_lengths(data.time, data.lat, infill_polar_days=infill_polar_days)
     # Create daily chunks to avoid memory issues after the resampling
     data = data.assign(
         daylength=daylength,

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -336,3 +336,43 @@ def test_make_hourly_temperature(tasmax_series, tasmin_series, calendar):
         ]
     )
     np.testing.assert_allclose(tas_hourly.isel(lat=0).values, expected)
+
+
+@pytest.mark.parametrize("calendar", [None, "standard"])
+def test_make_hourly_temperature_polar_fill(tasmax_series, tasmin_series, calendar):
+    tasmax = tasmax_series(np.array([20]), units="degC", calendar=calendar)
+    tasmin = tasmin_series(np.array([0]), units="degC", calendar=calendar).expand_dims(lat=[0])
+
+    tasmin.lat.attrs["units"] = "degree_north"
+    tas_hourly = helpers.make_hourly_temperature(tasmax, tasmin)
+    assert tas_hourly.attrs["units"] == "degC"
+    assert tas_hourly.time.size == 24
+    expected = np.array(
+        [
+            0.0,
+            3.90180644,
+            7.65366865,
+            11.11140466,
+            14.14213562,
+            16.62939225,
+            18.47759065,
+            19.61570561,
+            20.0,
+            19.61570561,
+            18.47759065,
+            16.62939225,
+            14.14213562,
+            10.32039099,
+            8.0848137,
+            6.49864636,
+            5.26831939,
+            4.26306907,
+            3.41314202,
+            2.67690173,
+            2.02749177,
+            1.44657476,
+            0.92107141,
+            0.44132444,
+        ]
+    )
+    np.testing.assert_allclose(tas_hourly.isel(lat=0).values, expected)


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGELOG.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

*Add `infill_polar_days` option to ``xclim.indices.helpers.make_hourly_temperature``

### Does this PR introduce a breaking change?
no

### Other information:
