### PR TITLE
fix: correct constant term of the equation of time

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Breaking changes
 * Fix ``maximum_consecutive_*`` indicators to harmonize them with their docstring, add ``op`` argument to control comparison and fix some non-existing standard names. (:issue:`2368`, :pull:`2370`).
 * `xdoctest` is no longer required to run the doctests and has been removed from the development dependencies. (:pull:`2383`)
 
+Bug fixes
+^^^^^^^^^
+* Fixed the constant term of the equation of time in ``xclim.indices.helpers.time_correction_for_solar_angle``: it was ten times too large. (:issue:`2388`, :pull:`2389`).
+
 Internal changes
 ^^^^^^^^^^^^^^^^
 * `zizmor` added to `pre-commit` hooks. GitHub workflow permissions have been adapted for better security settings by default. (:pull:`2367`):

--- a/src/xclim/indices/helpers.py
+++ b/src/xclim/indices/helpers.py
@@ -186,7 +186,7 @@ def time_correction_for_solar_angle(time: xr.DataArray) -> xr.DataArray:
     """
     da = convert_units_to(day_angle(time), "rad")
     tc = (
-        0.004297 + 0.107029 * np.cos(da) - 1.837877 * np.sin(da) - 0.837378 * np.cos(2 * da) - 2.340475 * np.sin(2 * da)
+        0.0004297 + 0.107029 * np.cos(da) - 1.837877 * np.sin(da) - 0.837378 * np.cos(2 * da) - 2.340475 * np.sin(2 * da)
     )
     tc = tc.assign_attrs(units="degrees")
     return _wrap_radians(convert_units_to(tc, "rad"))

--- a/src/xclim/indices/helpers.py
+++ b/src/xclim/indices/helpers.py
@@ -186,7 +186,11 @@ def time_correction_for_solar_angle(time: xr.DataArray) -> xr.DataArray:
     """
     da = convert_units_to(day_angle(time), "rad")
     tc = (
-        0.0004297 + 0.107029 * np.cos(da) - 1.837877 * np.sin(da) - 0.837378 * np.cos(2 * da) - 2.340475 * np.sin(2 * da)
+        0.0004297
+        + 0.107029 * np.cos(da)
+        - 1.837877 * np.sin(da)
+        - 0.837378 * np.cos(2 * da)
+        - 2.340475 * np.sin(2 * da)
     )
     tc = tc.assign_attrs(units="degrees")
     return _wrap_radians(convert_units_to(tc, "rad"))

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -27,6 +27,25 @@ def test_solar_declinaton(method, rtol):
     )
 
 
+def test_time_correction_for_solar_angle():
+    # The coefficients are Spencer (1971)'s equation-of-time series, expressed in
+    # degrees. Compare against the original series in radians.
+    times = xr.DataArray(
+        xr.date_range("2000-01-01", "2000-12-31", freq="D"),
+        dims=("time",),
+        name="time",
+    )
+    da = convert_units_to(helpers.day_angle(times), "rad")
+    exp = (
+        0.0000075
+        + 0.001868 * np.cos(da)
+        - 0.032077 * np.sin(da)
+        - 0.014615 * np.cos(2 * da)
+        - 0.040849 * np.sin(2 * da)
+    )
+    np.testing.assert_allclose(helpers.time_correction_for_solar_angle(times), exp, atol=1e-6)
+
+
 @pytest.mark.parametrize("method", ["spencer", "simple"])
 def test_extraterrestrial_radiation(method):
     # Expected values from https://www.engr.scu.edu/~emaurer/tools/calc_solar_cgi.pl


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #2388
- [x] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGELOG.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Bug fix. The constant term of the equation of time in `time_correction_for_solar_angle` was `0.004297` instead of `0.0004297` — Spencer (1971) uses `0.0000075` rad, and `0.0000075 * 180/pi = 0.0004297`. The other four coefficients convert correctly, so only the first was ten times too large, giving a constant ~6.75e-5 rad (~0.0039°, ~0.016 min of solar time) offset on every timestep.

### Does this PR introduce a breaking change?

No, but values of `time_correction_for_solar_angle` (and anything downstream of it, e.g. `cosine_of_solar_zenith_angle`) shift very slightly.

### Other information:

The new `test_time_correction_for_solar_angle` compares the helper against Spencer's original radian series over a full year; it fails on `main` and passes with the fix.
