### PR TITLE
Add Canadian Hardiness Zones

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,7 @@ New indicators and features
     * Open `date_bounds` and `doy_bounds` are now supported (i.e., `None` as start or end).
     * The `include_doy_bounds_nans` argument has been added to control whether NaN values in the bounds should be filled or not. When set to `True`, missing values in the start or end bounds are replaced by the start and end of the period, respectively.
     * The `bounds_freq` argument has been added to allow users to specify the frequency to use when using open `date_bounds`.
+* New indicator ``canadian_hardiness_zones`` for calculating climate hardiness suitability index of regions according to Canadian categorization standards has been added. (:pull:`2398`).
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,7 +27,7 @@ New indicators and features
     * Open `date_bounds` and `doy_bounds` are now supported (i.e., `None` as start or end).
     * The `include_doy_bounds_nans` argument has been added to control whether NaN values in the bounds should be filled or not. When set to `True`, missing values in the start or end bounds are replaced by the start and end of the period, respectively.
     * The `bounds_freq` argument has been added to allow users to specify the frequency to use when using open `date_bounds`.
-* New indicator ``canadian_hardiness_zones`` for calculating climate hardiness suitability index of regions according to Canadian categorization standards has been added. (:pull:`2398`).
+* New indicator ``canadian_hardiness_zones`` for calculating climate hardiness suitability index of regions according to Canadian categorization standards has been added. (:issue:`1290`, :pull:`2398`).
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -4111,7 +4111,7 @@
   year          = {1967},
   doi           = {10.4141/cjps67-064},
   url           = {https://doi.org/10.4141/cjps67-064},
-  eprint        = {https://doi.org/10.4141/cjps67-064},
+  eprint        = {https://doi.org/10.4141/cjps67-064}
 }
 @article{ouellet_hardiness_1967c,
   author        = {Ouellet, C. E. and Sherk, L. C.},

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -4112,23 +4112,6 @@
   doi           = {10.4141/cjps67-064},
   url           = {https://doi.org/10.4141/cjps67-064},
   eprint        = {https://doi.org/10.4141/cjps67-064},
-  abstract      = {
-    A method has been developed to estimate the relative suitability index for
-    the winter survival of ornamental trees and shrubs at any locality in
-    Canada from which average climatic data are available. It was based
-    essentially on hardiness data obtained from 108 stations for 174 species
-    and cultivars. Of nine regression equations studied, one gave estimates of
-    suitability indices in best agreement with field experience. This equation
-    was developed with 40 actual indices chosen for their geographic
-    representation. These actual indices are based on the collected hardiness
-    data and plant hardiness indices previously determined. Seven
-    meteorological variables, that is, low winter temperatures, frost-free
-    period, summer and winter rainfall, summer high temperatures, snow depth,
-    and wind speed were involved in this equation. The multiple correlation
-    coefficient obtained was 0.98, and the coefficient of variation of the
-    indices estimated from regression equalled 9.6 percent of the mean, which
-    was 49.
-  }
 }
 @article{ouellet_hardiness_1967c,
   author        = {Ouellet, C. E. and Sherk, L. C.},

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -4074,3 +4074,55 @@
   year          = {2022},
   publisher     = {Nature Publishing Group UK London}
 }
+@article{ouellet_hardiness_1967b,
+  author        = {Ouellet, C. E. and Sherk, L. C.},
+  title         = {WOODY ORNAMENTAL PLANT ZONATION: II. SUITABILITY INDICES OF LOCALITIES},
+  journal       = {Canadian Journal of Plant Science},
+  volume        = {47},
+  number        = {4},
+  pages         = {339--349},
+  year          = {1967},
+  doi           = {10.4141/cjps67-064},
+  url           = {https://doi.org/10.4141/cjps67-064},
+  eprint        = {https://doi.org/10.4141/cjps67-064},
+  abstract      = {
+    A method has been developed to estimate the relative suitability index for
+    the winter survival of ornamental trees and shrubs at any locality in
+    Canada from which average climatic data are available. It was based
+    essentially on hardiness data obtained from 108 stations for 174 species
+    and cultivars. Of nine regression equations studied, one gave estimates of
+    suitability indices in best agreement with field experience. This equation
+    was developed with 40 actual indices chosen for their geographic
+    representation. These actual indices are based on the collected hardiness
+    data and plant hardiness indices previously determined. Seven
+    meteorological variables, that is, low winter temperatures, frost-free
+    period, summer and winter rainfall, summer high temperatures, snow depth,
+    and wind speed were involved in this equation. The multiple correlation
+    coefficient obtained was 0.98, and the coefficient of variation of the
+    indices estimated from regression equalled 9.6 percent of the mean, which
+    was 49.
+  }
+}
+@article{ouellet_hardiness_1967c,
+  author        = {Ouellet, C. E. and Sherk, L. C.},
+  title         = {
+    WOODY ORNAMENTAL PLANT ZONATION: III. SUITABILITY MAP FOR THE PROBABLE
+    WINTER SURVIVAL OF ORNAMENTAL TREES AND SHRUBS
+  },
+  journal       = {Canadian Journal of Plant Science},
+  volume        = {47},
+  number        = {4},
+  pages         = {351--358},
+  year          = {1967},
+  doi           = {10.4141/cjps67-065},
+  url           = {https://doi.org/10.4141/cjps67-065},
+  eprint        = {https://doi.org/10.4141/cjps67-065},
+  abstract      = {
+    A map showing suitability for winter survival of ornamental trees and
+    shrubs has been prepared for Canada. It is based on the estimated
+    suitability indices (from 0 to 92) for 640 localities. It includes 10 zones
+    with a spread of 10 units; each zone is subdivided into 2 sub-zones. In
+    addition, probability curves indicate the chances of survival within zones
+    and sub-zones of any plant for which the index of hardiness is known.
+  }
+}

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -4126,3 +4126,45 @@
     and sub-zones of any plant for which the index of hardiness is known.
   }
 }
+@article{mckenney_updated_2025,
+  title         = {
+    Updated plant hardiness zones for {Canada} and assessment of change over
+    time
+  },
+  volume        = {15},
+  issn          = {2045-2322},
+  url           = {https://doi.org/10.1038/s41598-025-00931-5},
+  doi           = {10.1038/s41598-025-00931-5},
+  abstract      = {
+    Plant hardiness systems have been developed for various regions around the
+    world to help ensure that cultivated plants are grown at locations where
+    suitable climate conditions prevail. In Canada, a multivariate plant
+    hardiness index was developed in the 1960s that incorporates several
+    temperature- and precipitation-related variables, as well as snow depth and
+    wind speed. In the United States, the plant hardiness system involves
+    averaging annual extreme minimum temperatures over a period of interest,
+    with values subsequently classified into hardiness zones. Here we report on
+    efforts to update hardiness zone maps for Canada using both the Canadian
+    and US approaches and using climate data for the 1991–2020 period. The two
+    hardiness systems produced generally similar spatial patterns in plant
+    hardiness across Canada, including high index values in southern and
+    coastal regions and low index values in northern and high-elevation areas.
+    Detailed comparisons to previous hardiness maps indicated that, since
+    1961–1990, zone values have increased by between half a zone and two full
+    zones across the country, with the largest increases occurring in western
+    and northwestern Canada. For the multivariate Canadian hardiness system, a
+    change attribution analysis indicated that three temperature-related
+    variables were primarily responsible for driving the observed changes in
+    the plant hardiness zones. The new maps are available at
+    http://planthardiness.gc.ca.
+  },
+  number        = {1},
+  journal       = {Scientific Reports},
+  author        = {
+    McKenney, Daniel W. and Pedlar, John H. and Lawrence, Kevin and DeBoer,
+    Kaitlin and MacDonald, Heather
+  },
+  month         = jul,
+  year          = {2025},
+  pages         = {22774}
+}

--- a/src/xclim/compute/_agro.py
+++ b/src/xclim/compute/_agro.py
@@ -1420,17 +1420,17 @@ def hardiness_zones(  # numpydoc ignore=SS05
     """
     if method.lower() == "usda":
         zone_min, zone_max, zone_step = "-60 degF", "70 degF", "5 degF"
-
     elif method.lower() == "anbg":
         zone_min, zone_max, zone_step = "-15 degC", "20 degC", "5 degC"
-
     else:
         raise NotImplementedError(f"Method {method} not supported. Must be either `usda` or `anbg`.")
 
-    tn_min_rolling = statistics(tasmin, statistic="min", freq=freq).rolling(time=window).mean()
-    zones: xarray.DataArray = get_zones(tn_min_rolling, zone_min=zone_min, zone_max=zone_max, zone_step=zone_step)
+    flag_vals = ", ".join([str(n) for n in range(28)])
+    flag_means = ", ".join([f"{(n // 2) + 1}{'a' if n % 2 == 0 else 'b'}" for n in range(0, 28)])
 
-    zones = zones.assign_attrs(units="")
+    tn_min_rolling = statistics(tasmin, statistic="min", freq=freq).rolling(time=window).mean()
+    zones: xarray.DataArray = get_zones(tn_min_rolling, zone_min=zone_min, zone_max=zone_max, zone_step=zone_step).clip(min=0)
+    zones = zones.assign_attrs(units="", flag_values=flag_vals, flag_meanings=flag_means)
     return zones
 
 

--- a/src/xclim/compute/_agro.py
+++ b/src/xclim/compute/_agro.py
@@ -1594,7 +1594,9 @@ def chill_units(tas: xarray.DataArray, positive_only: bool = False, freq: Freq =
     return cu.resample(time=freq).sum().assign_attrs(units="")
 
 
-# TODO: declare_units()
+@declare_units(
+    tasmin="[temperature]", tasmax="[temperature]", pr="[precipitation]", snd="[length]", wsgmax10m="[speed]"
+)
 def canadian_hardiness_zones(
     tasmin: xarray.DataArray,
     tasmax: xarray.DataArray,
@@ -1619,7 +1621,7 @@ def canadian_hardiness_zones(
     wsgmax10m : xarray.DataArray
         Maximum wind gust.
     freq : str
-        Resampling frequency for the input data, by default "YS" (yearly start).
+        Resampling frequency for the climatology. Default is ``"30YS"`` (30-years).
 
     Returns
     -------
@@ -1685,7 +1687,7 @@ def canadian_hardiness_zones(
     # Maximum wind gust in experienced in a 30-year period
     x7 = _wsgmax10m.resample(time=freq).max()
 
-    suitability_index = (
+    canadian_hardiness_index = (
         -67.62
         + (1.734 * x1)
         + (0.1868 * x2)
@@ -1695,10 +1697,9 @@ def canadian_hardiness_zones(
         + (22.37 * x6)
         - (0.01832 * x7)
     )
-    suitability_index.attrs["long_name"] = "Canadian hardiness zones."
-    suitability_index.attrs["units"] = ""
 
-    return suitability_index
+    canadian_hardiness_index = canadian_hardiness_index.assign_attrs(units="")
+    return canadian_hardiness_index
 
 
 @declare_units(tas="[precipitation]")

--- a/src/xclim/compute/_agro.py
+++ b/src/xclim/compute/_agro.py
@@ -1697,9 +1697,10 @@ def canadian_hardiness_zones(
         + (22.37 * x6)
         - (0.01832 * x7)
     )
-
     canadian_hardiness_index = canadian_hardiness_index.assign_attrs(units="")
-    return canadian_hardiness_index
+
+    zones = get_zones(canadian_hardiness_index, zone_min="0", zone_max="99", zone_step="5")
+    return zones
 
 
 @declare_units(tas="[precipitation]")

--- a/src/xclim/compute/_agro.py
+++ b/src/xclim/compute/_agro.py
@@ -11,7 +11,7 @@ from scipy.stats import rv_continuous
 
 import xclim.compute.run_length as rl
 from xclim.compute.classify import get_zones
-from xclim.compute.generic import day_threshold_reached, statistics, statistics_between_dates
+from xclim.compute.generic import day_threshold_reached, season, statistics, statistics_between_dates
 from xclim.compute.helpers import (
     _gather_lat,
     gladstones_day_length_latitude_coefficient,
@@ -39,6 +39,7 @@ from xclim.core.utils import uses_dask
 
 __all__ = [
     "biologically_effective_degree_days",
+    "canadian_hardiness_zones",
     "chill_portions",
     "chill_units",
     "cool_night_index",
@@ -1580,3 +1581,101 @@ def chill_units(tas: xarray.DataArray, positive_only: bool = False, freq: Freq =
         daily = cu.resample(time="1D").sum()
         cu = daily.where(daily > 0)
     return cu.resample(time=freq).sum().assign_attrs(units="")
+
+
+def canadian_hardiness_zones(
+    tasmin: xarray.DataArray,
+    tasmax: xarray.DataArray,
+    pr: xarray.DataArray,
+    snd: xarray.DataArray,
+    sfcWindmax: xarray.DataArray,
+    freq: str = "YS",
+) -> xarray.DataArray:
+    """
+    Canadian hardiness zones.
+
+    Parameters
+    ----------
+    tasmin : xarray.DataArray
+        Minimum daily temperature.
+    tasmax : xarray.DataArray
+        Maximum daily temperature.
+    pr : xarray.DataArray
+        Precipitation.
+    snd : xarray.DataArray
+        Snow depth.
+    sfcWindmax : xarray.DataArray
+        Maximum surface wind speed.
+    freq : str
+        Resampling frequency for the input data, by default "YS" (yearly start).
+
+    Returns
+    -------
+    xarray.DataArray
+        Canadian hardiness zones.
+
+    Notes
+    -----
+    This index is based on the Canadian hardiness zones, which are used to classify regions based on their climate
+    suitability for growing plants. The index is calculated using a combination of temperature, precipitation,
+    snow depth, and wind speed data. The formula is adapted from the Canadian hardiness zones index as described in
+    :cite:t:`ouellet_hardiness_1967b` and :cite:t:`ouellet_hardiness_1967c`.
+
+    References
+    ----------
+    :cite:cts:`ouellet_hardiness_1967b,ouellet_hardiness_1967c`
+    """
+    _tasmin = convert_units_to(tasmin, "degC")
+    _tasmax = convert_units_to(tasmax, "degC")
+    _pr = convert_units_to(pr, "mm")
+    _snd = convert_units_to(snd, "mm")
+    _sfcWindmax = convert_units_to(sfcWindmax, "km h-1")
+
+    # Monthly mean of minimum temperatures of the coldest month
+    x1 = statistics(_tasmin, statistic="mean", freq="MS").resample(time=freq).min()
+
+    # Length of the frost free period (FFP)
+    x2 = season(
+        _tasmin,
+        thresh="0.0 degC",
+        window=5,
+        condition=">",
+        aspect="length",
+        freq=freq,
+        mid_date=None,
+    )
+
+    # Precipitation in the period from June to November, inclusive
+    _pr_constrained = (
+        select_time(_pr, date_bounds=("06-01", "12-01"), include_bounds=(True, False)).resample(time=freq).sum()
+    )
+    # Empirical adjustment for millimeters of precipitation
+    x3 = _pr_constrained / (_pr_constrained + 25.4)
+
+    # Monthly mean of maximum temperatures of the warmest month
+    x4 = statistics(_tasmax, statistic="mean", freq="MS").resample(time=freq).max()
+
+    # Winter factor
+    x5 = (0 - x1) * _pr.sel(time=_pr["time"].dt.month == 1).resample(time=freq).sum()
+
+    # Mean maximum snow depth
+    snd_above_0 = _snd.where(_snd > 0, np.nan).resample(time=freq).mean()
+    x6 = snd_above_0 / (snd_above_0 + 25.4)
+
+    # Maximum wind gust in experienced in a 30-year period
+    x7 = _sfcWindmax.resample(time=freq).max()
+
+    suitability_index = (
+        -67.62
+        + (1.734 * x1)
+        + (0.1868 * x2)
+        + (69.77 * x3)
+        + (1.256 * x4)
+        + (0.006119 * x5)
+        + (22.37 * x6)
+        - (0.01832 * x7)
+    )
+    suitability_index.attrs["long_name"] = "Canadian hardiness zones."
+    suitability_index.attrs["units"] = ""
+
+    return suitability_index

--- a/src/xclim/compute/_agro.py
+++ b/src/xclim/compute/_agro.py
@@ -1698,8 +1698,19 @@ def canadian_hardiness_zones(
         - (0.01832 * x7)
     )
     canadian_hardiness_index = canadian_hardiness_index.assign_attrs(units="")
+    zones = get_zones(
+        canadian_hardiness_index,
+        zone_min="0",
+        zone_max="100",
+        zone_step="5",
+        exclude_boundary_zones=False,
+        close_last_zone_right_boundary=False
+    ).clip(min=0)
 
-    zones = get_zones(canadian_hardiness_index, zone_min="0", zone_max="99", zone_step="5")
+    flag_vals = ", ".join([str(n) for n in range(20)])
+    flag_means = ", ".join([f"{n // 2}{'a' if n % 2 == 0 else 'b'}" for n in range(20)])
+    zones = zones.assign_attrs(flag_values=flag_vals, flag_meanings=flag_means)
+
     return zones
 
 

--- a/src/xclim/compute/_agro.py
+++ b/src/xclim/compute/_agro.py
@@ -1600,7 +1600,7 @@ def canadian_hardiness_zones(
     tasmax: xarray.DataArray,
     pr: xarray.DataArray,
     snd: xarray.DataArray,
-    sfcWindmax: xarray.DataArray,
+    wsgmax10m: xarray.DataArray,
     freq: str = "30YS",
 ) -> xarray.DataArray:
     """
@@ -1616,8 +1616,8 @@ def canadian_hardiness_zones(
         Precipitation.
     snd : xarray.DataArray
         Snow depth.
-    sfcWindmax : xarray.DataArray
-        Maximum surface wind speed.
+    wsgmax10m : xarray.DataArray
+        Maximum wind gust.
     freq : str
         Resampling frequency for the input data, by default "YS" (yearly start).
 
@@ -1641,7 +1641,7 @@ def canadian_hardiness_zones(
     _tasmax = convert_units_to(tasmax, "degC")
     _pr = convert_units_to(pr, "mm")
     _snd = convert_units_to(snd, "mm")
-    _sfcWindmax = convert_units_to(sfcWindmax, "km h-1")
+    _wsgmax10m = convert_units_to(wsgmax10m, "km h-1")
 
     # Monthly mean of minimum temperatures of the coldest month
     x1 = statistics(_tasmin, statistic="mean", freq="MS").resample(time="YS").min().resample(time=freq).mean()
@@ -1683,7 +1683,7 @@ def canadian_hardiness_zones(
     x6 = snd_above_0 / (snd_above_0 + 25.4)
 
     # Maximum wind gust in experienced in a 30-year period
-    x7 = _sfcWindmax.resample(time=freq).max()
+    x7 = _wsgmax10m.resample(time=freq).max()
 
     suitability_index = (
         -67.62

--- a/src/xclim/compute/_agro.py
+++ b/src/xclim/compute/_agro.py
@@ -1593,6 +1593,7 @@ def chill_units(tas: xarray.DataArray, positive_only: bool = False, freq: Freq =
         cu = daily.where(daily > 0)
     return cu.resample(time=freq).sum().assign_attrs(units="")
 
+
 # TODO: declare_units()
 def canadian_hardiness_zones(
     tasmin: xarray.DataArray,

--- a/src/xclim/compute/_agro.py
+++ b/src/xclim/compute/_agro.py
@@ -1429,7 +1429,9 @@ def hardiness_zones(  # numpydoc ignore=SS05
     flag_means = ", ".join([f"{(n // 2) + 1}{'a' if n % 2 == 0 else 'b'}" for n in range(0, 28)])
 
     tn_min_rolling = statistics(tasmin, statistic="min", freq=freq).rolling(time=window).mean()
-    zones: xarray.DataArray = get_zones(tn_min_rolling, zone_min=zone_min, zone_max=zone_max, zone_step=zone_step).clip(min=0)
+    zones: xarray.DataArray = get_zones(tn_min_rolling, zone_min=zone_min, zone_max=zone_max, zone_step=zone_step).clip(
+        min=0
+    )
     zones = zones.assign_attrs(units="", flag_values=flag_vals, flag_meanings=flag_means)
     return zones
 

--- a/src/xclim/compute/_agro.py
+++ b/src/xclim/compute/_agro.py
@@ -1589,7 +1589,7 @@ def canadian_hardiness_zones(
     pr: xarray.DataArray,
     snd: xarray.DataArray,
     sfcWindmax: xarray.DataArray,
-    freq: str = "YS",
+    freq: str = "30YS",
 ) -> xarray.DataArray:
     """
     Canadian hardiness zones.
@@ -1623,7 +1623,7 @@ def canadian_hardiness_zones(
 
     References
     ----------
-    :cite:cts:`ouellet_hardiness_1967b,ouellet_hardiness_1967c`
+    :cite:cts:`ouellet_hardiness_1967b,ouellet_hardiness_1967c,mckenney_updated_2025`
     """
     _tasmin = convert_units_to(tasmin, "degC")
     _tasmax = convert_units_to(tasmax, "degC")
@@ -1632,34 +1632,42 @@ def canadian_hardiness_zones(
     _sfcWindmax = convert_units_to(sfcWindmax, "km h-1")
 
     # Monthly mean of minimum temperatures of the coldest month
-    x1 = statistics(_tasmin, statistic="mean", freq="MS").resample(time=freq).min()
+    x1 = statistics(_tasmin, statistic="mean", freq="MS").resample(time="YS").min().resample(time=freq).mean()
 
     # Length of the frost free period (FFP)
-    x2 = season(
-        _tasmin,
-        thresh="0.0 degC",
-        window=5,
-        condition=">",
-        aspect="length",
-        freq=freq,
-        mid_date=None,
+    x2 = (
+        season(
+            _tasmin,
+            thresh="0.0 degC",
+            window=5,
+            condition=">",
+            aspect="length",
+            freq="YS",
+            mid_date=None,
+        )
+        .resample(time=freq)
+        .mean()
     )
 
     # Precipitation in the period from June to November, inclusive
     _pr_constrained = (
-        select_time(_pr, date_bounds=("06-01", "12-01"), include_bounds=(True, False)).resample(time=freq).sum()
+        select_time(_pr, date_bounds=("06-01", "12-01"), include_bounds=(True, False))
+        .resample(time="YS")
+        .sum()
+        .resample(time=freq)
+        .mean()
     )
     # Empirical adjustment for millimeters of precipitation
     x3 = _pr_constrained / (_pr_constrained + 25.4)
 
     # Monthly mean of maximum temperatures of the warmest month
-    x4 = statistics(_tasmax, statistic="mean", freq="MS").resample(time=freq).max()
+    x4 = statistics(_tasmax, statistic="mean", freq="MS").resample(time="YS").max().resample(time=freq).mean()
 
     # Winter factor
-    x5 = (0 - x1) * _pr.sel(time=_pr["time"].dt.month == 1).resample(time=freq).sum()
+    x5 = (0 - x1) * select_time(_pr, month=1).resample(time="YS").sum().resample(time=freq).mean()
 
     # Mean maximum snow depth
-    snd_above_0 = _snd.where(_snd > 0, np.nan).resample(time=freq).mean()
+    snd_above_0 = _snd.resample(time="YS").max().resample(time=freq).mean()
     x6 = snd_above_0 / (snd_above_0 + 25.4)
 
     # Maximum wind gust in experienced in a 30-year period

--- a/src/xclim/compute/_agro.py
+++ b/src/xclim/compute/_agro.py
@@ -1704,7 +1704,7 @@ def canadian_hardiness_zones(
         zone_max="100",
         zone_step="5",
         exclude_boundary_zones=False,
-        close_last_zone_right_boundary=False
+        close_last_zone_right_boundary=False,
     ).clip(min=0)
 
     flag_vals = ", ".join([str(n) for n in range(20)])

--- a/src/xclim/core/formatting.py
+++ b/src/xclim/core/formatting.py
@@ -192,6 +192,7 @@ class AttrFormatter(string.Formatter):
 # Tag mappings between keyword arguments and long-form text.
 default_formatter = AttrFormatter(
     {
+        # TODO: Can we support intervals with scalars? e.g. 10/20/30YS?
         # Arguments to "freq"
         "D": ["daily", "days"],
         "YS": ["annual", "years"],
@@ -199,6 +200,7 @@ default_formatter = AttrFormatter(
         "MS": ["monthly", "months"],
         "QS-*": ["seasonal", "seasons"],
         # Arguments to "indexer"
+        # TODO: These seasons are only true for Northern Hemisphere
         "DJF": ["winter"],
         "MAM": ["spring"],
         "JJA": ["summer"],
@@ -236,7 +238,7 @@ default_formatter = AttrFormatter(
 )
 
 
-def parse_doc(doc: str) -> dict:
+def parse_doc(doc: str | None) -> dict:
     """
     Crude regex parsing reading a function docstring and extracting information needed in indicator construction.
 

--- a/src/xclim/core/indicator.py
+++ b/src/xclim/core/indicator.py
@@ -374,7 +374,7 @@ class Indicator(IndicatorRegistrar):
         A long description of what is in the computed outputs.
         Parsed from `compute` docstring if None (second paragraph).
     keywords : str
-        Comma separated list of keywords.
+        Space-separated list of keywords.
         Parsed from `compute` docstring if None (from a "Keywords" section).
     references : str
         Published or web-based references that describe the data or methods used to produce it.
@@ -438,7 +438,7 @@ class Indicator(IndicatorRegistrar):
 
     # Note: typing and class types in this call signature will cause errors with sphinx-autodoc-typehints
     # See: https://github.com/tox-dev/sphinx-autodoc-typehints/issues/186#issuecomment-1450739378
-    cf_attrs: list[dict[str, str]] = None
+    cf_attrs: list[dict[str, str]] = [{}]
     """A list of metadata information for each output of the indicator.
 
     It minimally contains a "var_name" entry, and may contain : "standard_name", "long_name",

--- a/src/xclim/data/fr.json
+++ b/src/xclim/data/fr.json
@@ -632,6 +632,12 @@
     "title": "Zones de rusticité australiennes",
     "abstract": "Indice climatique basé sur une moyenne mobile multi-annuelle de la température minimale annuelle. Développé spécifiquement pour aider à déterminer l'adéquation des plantes aux régions géographiques. Le système de classification des jardins botaniques nationaux australiens (ANBG) divise les catégories en zones de 5 degrés Celsius, allant de -15 degrés Celsius à 20 degrés Celsius."
   },
+  "CANADIAN_HARDINESS_ZONES": {
+    "long_name": "Zones de rusticité",
+    "description": "Indice climatique basé sur une climatologie {freq} de la moyenne annuelle des températures mensuelles maximales et minimales, des précipitations saisonnières, de l'épaisseur moyenne annuelle maximale de la neige et des rafales de vent maximales enregistrées sur l'ensemble de la période. Conçu spécialement pour aider à déterminer l'aptitude des régions géographiques canadiennes à l'implantation de plantes.",
+    "title": "Zones de rusticité canadiennes",
+    "abstract": "Indice climatique basé sur une climatologie multi-annuelle de la moyenne annuelle des températures mensuelles maximales et minimales, des précipitations saisonnières, de l'épaisseur moyenne annuelle maximale de la neige et des rafales de vent maximales enregistrées sur l'ensemble de la période. Conçu spécialement pour aider à déterminer l'aptitude des régions géographiques canadiennes à l'implantation de plantes."
+  },
   "USDA_HARDINESS_ZONES": {
     "long_name": "Zones de rusticité",
     "description": "Indice climatique basé sur une moyenne mobile de {window} années de la température minimale annuelle. Développé spécifiquement pour aider à déterminer l'adéquation des plantes aux régions géographiques. Le système de classification de l'USDA divise les catégories en zones de 10 degrés Fahrenheit, avec des demi-zones de 5 degrés Fahrenheit, allant de -65 degrés Fahrenheit à 65 degrés Fahrenheit.",

--- a/src/xclim/data/variables.yml
+++ b/src/xclim/data/variables.yml
@@ -390,6 +390,21 @@ variables:
           op: gt
           thresh: 4.0 m s-1
           n: 5
+  wsgmax10m:
+    cmip6: True
+    canonical_units: m s-1
+    cell_methods: "time: maximum"
+    description: Maximum wind speed of gust at 10m above surface.
+    dimensions: "[speed]"
+    standard_name: wind_speed_of_gust
+    data_flags:
+      - wind_values_outside_of_bounds:
+          upper: 76.0 m s-1
+          lower: 0 m s-1
+      - values_op_thresh_repeating_for_n_or_more_days:
+          op: gt
+          thresh: 4.0 m s-1
+          n: 5
 conversions:
   amount2rate:  # Standard names allowed in automatic `amount2rate` and `rate2amount` conversions.
     dimensionality:  # amount.dimensionality / flux.dimensionality

--- a/src/xclim/indicators/atmos/__init__.py
+++ b/src/xclim/indicators/atmos/__init__.py
@@ -18,6 +18,8 @@ import warnings
 from xclim.indicators import convert
 from xclim.indicators.convert._conversion import __all__ as _conversion_all  # noqa: F401
 
+from ._multivariate import *
+from ._multivariate import __all__ as _multivariate_all
 from ._precip import *
 from ._precip import __all__ as _precip_all
 from ._synoptic import *
@@ -27,7 +29,7 @@ from ._temperature import __all__ as _temperature_all
 from ._wind import *
 from ._wind import __all__ as _wind_all
 
-__all__ = _precip_all + _synoptic_all + _temperature_all + _wind_all
+__all__ = _multivariate_all + _precip_all + _synoptic_all + _temperature_all + _wind_all  # pyright: ignore
 
 
 def _deprecated_alias(func_name):

--- a/src/xclim/indicators/atmos/_multivariate.py
+++ b/src/xclim/indicators/atmos/_multivariate.py
@@ -19,12 +19,14 @@ canadian_hardiness_zones = MultivariateIndicator(
     standard_name="",
     units="",
     long_name="Canadian hardiness zones",
-    description="A climate indice based on a {freq} climatology of the annual average of maximum and minimum monthly "
-    "temperatures, seasonal precipitation, average annual maximum snow depth, and maximum wind gust experienced over "
-    "the entire period. Developed specifically to aid in determining plant suitability of Canadian geographic regions.",
-    abstract="A climate indice based on a multi-year climatology of the annual average of maximum and minimum monthly "
-    "temperatures, seasonal precipitation, average annual maximum snow depth, and maximum wind gust experienced over "
-    "the entire period. Developed specifically to aid in determining plant suitability of Canadian geographic regions.",
+    description="A climate index based on a {freq} climatology of the annual average of maximum and minimum "
+    "monthly temperatures, seasonal precipitation, average annual maximum snow depth, and maximum wind gust "
+    "experienced over the entire period. Developed specifically to aid in determining plant suitability of Canadian "
+    "geographic regions.",
+    abstract="A climate index based on a multi-year climatology of the annual average of maximum and minimum "
+    "monthly temperatures, seasonal precipitation, average annual maximum snow depth, and maximum wind gust "
+    "experienced over the entire period. Developed specifically to aid in determining plant suitability of Canadian "
+    "geographic regions.",
     cell_methods="",
     var_name="chz",
     compute=compute.canadian_hardiness_zones,

--- a/src/xclim/indicators/atmos/_multivariate.py
+++ b/src/xclim/indicators/atmos/_multivariate.py
@@ -1,0 +1,34 @@
+"""Complex multivariate indicator definitions."""
+
+from __future__ import annotations
+
+from xclim import compute
+from xclim.core.indicator import Indicator
+
+__all__ = ["canadian_hardiness_zones"]
+
+
+class MultivariateIndicator(Indicator):
+    """Indicators involving daily temperature, precipitation, and other variables."""
+
+
+canadian_hardiness_zones = MultivariateIndicator(
+    keywords="temperature precipitation speed",
+    title="Canadian hardiness zones",
+    identifier="canadian_hardiness_zones",
+    standard_name="",
+    units="",
+    long_name="Canadian hardiness zones",
+    description="A climate indice based on a {freq} climatology of the annual average of maximum and minimum monthly "
+    "temperatures, seasonal precipitation, average annual maximum snow depth, and maximum wind gust experienced over "
+    "the entire period. Developed specifically to aid in determining plant suitability of Canadian geographic regions.",
+    abstract="A climate indice based on a multi-year climatology of the annual average of maximum and minimum monthly "
+    "temperatures, seasonal precipitation, average annual maximum snow depth, and maximum wind gust experienced over "
+    "the entire period. Developed specifically to aid in determining plant suitability of Canadian geographic regions.",
+    cell_methods="",
+    var_name="chz",
+    compute=compute.canadian_hardiness_zones,
+    parameters={
+        "freq": {"default": "30YS"},
+    },
+)

--- a/src/xclim/testing/utils.py
+++ b/src/xclim/testing/utils.py
@@ -622,7 +622,7 @@ def populate_testing_data(
             n.fetch(file)
         except HTTPError:
             msg = f"File `{file}` not accessible in remote repository."
-            logging.error(msg)
+            logger.error(msg)
             errored_files.append(file)
         except SocketBlockedError as err:
             msg = (
@@ -632,10 +632,10 @@ def populate_testing_data(
             )
             raise SocketBlockedError(msg) from err
         else:
-            logging.info("Files were downloaded successfully.")
+            logger.info("Files were downloaded successfully.")
 
     if errored_files:
-        logging.error(
+        logger.error(
             "The following files were unable to be downloaded: %s",
             errored_files,
         )

--- a/tests/test_atmos.py
+++ b/tests/test_atmos.py
@@ -148,4 +148,4 @@ class TestCanadianHardinessZones:
             freq="4YS",
         )
 
-        np.testing.assert_allclose(chz, np.array([[58.1458], [74.6359], [-4.0576], [27.4931], [96.5160]]), rtol=1e-4)
+        np.testing.assert_array_equal(chz, np.array([[11.0], [14.0], [np.nan], [5.0], [19.0]]))

--- a/tests/test_atmos.py
+++ b/tests/test_atmos.py
@@ -147,5 +147,4 @@ class TestCanadianHardinessZones:
             wsgmax10m=wsgmax10m,
             freq="4YS",
         )
-
-        np.testing.assert_array_equal(chz, np.array([[11.0], [14.0], [np.nan], [5.0], [19.0]]))
+        np.testing.assert_array_equal(chz.values.ravel(), [11, 14, 0, 5, 19])

--- a/tests/test_atmos.py
+++ b/tests/test_atmos.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from xclim import atmos, set_options
+from xclim.compute.generic import statistics
 from xclim.compute.helpers import make_hourly_temperature
 
 K2C = 273.16
@@ -125,3 +126,26 @@ class TestAridityIndex:
 
         assert out.attrs["units"] == "1"
         np.testing.assert_allclose(out.values, expected)
+
+
+class TestCanadianHardinessZones:
+    def test_simple(self, atmosds):
+        ds = atmosds
+
+        tasmin = ds.tasmin
+        tasmax = ds.tasmax
+        pr = ds.pr
+        snd = ds.snd
+        wsgmax10m = statistics(ds.sfcWind, statistic="max", freq="MS")
+
+        # Should be caulculated over 30 years, but only four years of data available
+        chz = atmos.canadian_hardiness_zones(
+            tasmin=tasmin,
+            tasmax=tasmax,
+            pr=pr,
+            snd=snd,
+            wsgmax10m=wsgmax10m,
+            freq="4YS",
+        )
+
+        np.testing.assert_allclose(chz, np.array([[58.1458], [74.6359], [-4.0576], [27.4931], [96.5160]]), rtol=1e-4)

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -354,7 +354,7 @@ class TestCanadianHardinessZones:
         tasmax = ds.tasmax
         pr = ds.pr
         snd = ds.snd
-        sfcWindmax = generic.statistics(ds.sfcWind, statistic="max", freq="MS")
+        wsgmax10m = generic.statistics(ds.sfcWind, statistic="max", freq="MS")
 
         # Should be caulculated over 30 years, but only four years of data available
         chz = xcc.canadian_hardiness_zones(
@@ -362,7 +362,7 @@ class TestCanadianHardinessZones:
             tasmax=tasmax,
             pr=pr,
             snd=snd,
-            sfcWindmax=sfcWindmax,
+            wsgmax10m=wsgmax10m,
             freq="4YS",
         )
 

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -2764,9 +2764,7 @@ class TestHardinessZones:
             freq="4YS",
         )
         np.testing.assert_array_equal(chz.values.ravel(), [11, 14, 0, 5, 19])
-        assert chz.attrs["flag_values"] == (
-            "0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19"
-        )
+        assert chz.attrs["flag_values"] == ("0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19")
         assert chz.attrs["flag_meanings"] == (
             "0a, 0b, 1a, 1b, 2a, 2b, 3a, 3b, 4a, 4b, 5a, 5b, 6a, 6b, 7a, 7b, 8a, 8b, 9a, 9b"
         )

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -2763,8 +2763,13 @@ class TestHardinessZones:
             wsgmax10m=wsgmax10m,
             freq="4YS",
         )
-
-        np.testing.assert_array_equal(chz, np.array([[11.0], [14.0], [np.nan], [5.0], [19.0]]))
+        np.testing.assert_array_equal(chz.values.ravel(), [11, 14, 0, 5, 19])
+        assert chz.attrs["flag_values"] == (
+            "0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19"
+        )
+        assert chz.attrs["flag_meanings"] == (
+            "0a, 0b, 1a, 1b, 2a, 2b, 3a, 3b, 4a, 4b, 5a, 5b, 6a, 6b, 7a, 7b, 8a, 8b, 9a, 9b"
+        )
 
 
 class TestWindProfile:

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -346,6 +346,31 @@ class TestAgroclimaticIndices:
         np.testing.assert_array_equal(out, np.array([np.nan, expected]))
 
 
+class TestCanadianHardinessZones:
+    def test_simple(self, atmosds):
+        ds = atmosds
+
+        tasmin = ds.tasmin
+        tasmax = ds.tasmax
+        pr = ds.pr
+        snd = ds.snd
+        sfcWindmax = generic.statistics(ds.sfcWind, statistic="max", freq="MS")
+
+        # Should be caulculated over 30 years, but only four years of data available
+        chz = xcc.canadian_hardiness_zones(
+            tasmin=tasmin,
+            tasmax=tasmax,
+            pr=pr,
+            snd=snd,
+            sfcWindmax=sfcWindmax,
+            freq="4YS",
+        )
+
+        np.testing.assert_allclose(
+            chz, np.array([[58.1458], [74.6359], [-4.0576], [27.4931], [96.5160]]), rtol=1e-4
+        )
+
+
 class TestStandardizedIndices:
     # gamma/APP reference results: Obtained with `monocongo/climate_indices` library
     # MS/fisk/ML reference results: Obtained with R package `SPEI`

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -346,29 +346,6 @@ class TestAgroclimaticIndices:
         np.testing.assert_array_equal(out, np.array([np.nan, expected]))
 
 
-class TestCanadianHardinessZones:
-    def test_simple(self, atmosds):
-        ds = atmosds
-
-        tasmin = ds.tasmin
-        tasmax = ds.tasmax
-        pr = ds.pr
-        snd = ds.snd
-        wsgmax10m = generic.statistics(ds.sfcWind, statistic="max", freq="MS")
-
-        # Should be caulculated over 30 years, but only four years of data available
-        chz = xcc.canadian_hardiness_zones(
-            tasmin=tasmin,
-            tasmax=tasmax,
-            pr=pr,
-            snd=snd,
-            wsgmax10m=wsgmax10m,
-            freq="4YS",
-        )
-
-        np.testing.assert_allclose(chz, np.array([[58.1458], [74.6359], [-4.0576], [27.4931], [96.5160]]), rtol=1e-4)
-
-
 class TestStandardizedIndices:
     # gamma/APP reference results: Obtained with `monocongo/climate_indices` library
     # MS/fisk/ML reference results: Obtained with R package `SPEI`
@@ -2740,32 +2717,54 @@ class TestDrynessIndex:
         np.testing.assert_allclose(di_wet, di_plus_100)
 
 
-@pytest.mark.parametrize(
-    "tmin,meth,zone",
-    [
-        (-6, "usda", 16),
-        (19, "usda", 25),
-        (-47, "usda", 1),
-        (-6, "anbg", 1),
-        (19, "anbg", 6),
-        (-47, "anbg", np.nan),
-    ],
-    # There are 26 USDA zones: 1a -> 1, 1b -> 2, ... 13b -> 26
-    # There are 7 angb zones: 1,2, ..., 7
-    # Example for "angb":
-    # Zone 1 : -15 degC <= tmin < -10 degC
-    # Zone 2 : -10 degC <= tmin < -5 degC
-    # ...
-    # Zone 7 : 15 degC <= tmin <= 20 degC
-    # Below -15 degC or above 20 degC, this is NaN
-)
-def test_hardiness_zones(tasmin_series, tmin, meth, zone):
-    tasmin = tasmin_series(np.zeros(10957) + 20, start="1997-01-01", units="degC")
-    tasmin = tasmin.where(tasmin.time.dt.dayofyear != 1, tmin)
+class TestHardinessZones:
+    @pytest.mark.parametrize(
+        "tmin,meth,zone",
+        [
+            (-6, "usda", 16),
+            (19, "usda", 25),
+            (-47, "usda", 1),
+            (-6, "anbg", 1),
+            (19, "anbg", 6),
+            (-47, "anbg", np.nan),
+        ],
+        # There are 26 USDA zones: 1a -> 1, 1b -> 2, ... 13b -> 26
+        # There are 7 angb zones: 1,2, ..., 7
+        # Example for "angb":
+        # Zone 1 : -15 degC <= tmin < -10 degC
+        # Zone 2 : -10 degC <= tmin < -5 degC
+        # ...
+        # Zone 7 : 15 degC <= tmin <= 20 degC
+        # Below -15 degC or above 20 degC, this is NaN
+    )
+    def test_hardiness_zones(self, tasmin_series, tmin, meth, zone):
+        tasmin = tasmin_series(np.zeros(10957) + 20, start="1997-01-01", units="degC")
+        tasmin = tasmin.where(tasmin.time.dt.dayofyear != 1, tmin)
 
-    hz = xcc.hardiness_zones(tasmin=tasmin, method=meth)
-    np.testing.assert_array_equal(hz[-1], zone)
-    assert hz[:-1].isnull().all()
+        hz = xcc.hardiness_zones(tasmin=tasmin, method=meth)
+        np.testing.assert_array_equal(hz[-1], zone)
+        assert hz[:-1].isnull().all()
+
+    def test_canadian_hardiness_zones(self, atmosds):
+        ds = atmosds
+
+        tasmin = ds.tasmin
+        tasmax = ds.tasmax
+        pr = ds.pr
+        snd = ds.snd
+        wsgmax10m = generic.statistics(ds.sfcWind, statistic="max", freq="MS")
+
+        # Should be caulculated over 30 years, but only four years of data available
+        chz = xcc.canadian_hardiness_zones(
+            tasmin=tasmin,
+            tasmax=tasmax,
+            pr=pr,
+            snd=snd,
+            wsgmax10m=wsgmax10m,
+            freq="4YS",
+        )
+
+        np.testing.assert_array_equal(chz, np.array([[11.0], [14.0], [np.nan], [5.0], [19.0]]))
 
 
 class TestWindProfile:

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -366,9 +366,7 @@ class TestCanadianHardinessZones:
             freq="4YS",
         )
 
-        np.testing.assert_allclose(
-            chz, np.array([[58.1458], [74.6359], [-4.0576], [27.4931], [96.5160]]), rtol=1e-4
-        )
+        np.testing.assert_allclose(chz, np.array([[58.1458], [74.6359], [-4.0576], [27.4931], [96.5160]]), rtol=1e-4)
 
 
 class TestStandardizedIndices:

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -76,7 +76,8 @@ class TestConvertUnitsTo:
 
         with pytest.raises(TypeError):
             tas = tas_series(np.arange(365), start="1/1/2001")
-            out = compute.tx_days_above(tas, 30)  # noqa
+            with pytest.warns(DeprecationWarning):
+                compute.tx_days_above(tas, 30)  # noqa
 
     def test_fraction(self):
         out = convert_units_to(xr.DataArray([10], attrs={"units": "%"}), "")


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #1290
- [x] Tests for the changes have been added (for bug fixes / features)
  - [x] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGELOG.rst has been updated (with summary of main changes)
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added

### What kind of change does this PR introduce?

* Adds the `canadian_hardiness_zones` compute function.
* Update the `hardiness_zones` function to add the `flag_values` and `flag_meanings` for zones.

### Does this PR introduce a breaking change?

No. This adds more attribute information to existing hardiness zones indicators.

### Other information:

The changes here were adapted from previous work in the now-deleted `plant-hardiness-zones` branch.

The zones follow the `flag` CF-Conventions (https://cfconventions.org/Data/cf-conventions/cf-conventions-1.9/cf-conventions.html#flags); This only satisfies a portion of the CF-Conventions pertaining to variable attributes, which is fine/an improvement.

### Questions

This indicator is one of those that should _technically_ be returning a categorization, rather than an index value as the compute function is currently coded:
- _Would it be more accurate to rename this function to return an `*_index` with the index values?_
  - No.
- _Should the indicator version return the zones based on the index values?_
  - Yes, now returned as flags

There is also the issue that this zoning categorization is meant to be performed on series' of variables spanning at least 30 years. The current tests rely on the `atmosds` (four years of real-world data).
- Should I be adding more tests based on artificial time series data?